### PR TITLE
Renner monoid of type B and D (EG and Gay-Hivert presentation)

### DIFF
--- a/tests/cong.test.cc
+++ b/tests/cong.test.cc
@@ -878,8 +878,8 @@ TEST_CASE("Congruence 28: test_less_than",
   REQUIRE(!cong.test_less_than({0, 0}, {0}));
 }
 
-std::vector<relation_t> GodelleTypeBMonoid(size_t l) {
-
+std::vector<relation_t> RennerCommonTypeBMonoid(size_t l, int q) {
+// q is supposed to be 0 or 1
   std::vector<size_t> s;
   std::vector<size_t> e;
   for (size_t i = 0; i < l; ++i) {
@@ -901,12 +901,17 @@ std::vector<relation_t> GodelleTypeBMonoid(size_t l) {
   rels.push_back({{id, e[l]}, {e[l]}});
   rels.push_back({{e[l], id}, {e[l]}});
 
-  for (size_t i = 0; i < l; ++i) {
-    rels.push_back({{s[i], s[i]}, {id}});
+  switch (q) {
+  case 0:
+    for (size_t i = 0; i < l; ++i) rels.push_back({{s[i], s[i]}, {s[i]}});
+    break;
+  case 1:
+    for (size_t i = 0; i < l; ++i) rels.push_back({{s[i], s[i]}, {id}});
+    break;
+    // default: assert(FALSE)
   }
-
-  for (int i = 0; i < l; ++i) {
-    for (int j = 0; j < l; ++j) {
+  for (int i = 0; i < static_cast<int>(l); ++i) {
+    for (int j = 0; j < static_cast<int>(l); ++j) {
       if (std::abs(i - j) >= 2) {
         rels.push_back({{s[i], s[j]}, {s[j], s[i]}});
       }
@@ -943,22 +948,178 @@ std::vector<relation_t> GodelleTypeBMonoid(size_t l) {
     rels.push_back({{e[i], s[i], e[i]}, {e[i + 1]}});
   }
 
-  rels.push_back({{e[0], s[0], s[1], s[0], e[0]}, {e[2]}});
+  // Extra check relations
+  // rels.push_back({{e[3]},{e[2]}});
+  // rels.push_back({{e[0], s[0], s[1], s[0], s[2], s[1], s[0], e[0]}, {s[2]}});
+
   return rels;
 }
 
-TEST_CASE("Congruence 29: Renner monoid type D2, q = 1",
+
+
+std::vector<relation_t> EGTypeBMonoid(size_t l, int q) {
+  std::vector<size_t> s;
+  std::vector<size_t> e;
+  for (size_t i = 0; i < l; ++i) {
+    s.push_back(i);
+  }
+  for (size_t i = l; i < 2 * l + 1; ++i) {
+    e.push_back(i);
+  }
+  size_t id = 2 * l + 1;
+
+  std::vector<relation_t> rels = RennerCommonTypeBMonoid(l, q);
+
+  if (l >= 2)
+    rels.push_back({{e[0], s[0], s[1], s[0], e[0]}, {e[2]}});
+
+  return rels;
+}
+
+
+std::vector<size_t> max_elt_B(size_t i) {
+  std::vector<size_t> t(0);
+  for (int end=i; end >= 0; end--) {
+    for (int k = 0; k <= end; k++) {
+      t.push_back(k);
+    }
+  }
+  return t;
+}
+
+std::vector<size_t> max_elt_D(size_t i, int g) {
+// g est 0 ou 1 : 0 pour f et 1 pour e
+  std::vector<size_t> t{0};
+  int parity = g;
+  for (int end=i; end > 0; end--) {
+    t.push_back(parity);
+    for(int k = 2; k <= end; k++) {
+      t.push_back(k);
+    }
+    parity = (parity + 1) % 2;
+  }
+  return t;
+}
+
+
+std::vector<relation_t> RennerTypeBMonoid(size_t l, int q) {
+  std::vector<size_t> s;
+  std::vector<size_t> e;
+  for (size_t i = 0; i < l; ++i) {
+    s.push_back(i);
+  }
+  for (size_t i = l; i < 2 * l + 1; ++i) {
+    e.push_back(i);
+  }
+  size_t id = 2 * l + 1;
+
+  std::vector<relation_t> rels = RennerCommonTypeBMonoid(l, q);
+
+  for (size_t i = 1; i<l; i++) {
+    std::vector<size_t> new_rel = max_elt_B(i);
+    new_rel.push_back(e[0]);
+    new_rel.insert(new_rel.begin(), e[0]);
+    rels.push_back({new_rel, {e[i+1]}});
+  }
+
+  return rels;
+}
+
+
+TEST_CASE("Congruence 29: Renner monoid type B2 (E. G. presentation), q = 1",
           "[congruence][fpsemigroup][29]") {
-  Congruence cong("twosided", 6, {}, GodelleTypeBMonoid(2));
+  Congruence cong("twosided", 6, {}, EGTypeBMonoid(2, 1));
   cong.set_report(true);
   REQUIRE(!cong.is_obviously_infinite());
   REQUIRE(cong.nr_classes() == 57);
 }
 
-/*TEST_CASE("Congruence 30: Renner monoid type D3, q = 1",
+TEST_CASE("Congruence 30: Renner monoid type B2 (E. G. presentation), q = 0",
           "[congruence][fpsemigroup][30]") {
-  Congruence cong("twosided", 8, {}, GodelleTypeBMonoid(3));
+  Congruence cong("twosided", 6, {}, EGTypeBMonoid(2, 0));
   cong.set_report(true);
   REQUIRE(!cong.is_obviously_infinite());
   REQUIRE(cong.nr_classes() == 57);
-}*/
+}
+
+// Infinite monoid ???
+TEST_CASE("Congruence 31: Renner monoid type B3 (E. G. presentation), q = 1",
+          "[congruence][fpsemigroup][31]") {
+  Congruence cong("twosided", 8, {}, EGTypeBMonoid(3, 1));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 757);
+}
+
+// Infinite monoid ???
+TEST_CASE("Congruence 32: Renner monoid type B3 (E. G. presentation), q = 0",
+          "[congruence][fpsemigroup][32]") {
+  Congruence cong("twosided", 8, {}, EGTypeBMonoid(3, 0));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 757);
+}
+
+TEST_CASE("Congruence 33: Renner monoid type B2 (Gay-Hivert presentation), q = 1",
+          "[congruence][fpsemigroup][33]") {
+  Congruence cong("twosided", 6, {}, RennerTypeBMonoid(2, 1));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 57);
+}
+
+TEST_CASE("Congruence 34: Renner monoid type B2 (Gay-Hivert presentation), q = 0",
+          "[congruence][fpsemigroup][34]") {
+  Congruence cong("twosided", 6, {}, RennerTypeBMonoid(2, 0));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 57);
+}
+
+TEST_CASE("Congruence 35: Renner monoid type B3 (Gay-Hivert presentation), q = 1",
+          "[congruence][fpsemigroup][35]") {
+  Congruence cong("twosided", 8, {}, RennerTypeBMonoid(3, 1));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 757);
+}
+
+TEST_CASE("Congruence 36: Renner monoid type B3 (Gay-Hivert presentation), q = 0",
+          "[congruence][fpsemigroup][36]") {
+  Congruence cong("twosided", 8, {}, RennerTypeBMonoid(3, 0));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 757);
+}
+
+TEST_CASE("Congruence 37: Renner monoid type B4 (Gay-Hivert presentation), q = 1",
+          "[congruence][fpsemigroup][37]") {
+  Congruence cong("twosided", 10, {}, RennerTypeBMonoid(4, 1));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 13889);
+}
+
+TEST_CASE("Congruence 38: Renner monoid type B4 (Gay-Hivert presentation), q = 0",
+          "[congruence][fpsemigroup][38]") {
+  Congruence cong("twosided", 10, {}, RennerTypeBMonoid(4, 0));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 13889);
+}
+
+TEST_CASE("Congruence 39: Renner monoid type B5 (Gay-Hivert presentation), q = 1",
+          "[congruence][fpsemigroup][39]") {
+  Congruence cong("twosided", 12, {}, RennerTypeBMonoid(5, 1));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 322021);
+}
+
+TEST_CASE("Congruence 40: Renner monoid type B5 (Gay-Hivert presentation), q = 0",
+          "[congruence][fpsemigroup][40]") {
+  Congruence cong("twosided", 12, {}, RennerTypeBMonoid(5, 0));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 322021);
+}

--- a/tests/cong.test.cc
+++ b/tests/cong.test.cc
@@ -1167,18 +1167,17 @@ std::vector<relation_t> RennerTypeDMonoid(size_t l, int q) {
 
   std::vector<relation_t> rels = RennerCommonTypeDMonoid(l, q);
 
-  for (size_t i = 1; i<l; i++) {
+  for (size_t i = 1; i < l; i++) {
     std::vector<size_t> new_rel_f = max_elt_D(i, 0);
     std::vector<size_t> new_rel_e = max_elt_D(i, 1);
-    if (i % 2 == 0){
+    if (i % 2 == 0) {
       new_rel_e.push_back(f);
       new_rel_e.insert(new_rel_e.begin(), e[0]);
       rels.push_back({new_rel_e, {e[i+1]}});
       new_rel_f.push_back(e[0]);
       new_rel_f.insert(new_rel_f.begin(), f);
       rels.push_back({new_rel_f, {e[i+1]}});
-    }
-    else{
+    } else {
       new_rel_e.push_back(e[0]);
       new_rel_e.insert(new_rel_e.begin(), e[0]);
       rels.push_back({new_rel_e, {e[i+1]}});
@@ -1293,7 +1292,15 @@ TEST_CASE("Congruence 40: Renner monoid type B5 (Gay-Hivert presentation), q = 0
 
 TEST_CASE("Congruence 41: Renner monoid type D2 (E. G. presentation), q = 1",
           "[congruence][fpsemigroup][41]") {
-  Congruence cong("twosided", 6, {}, EGTypeDMonoid(2, 1));
+  Congruence cong("twosided", 7, {}, EGTypeDMonoid(2, 1));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 37);
+}
+
+TEST_CASE("Congruence 42: Renner monoid type D2 (Gay-Hivert presentation), q = 1",
+          "[congruence][fpsemigroup][42]") {
+  Congruence cong("twosided", 7, {}, RennerTypeDMonoid(2, 1));
   cong.set_report(true);
   REQUIRE(!cong.is_obviously_infinite());
   REQUIRE(cong.nr_classes() == 37);

--- a/tests/cong.test.cc
+++ b/tests/cong.test.cc
@@ -1140,7 +1140,7 @@ std::vector<relation_t> EGTypeDMonoid(size_t l, int q) {
 
 std::vector<size_t> max_elt_D(size_t i, int g) {
 // g est 0 ou 1 : 0 pour f et 1 pour e
-  std::vector<size_t> t{0};
+  std::vector<size_t> t(0);
   int parity = g;
   for (int end=i; end > 0; end--) {
     t.push_back(parity);
@@ -1152,6 +1152,7 @@ std::vector<size_t> max_elt_D(size_t i, int g) {
   return t;
 }
 
+#include<iostream>
 
 std::vector<relation_t> RennerTypeDMonoid(size_t l, int q) {
   std::vector<size_t> s;
@@ -1167,24 +1168,35 @@ std::vector<relation_t> RennerTypeDMonoid(size_t l, int q) {
 
   std::vector<relation_t> rels = RennerCommonTypeDMonoid(l, q);
 
-  for (size_t i = 1; i < l; i++) {
+  for (size_t i = 2; i < l; i++) {
     std::vector<size_t> new_rel_f = max_elt_D(i, 0);
     std::vector<size_t> new_rel_e = max_elt_D(i, 1);
+
     if (i % 2 == 0) {
-      new_rel_e.push_back(f);
-      new_rel_e.insert(new_rel_e.begin(), e[0]);
+      new_rel_e.insert(new_rel_e.begin(), f);
+      new_rel_e.push_back(e[0]);
       rels.push_back({new_rel_e, {e[i+1]}});
-      new_rel_f.push_back(e[0]);
-      new_rel_f.insert(new_rel_f.begin(), f);
+
+      new_rel_f.insert(new_rel_f.begin(), e[0]);
+      new_rel_f.push_back(f);
       rels.push_back({new_rel_f, {e[i+1]}});
     } else {
-      new_rel_e.push_back(e[0]);
-      new_rel_e.insert(new_rel_e.begin(), e[0]);
+      new_rel_e.insert(new_rel_e.begin(), f);
+      new_rel_e.push_back(f);
       rels.push_back({new_rel_e, {e[i+1]}});
-      new_rel_f.push_back(f);
-      new_rel_f.insert(new_rel_f.begin(), f);
+
+      new_rel_f.insert(new_rel_f.begin(), e[0]);
+      new_rel_f.push_back(e[0]);
       rels.push_back({new_rel_f, {e[i+1]}});
     }
+
+    std::cout << "new_rel_e : ";
+    for (auto lt : new_rel_e) std::cout << " " << lt;
+    std::cout << std::endl;
+    std::cout << "new_rel_f : ";
+    for (auto lt : new_rel_f) std::cout << " " << lt;
+    std::cout << std::endl;
+
   }
   return rels;
 }
@@ -1208,7 +1220,7 @@ TEST_CASE("Congruence 30: Renner monoid type B2 (E. G. presentation), q = 0",
   REQUIRE(cong.nr_classes() == 57);
 }
 
-// Infinite monoid ???
+// Loops for ever: Infinite monoid ???
 TEST_CASE("Congruence 31: Renner monoid type B3 (E. G. presentation), q = 1",
           "[congruence][fpsemigroup][31]") {
   Congruence cong("twosided", 8, {}, EGTypeBMonoid(3, 1));
@@ -1217,7 +1229,7 @@ TEST_CASE("Congruence 31: Renner monoid type B3 (E. G. presentation), q = 1",
   REQUIRE(cong.nr_classes() == 757);
 }
 
-// Infinite monoid ???
+// Loops for ever: Infinite monoid ???
 TEST_CASE("Congruence 32: Renner monoid type B3 (E. G. presentation), q = 0",
           "[congruence][fpsemigroup][32]") {
   Congruence cong("twosided", 8, {}, EGTypeBMonoid(3, 0));
@@ -1290,6 +1302,7 @@ TEST_CASE("Congruence 40: Renner monoid type B5 (Gay-Hivert presentation), q = 0
   REQUIRE(cong.nr_classes() == 322021);
 }
 
+
 TEST_CASE("Congruence 41: Renner monoid type D2 (E. G. presentation), q = 1",
           "[congruence][fpsemigroup][41]") {
   Congruence cong("twosided", 7, {}, EGTypeDMonoid(2, 1));
@@ -1298,10 +1311,130 @@ TEST_CASE("Congruence 41: Renner monoid type D2 (E. G. presentation), q = 1",
   REQUIRE(cong.nr_classes() == 37);
 }
 
-TEST_CASE("Congruence 42: Renner monoid type D2 (Gay-Hivert presentation), q = 1",
+TEST_CASE("Congruence 42: Renner monoid type D2 (E. G. presentation), q = 0",
           "[congruence][fpsemigroup][42]") {
+  Congruence cong("twosided", 7, {}, EGTypeDMonoid(2, 0));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 37);
+}
+
+TEST_CASE("Congruence 43: Renner monoid type D3 (E. G. presentation), q = 1",
+          "[congruence][fpsemigroup][43]") {
+  Congruence cong("twosided", 9, {}, EGTypeDMonoid(3, 1));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 541);
+}
+
+TEST_CASE("Congruence 44: Renner monoid type D3 (E. G. presentation), q = 0",
+          "[congruence][fpsemigroup][44]") {
+  Congruence cong("twosided", 9, {}, EGTypeDMonoid(3, 0));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 541);
+}
+
+// Loops for ever: Infinite monoid ???
+TEST_CASE("Congruence 45: Renner monoid type D4 (E. G. presentation), q = 1",
+          "[congruence][fpsemigroup][45]") {
+  Congruence cong("twosided", 11, {}, EGTypeDMonoid(4, 1));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 10625);
+}
+
+// Loops for ever: Infinite monoid ???
+TEST_CASE("Congruence 46: Renner monoid type D4 (E. G. presentation), q = 0",
+          "[congruence][fpsemigroup][46]") {
+  Congruence cong("twosided", 11, {}, EGTypeDMonoid(4, 0));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 10625);
+}
+
+
+
+TEST_CASE("Congruence 47: Renner monoid type D2 (Gay-Hivert presentation), q = 1",
+          "[congruence][fpsemigroup][47]") {
   Congruence cong("twosided", 7, {}, RennerTypeDMonoid(2, 1));
   cong.set_report(true);
   REQUIRE(!cong.is_obviously_infinite());
   REQUIRE(cong.nr_classes() == 37);
 }
+
+TEST_CASE("Congruence 48: Renner monoid type D2 (Gay-Hivert presentation), q = 0",
+          "[congruence][fpsemigroup][48]") {
+  Congruence cong("twosided", 7, {}, RennerTypeDMonoid(2, 0));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 37);
+}
+
+TEST_CASE("Congruence 49: Renner monoid type D3 (Gay-Hivert presentation), q = 1",
+          "[congruence][fpsemigroup][49]") {
+  Congruence cong("twosided", 9, {}, RennerTypeDMonoid(3, 1));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 541);
+}
+
+TEST_CASE("Congruence 50: Renner monoid type D3 (Gay-Hivert presentation), q = 0",
+          "[congruence][fpsemigroup][50]") {
+  Congruence cong("twosided", 9, {}, RennerTypeDMonoid(3, 0));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 541);
+}
+
+TEST_CASE("Congruence 51: Renner monoid type D4 (Gay-Hivert presentation), q = 1",
+          "[congruence][fpsemigroup][51]") {
+  Congruence cong("twosided", 11, {}, RennerTypeDMonoid(4, 1));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 10625);
+}
+
+TEST_CASE("Congruence 52: Renner monoid type D4 (Gay-Hivert presentation), q = 0",
+          "[congruence][fpsemigroup][52]") {
+  Congruence cong("twosided", 11, {}, RennerTypeDMonoid(4, 0));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 10625);
+}
+
+TEST_CASE("Congruence 53: Renner monoid type D5 (Gay-Hivert presentation), q = 1",
+          "[congruence][fpsemigroup][53]") {
+  Congruence cong("twosided", 13, {}, RennerTypeDMonoid(5, 1));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 258661);
+}
+
+TEST_CASE("Congruence 54: Renner monoid type D5 (Gay-Hivert presentation), q = 0",
+          "[congruence][fpsemigroup][54]") {
+  Congruence cong("twosided", 13, {}, RennerTypeDMonoid(5, 0));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 258661);
+}
+
+// The two following are quite large, so I keep them commented out
+// TEST_CASE("Congruence 55: Renner monoid type D6 (Gay-Hivert presentation), q = 1",
+//           "[congruence][fpsemigroup][55]") {
+//   Congruence cong("twosided", 15, {}, RennerTypeDMonoid(6, 1));
+//   cong.set_report(true);
+//   REQUIRE(!cong.is_obviously_infinite());
+//   REQUIRE(cong.nr_classes() == 7464625);
+// }
+
+// TEST_CASE("Congruence 56: Renner monoid type D6 (Gay-Hivert presentation), q = 0",
+//           "[congruence][fpsemigroup][56]") {
+//   Congruence cong("twosided", 15, {}, RennerTypeDMonoid(6, 0));
+//   cong.set_report(true);
+//   REQUIRE(!cong.is_obviously_infinite());
+//   REQUIRE(cong.nr_classes() == 7464625);
+// }
+
+
+

--- a/tests/cong.test.cc
+++ b/tests/cong.test.cc
@@ -1437,4 +1437,147 @@ TEST_CASE("Congruence 54: Renner monoid type D5 (Gay-Hivert presentation), q = 0
 // }
 
 
+std::vector<relation_t> RookMonoid(size_t l, int q) {
+// q is supposed to be 0 or 1
 
+  std::vector<size_t> s;
+  for (size_t i = 0; i < l; ++i) {
+    s.push_back(i);     // 0 est \pi_0
+  }
+
+  // identity relations
+  size_t id = l;
+  std::vector<relation_t> rels = {relation_t({id, id}, {id})};
+  for (size_t i = 0; i < l; ++i) {
+    rels.push_back({{s[i], id}, {s[i]}});
+    rels.push_back({{id, s[i]}, {s[i]}});
+  }
+
+  switch (q) {
+  case 0:
+    for (size_t i = 0; i < l; ++i) rels.push_back({{s[i], s[i]}, {s[i]}});
+    break;
+  case 1:
+    rels.push_back({{s[0], s[0]}, {s[0]}});
+    for (size_t i = 1; i < l; ++i) rels.push_back({{s[i], s[i]}, {id}});
+    break;
+    // default: assert(FALSE)
+  }
+  for (int i = 0; i < static_cast<int>(l); ++i) {
+    for (int j = 0; j < static_cast<int>(l); ++j) {
+      if (std::abs(i - j) >= 2) {
+        rels.push_back({{s[i], s[j]}, {s[j], s[i]}});
+      }
+    }
+  }
+
+  for (size_t i = 1; i < l - 1; ++i) {
+    rels.push_back({{s[i], s[i + 1], s[i]}, {s[i + 1], s[i], s[i + 1]}});
+  }
+
+  rels.push_back({{s[1], s[0], s[1], s[0]}, {s[0], s[1], s[0], s[1]}});
+  rels.push_back({{s[1], s[0], s[1], s[0]}, {s[0], s[1], s[0]}});
+
+  return rels;
+}
+
+TEST_CASE("Congruence 57: Rook monoid R5, q = 0",
+          "[congruence][fpsemigroup][57]") {
+  Congruence cong("twosided", 6, {}, RookMonoid(5, 0));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 1546);
+}
+
+TEST_CASE("Congruence 58: Rook monoid R5, q = 1",
+          "[congruence][fpsemigroup][58]") {
+  Congruence cong("twosided", 6, {}, RookMonoid(5, 1));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 1546);
+}
+
+TEST_CASE("Congruence 59: Rook monoid R6, q = 0",
+          "[congruence][fpsemigroup][59]") {
+  Congruence cong("twosided", 7, {}, RookMonoid(6, 0));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 13327);
+}
+
+TEST_CASE("Congruence 60: Rook monoid R6, q = 1",
+          "[congruence][fpsemigroup][60]") {
+  Congruence cong("twosided", 7, {}, RookMonoid(6, 1));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 13327);
+}
+
+template <typename T>
+std::vector<T> concat(std::vector<T> lhs, const std::vector<T> & rhs) {
+  lhs.insert(lhs.end(), rhs.begin(), rhs.end());
+  return lhs;
+}
+
+std::vector<relation_t> Stell(size_t l) {
+  std::vector<size_t> pi;
+  for (size_t i = 0; i < l; ++i) {
+    pi.push_back(i);     // 0 est \pi_0
+  }
+
+  std::vector<relation_t> rels {};
+  std::vector<size_t> t {pi[0]};
+  for (int i = 1; i < static_cast<int>(l); ++i) {
+    t.insert(t.begin(),pi[i]);
+    rels.push_back({concat(t, {pi[i]}), t});
+  }
+  return rels;
+}
+
+TEST_CASE("Congruence 61: Stellar S2",
+          "[congruence][fpsemigroup][61]") {
+  Congruence cong("twosided", 3, RookMonoid(2, 0), Stell(2));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 5);
+}
+
+TEST_CASE("Congruence 62: Stellar S3",
+          "[congruence][fpsemigroup][62]") {
+  Congruence cong("twosided", 4, RookMonoid(3, 0), Stell(3));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 16);
+}
+
+TEST_CASE("Congruence 63: Stellar S4",
+          "[congruence][fpsemigroup][63]") {
+  Congruence cong("twosided", 5, RookMonoid(4, 0), Stell(4));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 65);
+}
+
+TEST_CASE("Congruence 64: Stellar S5",
+          "[congruence][fpsemigroup][64]") {
+  Congruence cong("twosided", 6, RookMonoid(5, 0), Stell(5));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 326);
+}
+
+TEST_CASE("Congruence 65: Stellar S6",
+          "[congruence][fpsemigroup][65]") {
+  Congruence cong("twosided", 7, RookMonoid(6, 0), Stell(6));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 1957);
+}
+
+TEST_CASE("Congruence 66: Stellar S7",
+          "[congruence][fpsemigroup][66]") {
+  Congruence cong("twosided", 8, RookMonoid(7, 0), Stell(7));
+  cong.set_report(true);
+  REQUIRE(!cong.is_obviously_infinite());
+  REQUIRE(cong.nr_classes() == 13700);
+}


### PR DESCRIPTION
Dear James,

Thanks to you, we've been able to check everything we wanted ! It even allowed to detect and fix a small index mistake (a interval starting from 1 instead of 0) in the paper ! As you asked, I'm submitted a pull request but you don't yet should merge it (indeed travis will complain).

Some of the test seems to define infinite semigroups, so that Froidure-Pin will loop forever exhausting all the memory. Those tests (4 of them) are marked with a comment `// Loops for ever: Infinite monoid ???`. They should be fixed with something saying that there is at least a large number of elements. The current number marked as expected is the number which is wrongly claimed by E.G. So to prove what we need, say that the size is at least this number + 1 is ok.

Also I commented out two more tests which require 2 mins on my computer.

Again thanks a lot !

Best

Florent

