### PR TITLE
Fix test failures on 32-bit systems

### DIFF
--- a/include/schreier-sims.hpp
+++ b/include/schreier-sims.hpp
@@ -368,16 +368,16 @@ namespace libsemigroups {
 
     //! Returns the size of the group represented by this.
     //!
-    //! \returns the size, a value of \c size_t.
+    //! \returns the size, a value of \c uint64_t.
     //!
     //! \par Parameters
     //! (None)
-    size_t size() {
+    uint64_t size() {
       if (empty()) {
         return 1;
       }
       schreier_sims();
-      size_t out = 1;
+      uint64_t out = 1;
       for (index_type i = 0; i < _base_size; i++) {
         out *= _orbits.size(i);
       }

--- a/include/string.hpp
+++ b/include/string.hpp
@@ -165,13 +165,11 @@ namespace libsemigroups {
               std::string::const_iterator const& first_prefix,
               std::string::const_iterator const& last_prefix) {
       LIBSEMIGROUPS_ASSERT(first_word <= last_word);
-      // We don't care if first_prefix > last_prefix
-      if (last_prefix - first_prefix > last_word - first_word) {
-        return false;
-      }
       // Check if [first_prefix, last_prefix) equals [first_word, first_word +
       // (last_suffix - first_suffix))
-      return std::equal(first_prefix, last_prefix, first_word);
+      return first_prefix <= last_prefix &&
+             last_prefix - first_prefix <= last_word - first_word &&
+             std::equal(first_prefix, last_prefix, first_word);
     }
 
     static inline std::pair<std::string::const_iterator,

--- a/src/bmat8.cpp
+++ b/src/bmat8.cpp
@@ -367,10 +367,10 @@ namespace libsemigroups {
   namespace bmat8_helpers {
     size_t minimum_dim(BMat8 const& x) noexcept {
       size_t i = 0;
-      size_t c = x.to_int();
-      size_t d = x.to_int();
-      size_t y = x.transpose().to_int();
-      size_t z = x.transpose().to_int();
+      uint64_t c = x.to_int();
+      uint64_t d = x.to_int();
+      uint64_t y = x.transpose().to_int();
+      uint64_t z = x.transpose().to_int();
 
       do {
         d = d >> 8;

--- a/tests/test-bmat8.cpp
+++ b/tests/test-bmat8.cpp
@@ -589,7 +589,7 @@ namespace libsemigroups {
     BMat8 zero(0);
     REQUIRE(BMat8({{0, 0}, {0, 0}}) == zero);
     REQUIRE(BMat8({{0, 0}, {0, 1}}) != zero);
-    REQUIRE(BMat8({{0, 0}, {0, 1}}) == BMat8(size_t(1) << 54));
+    REQUIRE(BMat8({{0, 0}, {0, 1}}) == BMat8(uint64_t(1) << 54));
 
     REQUIRE_THROWS_AS(BMat8({{0, 0}}), LibsemigroupsException);
     REQUIRE_THROWS_AS(BMat8({{0, 1}}), LibsemigroupsException);


### PR DESCRIPTION
The first commit fixes issue 60.  It appears that when the first two iterators passed to std::equal are in reverse order, std::equal sometimes returns true and sometimes returns false.  I have only seen it return true on 32-bit x86 systems, and this may very well be a bug in the version of the C++ library I am using.  In any case, this commit seems to me like the right thing to do, and it resolves the issue.

The second commit fixes test failures due to integer overflow.  Note that size_t is a 32-bit type on 32-bit Linux systems.