### PR TITLE
order: add doc. and missing functions

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -26,7 +26,7 @@ EXCLUDE_SYMBOLS       = std::hash \
                         Internal* \
                         THREAD_ID_MANAGER \
                         REPORTER
-EXCLUDE_PATTERNS      = *-impl.hpp transf.hpp order.hpp string.hpp *KBE*
+EXCLUDE_PATTERNS      = *-impl.hpp transf.hpp string.hpp *KBE*
 ALIASES               =  exceptions="\par Exceptions"
 ALIASES               += noexcept="This function is `noexcept` and is guaranteed never to throw."
 ALIASES               += no_libsemigroups_except="This function guarantees not to throw a LibsemigroupsException."

--- a/docs/source/api/lexicographical_compare_pointers.rst
+++ b/docs/source/api/lexicographical_compare_pointers.rst
@@ -1,0 +1,11 @@
+.. Copyright (c) 2019, J. D. Mitchell
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+lexicographical_compare (pointers)
+==================================
+
+.. doxygenfunction:: libsemigroups::lexicographical_compare(T *const, T *const)
+   :project: libsemigroups

--- a/docs/source/api/lexicographical_compare_references.rst
+++ b/docs/source/api/lexicographical_compare_references.rst
@@ -1,0 +1,11 @@
+.. Copyright (c) 2019, J. D. Mitchell
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+lexicographical_compare (references)
+====================================
+
+.. doxygenfunction:: libsemigroups::lexicographical_compare(T const&, T const&)
+   :project: libsemigroups

--- a/docs/source/api/lexicographicalcompare_struct.rst
+++ b/docs/source/api/lexicographicalcompare_struct.rst
@@ -1,0 +1,12 @@
+.. Copyright (c) 2019, J. D. Mitchell
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+LexicographicalCompare
+======================
+
+.. doxygenstruct:: libsemigroups::LexicographicalCompare
+   :project: libsemigroups
+   :members:

--- a/docs/source/api/recursive_path_compare_iterators.rst
+++ b/docs/source/api/recursive_path_compare_iterators.rst
@@ -1,0 +1,11 @@
+.. Copyright (c) 2019, J. D. Mitchell
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+recursive_path_compare (iterators)
+==================================
+
+.. doxygenfunction:: libsemigroups::recursive_path_compare(T const, T, S const, S)
+   :project: libsemigroups

--- a/docs/source/api/recursive_path_compare_pointers.rst
+++ b/docs/source/api/recursive_path_compare_pointers.rst
@@ -1,0 +1,11 @@
+.. Copyright (c) 2019, J. D. Mitchell
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+recursive_path_compare (pointers)
+=================================
+
+.. doxygenfunction:: libsemigroups::recursive_path_compare(T *const, T *const)
+   :project: libsemigroups

--- a/docs/source/api/recursive_path_compare_references.rst
+++ b/docs/source/api/recursive_path_compare_references.rst
@@ -1,0 +1,11 @@
+.. Copyright (c) 2019, J. D. Mitchell
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+recursive_path_compare (references)
+===================================
+
+.. doxygenfunction:: libsemigroups::recursive_path_compare(T const&, T const&)
+   :project: libsemigroups

--- a/docs/source/api/recursivepathcompare_struct.rst
+++ b/docs/source/api/recursivepathcompare_struct.rst
@@ -1,0 +1,12 @@
+.. Copyright (c) 2019, J. D. Mitchell
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+RecursivePathCompare
+====================
+
+.. doxygenstruct:: libsemigroups::RecursivePathCompare
+   :project: libsemigroups
+   :members:

--- a/docs/source/api/shortlex_compare_iterators.rst
+++ b/docs/source/api/shortlex_compare_iterators.rst
@@ -1,0 +1,11 @@
+.. Copyright (c) 2019, J. D. Mitchell
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+shortlex_compare (iterators)
+============================
+
+.. doxygenfunction:: libsemigroups::shortlex_compare(T const, T const, S const, S const)
+   :project: libsemigroups

--- a/docs/source/api/shortlex_compare_pointers.rst
+++ b/docs/source/api/shortlex_compare_pointers.rst
@@ -1,0 +1,11 @@
+.. Copyright (c) 2019, J. D. Mitchell
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+shortlex_compare (pointers)
+===========================
+
+.. doxygenfunction:: libsemigroups::shortlex_compare(T *const, T *const)
+   :project: libsemigroups

--- a/docs/source/api/shortlex_compare_references.rst
+++ b/docs/source/api/shortlex_compare_references.rst
@@ -1,0 +1,11 @@
+.. Copyright (c) 2019, J. D. Mitchell
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+shortlex_compare (references)
+=============================
+
+.. doxygenfunction:: libsemigroups::shortlex_compare(T const&, T const&)
+   :project: libsemigroups

--- a/docs/source/api/shortlexcompare_struct.rst
+++ b/docs/source/api/shortlexcompare_struct.rst
@@ -1,0 +1,12 @@
+.. Copyright (c) 2019, J. D. Mitchell
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+ShortLexCompare
+===============
+
+.. doxygenstruct:: libsemigroups::ShortLexCompare
+   :project: libsemigroups
+   :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -69,6 +69,7 @@ be in the future too, but presently they don't work.
    digraphs
    elements
    fpsemigroups
+   order
    semigroups
    semiring
    misc

--- a/docs/source/libsemigroups.bib
+++ b/docs/source/libsemigroups.bib
@@ -1,12 +1,27 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% https://bibdesk.sourceforge.io/
 
-%% Created for James Mitchell at 2019-10-23 12:55:43 +0100 
+%% Created for James Mitchell at 2019-12-20 14:31:26 +0000 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
 
+@misc{Holt2018aa,
+	Author = {Holt, Derek},
+	Title = {kbmag -- {GAP} package, {V}ersion 1.5.9},
+        Month = { July },
+        Year = { 2019 },
+        Url = {https://gap-packages.github.io/kbmag/},
+}
 
+@book{Jantzen2012aa,
+	Author = {Jantzen, Matthias},
+	Date-Added = {2019-12-20 14:27:56 +0000},
+	Date-Modified = {2019-12-20 14:28:00 +0000},
+	Publisher = {Springer Science \& Business Media},
+	Title = {Confluent string rewriting},
+	Volume = {14},
+	Year = {2012}}
 
 @book{Sims1994aa,
 	Address = {Cambridge,, England, New York},

--- a/docs/source/order.rst
+++ b/docs/source/order.rst
@@ -1,0 +1,40 @@
+.. Copyright (c) 2019, J. D. Mitchell
+
+   Distributed under the terms of the GPL license version 3.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+.. _order:
+
+Orders
+======
+
+Declared in ``order.hpp``.
+
+This file contains documentation for several class and function templates for
+comparing words or strings with respect to certain reduction orderings. 
+
+Functions
+~~~~~~~~~
+
+.. toctree::
+   :maxdepth: 1
+
+   api/lexicographical_compare_references.rst
+   api/lexicographical_compare_pointers.rst
+   api/shortlex_compare_iterators.rst
+   api/shortlex_compare_references.rst
+   api/shortlex_compare_pointers.rst
+   api/recursive_path_compare_iterators.rst
+   api/recursive_path_compare_references.rst
+   api/recursive_path_compare_pointers.rst
+
+Types
+~~~~~
+
+.. toctree::
+   :maxdepth: 1
+
+   api/lexicographicalcompare_struct.rst
+   api/shortlexcompare_struct.rst
+   api/recursivepathcompare_struct.rst

--- a/include/order.hpp
+++ b/include/order.hpp
@@ -35,14 +35,143 @@
 namespace libsemigroups {
   std::vector<word_type> shortlex_words(size_t nr_gens, size_t len);
 
+  //! Defined in ``order.hpp``.
+  //!
+  //! A stateless struct with binary call operator using
+  //! [std::lexicographical_compare].
+  //!
+  //! This only exists to be used as a template parameter, and has no
+  //! advantages over using [std::lexicographical_compare] otherwise.
+  //!
+  //! \tparam T the type of the objects to be compared.
+  //!
+  //! \sa
+  //! [std::lexicographical_compare].
+  //!
+  //! [std::lexicographical_compare]:
+  //! https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
   template <typename T>
   struct LexicographicalCompare {
+    //! Call operator that compares \p x and \p y using
+    //! std::lexicographical_compare.
+    //!
+    //! \param x const reference to the first object for comparison
+    //! \param y const reference to the second object for comparison
+    //!
+    //! \returns A `bool`.
+    //!
+    //! \exceptions
+    //! See [std::lexicographical_compare].
+    //!
+    //! \complexity
+    //! See [std::lexicographical_compare].
+    //!
+    //! [std::lexicographical_compare]:
+    //! https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
     bool operator()(T const& x, T const& y) {
       return std::lexicographical_compare(
           x.cbegin(), x.cend(), y.cbegin(), y.cend());
     }
   };
 
+  //! Compare two objects of the same type using
+  //! [std::lexicographical_compare].
+  //!
+  //! Defined in ``order.hpp``.
+  //!
+  //! \par Possible Implementation
+  //! \code
+  //! std::lexicographical_compare(
+  //!   x.cbegin(), x.cend(), y.cbegin(), y.cend());
+  //! \endcode
+  //!
+  //! \tparam T the type of the objects to be compared.
+  //!
+  //! \param x const reference to the first object for comparison
+  //! \param y const reference to the second object for comparison
+  //!
+  //! \returns A `bool`.
+  //!
+  //! \exceptions
+  //! See [std::lexicographical_compare].
+  //!
+  //! \complexity
+  //! See [std::lexicographical_compare].
+  //!
+  //! [std::lexicographical_compare]:
+  //! https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
+  template <typename T>
+  bool lexicographical_compare(T const& x, T const& y) {
+    return std::lexicographical_compare(
+        x.cbegin(), x.cend(), y.cbegin(), y.cend());
+  }
+
+  //! Compare two objects via their pointers using [lexicographical_compare].
+  //!
+  //! Defined in ``order.hpp``.
+  //!
+  //! \par Possible Implementation
+  //! \code
+  //! lexicographical_compare(
+  //!   x->cbegin(), x->cend(), y->cbegin(), y->cend());
+  //! \endcode
+  //!
+  //! \tparam T the type of the objects to be compared.
+  //!
+  //! \param x pointer to the first object for comparison
+  //! \param y pointer to the second object for comparison
+  //!
+  //! \returns A `bool`.
+  //!
+  //! \sa
+  //! [std::lexicographical_compare].
+  //!
+  //! [std::lexicographical_compare]:
+  //! https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
+  template <typename T>
+  bool lexicographical_compare(T* const x, T* const y) {
+    return std::lexicographical_compare(
+        x->cbegin(), x->cend(), y->cbegin(), y->cend());
+  }
+
+  //! Compare two objects of the same type using the short-lex reduction
+  //! ordering.
+  //!
+  //! Defined in ``order.hpp``.
+  //!
+  //! \par Possible Implementation
+  //! \code
+  //! template <typename T, typename S>
+  //! bool shortlex_compare(T const first1,
+  //!                       T const last1,
+  //!                       S const first2,
+  //!                       S const last2) {
+  //!   return (last1 - first1) < (last2 - first2)
+  //!          || ((last1 - first1) == (last2 - first2)
+  //!              && std::lexicographical_compare
+  //!                   (first1, last1, first2, last2));
+  //! }
+  //! \endcode
+  //!
+  //! \tparam T the type of iterators to the first object to be compared.
+  //! \tparam S the type of iterators to the second object to be compared.
+  //!
+  //! \param first1 beginning iterator of first object for comparison.
+  //! \param last1 ending iterator of first object for comparison.
+  //! \param first2 beginning iterator of second object for comparison.
+  //! \param last2 ending iterator of second object for comparison.
+  //!
+  //! \returns A `bool`.
+  //!
+  //! \exceptions
+  //! Throws if [std::lexicographical_compare] does.
+  //!
+  //! \complexity
+  //! At most \f$O(n)\f$ where \f$n\f$ is the minimum of the distance between
+  //! \p last1 and \p first1, and the distance between \p last2 and \p first2.
+  //!
+  //! [std::lexicographical_compare]:
+  //! https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
   template <typename T, typename S>
   bool shortlex_compare(T const first1,
                         T const last1,
@@ -53,26 +182,125 @@ namespace libsemigroups {
                && std::lexicographical_compare(first1, last1, first2, last2));
   }
 
+  //! Compare two objects of the same type using shortlex_compare.
+  //!
+  //! Defined in ``order.hpp``.
+  //!
+  //! \par Possible Implementation
+  //! \code
+  //! shortlex_compare(
+  //!   x.cbegin(), x.cend(), y.cbegin(), y.cend());
+  //! \endcode
+  //!
+  //! \tparam T the type of the objects to be compared.
+  //!
+  //! \param x const reference to the first object for comparison
+  //! \param y const reference to the second object for comparison
+  //!
+  //! \returns A `bool`.
+  //!
+  //! \sa shortlex_compare(T const, T const, S const, S const)
   template <typename T>
   bool shortlex_compare(T const& x, T const& y) {
     return shortlex_compare(x.cbegin(), x.cend(), y.cbegin(), y.cend());
   }
 
+  //! Compare two objects via their pointers using shortlex_compare.
+  //!
+  //! Defined in ``order.hpp``.
+  //!
+  //! \par Possible Implementation
+  //! \code
+  //! shortlex_compare(
+  //!   x->cbegin(), x->cend(), y->cbegin(), y->cend());
+  //! \endcode
+  //!
+  //! \tparam T the type of the objects to be compared.
+  //!
+  //! \param x pointer to the first object for comparison
+  //! \param y pointer to the second object for comparison
+  //!
+  //! \returns A `bool`.
+  //!
+  //! \sa shortlex_compare(T const, T const, S const, S const)
   template <typename T>
   bool shortlex_compare(T* const x, T* const y) {
     return shortlex_compare(x->cbegin(), x->cend(), y->cbegin(), y->cend());
   }
 
+  //! Defined in ``order.hpp``.
+  //!
+  //! A stateless struct with binary call operator using
+  //! shortlex_compare.
+  //!
+  //! This only exists to be used as a template parameter, and has no
+  //! advantages over using shortlex_compare otherwise.
+  //!
+  //! \tparam T the type of the objects to be compared.
+  //!
+  //! \sa
+  //! shortlex_compare(T const, T const, S const, S const)
   template <typename T>
   struct ShortLexCompare {
+    //! Call operator that compares \p x and \p y using
+    //! std::lexicographical_compare.
+    //!
+    //! \param x const reference to the first object for comparison
+    //! \param y const reference to the second object for comparison
+    //!
+    //! \returns A `bool`.
+    //!
+    //! \exceptions
+    //! See shortlex_compare(T const, T const, S const, S const)
+    //!
+    //! \complexity
+    //! See shortlex_compare(T const, T const, S const, S const)
     bool operator()(T const& x, T const& y) {
       return shortlex_compare(x.cbegin(), x.cend(), y.cbegin(), y.cend());
     }
   };
 
+  //! Compare two objects of the same type using the recursive path comparison
+  //! described in [Jan12](../biblio.html#Jantzen2012aa) (Definition 1.2.14,
+  //! page 24).
+  //!
+  //! Defined in ``order.hpp``.
+  //!
+  //! If \f$u, v\in X ^ {*}\f$, \f$u \neq v\f$, and \f$u = a'u\f$,
+  //! \f$v = bv'\f$ for some \f$a,b \in X\f$, \f$u',v'\in X ^ {*}\f$, then
+  //! \f$u > v\f$ if one of the following conditions holds:
+  //! 1. \f$a = b\f$ and \f$u' \geq v'\f$;
+  //! 2. \f$a > b\f$ and \f$u  > v'\f$;
+  //! 3. \f$b > a\f$ and \f$u' > v\f$.
+  //!
+  //! This documentation and the implementation of recursive_path_compare is
+  //! based on the source code of [Hol19]((../biblio.html#Holt2019aa).
+  //!
+  //! \tparam T the type of iterators to the first object to be compared.
+  //! \tparam S the type of iterators to the second object to be compared.
+  //!
+  //! \param first1 beginning iterator of first object for comparison.
+  //! \param last1 ending iterator of first object for comparison.
+  //! \param first2 beginning iterator of second object for comparison.
+  //! \param last2 ending iterator of second object for comparison.
+  //!
+  //! \returns A `bool`.
+  //!
+  //! \exceptions
+  //! \noexcept
+  //!
+  //! \warning
+  //! This function has signifcantly worse performance than all
+  //! the variants of short_lex_compare(T
+  //! const, T const, S const) and [std::lexicographical_compare].
+  //!
+  //! [std::lexicographical_compare]:
+  //! https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
   template <typename T, typename S>
-  bool
-  recursive_path_compare(T const first1, T last1, S const first2, S last2) {
+  bool recursive_path_compare(T const first1,
+                              T       last1,
+                              S const first2,
+                              S       last2) noexcept {
     bool lastmoved = false;
     --last1;
     --last2;
@@ -99,9 +327,84 @@ namespace libsemigroups {
     }
   }
 
+  //! Compare two objects of the same type using recursive_path_compare.
+  //!
+  //! Defined in ``order.hpp``.
+  //!
+  //! \par Possible Implementation
+  //! \code
+  //! recursive_path_compare(
+  //!   x.cbegin(), x.cend(), y.cbegin(), y.cend());
+  //! \endcode
+  //!
+  //! \tparam T the type of the objects to be compared.
+  //!
+  //! \param x const reference to the first object for comparison
+  //! \param y const reference to the second object for comparison
+  //!
+  //! \returns A `bool`.
+  //!
+  //! \exceptions
+  //! \noexcept
+  //!
+  //! \sa recursive_path_compare(T const, T, S const, S)
+  template <typename T>
+  bool recursive_path_compare(T const& x, T const& y) noexcept {
+    return recursive_path_compare(x.cbegin(), x.cend(), y.cbegin(), y.cend());
+  }
+
+  //! Compare two objects via their pointers using recursive_path_compare.
+  //!
+  //! Defined in ``order.hpp``.
+  //!
+  //! \par Possible Implementation
+  //! \code
+  //! recursive_path_compare(
+  //!   x->cbegin(), x->cend(), y->cbegin(), y->cend());
+  //! \endcode
+  //!
+  //! \tparam T the type of the objects to be compared.
+  //!
+  //! \param x pointer to the first object for comparison
+  //! \param y pointer to the second object for comparison
+  //!
+  //! \returns A `bool`.
+  //!
+  //! \exceptions
+  //! \noexcept
+  //!
+  //! \sa recursive_path_compare(T const, T, S const, S)
+  template <typename T>
+  bool recursive_path_compare(T* const x, T* const y) noexcept {
+    return recursive_path_compare(
+        x->cbegin(), x->cend(), y->cbegin(), y->cend());
+  }
+
+  //! Defined in ``order.hpp``.
+  //!
+  //! A stateless struct with binary call operator using
+  //! recursive_path_compare.
+  //!
+  //! This only exists to be used as a template parameter, and has no
+  //! advantages over using recursive_path_compare otherwise.
+  //!
+  //! \tparam T the type of the objects to be compared.
+  //!
+  //! \sa
+  //! recursive_path_compare(T const, T const, S const, S const)
   template <typename T>
   struct RecursivePathCompare {
-    bool operator()(T const& x, T const& y) {
+    //! Call operator that compares \p x and \p y using
+    //! recursive_path_compare.
+    //!
+    //! \param x const reference to the first object for comparison
+    //! \param y const reference to the second object for comparison
+    //!
+    //! \returns A `bool`.
+    //!
+    //! \exceptions
+    //! \noexcept
+    bool operator()(T const& x, T const& y) noexcept {
       return recursive_path_compare(x.cbegin(), x.cend(), y.cbegin(), y.cend());
     }
   };

--- a/include/string.hpp
+++ b/include/string.hpp
@@ -167,9 +167,9 @@ namespace libsemigroups {
       LIBSEMIGROUPS_ASSERT(first_word <= last_word);
       // Check if [first_prefix, last_prefix) equals [first_word, first_word +
       // (last_suffix - first_suffix))
-      return first_prefix <= last_prefix &&
-             last_prefix - first_prefix <= last_word - first_word &&
-             std::equal(first_prefix, last_prefix, first_word);
+      return first_prefix <= last_prefix
+             && last_prefix - first_prefix <= last_word - first_word
+             && std::equal(first_prefix, last_prefix, first_word);
     }
 
     static inline std::pair<std::string::const_iterator,

--- a/src/bmat8.cpp
+++ b/src/bmat8.cpp
@@ -366,7 +366,7 @@ namespace libsemigroups {
 
   namespace bmat8_helpers {
     size_t minimum_dim(BMat8 const& x) noexcept {
-      size_t i = 0;
+      size_t   i = 0;
       uint64_t c = x.to_int();
       uint64_t d = x.to_int();
       uint64_t y = x.transpose().to_int();


### PR DESCRIPTION
This PR adds documentation and some missing convenience functions to `order.hpp`.