### PR TITLE
Partially resolve Issue #145

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -106,7 +106,7 @@ pkginclude_HEADERS += extern/HPCombi/include/vect16.hpp
 pkginclude_HEADERS += extern/HPCombi/include/vect_generic.hpp
 endif
 
-fmtincludedir = $(includedir)/fmt
+fmtincludedir = $(includedir)/libsemigroups/fmt
 fmtinclude_HEADERS =  extern/fmt-5.3.0/include/fmt/chrono.h  
 fmtinclude_HEADERS += extern/fmt-5.3.0/include/fmt/color.h  
 fmtinclude_HEADERS += extern/fmt-5.3.0/include/fmt/core.h  


### PR DESCRIPTION
The remaining thing to do is to check if `libsemigroups` works with newer versions of `fmt` and to add a `--with-external-fmt` configuration option.