### PR TITLE
fpsemi: fix nr_rules, run_for, and run_until

### DIFF
--- a/include/libsemigroups/fpsemi.hpp
+++ b/include/libsemigroups/fpsemi.hpp
@@ -251,7 +251,7 @@ namespace libsemigroups {
     bool                             is_obviously_infinite_impl() override;
 
     void run_impl() override {
-      _race.winner();
+      _race.run_until([this]() { return this->stopped(); });
     }
 
     bool finished_impl() const override {

--- a/include/libsemigroups/race.hpp
+++ b/include/libsemigroups/race.hpp
@@ -144,9 +144,7 @@ namespace libsemigroups {
         while (!func() && _winner == nullptr) {
           // if _winner != nullptr, then the race is over.
           run_for(check_interval);
-          if (check_interval < std::chrono::milliseconds(1024)) {
-            check_interval *= 2;
-          }
+          check_interval *= 2;
         }
       }
 

--- a/include/libsemigroups/runner.hpp
+++ b/include/libsemigroups/runner.hpp
@@ -29,6 +29,7 @@
 
 #include "function-ref.hpp"             // for FunctionRef
 #include "libsemigroups-exception.hpp"  // for LibsemigroupsException
+#include "report.hpp"                   // for REPORT_DEFAULT
 
 namespace libsemigroups {
   //! A pseudonym for std::chrono::nanoseconds::max().
@@ -205,6 +206,7 @@ namespace libsemigroups {
     // At the end of this either finished, dead, or stopped_by_predicate.
     template <typename T>
     void run_until(T&& func) {
+      REPORT_DEFAULT("running until predicate returns true or finished. . .\n");
       if (!finished() && !dead()) {
         before_run();
         _stopper = std::forward<T>(func);

--- a/src/fpsemi.cpp
+++ b/src/fpsemi.cpp
@@ -44,11 +44,11 @@ namespace libsemigroups {
     _race.add_runner(std::make_shared<KnuthBendix>());
   }
 
-  FpSemigroup::FpSemigroup(std::shared_ptr<FroidurePinBase> S)
-      : FpSemigroupInterface(), _race() {
+  FpSemigroup::FpSemigroup(std::shared_ptr<FroidurePinBase> S) : FpSemigroup() {
     set_alphabet(S->nr_generators());
-    _race.add_runner(std::make_shared<ToddCoxeter>(S));
-    _race.add_runner(std::make_shared<KnuthBendix>(S));
+    for (auto it = S->cbegin_rules(); it != S->cend_rules(); ++it) {
+      add_rule(*it);
+    }
   }
 
   //////////////////////////////////////////////////////////////////////////

--- a/src/todd-coxeter.cpp
+++ b/src/todd-coxeter.cpp
@@ -1491,7 +1491,7 @@ namespace libsemigroups {
         }
       }
       apply_permutation(p, q);
-      REPORT("%d\n", tmr.string()).prefix().flush_right().flush();
+      REPORT("%s\n", tmr.string()).prefix().flush_right().flush();
 #ifdef LIBSEMIGROUPS_DEBUG
       debug_validate_forwd_bckwd();
       debug_validate_table();

--- a/tests/test-fpsemi.cpp
+++ b/tests/test-fpsemi.cpp
@@ -678,8 +678,10 @@ namespace libsemigroups {
     REQUIRE(S.nr_rules() == 18);
 
     FpSemigroup T(S);
+    REQUIRE(T.nr_rules() == 18);
     T.add_rule(S.factorisation(Transf({3, 4, 4, 4, 4})),
                S.factorisation(Transf({3, 1, 3, 3, 3})));
+    REQUIRE(T.nr_rules() == 19);
 
     REQUIRE(T.size() == 21);
     REQUIRE(T.equal_to(S.factorisation(Transf({1, 3, 1, 3, 3})),
@@ -834,6 +836,7 @@ namespace libsemigroups {
     S.add_rule("001010101010", "00");
 
     REQUIRE(S.size() == 240);
+    REQUIRE(S.froidure_pin()->size() == 240);
   }
 
   LIBSEMIGROUPS_TEST_CASE("FpSemigroup", "039", "add_rule", "[quick][fpsemi]") {
@@ -923,5 +926,29 @@ namespace libsemigroups {
     S.add_rule(lhs, rhs);
 
     REQUIRE(S.size() == 3);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("FpSemigroup",
+                          "044",
+                          "run_for/until",
+                          "[fpsemigroup][quick]") {
+    auto        rg = ReportGuard(REPORT);
+    FpSemigroup S;
+    S.set_alphabet("abce");
+    S.set_identity("e");
+    S.add_rule("aa", "e");
+    S.add_rule("bc", "e");
+    S.add_rule("bbb", "e");
+    S.add_rule("ababababababab", "e");
+    S.add_rule("abacabacabacabacabacabacabacabac", "e");
+    S.run_for(std::chrono::nanoseconds(1));
+    REQUIRE(!S.finished());
+    size_t nr_calls = 0;
+    S.run_until([&nr_calls]() {
+      ++nr_calls;
+      return nr_calls == 3;
+    });
+    REQUIRE(!S.finished());
+    REQUIRE(nr_calls == 3);
   }
 }  // namespace libsemigroups


### PR DESCRIPTION
Fix some minor issues highlighted by `libsemigroups_cppyy`:

* `nr_rules` always returned 0 for `FpSemigroup` instances
* both `run_for` and `run_until` just ran `FpSemigroup` until it was finished.