### PR TITLE
build: fix fmt flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@ if LIBSEMIGROUPS_HPCOMBI_ENABLED
 AM_CXXFLAGS += $(HPCOMBI_CXXFLAGS)
 endif
 
-AM_LDFLAGS  =  -no-undefined -lpthread
+AM_LDFLAGS  =  -no-undefined -lpthread $(FMT_LIBS)
 
 if LIBSEMIGROUPS_DEBUG
 AM_CPPFLAGS = -DDEBUG
@@ -28,7 +28,7 @@ endif
 AM_CPPFLAGS += $(CODE_COVERAGE_CPPFLAGS)
 AM_CXXFLAGS += $(CODE_COVERAGE_CXXFLAGS)
 
-if LIBSEMIGROUPS_FMT_ENABLED
+if LIBSEMIGROUPS_WITH_INTERNAL_FMT
 AM_CPPFLAGS += -DFMT_HEADER_ONLY
 endif
 
@@ -122,7 +122,7 @@ hpcombifallbackinclude_HEADERS =  extern/HPCombi/include/fallback/gcdlcm.hpp
 hpcombifallbackinclude_HEADERS += extern/HPCombi/include/fallback/seq.hpp
 endif ## LIBSEMIGROUPS_HPCOMBI_ENABLED
 
-if LIBSEMIGROUPS_FMT_ENABLED
+if LIBSEMIGROUPS_WITH_INTERNAL_FMT
 fmtincludedir = $(includedir)/libsemigroups/fmt
 fmtinclude_HEADERS =  extern/fmt-5.3.0/include/fmt/chrono.h  
 fmtinclude_HEADERS += extern/fmt-5.3.0/include/fmt/color.h  

--- a/m4/ax_check_fmt.m4
+++ b/m4/ax_check_fmt.m4
@@ -4,22 +4,26 @@ dnl if --enable-fmt and if --with-external-fmt is supplied, use it if it is
 dnl known to pkg-config and is new enough; otherwise use the included version
 dnl
 AC_DEFUN([AX_CHECK_FMT], [
-    AC_ARG_ENABLE([fmt],
-      [AS_HELP_STRING([--enable-fmt], [enable fmt])],
-      [AC_DEFINE([FMT_ENABLED], [1], [define if building with fmt])],
-      [enable_fmt=no]
-      )
-    AC_MSG_CHECKING([whether to enable fmt])
-    AC_MSG_RESULT([$enable_fmt])
+  AC_ARG_ENABLE(
+    [fmt],
+    [AS_HELP_STRING([--enable-fmt], [enable fmt])],
+    [],
+    [enable_fmt=no]
+  )
+  AC_MSG_CHECKING([whether to enable fmt])
+  AC_MSG_RESULT([$enable_fmt])
 
-    AM_CONDITIONAL([LIBSEMIGROUPS_FMT_ENABLED], [test "x$enable_fmt" = xyes])
+  AS_IF([test "x$enable_fmt" = xyes], 
+    [AC_DEFINE([FMT_ENABLED], [1], [define if building with fmt])])
+  AM_CONDITIONAL([LIBSEMIGROUPS_FMT_ENABLED], [test "x$enable_fmt" = xyes])
 
   if test "x$enable_fmt" = xyes;  then
-    AC_ARG_WITH([external-fmt],
-                [AC_HELP_STRING([--with-external-fmt],
-                                [use the external fmt])],
-        [with_external_fmt=yes], 
-        [with_external_fmt=no])
+    AC_ARG_WITH(
+      [external-fmt],
+      [AC_HELP_STRING([--with-external-fmt], [use the external fmt])],
+      [],
+      [with_external_fmt=no]
+    )
     AC_MSG_CHECKING([whether to use external fmt])
     AC_MSG_RESULT([$with_external_fmt])
 
@@ -34,4 +38,7 @@ AC_DEFUN([AX_CHECK_FMT], [
           AC_SUBST(FMT_CFLAGS, ['-I$(srcdir)/extern/fmt-5.3.0/include'])
     fi
   fi
+
+  AM_CONDITIONAL([LIBSEMIGROUPS_WITH_INTERNAL_FMT], [test "x$enable_fmt" = xyes && test "x$with_external_fmt" != xyes])
 ])
+


### PR DESCRIPTION
Update the build system to properly handle `--disable-fmt` and to not included the vendored `fmt` headers in the distro if compiled with `--with-external-fmt`, which caused the conda feedstock to behave weirdly. 