### PR TITLE
Include ./autogen.sh in the distro

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -958,7 +958,6 @@ clean-local-check:
 distclean-local:
 	rm -f configure
 	rm -f include/libsemigroups/libsemigroups-config.hpp
-	rm -f .VERSION
 .PHONY: distclean-local
 
 uninstall-hook:

--- a/Makefile.am
+++ b/Makefile.am
@@ -572,7 +572,12 @@ libsemigroups_la_LDFLAGS = -version-info 1:0:0
 
 ## Extra files for the distribution
 
+## Note that `autogen.sh` is required in the distro because the `make distclean`
+## target removes the `configure` script, and `.VERSION` file, and `autogen.sh`
+## is required to regenerate these.
+
 EXTRA_DIST =  .clang-format
+EXTRA_DIST += autogen.sh
 EXTRA_DIST += CPPLINT.cfg 
 EXTRA_DIST += LICENSE 
 EXTRA_DIST += README.rst


### PR DESCRIPTION
This PR adds the `./autogen.sh` file to the distro. 

Rationale: the `make distclean` target deletes files created by `./autogen.sh` (namely `configure` and `.VERSION`) and is always present in the distro for `libsemigroups`, so without the `autogen.sh` file it is always possible to run `make distclean` in a release version of `libsemigroups` and not have a mechanism to regenerate these files. 
