### PR TITLE
Check for C headers, types, and functions in C mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,7 @@ AC_LANG([C++])
 AX_CXX_COMPILE_STDCXX_14(,[mandatory])
 
 dnl ## Check for pthread, this seems to be required to compile with GCC
+AC_LANG_PUSH([C])
 AX_PTHREAD(,[AC_MSG_ERROR([pthread is required])])
 AC_CHECK_LIB([pthread], [pthread_create])
 
@@ -53,6 +54,7 @@ AC_CHECK_SIZEOF([void *])
 # Checks for library functions.
 AC_FUNC_MALLOC
 AC_CHECK_FUNCS([gettimeofday memset pow sqrt])
+AC_LANG_POP([C])
 
 # Check if debug mode is enabled
 AC_ARG_ENABLE([debug],


### PR DESCRIPTION
I noticed that some configure checks were failing, e.g.:
```
checking for stdbool.h that conforms to C99... no
checking for _Bool... no
checking for inline... inline
checking for int64_t... yes
checking for size_t... yes
checking for uint64_t... yes
checking for ptrdiff_t... no
```

The problem is that `AC_LANG([C++])` shifts autoconf into C++ mode, so it performs those checks with g++.  The fix is to be in C mode while checking C headers, types, and functions, then shift back to C++ mode.  With this change, those configure tests pass.