### PR TITLE
Konieczny: destructor codecov and cbegin_D_classes fix

### DIFF
--- a/include/libsemigroups/konieczny.hpp
+++ b/include/libsemigroups/konieczny.hpp
@@ -1124,9 +1124,12 @@ namespace libsemigroups {
     // not noexcept because operator++ isn't necessarily
     const_d_class_iterator cbegin_D_classes() const {
       auto it = _D_classes.cbegin();
-      return const_d_class_iterator(it)
-             + ((_D_classes.size() > 0 && _adjoined_identity_contained) ? 0
-                                                                        : 1);
+      if (_run_initialised) {
+        return const_d_class_iterator(it)
+               + (_adjoined_identity_contained ? 0 : 1);
+      } else {
+        return const_d_class_iterator(it);
+      }
     }
 
     //! Returns a const iterator referring to past the pointer to the last
@@ -1178,10 +1181,12 @@ namespace libsemigroups {
     // not noexcept because operator++ isn't necessarily
     const_regular_d_class_iterator cbegin_regular_D_classes() const {
       auto it = _regular_D_classes.cbegin();
-      return const_regular_d_class_iterator(it)
-             + ((_regular_D_classes.size() > 0 && _adjoined_identity_contained)
-                    ? 0
-                    : 1);
+      if (_run_initialised) {
+        return const_regular_d_class_iterator(it)
+               + (_adjoined_identity_contained ? 0 : 1);
+      } else {
+        return const_regular_d_class_iterator(it);
+      }
     }
 
     //! Shorter form of \ref cbegin_regular_D_classes.
@@ -3745,7 +3750,9 @@ namespace libsemigroups {
       for (auto rep_info : _reg_reps[max_rank()]) {
         this->internal_free(rep_info._elt);
       }
-      LIBSEMIGROUPS_ASSERT(_nonregular_reps[max_rank()].empty());
+      for (auto rep_info : _nonregular_reps[max_rank()]) {
+        this->internal_free(rep_info._elt);
+      }
       _ranks.erase(max_rank());
     }
     delete _rank_state;

--- a/tests/test-konieczny-transf.cpp
+++ b/tests/test-konieczny-transf.cpp
@@ -255,4 +255,49 @@ namespace libsemigroups {
                 0, 0, 0, 16, 2, 10, 2, 26, 1, 1, 5, 21, 3, 11, 7}));
     REQUIRE(K.size() == 23191071);
   }
+
+  LIBSEMIGROUPS_TEST_CASE("Konieczny",
+                          "040",
+                          "transformations - destructor coverage",
+                          "[standard][transf]") {
+    auto rg      = ReportGuard();
+    using Transf = LeastTransf<9>;
+    Konieczny<Transf> S({Transf({2, 1, 0, 4, 2, 1, 1, 8, 0}),
+                         Transf({1, 7, 6, 2, 5, 1, 1, 4, 3}),
+                         Transf({1, 0, 7, 2, 1, 3, 1, 3, 7}),
+                         Transf({0, 3, 8, 1, 2, 8, 1, 7, 0}),
+                         Transf({0, 0, 0, 2, 7, 7, 5, 5, 3})});
+    S.run_until([&S]() -> bool {
+      return S.current_number_of_regular_D_classes() > 2;
+    });
+
+    // if these fail, this test won't get the coverage hoped for
+    REQUIRE(S.current_number_of_regular_D_classes() < 5);
+    REQUIRE(S.current_number_of_D_classes()
+            - S.number_of_regular_D_classes() < 2117);
+    // now all of the destructor should run
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Konieczny",
+                          "041",
+                          "current_number_D_classes",
+                          "[standard][transf]") {
+    auto rg      = ReportGuard();
+    using Transf = LeastTransf<9>;
+    Konieczny<Transf> S({Transf({2, 1, 0, 4, 2, 1, 1, 8, 0}),
+                         Transf({1, 7, 6, 2, 5, 1, 1, 4, 3}),
+                         Transf({1, 0, 7, 2, 1, 3, 1, 3, 7}),
+                         Transf({0, 3, 8, 1, 2, 8, 1, 7, 0}),
+                         Transf({0, 0, 0, 2, 7, 7, 5, 5, 3})});
+    REQUIRE(S.current_number_of_regular_D_classes() == 0);
+    REQUIRE(S.current_number_of_D_classes() == 0);
+    S.run_until([&S]() -> bool {
+      return S.current_number_of_regular_D_classes() > 2;
+    });
+
+    S.run();
+    REQUIRE(S.current_number_of_regular_D_classes() == 5);
+    REQUIRE(S.current_number_of_D_classes()
+            - S.number_of_regular_D_classes() == 2117);
+  }
 }  // namespace libsemigroups


### PR DESCRIPTION
Reverts a change in the Konieczny destructor and adds a test for those lines; this also involved fixing a bug in `cbegin_D_classes` and `cbegin_regular_D_classes`.