### PR TITLE
testing

### DIFF
--- a/docs/source/matrix/dynamicmatrix-compile/operator_prod_equals.rst
+++ b/docs/source/matrix/dynamicmatrix-compile/operator_prod_equals.rst
@@ -13,9 +13,9 @@ operator*=
 
 .. cpp:function:: void operator*=(scalar_type const a)
 
-   Adds a scalar to every entry of the matrix in-place.
+   Multiplies every entry of the matrix by a scalar in-place.
 
-   :param a: the scalar to add to every entry of ``this``.
+   :param a: the scalar to multiply every entry of ``this``.
     
    :returns: (None)
 

--- a/docs/source/matrix/dynamicmatrix-compile/transpose.rst
+++ b/docs/source/matrix/dynamicmatrix-compile/transpose.rst
@@ -13,7 +13,7 @@ transpose
 
 .. cpp:function::  void transpose() noexcept
 
-   Swaps the contents of ``this`` with the contents of ``that``. 
+   Transposes the matrix in-place. 
 
    :parameters: (None)
 
@@ -23,9 +23,8 @@ transpose
      this function guarantees not to throw a :cpp:any:`LibsemigroupsException`. 
    
    :complexity: 
-     :math:`O(mn)` where :math:`m` is the template parameter :code:`R` and
-     :math:`n` is the template parameter :code:`C`. 
-
+     :math:`O(n ^ 2)` where :math:`n` is the number of rows and
+     the number of columns in the matrix. 
+   
    .. warning:: 
-     This only works when the template parameters ``R`` and ``C`` are equal
-     (i.e. for square matrices).
+     This only works for square matrices. 

--- a/docs/source/matrix/dynamicmatrix-run/operator_prod_equals.rst
+++ b/docs/source/matrix/dynamicmatrix-run/operator_prod_equals.rst
@@ -13,9 +13,9 @@ operator*=
 
 .. cpp:function:: void operator*=(scalar_type const a)
 
-   Adds a scalar to every entry of the matrix in-place.
+   Multiplies every entry of the matrix by a scalar in-place.
 
-   :param a: the scalar to add to every entry of ``this``.
+   :param a: the scalar to multiply every entry of ``this``.
     
    :returns: (None)
 

--- a/docs/source/matrix/dynamicmatrix-run/transpose.rst
+++ b/docs/source/matrix/dynamicmatrix-run/transpose.rst
@@ -13,7 +13,7 @@ transpose
 
 .. cpp:function::  void transpose() noexcept
 
-   Swaps the contents of ``this`` with the contents of ``that``. 
+   Transposes the matrix in-place. 
 
    :parameters: (None)
 
@@ -23,9 +23,8 @@ transpose
      this function guarantees not to throw a :cpp:any:`LibsemigroupsException`. 
    
    :complexity: 
-     :math:`O(mn)` where :math:`m` is the template parameter :code:`R` and
-     :math:`n` is the template parameter :code:`C`. 
+     :math:`O(n ^ 2)` where :math:`n` is the number of rows and
+     the number of columns in the matrix. 
 
    .. warning:: 
-     This only works when the template parameters ``R`` and ``C`` are equal
-     (i.e. for square matrices).
+     This only works for square matrices. 

--- a/docs/source/matrix/staticmatrix/operator_prod_equals.rst
+++ b/docs/source/matrix/staticmatrix/operator_prod_equals.rst
@@ -13,9 +13,9 @@ operator*=
 
 .. cpp:function:: void operator*=(scalar_type const a)
 
-   Adds a scalar to every entry of the matrix in-place.
+   Multiplies every entry of the matrix by a scalar in-place.
 
-   :param a: the scalar to add to every entry of ``this``.
+   :param a: the scalar to multiply every entry of ``this``.
     
    :returns: (None)
 

--- a/docs/source/matrix/staticmatrix/transpose.rst
+++ b/docs/source/matrix/staticmatrix/transpose.rst
@@ -13,7 +13,7 @@ transpose
 
 .. cpp:function::  void transpose() noexcept
 
-   Swaps the contents of ``this`` with the contents of ``that``. 
+   Transposes the matrix in-place. 
 
    :parameters: (None)
 

--- a/docs/yml/action.yml
+++ b/docs/yml/action.yml
@@ -67,5 +67,6 @@ libsemigroups::Action:
   - run_until(bool(*)())
   - report_every(TIntType)
   - report_every(std::chrono::nanoseconds)
+  - report_every() const noexcept
   - report() const
   - report_why_we_stopped() const

--- a/docs/yml/cong-wrap.yml
+++ b/docs/yml/cong-wrap.yml
@@ -88,5 +88,6 @@ libsemigroups::CongruenceWrapper:
   - run_until(bool(*)())
   - report_every(TIntType)
   - report_every(std::chrono::nanoseconds)
+  - report_every() const noexcept
   - report() const
   - report_why_we_stopped() const

--- a/docs/yml/congruence.yml
+++ b/docs/yml/congruence.yml
@@ -82,5 +82,6 @@ libsemigroups::Congruence:
   - run_until(bool(*)())
   - report_every(TIntType)
   - report_every(std::chrono::nanoseconds)
+  - report_every() const noexcept
   - report() const
   - report_why_we_stopped() const

--- a/docs/yml/congruence_knuth_bendix.yml
+++ b/docs/yml/congruence_knuth_bendix.yml
@@ -70,5 +70,6 @@ libsemigroups::congruence::KnuthBendix:
   - run_until(bool(*)())
   - report_every(TIntType)
   - report_every(std::chrono::nanoseconds)
+  - report_every() const noexcept
   - report() const
   - report_why_we_stopped() const

--- a/docs/yml/congruence_toddcoxeter.yml
+++ b/docs/yml/congruence_toddcoxeter.yml
@@ -140,5 +140,6 @@ libsemigroups::congruence::ToddCoxeter:
   - run_until(bool(*)())
   - report_every(TIntType)
   - report_every(std::chrono::nanoseconds)
+  - report_every() const noexcept
   - report() const
   - report_why_we_stopped() const

--- a/docs/yml/congruencebypairs.yml
+++ b/docs/yml/congruencebypairs.yml
@@ -70,5 +70,6 @@ libsemigroups::CongruenceByPairs:
   - run_until(bool(*)())
   - report_every(TIntType)
   - report_every(std::chrono::nanoseconds)
+  - report_every() const noexcept
   - report() const
   - report_why_we_stopped() const

--- a/docs/yml/congruenceinterface.yml
+++ b/docs/yml/congruenceinterface.yml
@@ -81,5 +81,6 @@ libsemigroups::CongruenceInterface:
   - run_until(bool(*)())
   - report_every(TIntType)
   - report_every(std::chrono::nanoseconds)
+  - report_every() const noexcept
   - report() const
   - report_why_we_stopped() const

--- a/docs/yml/dynamicptransf.yml
+++ b/docs/yml/dynamicptransf.yml
@@ -51,3 +51,4 @@ libsemigroups::DynamicPTransf:
   - rank() const
   - hash_value() const
   - degree() const noexcept
+  - undef() noexcept

--- a/docs/yml/fpsemigroup.yml
+++ b/docs/yml/fpsemigroup.yml
@@ -83,5 +83,6 @@ libsemigroups::FpSemigroup:
   - run_until(bool(*)())
   - report_every(TIntType)
   - report_every(std::chrono::nanoseconds)
+  - report_every() const noexcept
   - report() const
   - report_why_we_stopped() const

--- a/docs/yml/fpsemigroup_knuth_bendix.yml
+++ b/docs/yml/fpsemigroup_knuth_bendix.yml
@@ -110,5 +110,6 @@ libsemigroups::fpsemigroup::KnuthBendix:
   - run_until(bool(*)())
   - report_every(TIntType)
   - report_every(std::chrono::nanoseconds)
+  - report_every() const noexcept
   - report() const
   - report_why_we_stopped() const

--- a/docs/yml/fpsemigroupinterface.yml
+++ b/docs/yml/fpsemigroupinterface.yml
@@ -107,5 +107,6 @@ libsemigroups::FpSemigroupInterface:
   - run_until(bool(*)())
   - report_every(TIntType)
   - report_every(std::chrono::nanoseconds)
+  - report_every() const noexcept
   - report() const
   - report_why_we_stopped() const

--- a/docs/yml/froidurepin.yml
+++ b/docs/yml/froidurepin.yml
@@ -157,5 +157,6 @@ libsemigroups::FroidurePin:
   - run_until(bool(*)())
   - report_every(TIntType)
   - report_every(std::chrono::nanoseconds)
+  - report_every() const noexcept
   - report() const
   - report_why_we_stopped() const

--- a/docs/yml/froidurepinbase.yml
+++ b/docs/yml/froidurepinbase.yml
@@ -88,5 +88,6 @@ libsemigroups::FroidurePinBase:
   - run_until(bool(*)())
   - report_every(TIntType)
   - report_every(std::chrono::nanoseconds)
+  - report_every() const noexcept
   - report() const
   - report_why_we_stopped() const

--- a/docs/yml/knuthbendixcongruencebypairs.yml
+++ b/docs/yml/knuthbendixcongruencebypairs.yml
@@ -62,5 +62,6 @@ libsemigroups::KnuthBendixCongruenceByPairs:
   - run_until(bool(*)())
   - report_every(TIntType)
   - report_every(std::chrono::nanoseconds)
+  - report_every() const noexcept
   - report() const
   - report_why_we_stopped() const

--- a/docs/yml/konieczny.yml
+++ b/docs/yml/konieczny.yml
@@ -108,6 +108,7 @@ libsemigroups::Konieczny:
   - run_until(bool(*)())
   - report_every(TIntType)
   - report_every(std::chrono::nanoseconds)
+  - report_every() const noexcept
   - report() const
   - report_why_we_stopped() const
   

--- a/docs/yml/pbr.yml
+++ b/docs/yml/pbr.yml
@@ -9,10 +9,16 @@ libsemigroups::PBR:
   - operator<<(std::ostream &,PBR const &)
 - Constructors:
   - ["This page lists the constructors of :cpp:any:`PBR`."]
-  - PBR(vector_type)
   - PBR(initializer_list_type<uint32_t>)
+  - PBR(vector_type<uint32_t>)
   - PBR(size_t)
   - PBR(initializer_list_type<int32_t>,initializer_list_type<int32_t>)
+  - PBR(vector_type<int32_t>,vector_type<int32_t>)
+  - PBR() = delete
+  - PBR(PBR const &) = default
+  - PBR(PBR &&) = default
+  - operator=(PBR const &) = default
+  - operator=(PBR &&) = default
 - Static member functions:
   - ["This page lists the static member functions of :cpp:any:`PBR`."]
   - identity() const

--- a/docs/yml/runner.yml
+++ b/docs/yml/runner.yml
@@ -9,6 +9,7 @@ libsemigroups::Runner:
 - Reporting:
   - report_every(TIntType)
   - report_every(std::chrono::nanoseconds)
+  - report_every() const noexcept
   - report() const
   - report_why_we_stopped() const
 - State:

--- a/docs/yml/staticptransf.yml
+++ b/docs/yml/staticptransf.yml
@@ -37,3 +37,4 @@ libsemigroups::StaticPTransf:
   - rank() const
   - hash_value() const
   - degree() const noexcept
+  - undef() noexcept

--- a/etc/generate_pybind11.py
+++ b/etc/generate_pybind11.py
@@ -150,6 +150,10 @@ def is_overloaded(class_n, mem_fn):
 def skip_mem_fn(class_n, mem_fn, params_t):
     if mem_fn.startswith("operator"):
         return True
+    try:
+        get_xml(class_n, mem_fn, params_t)
+    except KeyError:
+        return True
     return is_deleted_mem_fn(class_n, mem_fn, params_t) or is_mem_fn_template(
         class_n, mem_fn, params_t
     )
@@ -224,7 +228,9 @@ def pybind11_doc(class_n, mem_fn, params_t):
                 doc += "\n                            "
     # get return text
     return_ = [
-        x for x in detailed.find_all("simplesect") if x.attrs["kind"] == "return"
+        x
+        for x in detailed.find_all("simplesect")
+        if x.attrs["kind"] == "return"
     ]
     if len(return_) > 0:
         if not is_overloaded(class_n, mem_fn):

--- a/include/libsemigroups/bipart.hpp
+++ b/include/libsemigroups/bipart.hpp
@@ -1135,7 +1135,24 @@ namespace libsemigroups {
   //!
   //! \complexity
   //! At worst linear in the degree of \p x and \p y.
-  bool operator!=(Bipartition const& x, Bipartition const& y);
+  inline bool operator!=(Bipartition const& x, Bipartition const& y) {
+    return !(x == y);
+  }
+
+  //! Convenience function that just calls ``operator<`` and ``operator==``.
+  inline bool operator<=(Bipartition const& x, Bipartition const& y) {
+    return x < y || x == y;
+  }
+
+  //! Convenience function that just calls ``operator<``.
+  inline bool operator>(Bipartition const& x, Bipartition const& y) {
+    return y < x;
+  }
+
+  //! Convenience function that just calls ``operator<=``.
+  inline bool operator>=(Bipartition const& x, Bipartition const& y) {
+    return y <= x;
+  }
 
   ////////////////////////////////////////////////////////////////////////
   // Adapters

--- a/include/libsemigroups/bipart.hpp
+++ b/include/libsemigroups/bipart.hpp
@@ -1200,5 +1200,10 @@ namespace libsemigroups {
     }
   };
 
+  template <>
+  struct IncreaseDegree<Bipartition> {
+    void operator()(Bipartition&, size_t) {}
+  };
+
 }  // namespace libsemigroups
 #endif  // LIBSEMIGROUPS_BIPART_HPP_

--- a/include/libsemigroups/bipart.hpp
+++ b/include/libsemigroups/bipart.hpp
@@ -264,7 +264,7 @@ namespace libsemigroups {
     //! This function returns the number of parts in the partition that
     //! instances of this class represent.
     //!
-    //! \returns The number of blocks in a Blocks object.
+    //! \returns The number of blocks in a Bipartition object.
     //!
     //! \exceptions
     //! \noexcept

--- a/include/libsemigroups/bmat8.hpp
+++ b/include/libsemigroups/bmat8.hpp
@@ -680,7 +680,7 @@ namespace libsemigroups {
   template <>
   struct IncreaseDegree<BMat8> {
     //! Does nothing.
-    inline void operator()(BMat8 const&) const noexcept {}
+    inline void operator()(BMat8 const&, size_t) const noexcept {}
   };
 
   //! Specialization of the adapter One for instances of BMat8.

--- a/include/libsemigroups/matrix.hpp
+++ b/include/libsemigroups/matrix.hpp
@@ -2337,11 +2337,15 @@ namespace libsemigroups {
       ProjMaxPlusMat(size_t r, size_t c)
           : _is_normalized(false), _underlying_mat(r, c) {}
 
-      ProjMaxPlusMat(
-          std::initializer_list<std::initializer_list<scalar_type>> const& m)
+      ProjMaxPlusMat(std::vector<std::vector<scalar_type>> const& m)
           : _is_normalized(false), _underlying_mat(m) {
         normalize();
       }
+
+      ProjMaxPlusMat(
+          std::initializer_list<std::initializer_list<scalar_type>> const& m)
+          : ProjMaxPlusMat(
+              std::vector<std::vector<scalar_type>>(m.begin(), m.end())) {}
 
       static ProjMaxPlusMat make(
           std::initializer_list<std::initializer_list<scalar_type>> const& il) {
@@ -2377,15 +2381,17 @@ namespace libsemigroups {
       }
 
       bool operator!=(ProjMaxPlusMat const& that) const {
-        normalize();
-        that.normalize();
-        return _underlying_mat != that._underlying_mat;
+        return !(_underlying_mat == that._underlying_mat);
       }
 
       bool operator<(ProjMaxPlusMat const& that) const {
         normalize();
         that.normalize();
         return _underlying_mat < that._underlying_mat;
+      }
+
+      bool operator>(ProjMaxPlusMat const& that) const {
+        return that < *this;
       }
 
       ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/matrix.hpp
+++ b/include/libsemigroups/matrix.hpp
@@ -3010,9 +3010,8 @@ namespace libsemigroups {
   }
 
   template <typename T>
-  auto operator<<(std::ostringstream& os, T const& x) -> std::enable_if_t<
-      std::is_base_of<detail::MatrixPolymorphicBase, T>::value,
-      std::ostringstream&> {
+  auto operator<<(std::ostringstream& os, T const& x)
+      -> std::enable_if_t<IsMatrix<T>, std::ostringstream&> {
     size_t n = 0;
     if (x.number_of_rows() != 1) {
       os << "{";

--- a/include/libsemigroups/matrix.hpp
+++ b/include/libsemigroups/matrix.hpp
@@ -1090,6 +1090,13 @@ namespace libsemigroups {
       return x;
     }
 
+    static StaticMatrix identity(void const* ptr, size_t n = 0) {
+      (void) ptr;
+      LIBSEMIGROUPS_ASSERT(ptr == nullptr);
+      LIBSEMIGROUPS_ASSERT(n == 0 || n == R);
+      return identity(n);
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // StaticMatrix - member function aliases - public
     ////////////////////////////////////////////////////////////////////////
@@ -1194,6 +1201,12 @@ namespace libsemigroups {
     }
 
     ~DynamicMatrix();
+
+    static DynamicMatrix identity(void const* ptr, size_t n) {
+      (void) ptr;
+      LIBSEMIGROUPS_ASSERT(ptr == nullptr);
+      return identity(n);
+    }
 
     static DynamicMatrix identity(size_t n) {
       DynamicMatrix x(n, n);
@@ -1308,9 +1321,20 @@ namespace libsemigroups {
       return m;
     }
 
+    // No static DynamicMatrix::identity(size_t n) because we need a semiring!
+    static DynamicMatrix identity(Semiring const* sr, size_t n) {
+      DynamicMatrix x(sr, n, n);
+      std::fill(x.begin(), x.end(), x.zero());
+      for (size_t r = 0; r < n; ++r) {
+        x(r, r) = x.one();
+      }
+      return x;
+    }
+
     ~DynamicMatrix();
 
     using MatrixCommon::begin;
+    using MatrixCommon::identity;
     using MatrixCommon::number_of_cols;
     using MatrixCommon::number_of_rows;
     using MatrixCommon::resize;

--- a/include/libsemigroups/pbr.hpp
+++ b/include/libsemigroups/pbr.hpp
@@ -42,11 +42,27 @@ namespace libsemigroups {
 
    public:
     //! Type of constructor argument.
-    using vector_type = std::vector<std::vector<uint32_t>> const&;
+    template <typename T>
+    using vector_type = std::vector<std::vector<T>> const&;
 
     //! Type of constructor argument.
     template <typename T>
     using initializer_list_type = std::initializer_list<std::vector<T>> const&;
+
+    //! Deleted.
+    PBR() = delete;
+
+    //! Default copy constructor.
+    PBR(PBR const&) = default;
+
+    //! Default move constructor.
+    PBR(PBR&&) = default;
+
+    //! Default copy assignment operator.
+    PBR& operator=(PBR const&) = default;
+
+    //! Default move assignment operator.
+    PBR& operator=(PBR&&) = default;
 
     //! Construct from adjacencies \c 0 to `2n - 1`.
     //!
@@ -64,7 +80,7 @@ namespace libsemigroups {
     //! No checks whatsoever on the validity of \p x are performed.
     //!
     //! \sa \ref libsemigroups::validate(PBR const&)
-    explicit PBR(vector_type x);
+    explicit PBR(vector_type<uint32_t> x);
 
     //! \copydoc PBR(vector_type)
     explicit PBR(initializer_list_type<uint32_t> x);
@@ -101,6 +117,11 @@ namespace libsemigroups {
     //! make(initializer_list_type<int32_t>, initializer_list_type<int32_t>)
     PBR(initializer_list_type<int32_t> left,
         initializer_list_type<int32_t> right);
+
+    // clang-format off
+    //! \copydoc PBR(initializer_list_type<int32_t>, initializer_list_type<int32_t>) NOLINT(whitespace/line_length)
+    // clang-format on
+    PBR(vector_type<int32_t> left, vector_type<int32_t> right);
 
     //! Construct and validate.
     //!

--- a/include/libsemigroups/pbr.hpp
+++ b/include/libsemigroups/pbr.hpp
@@ -82,7 +82,7 @@ namespace libsemigroups {
     //! \sa \ref libsemigroups::validate(PBR const&)
     explicit PBR(vector_type<uint32_t> x);
 
-    //! \copydoc PBR(vector_type)
+    //! \copydoc PBR(vector_type<uint32_t>)
     explicit PBR(initializer_list_type<uint32_t> x);
 
     //! Construct empty PBR of given \ref degree.
@@ -385,7 +385,24 @@ namespace libsemigroups {
   //!
   //! \complexity
   //! At worst quadratic in the degree of \p x and \p y.
-  bool operator!=(PBR const& x, PBR const& y);
+  inline bool operator!=(PBR const& x, PBR const& y) {
+    return !(x == y);
+  }
+
+  //! Convenience function that just calls ``operator<``.
+  inline bool operator>(PBR const& x, PBR const& y) {
+    return y < x;
+  }
+
+  //! Convenience function that just calls ``operator<`` and ``operator==``.
+  inline bool operator<=(PBR const& x, PBR const& y) {
+    return x < y || x == y;
+  }
+
+  //! Convenience function that just calls ``operator<=``.
+  inline bool operator>=(PBR const& x, PBR const& y) {
+    return y <= x;
+  }
 
   namespace detail {
 

--- a/include/libsemigroups/pbr.hpp
+++ b/include/libsemigroups/pbr.hpp
@@ -445,5 +445,10 @@ namespace libsemigroups {
     }
   };
 
+  template <>
+  struct IncreaseDegree<PBR> {
+    void operator()(PBR&, size_t) {}
+  };
+
 }  // namespace libsemigroups
 #endif  // LIBSEMIGROUPS_PBR_HPP_

--- a/include/libsemigroups/runner.hpp
+++ b/include/libsemigroups/runner.hpp
@@ -298,6 +298,13 @@ namespace libsemigroups {
       report_every(std::chrono::nanoseconds(t));
     }
 
+    //! Get the minimum elapsed time between reports.
+    //!
+    //! \par Parameters
+    //! (None)
+    //!
+    //! \returns
+    //! The number of nanoseconds between reports.
     std::chrono::nanoseconds report_every() const noexcept {
       return _report_time_interval;
     }

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -1683,7 +1683,10 @@ namespace libsemigroups {
   //! Perm has the same member functions as \ref StaticPTransf and \ref
   //! DynamicPTransf, this isn't current reflected by the contents of this
   //! page.
-  template <size_t N = 0, typename Scalar = uint32_t>
+  template <
+      size_t N = 0,
+      typename Scalar
+      = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
   class Perm final : public Transf<N, Scalar> {
     using base_type = PTransf<N, Scalar>;
 

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -1872,15 +1872,6 @@ namespace libsemigroups {
     }
   };
 
-  template <size_t N, typename Scalar>
-  struct ImageRightAction<Perm<N, Scalar>,
-                          Scalar,
-                          std::enable_if_t<std::is_integral<Scalar>::value>> {
-    Scalar operator()(Scalar pt, Perm<N, Scalar> const& x) {
-      return x[pt];
-    }
-  };
-
   template <typename TSubclass>
   struct Product<TSubclass, std::enable_if_t<IsDerivedFromPTransf<TSubclass>>> {
     void operator()(TSubclass&       xy,

--- a/src/bipart.cpp
+++ b/src/bipart.cpp
@@ -201,11 +201,6 @@ namespace libsemigroups {
     return xy;
   }
 
-  // TODO(now) Should be defined for all of the new element types
-  bool operator!=(Bipartition const& x, Bipartition const& y) {
-    return !(x == y);
-  }
-
   ////////////////////////////////////////////////////////////////////////
   // Bipartitions
   ////////////////////////////////////////////////////////////////////////

--- a/src/pbr.cpp
+++ b/src/pbr.cpp
@@ -158,14 +158,12 @@ namespace libsemigroups {
 
   }  // namespace
 
-  // TODO(now) Should be defined for all of the new element types
   PBR operator*(PBR const& x, PBR const& y) {
     PBR xy(x.degree());
     xy.product_inplace(x, y);
     return xy;
   }
 
-  // TODO(now) Should be defined for all of the new element types
   bool operator!=(PBR const& x, PBR const& y) {
     return !(x == y);
   }
@@ -209,6 +207,10 @@ namespace libsemigroups {
 
   PBR::PBR(std::initializer_list<std::vector<int32_t>> const& left,
            std::initializer_list<std::vector<int32_t>> const& right)
+      : PBR(process_left_right(left, right)) {}
+
+  PBR::PBR(std::vector<std::vector<int32_t>> const& left,
+           std::vector<std::vector<int32_t>> const& right)
       : PBR(process_left_right(left, right)) {}
 
   std::ostringstream& operator<<(std::ostringstream& os, PBR const& pbr) {

--- a/src/pbr.cpp
+++ b/src/pbr.cpp
@@ -164,10 +164,6 @@ namespace libsemigroups {
     return xy;
   }
 
-  bool operator!=(PBR const& x, PBR const& y) {
-    return !(x == y);
-  }
-
   void validate(PBR const& x) {
     size_t n = x._vector.size();
     if (n % 2 == 1) {

--- a/tests/test-bipart.cpp
+++ b/tests/test-bipart.cpp
@@ -532,4 +532,9 @@ namespace libsemigroups {
     z.product_inplace(y, id, 0);
     REQUIRE(z == y);
   }
+
+  LIBSEMIGROUPS_TEST_CASE("Bipartition", "017", "adapters", "[quick][pbr]") {
+    Bipartition x({0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 3, 3, 1, 2, 1});
+    REQUIRE_NOTHROW(IncreaseDegree<Bipartition>()(x, 0));
+  }
 }  // namespace libsemigroups

--- a/tests/test-bipart.cpp
+++ b/tests/test-bipart.cpp
@@ -445,6 +445,10 @@ namespace libsemigroups {
     REQUIRE_NOTHROW(validate(xxx));
     REQUIRE(x != xxx);
     REQUIRE(xx != xxx);
+    REQUIRE(xx > xxx);
+    REQUIRE(xxx < xx);
+    REQUIRE(xxx <= xx);
+    REQUIRE(xx >= xxx);
 
     REQUIRE_THROWS_AS(Bipartition::make({{0, 2, 3, 4, 5, 6, 9, -1, -2, -7},
                                          {7, 10, -3, -9, -10},

--- a/tests/test-bmat8.cpp
+++ b/tests/test-bmat8.cpp
@@ -648,7 +648,7 @@ namespace libsemigroups {
     BMat8 bm1(0);
     REQUIRE(Complexity<BMat8>()(bm1) == 0);
     REQUIRE(Degree<BMat8>()(bm1) == 8);
-    REQUIRE_NOTHROW(IncreaseDegree<BMat8>()(bm1));
+    REQUIRE_NOTHROW(IncreaseDegree<BMat8>()(bm1, 0));
     REQUIRE(One<BMat8>()(bm1) == bm1.one());
     REQUIRE(One<BMat8>()(4) == bmat8_helpers::one<BMat8>(4));
 

--- a/tests/test-kbe.cpp
+++ b/tests/test-kbe.cpp
@@ -124,6 +124,9 @@ namespace libsemigroups {
       REQUIRE(Complexity<KBE>()(x) == LIMIT_MAX);
       REQUIRE(EqualTo<KBE>()(x, x));
       REQUIRE(One<KBE>()(x) == KBE());
+      auto y(x);
+      IncreaseDegree<KBE>()(y, 10);
+      REQUIRE(x == y);
     }
 
     LIBSEMIGROUPS_TEST_CASE("KBE", "005", "conversions", "[quick]") {

--- a/tests/test-matrix.cpp
+++ b/tests/test-matrix.cpp
@@ -754,6 +754,7 @@ namespace libsemigroups {
       REQUIRE(y == expected);
 
       REQUIRE(x < y);
+      REQUIRE(y > x);
       REQUIRE(Degree<Mat>()(x) == 3);
       REQUIRE(Degree<Mat>()(y) == 3);
       REQUIRE(Complexity<Mat>()(x) == 27);

--- a/tests/test-matrix.cpp
+++ b/tests/test-matrix.cpp
@@ -318,6 +318,8 @@ namespace libsemigroups {
       REQUIRE(r[0] == Row(sr, {1, 0, 2}));
       REQUIRE(r[1] == Row(sr, {1, 1, 0}));
       REQUIRE(r[2] == Row(sr, {2, 1, 1}));
+      REQUIRE(m * Mat::identity(sr, 3) == m);
+      REQUIRE(Mat::identity(sr, 3) * m == m);
     }
 
     template <typename Mat>
@@ -532,6 +534,8 @@ namespace libsemigroups {
       expected.push_back({0, 1, 0, 1});
       tropical_max_plus_row_basis<4, 5>(expected);
       REQUIRE(expected.size() == 4);
+      REQUIRE(m * Mat::identity(sr, 4) == m);
+      REQUIRE(Mat::identity(sr, 4) * m == m);
     }
 
     template <typename Mat>
@@ -556,6 +560,8 @@ namespace libsemigroups {
       y.product_inplace(x, id);
       REQUIRE(y == x);
       REQUIRE(Hash<Mat>()(y) != 0);
+      REQUIRE(x * Mat::identity(sr, 3) == x);
+      REQUIRE(Mat::identity(sr, 3) * x == x);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -728,6 +734,8 @@ namespace libsemigroups {
       REQUIRE(Hash<Mat>()(y) != 0);
       REQUIRE_THROWS_AS(Mat::make(sr, {{-22, 21, 0}, {10, 0, 0}, {1, 32, 1}}),
                         LibsemigroupsException);
+      REQUIRE(x * Mat::identity(sr, 3) == x);
+      REQUIRE(Mat::identity(sr, 3) * x == x);
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/tests/test-pbr.cpp
+++ b/tests/test-pbr.cpp
@@ -32,8 +32,12 @@ namespace libsemigroups {
                           "001",
                           "universal product with convenience constructor",
                           "[quick][pbr]") {
-    PBR x({{-3, -1}, {-3, -2, -1, 1, 2, 3}, {-3, -2, -1, 1, 3}},
-          {{-3, -1, 1, 2, 3}, {-3, 1, 3}, {-3, -2, -1, 2, 3}});
+    std::vector<std::vector<int32_t>> const left
+        = {{-3, -1}, {-3, -2, -1, 1, 2, 3}, {-3, -2, -1, 1, 3}};
+
+    std::vector<std::vector<int32_t>> const right
+        = {{-3, -1, 1, 2, 3}, {-3, 1, 3}, {-3, -2, -1, 2, 3}};
+    PBR x(left, right);
 
     PBR y({{-3, -2, -1, 1}, {-3, -2, 3}, {-3, 2, 3}},
           {{-3, -2, -1, 3}, {-3, -2, -1, 3}, {-2, 2, 3}});

--- a/tests/test-pbr.cpp
+++ b/tests/test-pbr.cpp
@@ -225,6 +225,12 @@ namespace libsemigroups {
                   {0, 1, 2, 3, 4, 5}});
     REQUIRE(x * y == expected);
     REQUIRE(y * y != expected);
+    REQUIRE(y * y > expected);
+    REQUIRE(y * y >= expected);
+    REQUIRE(expected < y * y);
+    REQUIRE(expected <= y * y);
+    REQUIRE(x * x >= expected);
+    REQUIRE(expected <= x * x);
   }
 
   LIBSEMIGROUPS_TEST_CASE("PBR", "008", "to_string", "[quick][pbr]") {

--- a/tests/test-pbr.cpp
+++ b/tests/test-pbr.cpp
@@ -189,4 +189,9 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(PBR::make({{}, {2}, {1}, {3, 0}}),
                       LibsemigroupsException);
   }
+
+  LIBSEMIGROUPS_TEST_CASE("PBR", "010", "adapters", "[quick][pbr]") {
+    PBR x({});
+    REQUIRE_NOTHROW(IncreaseDegree<PBR>()(x, 0));
+  }
 }  // namespace libsemigroups

--- a/tests/test-pbr.cpp
+++ b/tests/test-pbr.cpp
@@ -56,6 +56,7 @@ namespace libsemigroups {
 
     REQUIRE(x == xx);
     REQUIRE(y == yy);
+    REQUIRE(x.degree() == 3);
 
     z.product_inplace(x, y);
 
@@ -148,7 +149,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("PBR", "005", "delete/copy", "[quick][pbr]") {
-    PBR x({{1}, {4}, {3}, {1}, {0, 2}, {0, 3, 4, 5}});
+    PBR x = PBR::make({{1}, {4}, {3}, {1}, {0, 2}, {0, 3, 4, 5}});
     PBR y(x);
     PBR z({{1}, {4}, {3}, {1}, {0, 2}, {0, 3, 4, 5}});
     REQUIRE(y == z);
@@ -157,6 +158,10 @@ namespace libsemigroups {
     PBR zz(yy);
     PBR a({{1}, {4}, {3}, {1}, {0, 2}, {0, 3, 4, 5}});
     REQUIRE(zz == a);
+    PBR tt(std::move(zz));
+    REQUIRE(tt == a);
+    tt = z;
+    REQUIRE(tt == z);
   }
 
   LIBSEMIGROUPS_TEST_CASE("PBR", "006", "exceptions", "[quick][pbr]") {
@@ -185,9 +190,65 @@ namespace libsemigroups {
             {{-4, -1}, {-3, -2, -1, 1, 2, 3}, {-3, -2, -1, 1, 3}},
             {{-3, -1, 1, 2, 3}, {-3, 1, 3}, {-3, -2, -1, 2, 3}, {-1, -2}}),
         LibsemigroupsException);
+    REQUIRE_THROWS_AS(
+        PBR::make({{-3, -1, 1, 2, 3}, {-3, 1, 3}, {-3, -2, -1, 2, 3}},
+                  {{-4, -1}, {-3, -2, -1, 1, 2, 3}, {-3, -2, -1, 1, 3}}),
+        LibsemigroupsException);
 
     REQUIRE_THROWS_AS(PBR::make({{}, {2}, {1}, {3, 0}}),
                       LibsemigroupsException);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("PBR", "007", "operators", "[quick][pbr]") {
+    PBR x({{3, 5},
+           {0, 1, 2, 3, 4, 5},
+           {0, 2, 3, 4, 5},
+           {0, 1, 2, 3, 5},
+           {0, 2, 5},
+           {1, 2, 3, 4, 5}});
+    PBR y({{0, 3, 4, 5},
+           {2, 4, 5},
+           {1, 2, 5},
+           {2, 3, 4, 5},
+           {2, 3, 4, 5},
+           {1, 2, 4}});
+
+    PBR expected({{0, 1, 2, 3, 4, 5},
+                  {0, 1, 2, 3, 4, 5},
+                  {0, 1, 2, 3, 4, 5},
+                  {0, 1, 2, 3, 4, 5},
+                  {0, 1, 2, 3, 4, 5},
+                  {0, 1, 2, 3, 4, 5}});
+    REQUIRE(x * y == expected);
+    REQUIRE(y * y != expected);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("PBR", "008", "to_string", "[quick][pbr]") {
+    PBR x({{3, 5},
+           {0, 1, 2, 3, 4, 5},
+           {0, 2, 3, 4, 5},
+           {0, 1, 2, 3, 5},
+           {0, 2, 5},
+           {1, 2, 3, 4, 5}});
+    REQUIRE_NOTHROW(detail::to_string(x));
+    x = PBR({});
+    REQUIRE_NOTHROW(detail::to_string(x));
+    std::stringbuf buf;
+    std::ostream   os(&buf);
+    os << x;  // doesn't do anything visible
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("PBR", "009", "identity", "[quick][pbr]") {
+    PBR x({{3, 5},
+           {0, 1, 2, 3, 4, 5},
+           {0, 2, 3, 4, 5},
+           {0, 1, 2, 3, 5},
+           {0, 2, 5},
+           {1, 2, 3, 4, 5}});
+    REQUIRE(x == x * x.identity());
+    REQUIRE(x == x.identity() * x);
+    REQUIRE(x == x * PBR::identity(3));
+    REQUIRE(x == PBR::identity(3) * x);
   }
 
   LIBSEMIGROUPS_TEST_CASE("PBR", "010", "adapters", "[quick][pbr]") {

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -1190,6 +1190,7 @@ namespace libsemigroups {
                                    TCE(26), TCE(27), TCE(28), TCE(29), TCE(30),
                                    TCE(31), TCE(32), TCE(33), TCE(34)}));
       REQUIRE(detail::to_string(TCE(1)) == "1");
+      REQUIRE_NOTHROW(IncreaseDegree<TCE>()(TCE(1), 10));
 
       std::ostringstream oss;
       oss << TCE(10);  // Does not do anything visible
@@ -3530,6 +3531,17 @@ namespace libsemigroups {
 
       REQUIRE_THROWS_AS(tc.congruence().sort_generating_pairs(shortlex_compare),
                         LibsemigroupsException);
+    }
+
+    LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                            "099",
+                            "short circuit size in obviously infinite",
+                            "[todd-coxeter][quick]") {
+      auto        rg = ReportGuard(REPORT);
+      ToddCoxeter tc;
+      tc.set_alphabet("abc");
+      tc.add_rule("aaaa", "a");
+      REQUIRE(tc.size() == POSITIVE_INFINITY);
     }
   }  // namespace fpsemigroup
 }  // namespace libsemigroups


### PR DESCRIPTION
- etc: tweak pybind11 generator script
- transf: use smallest int in Perm
- transf: remove bad adapter
- bipart: fix doc
- pbr + bipart: add missing adapter
- matrix: some doc fixes
- matrix: add missing ops + cstr for ProjMaxPlusMat
- matrix: use IsMatrix in operator<<
- matrix: add missing identity function
- bmat8: fix IncreaseDegree
- pbr: add tests for code coverage
- pbr: add missing default constructors
- doc: add doc for report_every() const noexcept
- doc: add  PTransf::undef() to yml
- pbr: add missing operators + fix doc
- bipart: add operator>, <=, and >=
- Add some tests for code coverage
