### PR TITLE
ci: re-enable extra-config tests

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -184,7 +184,7 @@ jobs:
                 echo 
                 ( ! (grep "WARNING:" make-doc-sphinx.log | grep -v "WARNING: bibtex citations changed, rerun sphinx" | grep -v "WARNING: Could not lex literal_block") )
    macosx:
-      timeout-minutes: 15
+      timeout-minutes: 30
       runs-on: macOS-latest
       env: 
          CXX: "ccache clang++"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,7 +122,7 @@ jobs:
       ccache -z
       make test_todd_coxeter -j4 || exit 1
       ccache -s
-      ./test_todd_coxeter "[123]"
+      ./test_todd_coxeter "[041],[045]"
     displayName: "Test flags: --enable-fmt --enable-stats"
   - bash: |
       make clean
@@ -130,7 +130,7 @@ jobs:
       ccache -z
       make test_todd_coxeter -j4 || exit 1
       ccache -s
-      ./test_todd_coxeter "[123]"
+      ./test_todd_coxeter "[041],[045]"
     displayName: "Test flags: --enable-fmt --disable-stats"
   - bash: |
       make clean
@@ -138,7 +138,7 @@ jobs:
       ccache -z
       make test_todd_coxeter -j4 || exit 1
       ccache -s
-      ./test_todd_coxeter "[123]"
+      ./test_todd_coxeter "[041],[045]"
     displayName: "Test flags: --disable-fmt --enable-stats"
   - bash: |
       make clean
@@ -146,7 +146,7 @@ jobs:
       ccache -z
       make test_todd_coxeter -j4 || exit 1
       ccache -s
-      ./test_todd_coxeter "[123]"
+      ./test_todd_coxeter "[041],[045]"
     displayName: "Test flags: --disable-fmt --disable-stats"
 
 - job: libsemigroups_pybind11


### PR DESCRIPTION
For some reason (probably renumber test cases), the `extra-config-options` job on azure didn't actually run any tests. This adds some tests. 