### PR TITLE
Partially fix empty string segfault in `freeband_equal_to`.

### DIFF
--- a/src/freeband.cpp
+++ b/src/freeband.cpp
@@ -238,6 +238,11 @@ namespace libsemigroups {
     if (x == y) {
       return true;
     }
+    if (x.empty() || y.empty()) {
+      // FIXME: Code segfaults without this check, its possible there is some
+      // unsafe memory access further in the code.
+      return false;
+    }
     size_t N = content_size(x);
     if (N != content_size(y)) {
       return false;

--- a/tests/test-freeband.cpp
+++ b/tests/test-freeband.cpp
@@ -134,6 +134,9 @@ namespace libsemigroups {
   */
 
   LIBSEMIGROUPS_TEST_CASE("freeband_equal_to", "001", "", "[freeband][quick]") {
+    REQUIRE(freeband_equal_to({}, {}));
+    REQUIRE(!freeband_equal_to({0, 0}, {}));
+    REQUIRE(!freeband_equal_to({}, {0}));
     REQUIRE(freeband_equal_to({0, 0}, {0}));
     REQUIRE(!freeband_equal_to({0, 1}, {0}));
     REQUIRE(


### PR DESCRIPTION
Theres a segfault which occurs in `freeband_equal_to` if one of the parameters is the empty string. This is maybe theoretically not an issue since the empty word is technically not a part of the free band if we think of it as a the free object in a variety of semigroups as opposed to monoids. On the other hand since we dont lose anything by including the empty word, I've modified the code to now work in the free band with identity adjoined.

This isn't a full fix though since we just add a check which filters the empty word, without removing a possible unsafe memory access in some other underlying function.