### PR TITLE
Improve `equal_in_freeband` and the coverage test script

### DIFF
--- a/docs/source/freeband.rst
+++ b/docs/source/freeband.rst
@@ -20,7 +20,7 @@ The functions in ``libsemigroups`` for free bands are described on this page.
 
 .. cpp:namespace-pop::
 
-.. doxygenfunction:: libsemigroups::freeband_equal_to(word_type&&, word_type&&)
+.. doxygenfunction:: libsemigroups::freeband_equal_to(word_type const &, word_type const &)
    :project: libsemigroups
 
 .. doxygenfunction:: libsemigroups::freeband_equal_to(T, T)

--- a/etc/test-code-coverage.sh
+++ b/etc/test-code-coverage.sh
@@ -19,11 +19,11 @@ delete_gcda_files() {
 if [ -x "$(command -v ccache)" ]; then  
   bold "using ccache. . ."
   MYCXX="ccache g++"
-  MYCXXFLAGS="-fdiagnostics-color"
+  MYCXXFLAGS="-fdiagnostics-color --coverage"
 else
   bold "not using ccache (not available). . ."
   MYCXX="$CXX"
-  MYCXXFLAGS="$CXXFLAGS"
+  MYCXXFLAGS="$CXXFLAGS --coverage"
 fi
 
 bold "$MYCXX --version . . ." 
@@ -99,7 +99,7 @@ bold "Running lcov and genhtml . . .";
 printf "\033[2m";
 lcov  --directory . --capture --output-file "coverage.info.tmp" --test-name "libsemigroups_1_0_0" --no-checksum --no-external --compat-libtool --gcov-tool "gcov" | grep -v "ignoring data for external file"
 lcov  --directory . --remove "coverage.info.tmp" "/tmp/*" "/Applications/*" --output-file "coverage.info"
-LANG=C genhtml  --prefix . --output-directory "coverage" --title "libsemigroups Code Coverage" --legend --show-details "coverage.info"
+LANG=C genhtml  --prefix . --output-directory "coverage" --title "libsemigroups Code Coverage" --legend --show-details "coverage.info.tmp"
 rm -f coverage.info.tmp
 printf "\033[0m";
 

--- a/include/libsemigroups/freeband.hpp
+++ b/include/libsemigroups/freeband.hpp
@@ -34,6 +34,7 @@
 
 namespace libsemigroups {
 
+
   //! Check if two given words represent the same element in the free band.
   //!
   //! The free band is the free object in the variety of bands or idempotent
@@ -73,7 +74,7 @@ namespace libsemigroups {
   //!                    0, 2, 1, 3, 2, 1, 2, 3, 2, 1, 0, 2, 0, 1,
   //!                    0, 2, 0, 3, 2, 0, 1, 2, 2, 3, 0, 1}); // true
   //! \endcode
-  bool freeband_equal_to(word_type&& x, word_type&& y);
+  bool freeband_equal_to(word_type const& x, word_type const& y);
 
   //! Check if two given words represent the same element in the free band.
   //!
@@ -95,7 +96,8 @@ namespace libsemigroups {
   //! number of distinct letters appearing in \p x and \p y.
   template <typename T>
   bool freeband_equal_to(T x, T y) {
-    return freeband_equal_to(word_type(x), word_type(y));
+    word_type x1(x), y1(y);
+    return freeband_equal_to(x1, y1);
   }
 
   //! Check if two given words represent the same element in the free band.

--- a/src/freeband.cpp
+++ b/src/freeband.cpp
@@ -234,7 +234,7 @@ namespace libsemigroups {
     }
   }  // namespace
 
-  bool freeband_equal_to(word_type&& x, word_type&& y) {
+  bool freeband_equal_to(word_type const& x, word_type const& y) {
     if (x == y) {
       return true;
     }

--- a/tests/test-freeband.cpp
+++ b/tests/test-freeband.cpp
@@ -17,8 +17,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <random>  // for mt19937, random_device
-#include <string>  // for tests with strings
+#include <random>   // for mt19937, random_device
+#include <string>   // for tests with strings
+#include <utility>  // for std::move
 
 #include "catch.hpp"      // for REQUIRE etc
 #include "test-main.hpp"  // for LIBSEMIGROUPS_TEST_CASE
@@ -179,6 +180,8 @@ namespace libsemigroups {
     a = "adbcZ";
     b = "adadbcZ";
     REQUIRE(freeband_equal_to(a.begin(), a.end(), b.begin(), b.end()));
+    word_type w = {0, 1, 0}, x = {0, 1, 1, 0};
+    REQUIRE(freeband_equal_to(std::move(w), std::move(x)));
   }
 
 }  // namespace libsemigroups


### PR DESCRIPTION
This PR improves the `equal_in_freeband` method to work using constant references. It also fixes a bug in the `./etc/test-code-coverage.sh` which prevents it from working on my Ubuntu system. 