### PR TITLE
Modify `SymmetricInverseMonoid` presentation

### DIFF
--- a/tests/fpsemi-examples.cpp
+++ b/tests/fpsemi-examples.cpp
@@ -1101,8 +1101,8 @@ namespace libsemigroups {
         result.emplace_back(epsilon[k + 1] * pi[0], pi[0] * epsilon[k + 1]);
       }
 
-      result.emplace_back(pi[0] * epsilon[0] * epsilon[1],
-                          epsilon[0] * epsilon[1]);
+      result.emplace_back(epsilon[1] * epsilon[0] * pi[0],
+                          epsilon[1] * epsilon[0]);
       return result;
     }
     return {};

--- a/tests/fpsemi-examples.cpp
+++ b/tests/fpsemi-examples.cpp
@@ -1085,12 +1085,9 @@ namespace libsemigroups {
         pi.push_back({i});
       }
       std::vector<word_type> epsilon;
-      for (size_t i = n - 1; i <= 2 * n - 2; ++i) {
-        epsilon.push_back({i});
-      }
-
-      for (size_t k = 0; k <= n - 2; ++k) {
-        result.emplace_back(epsilon[k + 1], pi[k] * epsilon[0] * pi[k]);
+      epsilon.push_back({n - 1});
+      for (size_t i = 0; i <= n - 2; ++i) {
+        epsilon.push_back(pi[i] * epsilon[0] * pi[i]);
       }
 
       result.emplace_back(epsilon[0] ^ 2, epsilon[0]);

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -2583,29 +2583,28 @@ namespace libsemigroups {
                             "113",
                             "SymmetricInverseMonoid",
                             "[todd-coxeter][quick]") {
-      auto        rg = ReportGuard(REPORT);
-      auto s = SymmetricInverseMonoid(5, author::Sutov);
-      for (auto & rel : s) {
+      auto rg = ReportGuard(REPORT);
+      auto s  = SymmetricInverseMonoid(5, author::Sutov);
+      for (auto& rel : s) {
         if (rel.first.empty()) {
           rel.first = {5};
         }
         if (rel.second.empty()) {
-           rel.second = {5};
+          rel.second = {5};
         }
       }
       auto p = make<Presentation<word_type>>(s);
       p.alphabet(6);
       presentation::add_identity_rules(p, 5);
       p.validate();
-      
+
       ToddCoxeter tc(congruence_kind::twosided);
       tc.set_number_of_generators(6);
       for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
         tc.add_pair(p.rules[i], p.rules[i + 1]);
       }
-        REQUIRE(tc.number_of_classes() == 1546);
+      REQUIRE(tc.number_of_classes() == 1546);
     }
-
 
   }  // namespace congruence
 

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -2579,6 +2579,34 @@ namespace libsemigroups {
       REQUIRE(tc.number_of_classes() == 105);
     }
 
+    LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                            "113",
+                            "SymmetricInverseMonoid",
+                            "[todd-coxeter][quick]") {
+      auto        rg = ReportGuard(REPORT);
+      auto s = SymmetricInverseMonoid(5, author::Sutov);
+      for (auto & rel : s) {
+        if (rel.first.empty()) {
+          rel.first = {5};
+        }
+        if (rel.second.empty()) {
+           rel.second = {5};
+        }
+      }
+      auto p = make<Presentation<word_type>>(s);
+      p.alphabet(6);
+      presentation::add_identity_rules(p, 5);
+      p.validate();
+      
+      ToddCoxeter tc(congruence_kind::twosided);
+      tc.set_number_of_generators(6);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+        REQUIRE(tc.number_of_classes() == 1546);
+    }
+
+
   }  // namespace congruence
 
   namespace fpsemigroup {
@@ -4143,7 +4171,6 @@ namespace libsemigroups {
                 << std::endl;
       REQUIRE(tc.size() == 5'040 / 2);
     }
-
   }  // namespace fpsemigroup
 
 }  // namespace libsemigroups


### PR DESCRIPTION
This PR modifies the presentation constructed by `SymmetricInverseMonoid`, where a rule of the presentation was reversed as the textbook referenced composes functions from right to left.

Per our discussion @james-d-mitchell, I've also changed what the 'epsilons' are: this could also be achieved with `replace_subword` or something like it, but it seemed easy enough to do here, and this way the presentation given is in what I'd consider a simpler form, right off the bat.

A test which uses the example is also added.