### PR TITLE
Fix typo in a `ToddCoxeter` test

### DIFF
--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -2153,14 +2153,14 @@ namespace libsemigroups {
       REQUIRE(!tc.stats_string().empty());
     }
 
-    // Takes about 1m7s
+    // Takes about 6m
     LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                             "042",
                             "SymmetricGroup1",
                             "[todd-coxeter][extreme]") {
       auto        rg = ReportGuard(true);
       ToddCoxeter tc(twosided);
-      tc.set_number_of_generators(4);
+      tc.set_number_of_generators(3);
       for (auto const& w : SymmetricGroup1(10)) {
         tc.add_pair(w.first, w.second);
       }


### PR DESCRIPTION
This PR fixes a typo in a `ToddCoxeter` extreme test. The number of generators should be three, rather than four, otherwise the congruence has infinitely many classes.

(The test took 5m 55s to run for me, so I also changed the comment with the expected runtime. I know this is hardware dependent, though, so this might not be a good change.)