### PR TITLE
Standardise `SymmetricGroup` presentations

### DIFF
--- a/tests/fpsemi-examples.cpp
+++ b/tests/fpsemi-examples.cpp
@@ -626,20 +626,23 @@ namespace libsemigroups {
       // From Chapter 3, Proposition 1.2 in https://bit.ly/3R5ZpKW (Ruskuc
       // thesis)
 
-      std::vector<word_type> alphabet = {{0}};
-      for (size_t i = 0; i < n; ++i) {
-        alphabet.push_back({i});
+      std::vector<word_type> a;
+      for (size_t i = 0; i < n - 1; ++i) {
+        a.push_back({i});
       }
       std::vector<relation_type> result;
-      add_group_relations(alphabet, {0}, alphabet, result);
 
-      for (size_t j = 1; j <= n - 2; ++j) {
-        result.emplace_back(word_type({j, j + 1, j, j + 1, j, j + 1}),
-                            word_type({0}));
+      for (size_t i = 0; i < n - 1; i++) {
+        result.emplace_back(a[i]^2, word_type({}));
       }
-      for (size_t l = 3; l <= n - 1; ++l) {
-        for (size_t k = 1; k <= l - 2; ++k) {
-          result.emplace_back(word_type({k, l, k, l}), word_type({0}));
+
+      for (size_t j = 0; j < n - 2; ++j) {
+        result.emplace_back((a[j] * a[j + 1])^3,
+                            word_type({}));
+      }
+      for (size_t l = 2; l < n - 1; ++l) {
+        for (size_t k = 0; k <= l - 2; ++k) {
+          result.emplace_back((a[k] * a[l])^2, word_type({}));
         }
       }
       return result;

--- a/tests/fpsemi-examples.cpp
+++ b/tests/fpsemi-examples.cpp
@@ -607,31 +607,10 @@ namespace libsemigroups {
     return result;
   }
 
-  // From Proposition 1.2 in https://bit.ly/3R5ZpKW (Ruskuc thesis)
-  std::vector<relation_type> SymmetricGroup2(size_t n) {
-    std::vector<word_type> alphabet = {{0}};
-    for (size_t i = 0; i < n; ++i) {
-      alphabet.push_back({i});
-    }
-    std::vector<relation_type> result;
-    add_group_relations(alphabet, {0}, alphabet, result);
-
-    for (size_t j = 1; j <= n - 2; ++j) {
-      result.emplace_back(word_type({j, j + 1, j, j + 1, j, j + 1}),
-                          word_type({0}));
-    }
-    for (size_t l = 3; l <= n - 1; ++l) {
-      for (size_t k = 1; k <= l - 2; ++k) {
-        result.emplace_back(word_type({k, l, k, l}), word_type({0}));
-      }
-    }
-    return result;
-  }
-
-  // Exercise 9.5.2, p172 of
-  // https://link.springer.com/book/10.1007/978-1-84800-281-4
   std::vector<relation_type> SymmetricGroup(size_t n, author val) {
     if (val == author::Carmichael) {
+        // Exercise 9.5.2, p172 of
+  // https://link.springer.com/book/10.1007/978-1-84800-281-4
       std::vector<word_type> pi;
       for (size_t i = 0; i <= n - 2; ++i) {
         pi.push_back({i});
@@ -660,8 +639,30 @@ namespace libsemigroups {
                             word_type({}));
       }
       return result;
-    } else {
-      LIBSEMIGROUPS_EXCEPTION("the 2nd argument (author) should be Carmichael");
+    } else if (val == author::CoxeterMoser) {
+       // TODO Set up addition of authors
+       // From Chapter 3, Proposition 1.2 in https://bit.ly/3R5ZpKW (Ruskuc thesis)
+   
+    std::vector<word_type> alphabet = {{0}};
+    for (size_t i = 0; i < n; ++i) {
+      alphabet.push_back({i});
+    }
+    std::vector<relation_type> result;
+    add_group_relations(alphabet, {0}, alphabet, result);
+
+    for (size_t j = 1; j <= n - 2; ++j) {
+      result.emplace_back(word_type({j, j + 1, j, j + 1, j, j + 1}),
+                          word_type({0}));
+    }
+    for (size_t l = 3; l <= n - 1; ++l) {
+      for (size_t k = 1; k <= l - 2; ++k) {
+        result.emplace_back(word_type({k, l, k, l}), word_type({0}));
+      }
+    }
+    return result;
+
+      } else {
+      LIBSEMIGROUPS_EXCEPTION("not yet implemented");
     }
   }
 

--- a/tests/fpsemi-examples.cpp
+++ b/tests/fpsemi-examples.cpp
@@ -71,6 +71,7 @@ namespace libsemigroups {
       result.insert(result.end(), rhs.cbegin(), rhs.cend());
       return result;
     }
+
     void add_group_relations(std::vector<word_type> const& alphabet,
                              word_type                     id,
                              std::vector<word_type> const& inverse,
@@ -621,7 +622,7 @@ namespace libsemigroups {
                             word_type({}));
       }
       return result;
-    } else if (val == author::CoxeterMoser) {
+    } else if (val == author::Coxeter + author::Moser) {
        // TODO Set up addition of authors
        // From Chapter 3, Proposition 1.2 in https://bit.ly/3R5ZpKW (Ruskuc thesis)
    

--- a/tests/fpsemi-examples.cpp
+++ b/tests/fpsemi-examples.cpp
@@ -592,8 +592,8 @@ namespace libsemigroups {
 
   std::vector<relation_type> SymmetricGroup(size_t n, author val) {
     if (val == author::Carmichael) {
-        // Exercise 9.5.2, p172 of
-  // https://link.springer.com/book/10.1007/978-1-84800-281-4
+      // Exercise 9.5.2, p172 of
+      // https://link.springer.com/book/10.1007/978-1-84800-281-4
       std::vector<word_type> pi;
       for (size_t i = 0; i <= n - 2; ++i) {
         pi.push_back({i});
@@ -623,44 +623,45 @@ namespace libsemigroups {
       }
       return result;
     } else if (val == author::Coxeter + author::Moser) {
-       // TODO Set up addition of authors
-       // From Chapter 3, Proposition 1.2 in https://bit.ly/3R5ZpKW (Ruskuc thesis)
-   
-    std::vector<word_type> alphabet = {{0}};
-    for (size_t i = 0; i < n; ++i) {
-      alphabet.push_back({i});
-    }
-    std::vector<relation_type> result;
-    add_group_relations(alphabet, {0}, alphabet, result);
+      // From Chapter 3, Proposition 1.2 in https://bit.ly/3R5ZpKW (Ruskuc
+      // thesis)
 
-    for (size_t j = 1; j <= n - 2; ++j) {
-      result.emplace_back(word_type({j, j + 1, j, j + 1, j, j + 1}),
-                          word_type({0}));
-    }
-    for (size_t l = 3; l <= n - 1; ++l) {
-      for (size_t k = 1; k <= l - 2; ++k) {
-        result.emplace_back(word_type({k, l, k, l}), word_type({0}));
+      std::vector<word_type> alphabet = {{0}};
+      for (size_t i = 0; i < n; ++i) {
+        alphabet.push_back({i});
       }
-    }
-    return result;
+      std::vector<relation_type> result;
+      add_group_relations(alphabet, {0}, alphabet, result);
 
-      } else if (val == author::Moore) {
- // From Chapter 3, Proposition 1.1 in https://bit.ly/3R5ZpKW (Ruskuc thesis)
-    word_type const e = {0};
-    word_type const a = {1};
-    word_type const b = {2};
+      for (size_t j = 1; j <= n - 2; ++j) {
+        result.emplace_back(word_type({j, j + 1, j, j + 1, j, j + 1}),
+                            word_type({0}));
+      }
+      for (size_t l = 3; l <= n - 1; ++l) {
+        for (size_t k = 1; k <= l - 2; ++k) {
+          result.emplace_back(word_type({k, l, k, l}), word_type({0}));
+        }
+      }
+      return result;
 
-    std::vector<relation_type> result;
-    add_monoid_relations({e, a, b}, e, result);
-    result.emplace_back(a ^ 2, e);
-    result.emplace_back(b ^ n, e);
-    result.emplace_back((a * b) ^ (n - 1), e);
-    result.emplace_back((a * (b ^ (n - 1)) * a * b) ^ 3, e);
-    for (size_t j = 2; j <= n - 2; ++j) {
-      result.emplace_back((a * ((b ^ (n - 1)) ^ j) * a * (b ^ j)) ^ 2, e);
-    }
-    return result;
-      } else {
+    } else if (val == author::Moore) {
+      // From Chapter 3, Proposition 1.1 in https://bit.ly/3R5ZpKW (Ruskuc
+      // thesis)
+      word_type const e = {0};
+      word_type const a = {1};
+      word_type const b = {2};
+
+      std::vector<relation_type> result;
+      add_monoid_relations({e, a, b}, e, result);
+      result.emplace_back(a ^ 2, e);
+      result.emplace_back(b ^ n, e);
+      result.emplace_back((a * b) ^ (n - 1), e);
+      result.emplace_back((a * (b ^ (n - 1)) * a * b) ^ 3, e);
+      for (size_t j = 2; j <= n - 2; ++j) {
+        result.emplace_back((a * ((b ^ (n - 1)) ^ j) * a * (b ^ j)) ^ 2, e);
+      }
+      return result;
+    } else {
       LIBSEMIGROUPS_EXCEPTION("not yet implemented");
     }
   }
@@ -1206,7 +1207,7 @@ namespace libsemigroups {
     }
     if (val == author::Aizenstat) {
       // From Proposition 1.7 in https://bit.ly/3R5ZpKW
-    auto result = SymmetricGroup(n, author::Moore);
+      auto result = SymmetricGroup(n, author::Moore);
 
       word_type const a = {1};
       word_type const b = {2};

--- a/tests/fpsemi-examples.cpp
+++ b/tests/fpsemi-examples.cpp
@@ -72,22 +72,6 @@ namespace libsemigroups {
       return result;
     }
 
-    void add_group_relations(std::vector<word_type> const& alphabet,
-                             word_type                     id,
-                             std::vector<word_type> const& inverse,
-                             std::vector<relation_type>&   relations) {
-      for (size_t i = 0; i < alphabet.size(); ++i) {
-        relations.emplace_back(alphabet[i] * inverse[i], id);
-        if (alphabet[i] != inverse[i]) {
-          relations.emplace_back(inverse[i] * alphabet[i], id);
-        }
-        if (alphabet[i] != id) {
-          relations.emplace_back(alphabet[i] * id, alphabet[i]);
-          relations.emplace_back(id * alphabet[i], alphabet[i]);
-        }
-      }
-    }
-
     void add_monoid_relations(std::vector<word_type> const& alphabet,
                               word_type                     id,
                               std::vector<relation_type>&   relations) {
@@ -633,16 +617,15 @@ namespace libsemigroups {
       std::vector<relation_type> result;
 
       for (size_t i = 0; i < n - 1; i++) {
-        result.emplace_back(a[i]^2, word_type({}));
+        result.emplace_back(a[i] ^ 2, word_type({}));
       }
 
       for (size_t j = 0; j < n - 2; ++j) {
-        result.emplace_back((a[j] * a[j + 1])^3,
-                            word_type({}));
+        result.emplace_back((a[j] * a[j + 1]) ^ 3, word_type({}));
       }
       for (size_t l = 2; l < n - 1; ++l) {
         for (size_t k = 0; k <= l - 2; ++k) {
-          result.emplace_back((a[k] * a[l])^2, word_type({}));
+          result.emplace_back((a[k] * a[l]) ^ 2, word_type({}));
         }
       }
       return result;
@@ -650,12 +633,11 @@ namespace libsemigroups {
     } else if (val == author::Moore) {
       // From Chapter 3, Proposition 1.1 in https://bit.ly/3R5ZpKW (Ruskuc
       // thesis)
-      word_type const e = {0};
-      word_type const a = {1};
-      word_type const b = {2};
+      word_type const e = {};
+      word_type const a = {0};
+      word_type const b = {1};
 
       std::vector<relation_type> result;
-      add_monoid_relations({e, a, b}, e, result);
       result.emplace_back(a ^ 2, e);
       result.emplace_back(b ^ n, e);
       result.emplace_back((a * b) ^ (n - 1), e);

--- a/tests/fpsemi-examples.cpp
+++ b/tests/fpsemi-examples.cpp
@@ -589,24 +589,6 @@ namespace libsemigroups {
     return result;
   }
 
-  // From Proposition 1.1 in https://bit.ly/3R5ZpKW (Ruskuc thesis)
-  std::vector<relation_type> SymmetricGroup1(size_t n) {
-    word_type const e = {0};
-    word_type const a = {1};
-    word_type const b = {2};
-
-    std::vector<relation_type> result;
-    add_monoid_relations({e, a, b}, e, result);
-    result.emplace_back(a ^ 2, e);
-    result.emplace_back(b ^ n, e);
-    result.emplace_back((a * b) ^ (n - 1), e);
-    result.emplace_back((a * (b ^ (n - 1)) * a * b) ^ 3, e);
-    for (size_t j = 2; j <= n - 2; ++j) {
-      result.emplace_back((a * ((b ^ (n - 1)) ^ j) * a * (b ^ j)) ^ 2, e);
-    }
-    return result;
-  }
-
   std::vector<relation_type> SymmetricGroup(size_t n, author val) {
     if (val == author::Carmichael) {
         // Exercise 9.5.2, p172 of
@@ -661,6 +643,22 @@ namespace libsemigroups {
     }
     return result;
 
+      } else if (val == author::Moore) {
+ // From Chapter 3, Proposition 1.1 in https://bit.ly/3R5ZpKW (Ruskuc thesis)
+    word_type const e = {0};
+    word_type const a = {1};
+    word_type const b = {2};
+
+    std::vector<relation_type> result;
+    add_monoid_relations({e, a, b}, e, result);
+    result.emplace_back(a ^ 2, e);
+    result.emplace_back(b ^ n, e);
+    result.emplace_back((a * b) ^ (n - 1), e);
+    result.emplace_back((a * (b ^ (n - 1)) * a * b) ^ 3, e);
+    for (size_t j = 2; j <= n - 2; ++j) {
+      result.emplace_back((a * ((b ^ (n - 1)) ^ j) * a * (b ^ j)) ^ 2, e);
+    }
+    return result;
       } else {
       LIBSEMIGROUPS_EXCEPTION("not yet implemented");
     }
@@ -1207,7 +1205,7 @@ namespace libsemigroups {
     }
     if (val == author::Aizenstat) {
       // From Proposition 1.7 in https://bit.ly/3R5ZpKW
-      auto result = SymmetricGroup1(n);
+    auto result = SymmetricGroup(n, author::Moore);
 
       word_type const a = {1};
       word_type const b = {2};

--- a/tests/fpsemi-examples.hpp
+++ b/tests/fpsemi-examples.hpp
@@ -29,16 +29,21 @@
 #include "libsemigroups/types.hpp"    // for relation_type
 
 namespace libsemigroups {
-  enum class author {
-    Machine,
-    Aizenstat,
-    Carmichael,
-    CoxeterMoser,
-    East,
-    Iwahori,
-    Moore,
-    Sutov
+  enum class author:uint64_t {
+    Machine = 0,
+    Aizenstat = 1,
+    Carmichael = 2,
+    Coxeter = 4,
+    East = 8,
+    Iwahori = 16,
+    Moore = 32,
+    Moser = 64,
+    Sutov = 128
   };
+
+   inline author operator+(author auth1, author auth2){
+      return static_cast<author>(static_cast<uint64_t>(auth1) + static_cast<uint64_t>(auth2));
+    }
 
   std::vector<relation_type> RookMonoid(size_t l, int q);
 

--- a/tests/fpsemi-examples.hpp
+++ b/tests/fpsemi-examples.hpp
@@ -29,21 +29,22 @@
 #include "libsemigroups/types.hpp"    // for relation_type
 
 namespace libsemigroups {
-  enum class author:uint64_t {
-    Machine = 0,
-    Aizenstat = 1,
+  enum class author : uint64_t {
+    Machine    = 0,
+    Aizenstat  = 1,
     Carmichael = 2,
-    Coxeter = 4,
-    East = 8,
-    Iwahori = 16,
-    Moore = 32,
-    Moser = 64,
-    Sutov = 128
+    Coxeter    = 4,
+    East       = 8,
+    Iwahori    = 16,
+    Moore      = 32,
+    Moser      = 64,
+    Sutov      = 128
   };
 
-   inline author operator+(author auth1, author auth2){
-      return static_cast<author>(static_cast<uint64_t>(auth1) + static_cast<uint64_t>(auth2));
-    }
+  inline author operator+(author auth1, author auth2) {
+    return static_cast<author>(static_cast<uint64_t>(auth1)
+                               + static_cast<uint64_t>(auth2));
+  }
 
   std::vector<relation_type> RookMonoid(size_t l, int q);
 

--- a/tests/fpsemi-examples.hpp
+++ b/tests/fpsemi-examples.hpp
@@ -53,7 +53,6 @@ namespace libsemigroups {
   std::vector<relation_type> Plactic(size_t n);
   std::vector<relation_type> Stylic(size_t n);
 
-  std::vector<relation_type> SymmetricGroup1(size_t n);
   std::vector<relation_type> SymmetricGroup(size_t n, author val);
   std::vector<relation_type> DualSymmetricInverseMonoidEEF(size_t n);
   std::vector<relation_type> UniformBlockBijectionMonoidF(size_t n);

--- a/tests/fpsemi-examples.hpp
+++ b/tests/fpsemi-examples.hpp
@@ -33,6 +33,7 @@ namespace libsemigroups {
     Machine,
     Aizenstat,
     Carmichael,
+    CoxeterMoser,
     East,
     Iwahori,
     Moore,
@@ -53,7 +54,6 @@ namespace libsemigroups {
   std::vector<relation_type> Stylic(size_t n);
 
   std::vector<relation_type> SymmetricGroup1(size_t n);
-  std::vector<relation_type> SymmetricGroup2(size_t n);
   std::vector<relation_type> SymmetricGroup(size_t n, author val);
   std::vector<relation_type> DualSymmetricInverseMonoidEEF(size_t n);
   std::vector<relation_type> UniformBlockBijectionMonoidF(size_t n);

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -2170,12 +2170,12 @@ namespace libsemigroups {
 
     LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                             "043",
-                            "SymmetricGroup2",
+                            "SymmetricGroup Coxeter + Moser",
                             "[todd-coxeter][quick][no-valgrind]") {
       auto        rg = ReportGuard(REPORT);
       ToddCoxeter tc(twosided);
       tc.set_number_of_generators(7);
-      for (auto const& w : SymmetricGroup2(7)) {
+      for (auto const& w : SymmetricGroup(7, author::CoxeterMoser)) {
         tc.add_pair(w.first, w.second);
       }
       tc.run_for(std::chrono::microseconds(1));

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -2156,12 +2156,12 @@ namespace libsemigroups {
     // Takes about 6m
     LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                             "042",
-                            "SymmetricGroup1",
+                            "SymmetricGroup Moore",
                             "[todd-coxeter][extreme]") {
       auto        rg = ReportGuard(true);
       ToddCoxeter tc(twosided);
       tc.set_number_of_generators(3);
-      for (auto const& w : SymmetricGroup1(10)) {
+      for (auto const& w : SymmetricGroup(10, author::Moore)) {
         tc.add_pair(w.first, w.second);
       }
       REQUIRE(tc.number_of_classes() == 3'628'800);

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -2158,12 +2158,28 @@ namespace libsemigroups {
                             "042",
                             "SymmetricGroup Moore",
                             "[todd-coxeter][extreme]") {
-      auto        rg = ReportGuard(true);
+      auto rg = ReportGuard(true);
+
+      auto s = SymmetricGroup(10, author::Moore);
+      for (auto& rel : s) {
+        if (rel.first.empty()) {
+          rel.first = {2};
+        }
+        if (rel.second.empty()) {
+          rel.second = {2};
+        }
+      }
+      auto p = make<Presentation<word_type>>(s);
+      p.alphabet(3);
+      presentation::add_identity_rules(p, 2);
+      p.validate();
+
       ToddCoxeter tc(twosided);
       tc.set_number_of_generators(3);
-      for (auto const& w : SymmetricGroup(10, author::Moore)) {
-        tc.add_pair(w.first, w.second);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
       }
+
       REQUIRE(tc.number_of_classes() == 3'628'800);
       std::cout << tc.stats_string();
     }
@@ -2172,10 +2188,10 @@ namespace libsemigroups {
                             "043",
                             "SymmetricGroup(7, Coxeter + Moser)",
                             "[todd-coxeter][quick][no-valgrind]") {
-      auto        rg = ReportGuard(REPORT);
+      auto rg = ReportGuard(REPORT);
 
       size_t n = 7;
-      auto   s  = SymmetricGroup(n, author::Coxeter + author::Moser);
+      auto   s = SymmetricGroup(n, author::Coxeter + author::Moser);
       for (auto& rel : s) {
         if (rel.first.empty()) {
           rel.first = {n - 1};

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -2173,11 +2173,28 @@ namespace libsemigroups {
                             "SymmetricGroup(7, Coxeter + Moser)",
                             "[todd-coxeter][quick][no-valgrind]") {
       auto        rg = ReportGuard(REPORT);
-      ToddCoxeter tc(twosided);
-      tc.set_number_of_generators(7);
-      for (auto const& w : SymmetricGroup(7, author::Coxeter + author::Moser)) {
-        tc.add_pair(w.first, w.second);
+
+      size_t n = 7;
+      auto   s  = SymmetricGroup(n, author::Coxeter + author::Moser);
+      for (auto& rel : s) {
+        if (rel.first.empty()) {
+          rel.first = {n - 1};
+        }
+        if (rel.second.empty()) {
+          rel.second = {n - 1};
+        }
       }
+      auto p = make<Presentation<word_type>>(s);
+      p.alphabet(n);
+      presentation::add_identity_rules(p, n - 1);
+      p.validate();
+
+      ToddCoxeter tc(twosided);
+      tc.set_number_of_generators(n);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+
       tc.run_for(std::chrono::microseconds(1));
       REQUIRE(tc.is_non_trivial() == tril::TRUE);
       REQUIRE(!tc.finished());

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -2156,7 +2156,7 @@ namespace libsemigroups {
     // Takes about 6m
     LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                             "042",
-                            "SymmetricGroup Moore",
+                            "SymmetricGroup(10, Moore)",
                             "[todd-coxeter][extreme]") {
       auto rg = ReportGuard(true);
 

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -2170,12 +2170,12 @@ namespace libsemigroups {
 
     LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                             "043",
-                            "SymmetricGroup Coxeter + Moser",
+                            "SymmetricGroup(7, Coxeter + Moser)",
                             "[todd-coxeter][quick][no-valgrind]") {
       auto        rg = ReportGuard(REPORT);
       ToddCoxeter tc(twosided);
       tc.set_number_of_generators(7);
-      for (auto const& w : SymmetricGroup(7, author::CoxeterMoser)) {
+      for (auto const& w : SymmetricGroup(7, author::Coxeter + author::Moser)) {
         tc.add_pair(w.first, w.second);
       }
       tc.run_for(std::chrono::microseconds(1));


### PR DESCRIPTION
This PR combines the functions `SymmetricGroup`, `SymmetricGroup1` and `SymmetricGroup2` into one -- `SymmetricGroup` -- which takes an author value for each of the presentations it can construct.

The output is also standardised, to use the empty word.