### PR TITLE
Add Burnside and Miller presentation for `SymmetricGroup`

### DIFF
--- a/tests/fpsemi-examples.cpp
+++ b/tests/fpsemi-examples.cpp
@@ -646,6 +646,44 @@ namespace libsemigroups {
         result.emplace_back((a * ((b ^ (n - 1)) ^ j) * a * (b ^ j)) ^ 2, e);
       }
       return result;
+    } else if (val == author::Burnside + author::Miller) {
+      // See Eq 2.6 of 'Presentations of finite simple groups: A quantitative
+      // approach' J. Amer. Math. Soc. 21 (2008), 711-774
+      std::vector<word_type> a;
+      for (size_t i = 0; i <= n - 2; ++i) {
+        a.push_back({i});
+      }
+
+      std::vector<relation_type> result;
+
+      for (size_t i = 0; i <= n - 2; ++i) {
+        result.emplace_back(a[i] ^ 2, word_type({}));
+      }
+
+      for (size_t i = 0; i <= n - 2; ++i) {
+        for (size_t j = 0; j <= n - 2; ++j) {
+          if (i == j) {
+            continue;
+          }
+          result.emplace_back((a[i] * a[j]) ^ 3, word_type({}));
+        }
+      }
+
+      for (size_t i = 0; i <= n - 2; ++i) {
+        for (size_t j = 0; j <= n - 2; ++j) {
+          if (i == j) {
+            continue;
+          }
+          for (size_t k = 0; k <= n - 2; ++k) {
+            if (k == i || k == j) {
+              continue;
+            }
+            result.emplace_back((a[i] * a[j] * a[i] * a[k]) ^ 2, word_type({}));
+          }
+        }
+      }
+      return result;
+
     } else {
       LIBSEMIGROUPS_EXCEPTION("not yet implemented");
     }

--- a/tests/fpsemi-examples.hpp
+++ b/tests/fpsemi-examples.hpp
@@ -32,13 +32,15 @@ namespace libsemigroups {
   enum class author : uint64_t {
     Machine    = 0,
     Aizenstat  = 1,
-    Carmichael = 2,
-    Coxeter    = 4,
-    East       = 8,
-    Iwahori    = 16,
-    Moore      = 32,
-    Moser      = 64,
-    Sutov      = 128
+    Burnside   = 2,
+    Carmichael = 4,
+    Coxeter    = 8,
+    East       = 16,
+    Iwahori    = 32,
+    Miller     = 64,
+    Moore      = 128,
+    Moser      = 256,
+    Sutov      = 512
   };
 
   inline author operator+(author auth1, author auth2) {

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -2221,6 +2221,36 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                            "116",
+                            "SymmetricGroup(7, Burnside + Miller)",
+                            "[todd-coxeter][quick][no-valgrind]") {
+      auto rg = ReportGuard(REPORT);
+
+      size_t n = 7;
+      auto   s = SymmetricGroup(n, author::Burnside + author::Miller);
+      for (auto& rel : s) {
+        if (rel.first.empty()) {
+          rel.first = {n - 1};
+        }
+        if (rel.second.empty()) {
+          rel.second = {n - 1};
+        }
+      }
+      auto p = make<Presentation<word_type>>(s);
+      p.alphabet(n);
+      presentation::add_identity_rules(p, n - 1);
+      p.validate();
+
+      ToddCoxeter tc(twosided);
+      tc.set_number_of_generators(n);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+
+      REQUIRE(tc.number_of_classes() == 5'040);
+    }
+
+    LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                             "044",
                             "Option exceptions",
                             "[todd-coxeter][quick]") {


### PR DESCRIPTION
**Note: This PR is on top of #380**

This PR adds a presentation for the symmetric group, due to Burnside and Miller.

(Interesting note: the Carmichael presentation is a simplification of this one).