### PR TITLE
Add `SymmetricGroup` presentation mentioned by Guralnick et. al.

### DIFF
--- a/tests/fpsemi-examples.cpp
+++ b/tests/fpsemi-examples.cpp
@@ -683,6 +683,42 @@ namespace libsemigroups {
         }
       }
       return result;
+    } else if (val == author::Guralnick) {
+      // See Section 2.2 of 'Presentations of finite simple groups: A
+      // quantitative approach' J. Amer. Math. Soc. 21 (2008), 711-774
+      std::vector<word_type> a;
+      for (size_t i = 0; i <= n - 2; ++i) {
+        a.push_back({i});
+      }
+
+      std::vector<relation_type> result;
+
+      for (size_t i = 0; i <= n - 2; ++i) {
+        result.emplace_back(a[i] ^ 2, word_type({}));
+      }
+
+      for (size_t i = 0; i <= n - 2; ++i) {
+        for (size_t j = 0; j <= n - 2; ++j) {
+          if (i != j) {
+            result.emplace_back((a[i] * a[j]) ^ 3, word_type({}));
+          }
+        }
+      }
+
+      for (size_t i = 0; i <= n - 2; ++i) {
+        for (size_t j = 0; j <= n - 2; ++j) {
+          if (i == j) {
+            continue;
+          }
+          for (size_t k = 0; k <= n - 2; ++k) {
+            if (k != i && k != j) {
+              result.emplace_back((a[i] * a[j] * a[k]) ^ 4, word_type({}));
+            }
+          }
+        }
+      }
+
+      return result;
 
     } else {
       LIBSEMIGROUPS_EXCEPTION("not yet implemented");

--- a/tests/fpsemi-examples.hpp
+++ b/tests/fpsemi-examples.hpp
@@ -36,11 +36,12 @@ namespace libsemigroups {
     Carmichael = 4,
     Coxeter    = 8,
     East       = 16,
-    Iwahori    = 32,
-    Miller     = 64,
-    Moore      = 128,
-    Moser      = 256,
-    Sutov      = 512
+    Guralnick  = 32,
+    Iwahori    = 64,
+    Miller     = 128,
+    Moore      = 256,
+    Moser      = 512,
+    Sutov      = 1024
   };
 
   inline author operator+(author auth1, author auth2) {

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -2251,6 +2251,36 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                            "117",
+                            "SymmetricGroup(7, Guralnick)",
+                            "[todd-coxeter][quick]") {
+      auto rg = ReportGuard(REPORT);
+
+      size_t n = 7;
+      auto   s = SymmetricGroup(n, author::Burnside + author::Miller);
+      for (auto& rel : s) {
+        if (rel.first.empty()) {
+          rel.first = {n - 1};
+        }
+        if (rel.second.empty()) {
+          rel.second = {n - 1};
+        }
+      }
+      auto p = make<Presentation<word_type>>(s);
+      p.alphabet(n);
+      presentation::add_identity_rules(p, n - 1);
+      p.validate();
+
+      ToddCoxeter tc(twosided);
+      tc.set_number_of_generators(n);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+
+      REQUIRE(tc.number_of_classes() == 5'040);
+    }
+
+    LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                             "044",
                             "Option exceptions",
                             "[todd-coxeter][quick]") {


### PR DESCRIPTION
This PR adds a presentation for the symmetric group, mentioned in a paper of [Guralnick et. al.](https://www.ams.org/journals/jams/2008-21-03/S0894-0347-08-00590-0/S0894-0347-08-00590-0.pdf). The presentation is not numbered within the paper, but the authors mention on p. 720 of the volume that they used this presentation before they learnt of one due to Burnside.

I'm not sure from reading this paper how to attribute authorship, since no source is provided. I've just used `author::Guralnick` for the time being.