### PR TITLE
Fix issue with `replace_subword` and the empty word

### DIFF
--- a/include/libsemigroups/present.tpp
+++ b/include/libsemigroups/present.tpp
@@ -454,7 +454,7 @@ namespace libsemigroups {
                          W const&         existing,
                          W const&         replacement) {
       if (existing.empty()) {
-        LIBSEMIGROUPS_EXCEPTION("the second argument must not be the empty word");
+        LIBSEMIGROUPS_EXCEPTION("the second argument must not be empty");
       }
       auto rplc_sbwrd = [&existing, &replacement](W& word) {
         auto it = std::search(

--- a/include/libsemigroups/present.tpp
+++ b/include/libsemigroups/present.tpp
@@ -453,7 +453,7 @@ namespace libsemigroups {
     void replace_subword(Presentation<W>& p,
                          W const&         existing,
                          W const&         replacement) {
-      if (existing.cbegin() == existing.cend()) {
+      if (existing.empty()) {
         LIBSEMIGROUPS_EXCEPTION("the second argument must not be the empty word");
       }
       auto rplc_sbwrd = [&existing, &replacement](W& word) {

--- a/include/libsemigroups/present.tpp
+++ b/include/libsemigroups/present.tpp
@@ -453,6 +453,9 @@ namespace libsemigroups {
     void replace_subword(Presentation<W>& p,
                          W const&         existing,
                          W const&         replacement) {
+      if (existing.cbegin() == existing.cend()) {
+        LIBSEMIGROUPS_EXCEPTION("the second argument must not be the empty word");
+      }
       auto rplc_sbwrd = [&existing, &replacement](W& word) {
         auto it = std::search(
             word.begin(), word.end(), existing.cbegin(), existing.cend());

--- a/tests/test-present.cpp
+++ b/tests/test-present.cpp
@@ -1006,4 +1006,18 @@ namespace libsemigroups {
     check_in_alphabet<std::string>();
   }
 
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "029",
+                          "replace_subword with empty word",
+                          "[quick][presentation]") {
+    auto                      rg = ReportGuard(false);
+    Presentation<std::string> p;
+    p.alphabet(2);
+    p.contains_empty_word(true);
+    presentation::add_rule(p, {0, 0, 0}, {});
+    p.validate();
+    REQUIRE_THROWS_AS(presentation::replace_subword(p, {}, {2}),
+                      LibsemigroupsException);
+  }
+
 }  // namespace libsemigroups


### PR DESCRIPTION
This PR causes an exception to be thrown if the presentation helper `replace_subword` is used on the empty word, addressing issue #383.