### PR TITLE
Add `replace_word` presentation helper

### DIFF
--- a/docs/source/api/present-helper.rst
+++ b/docs/source/api/present-helper.rst
@@ -69,6 +69,9 @@ Contents
    * - :cpp:any:`replace_subword`
      - Replace non-overlapping instances of a subword.
 
+   * - :cpp:any:`replace_word`
+     - Replace instances of a word occupying either side of a rule.
+
    * - :cpp:any:`length`
      - Return the sum of the lengths of the rules.
 

--- a/include/libsemigroups/present.hpp
+++ b/include/libsemigroups/present.hpp
@@ -792,6 +792,27 @@ namespace libsemigroups {
       replace_subword(p, w.cbegin(), w.cend());
     }
 
+    //! Replace instances of a word on either side of a rule by another word.
+    //!
+    //! If \p existing and \p replacement are words, then this function
+    //! replaces every instance of \p existing in every rule of the form
+    //! \p existing \f$= w\f$ or \f$w = \f$ \p existing, with the word
+    //! \p replacement. The presentation \p p is changed in-place.
+    //!
+    //! \tparam W the type of the words in the presentation
+    //! \param p the presentation
+    //! \param existing the word to be replaced
+    //! \param replacement the replacement word
+    //!
+    //! \returns (None)
+    //!
+    //! \exceptions
+    //! \no_libsemigroups_except
+    template <typename W>
+    void replace_word(Presentation<W>& p,
+                      W const&         existing,
+                      W const&         replacement);
+
     //! Return the sum of the lengths of the rules.
     //!
     //! \tparam W the type of the words in the presentation
@@ -801,6 +822,7 @@ namespace libsemigroups {
     //!
     //! \exceptions
     //! \no_libsemigroups_except
+
     template <typename W>
     size_t length(Presentation<W> const& p) {
       auto op = [](size_t val, W const& x) { return val + x.size(); };

--- a/include/libsemigroups/present.tpp
+++ b/include/libsemigroups/present.tpp
@@ -476,6 +476,18 @@ namespace libsemigroups {
     }
 
     template <typename W>
+    void replace_word(Presentation<W>& p,
+                      W const&         existing,
+                      W const&         replacement) {
+      auto rplc_wrd = [&existing, &replacement](W& word) {
+        if (word == existing) {
+          word = replacement;
+        }
+      };
+      std::for_each(p.rules.begin(), p.rules.end(), rplc_wrd);
+    }
+
+    template <typename W>
     void normalize_alphabet(Presentation<W>& p) {
       using size_type   = typename Presentation<W>::size_type;
       using letter_type = typename Presentation<W>::letter_type;

--- a/tests/test-present.cpp
+++ b/tests/test-present.cpp
@@ -448,6 +448,40 @@ namespace libsemigroups {
     }
 
     template <typename W>
+    void check_replace_word() {
+      Presentation<W> p;
+      presentation::add_rule(p, {0, 1, 0}, {});
+      p.alphabet_from_rules();
+      presentation::replace_word(p, W({}), W({2}));
+      REQUIRE(p.rules == std::vector<W>{{0, 1, 0}, {2}});
+
+      p.rules.clear();
+      presentation::add_rule(p, {0, 1, 0}, {2, 1});
+      presentation::add_rule(p, {1, 1, 2}, {1, 2, 1});
+      presentation::add_rule(p, {2, 1, 2, 1}, {2, 2});
+      presentation::add_rule(p, {2, 1}, {0, 1, 1});
+      p.alphabet_from_rules();
+      presentation::replace_word(p, W({2, 1}), W({1, 2}));
+      REQUIRE(p.rules
+              == std::vector<W>{{0, 1, 0},
+                                {1, 2},
+                                {1, 1, 2},
+                                {1, 2, 1},
+                                {2, 1, 2, 1},
+                                {2, 2},
+                                {1, 2},
+                                {0, 1, 1}});
+
+      p.rules.clear();
+      presentation::add_rule(p, {0, 1, 0}, {1, 0, 1});
+      presentation::add_rule(p, {0, 1, 1}, {1, 0, 1, 0});
+      p.alphabet_from_rules();
+      presentation::replace_word(p, W({1, 0, 1}), W({}));
+      REQUIRE(p.rules
+              == std::vector<W>{{0, 1, 0}, {}, {0, 1, 1}, {1, 0, 1, 0}});
+    }
+
+    template <typename W>
     void check_longest_rule() {
       Presentation<W> p;
       p.rules.push_back(W({0, 1, 2, 1}));
@@ -954,6 +988,16 @@ namespace libsemigroups {
     check_replace_subword<word_type>();
     check_replace_subword<StaticVector1<uint16_t, 64>>();
     check_replace_subword<std::string>();
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "030",
+                          "helpers replace_word",
+                          "[quick][presentation]") {
+    auto rg = ReportGuard(false);
+    check_replace_word<word_type>();
+    check_replace_word<StaticVector1<uint16_t, 10>>();
+    check_replace_word<std::string>();
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",


### PR DESCRIPTION
This PR adds a `replace_word` presentation helper function, which replaces words occupying the whole of either side of a rule.