### PR TITLE
Expose `add_full_transformation_monoid_relations` function

### DIFF
--- a/tests/fpsemi-examples.cpp
+++ b/tests/fpsemi-examples.cpp
@@ -84,111 +84,6 @@ namespace libsemigroups {
         }
       }
     }
-    void add_iwahori_full_transformation_monoid_relations(
-        std::vector<relation_type>& result,
-        size_t                      n,
-        size_t                      m) {
-      // This function adds the full transformation monoid relations due to
-      // Iwahori, from Section 9.3, p161-162, (Ganyushkin + Mazorchuk),
-      // expressed in terms of the generating set {pi_2, ..., pi_n,
-      // epsilon_{12}} using the notation of that chapter.
-      // https://link.springer.com/book/10.1007/978-1-84800-281-4
-
-      // The argument m specifies the letter value the idempotent e12
-      // corresponds to. When adding these relations for the full transformation
-      // monoid presentation, we want m = n - 1. For the partial transformation
-      // monoid presentation, we want m = n.
-
-      // It is useful to have this as a separate function, to avoid computing
-      // duplicate presentations for the underlying symmetric group, when
-      // combining relations from the symmetric inverse and full transformation
-      // monoids.
-
-      word_type              e12 = {m};
-      std::vector<word_type> pi;
-      for (size_t i = 0; i <= n - 2; ++i) {
-        pi.push_back({i});
-      }
-
-      // The following expresses the epsilon idempotents in terms of the
-      // generating set
-      auto eps = [&e12, &pi](size_t i, size_t j) -> word_type {
-        LIBSEMIGROUPS_ASSERT(i != j);
-        if (i == 1 && j == 2) {
-          return e12;
-        } else if (i == 2 && j == 1) {
-          return pi[0] * e12 * pi[0];
-        } else if (i == 1) {
-          return pi[0] * pi[j - 2] * pi[0] * e12 * pi[0] * pi[j - 2] * pi[0];
-        } else if (j == 2) {
-          return pi[i - 2] * e12 * pi[i - 2];
-        } else if (j == 1) {
-          return pi[0] * pi[i - 2] * e12 * pi[i - 2] * pi[0];
-        } else if (i == 2) {
-          return pi[j - 2] * pi[0] * e12 * pi[0] * pi[j - 2];
-        }
-        return pi[i - 2] * pi[0] * pi[j - 2] * pi[0] * e12 * pi[0] * pi[j - 2]
-               * pi[0] * pi[i - 2];
-      };
-
-      auto transp = [&pi](size_t i, size_t j) -> word_type {
-        LIBSEMIGROUPS_ASSERT(i != j);
-        if (i > j) {
-          std::swap(i, j);
-        }
-        if (i == 1) {
-          return pi[j - 2];
-        }
-        return pi[i - 2] * pi[j - 2] * pi[i - 2];
-      };
-
-      // Relations a
-      for (size_t i = 1; i <= n; ++i) {
-        for (size_t j = 1; j <= n; ++j) {
-          if (j == i) {
-            continue;
-          }
-          // Relations (k)
-          result.emplace_back(transp(i, j) * eps(i, j), eps(i, j));
-          // Relations (j)
-          result.emplace_back(eps(j, i) * eps(i, j), eps(i, j));
-          // Relations (i)
-          result.emplace_back(eps(i, j) * eps(i, j), eps(i, j));
-          // Relations (d)
-          result.emplace_back(transp(i, j) * eps(i, j) * transp(i, j),
-                              eps(j, i));
-          for (size_t k = 1; k <= n; ++k) {
-            if (k == i || k == j) {
-              continue;
-            }
-            // Relations (h)
-            result.emplace_back(eps(k, j) * eps(i, j), eps(k, j));
-            // Relations (g)
-            result.emplace_back(eps(k, i) * eps(i, j),
-                                transp(i, j) * eps(k, j));
-            // Relations (f)
-            result.emplace_back(eps(j, k) * eps(i, j), eps(i, j) * eps(i, k));
-            result.emplace_back(eps(j, k) * eps(i, j), eps(i, k) * eps(i, j));
-            // Relations (c)
-            result.emplace_back(transp(k, i) * eps(i, j) * transp(k, i),
-                                eps(k, j));
-            // Relations (b)
-            result.emplace_back(transp(j, k) * eps(i, j) * transp(j, k),
-                                eps(i, k));
-            for (size_t l = 1; l <= n; ++l) {
-              if (l == i || l == j || l == k) {
-                continue;
-              }
-              // Relations (e)
-              result.emplace_back(eps(l, k) * eps(i, j), eps(i, j) * eps(l, k));
-              // Relations (a)
-              result.emplace_back(transp(k, l) * eps(i, j) * transp(k, l),
-                                  eps(i, j));
-            }
-          }
-        }
-      }
-    }
 
   }  // namespace
 
@@ -1293,7 +1188,7 @@ namespace libsemigroups {
       // of the pi_i and e_12.
       // https://link.springer.com/book/10.1007/978-1-84800-281-4
       auto result = SymmetricGroup(n, author::Carmichael);
-      add_iwahori_full_transformation_monoid_relations(result, n, n - 1);
+      add_full_transformation_monoid_relations(result, n, 0, n - 1);
       return result;
     }
     LIBSEMIGROUPS_EXCEPTION("not yet implemented");
@@ -1354,7 +1249,7 @@ namespace libsemigroups {
       // https://link.springer.com/book/10.1007/978-1-84800-281-4
       auto result = SymmetricInverseMonoid(n, author::Sutov);
 
-      add_iwahori_full_transformation_monoid_relations(result, n, n);
+      add_full_transformation_monoid_relations(result, n, 0, n);
       word_type              e12     = {n};
       std::vector<word_type> epsilon = {{n - 1}, {0, n - 1, 0}, {1, n - 1, 1}};
       result.emplace_back(e12 * epsilon[1], e12);
@@ -1421,6 +1316,125 @@ namespace libsemigroups {
       }
     }
     return result;
+  }
+
+  void
+  add_full_transformation_monoid_relations(std::vector<relation_type>& result,
+                                           size_t                      n,
+                                           size_t                      pi_start,
+                                           size_t e12_value) {
+    // This function adds the full transformation monoid relations due to
+    // Iwahori, from Section 9.3, p161-162, (Ganyushkin + Mazorchuk),
+    // expressed in terms of the generating set {pi_2, ..., pi_n,
+    // epsilon_{12}} using the notation of that chapter.
+    // https://link.springer.com/book/10.1007/978-1-84800-281-4
+
+    // The argument n specifies the degree of the full transformation monoid.
+    // The generators corresponding to the pi_i will always constitute n - 2
+    // consecutive integers, starting from the argument pi_start. The argument m
+    // specifies the value which will represent the idempotent e12.
+
+    // When adding these relations for the full transformation
+    // monoid presentation (Iwahori) in this file, we want e12_value = n - 1.
+    // For the partial transformation monoid presentation, we want e12_value =
+    // n.
+
+    if (n < 4) {
+      LIBSEMIGROUPS_EXCEPTION("n must be greater than or equal to 4");
+    }
+    if (pi_start < 0) {
+      LIBSEMIGROUPS_EXCEPTION("pi_start must be non-negative");
+    }
+    if (e12_value < 0) {
+      LIBSEMIGROUPS_EXCEPTION("e12_value must be non-negative");
+    }
+    if (e12_value >= pi_start && e12_value <= pi_start + n - 2) {
+      LIBSEMIGROUPS_EXCEPTION(
+          "e12 must not lie in the range [pi_start, pi_start + n - 2]");
+    }
+
+    word_type              e12 = {e12_value};
+    std::vector<word_type> pi;
+    for (size_t i = pi_start; i <= pi_start + n - 2; ++i) {
+      pi.push_back({i});
+    }
+
+    // The following expresses the epsilon idempotents in terms of the
+    // generating set
+    auto eps = [&e12, &pi](size_t i, size_t j) -> word_type {
+      LIBSEMIGROUPS_ASSERT(i != j);
+      if (i == 1 && j == 2) {
+        return e12;
+      } else if (i == 2 && j == 1) {
+        return pi[0] * e12 * pi[0];
+      } else if (i == 1) {
+        return pi[0] * pi[j - 2] * pi[0] * e12 * pi[0] * pi[j - 2] * pi[0];
+      } else if (j == 2) {
+        return pi[i - 2] * e12 * pi[i - 2];
+      } else if (j == 1) {
+        return pi[0] * pi[i - 2] * e12 * pi[i - 2] * pi[0];
+      } else if (i == 2) {
+        return pi[j - 2] * pi[0] * e12 * pi[0] * pi[j - 2];
+      }
+      return pi[i - 2] * pi[0] * pi[j - 2] * pi[0] * e12 * pi[0] * pi[j - 2]
+             * pi[0] * pi[i - 2];
+    };
+
+    auto transp = [&pi](size_t i, size_t j) -> word_type {
+      LIBSEMIGROUPS_ASSERT(i != j);
+      if (i > j) {
+        std::swap(i, j);
+      }
+      if (i == 1) {
+        return pi[j - 2];
+      }
+      return pi[i - 2] * pi[j - 2] * pi[i - 2];
+    };
+
+    // Relations a
+    for (size_t i = 1; i <= n; ++i) {
+      for (size_t j = 1; j <= n; ++j) {
+        if (j == i) {
+          continue;
+        }
+        // Relations (k)
+        result.emplace_back(transp(i, j) * eps(i, j), eps(i, j));
+        // Relations (j)
+        result.emplace_back(eps(j, i) * eps(i, j), eps(i, j));
+        // Relations (i)
+        result.emplace_back(eps(i, j) * eps(i, j), eps(i, j));
+        // Relations (d)
+        result.emplace_back(transp(i, j) * eps(i, j) * transp(i, j), eps(j, i));
+        for (size_t k = 1; k <= n; ++k) {
+          if (k == i || k == j) {
+            continue;
+          }
+          // Relations (h)
+          result.emplace_back(eps(k, j) * eps(i, j), eps(k, j));
+          // Relations (g)
+          result.emplace_back(eps(k, i) * eps(i, j), transp(i, j) * eps(k, j));
+          // Relations (f)
+          result.emplace_back(eps(j, k) * eps(i, j), eps(i, j) * eps(i, k));
+          result.emplace_back(eps(j, k) * eps(i, j), eps(i, k) * eps(i, j));
+          // Relations (c)
+          result.emplace_back(transp(k, i) * eps(i, j) * transp(k, i),
+                              eps(k, j));
+          // Relations (b)
+          result.emplace_back(transp(j, k) * eps(i, j) * transp(j, k),
+                              eps(i, k));
+          for (size_t l = 1; l <= n; ++l) {
+            if (l == i || l == j || l == k) {
+              continue;
+            }
+            // Relations (e)
+            result.emplace_back(eps(l, k) * eps(i, j), eps(i, j) * eps(l, k));
+            // Relations (a)
+            result.emplace_back(transp(k, l) * eps(i, j) * transp(k, l),
+                                eps(i, j));
+          }
+        }
+      }
+    }
   }
 
 }  // namespace libsemigroups

--- a/tests/fpsemi-examples.hpp
+++ b/tests/fpsemi-examples.hpp
@@ -78,6 +78,12 @@ namespace libsemigroups {
 
   std::vector<relation_type> ChineseMonoid(size_t n);
 
+  void
+  add_full_transformation_monoid_relations(std::vector<relation_type>& result,
+                                           size_t                      n,
+                                           size_t                      pi_start,
+                                           size_t e12_value);
+
   template <typename T, typename F, typename... Args>
   void setup(T& tc, size_t num_gens, F func, Args... args) {
     tc.set_number_of_generators(num_gens);


### PR DESCRIPTION
This PR exposes the function in `fpsemi-examples` which adds the Iwahori full transformation monoid relations from 'Classical Finite Transformation Semigroups'.

It takes a `std::vector<relation_type>` to change in place, plus the following three arguments:

- `n` - the degree of the full transformation monoid;
- `pi_start` - the generator representing the first of the \$n - 2\$ transpositions in the generating set (these are always represented by consecutive integers, to keep things simple);
- `e12_value` - the generator representing the idempotent \$\varepsilon_{1, 2}\$ from the generating set.