### PR TITLE
Fix inaccurate exception information for replace_subword

### DIFF
--- a/include/libsemigroups/present.hpp
+++ b/include/libsemigroups/present.hpp
@@ -761,8 +761,7 @@ namespace libsemigroups {
     //!
     //! \returns (None)
     //!
-    //! \exceptions
-    //! \no_libsemigroups_except
+    //! \throws LibsemigroupsException if `existing` is the empty word.
     // TODO(later) complexity
     template <typename W>
     void replace_subword(Presentation<W>& p,

--- a/include/libsemigroups/present.hpp
+++ b/include/libsemigroups/present.hpp
@@ -761,7 +761,7 @@ namespace libsemigroups {
     //!
     //! \returns (None)
     //!
-    //! \throws LibsemigroupsException if `existing` is the empty word.
+    //! \throws LibsemigroupsException if `existing` is empty.
     // TODO(later) complexity
     template <typename W>
     void replace_subword(Presentation<W>& p,


### PR DESCRIPTION
This PR fixes an inaccuracy in the documentation of the presentation helper `replace_subword`, introduced by the changes in #384.