### PR TITLE
matrix: add case for some Apple clang weirdness

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -223,6 +223,9 @@ jobs:
          - name: "Install dependencies . . ."
            run: |
                 brew install ccache autoconf automake
+         - name: "Clang version . . ."
+           run: |
+                clang++ --version
          - name: "Configure . . ."
            run: |
                 mkdir -p m4 && ./autogen.sh && ./configure --disable-hpcombi

--- a/include/libsemigroups/felsch-tree.hpp
+++ b/include/libsemigroups/felsch-tree.hpp
@@ -43,7 +43,11 @@ namespace libsemigroups {
             _parent(1, state_type(UNDEFINED)),
             _length(0) {}
 
+      FelschTree()                  = delete;
       FelschTree(FelschTree const&) = default;
+      FelschTree(FelschTree&&)      = default;
+      FelschTree& operator=(FelschTree const&) = default;
+      FelschTree& operator=(FelschTree&&) = default;
 
       using word_iterator = typename std::vector<word_type>::const_iterator;
 

--- a/include/libsemigroups/matrix.hpp
+++ b/include/libsemigroups/matrix.hpp
@@ -1077,14 +1077,24 @@ namespace libsemigroups {
     ~StaticMatrix() = default;
 
     static StaticMatrix identity(size_t n = 0) {
-      (void) n;
       static_assert(C == R, "cannot create non-square identity matrix");
       // If specified the value of n must equal R or otherwise weirdness will
       // ensue...
       LIBSEMIGROUPS_ASSERT(n == 0 || n == R);
-      StaticMatrix x(R, R);
+      (void) n;
+#if defined(__APPLE__) && defined(__clang__) \
+    && (__clang_major__ == 13 || __clang_major__ == 14)
+      // With Apple clang version 13.1.6 (clang-1316.0.21.2.5) something goes
+      // wrong and the value R is optimized away somehow, meaning that the
+      // values on the diagonal aren't actually set. This only occurs when
+      // libsemigroups is compiled with -O2 or higher.
+      size_t volatile m = R;
+#else
+      size_t m = R;
+#endif
+      StaticMatrix x(m, m);
       std::fill(x.begin(), x.end(), ZeroOp()());
-      for (size_t r = 0; r < R; ++r) {
+      for (size_t r = 0; r < m; ++r) {
         x(r, r) = OneOp()();
       }
       return x;


### PR DESCRIPTION
This is an attempt to fix the failing CI in, for example:

https://github.com/libsemigroups/libsemigroups/actions/runs/3336794000/jobs/5522366230

Seems to be some compiler weirdness, the version of clang specified in this PR is probably too restrictive.

