### PR TITLE
build: add missing eigen3 to pkg-config file

### DIFF
--- a/libsemigroups.pc.in
+++ b/libsemigroups.pc.in
@@ -8,3 +8,4 @@ Description: C++ library for semigroups and monoids
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lsemigroups
 Cflags: -I${includedir}
+Requires: @eigen_PCDEP@ @fmt_PCDEP@

--- a/m4/ax_check_eigen.m4
+++ b/m4/ax_check_eigen.m4
@@ -3,7 +3,7 @@ dnl handle eigen checks
 AC_DEFUN([AX_CHECK_EIGEN], [
   AC_ARG_ENABLE(
     [eigen],
-    [AS_HELP_STRING([--enable-eigen], [enable eigen])],
+    [AS_HELP_STRING([--enable-eigen], [enable eigen (default: yes)])],
     [],
     [enable_eigen=yes]
   )
@@ -18,7 +18,7 @@ AC_DEFUN([AX_CHECK_EIGEN], [
   if test "x$enable_eigen" = xyes; then
     AC_ARG_WITH(
       [external-eigen],
-      [AS_HELP_STRING([--with-external-eigen],[use the external eigen])],
+      [AS_HELP_STRING([--with-external-eigen], [use the external eigen (default: no)])],
       [], 
       [with_external_eigen=no]
     )
@@ -26,15 +26,18 @@ AC_DEFUN([AX_CHECK_EIGEN], [
     AC_MSG_RESULT([$with_external_eigen])
    
     MIN_EIGEN_VERSION="3.3.7"
+    eigen_PCDEP=""
 
     if test "x$with_external_eigen" = xyes;  then
           m4_ifdef([PKG_CHECK_MODULES], [
-          PKG_CHECK_MODULES([EIGEN3], 
-                            [eigen3 >= $MIN_EIGEN_VERSION])],
+              PKG_CHECK_MODULES([EIGEN3], [eigen3 >= $MIN_EIGEN_VERSION])
+              eigen_PCDEP="eigen3"
+          ],
           [AC_MSG_ERROR([cannot use flag --with-external-eigen, the libsemigroups configure file was created on a system without m4 macros for pkg-config available...])])
     else
           AC_SUBST(EIGEN3_CFLAGS, ['-I$(srcdir)/extern/eigen-3.3.9/'])
     fi
+    AC_SUBST([eigen_PCDEP])
   fi
 
   dnl The following makes LIBSEMIGROUPS_WITH_INTERNAL_EIGEN usable in Makefile.am

--- a/m4/ax_check_fmt.m4
+++ b/m4/ax_check_fmt.m4
@@ -3,7 +3,7 @@ dnl handle fmt checks
 AC_DEFUN([AX_CHECK_FMT], [
   AC_ARG_ENABLE(
     [fmt],
-    [AS_HELP_STRING([--enable-fmt], [enable fmt])],
+    [AS_HELP_STRING([--enable-fmt], [enable fmt (default: no)])],
     [],
     [enable_fmt=no]
   )
@@ -18,7 +18,7 @@ AC_DEFUN([AX_CHECK_FMT], [
   if test "x$enable_fmt" = xyes;  then
     AC_ARG_WITH(
       [external-fmt],
-      [AS_HELP_STRING([--with-external-fmt],[use the external fmt])],
+      [AS_HELP_STRING([--with-external-fmt], [use the external fmt (default: no)])],
       [],
       [with_external_fmt=no]
     )
@@ -27,14 +27,17 @@ AC_DEFUN([AX_CHECK_FMT], [
 
     MIN_FMT_VERSION="8.1.1"
 
+    fmt_PCDEP=""
     if test "x$with_external_fmt" = xyes;  then
           m4_ifdef([PKG_CHECK_MODULES], [
-          PKG_CHECK_MODULES([FMT], 
-                            [fmt >= $MIN_FMT_VERSION])],
+              PKG_CHECK_MODULES([FMT], [fmt >= $MIN_FMT_VERSION])
+              fmt_PCDEP="fmt"
+          ],
           [AC_MSG_ERROR([cannot use flag --with-external-fmt, the libsemigroups configure file was created on a system without m4 macros for pkg-config available...])])
     else
           AC_SUBST(FMT_CFLAGS, ['-I$(srcdir)/extern/fmt-8.1.1/include'])
     fi
+    AC_SUBST([fmt_PCDEP])
   fi
 
   dnl The following makes LIBSEMIGROUPS_WITH_INTERNAL_FMT usable in Makefile.am


### PR DESCRIPTION
A libsemigroups installed to /usr requires eigen3 to be present due to an #include line,

include/libsemigroups/digraph.hpp:#include <Eigen/Core>

However, with eigen3 not being specified in the .pc file, package managers do not install eigen3 alongside libsemigroups-devel. Rectify that.