### PR TITLE
Add a `not_symmetric_group` presentation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -738,6 +738,7 @@ test_all_SOURCES += tests/test-forest.cpp
 test_all_SOURCES += tests/test-fpsemi.cpp
 test_all_SOURCES += tests/test-fpsemi-examples-1.cpp
 test_all_SOURCES += tests/test-fpsemi-examples-2.cpp
+test_all_SOURCES += tests/test-fpsemi-examples-3.cpp
 test_all_SOURCES += tests/test-fpsemi-intf.cpp
 test_all_SOURCES += tests/test-freeband.cpp
 test_all_SOURCES += tests/test-froidure-pin-bipart.cpp
@@ -838,6 +839,7 @@ test_fpsemi_SOURCES += tests/test-main.cpp
 
 test_fpsemi_examples_SOURCES =  tests/test-fpsemi-examples-1.cpp
 test_fpsemi_examples_SOURCES += tests/test-fpsemi-examples-2.cpp
+test_fpsemi_examples_SOURCES += tests/test-fpsemi-examples-3.cpp
 test_fpsemi_examples_SOURCES += tests/test-main.cpp
 
 test_fpsemi_intf_SOURCES =  tests/test-fpsemi-intf.cpp

--- a/docs/source/api/fpsemi-examples.rst
+++ b/docs/source/api/fpsemi-examples.rst
@@ -108,6 +108,8 @@ Contents
      - A presentation for the monoid of orientation reversing
        mappings.
 
+   * - :cpp:any:`not_symmetric_group`
+     - A non-presentation for the symmetric group.
 .. cpp:namespace-pop::
 
 Full API
@@ -171,4 +173,7 @@ Full API
    :project: libsemigroups
 
 .. doxygenfunction:: libsemigroups::fpsemigroup::orientation_reversing_monoid
+   :project: libsemigroups
+
+.. doxygenfunction:: libsemigroups::fpsemigroup::not_symmetric_group
    :project: libsemigroups

--- a/docs/source/libsemigroups.bib
+++ b/docs/source/libsemigroups.bib
@@ -135,6 +135,15 @@
     publisher   = {Springer London},
     doi         = {10.1007/978-1-84800-281-4},
 }
+@article{Guralnick2008aa,
+    title       = {Presentations of finite simple groups: A quantitative approach},
+    author      = {Guralnick, R. M and Kantor, W. M and Kassabov, M. and Lubotzky, A.},
+    year        = 2008,
+    journal     = {Journal of the American Mathematical Society},
+    volume      = 21,
+    pages       = {711--774},
+    doi         = {10.1090/S0894-0347-08-00590-0},
+}
 @phdthesis{Havas1999iy,
     title       = {Coset enumeration: ACE},
     author      = {Havas, George and Ramsay, Colin},

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -448,6 +448,33 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `r = 0`
     std::vector<relation_type> monogenic_semigroup(size_t m, size_t r);
 
+    //! A non-presentation for the symmetric group.
+    //!
+    //! Returns a vector of relations giving a monoid presentation which is
+    //! claimed to define the symmetric group of degree `n`, but does not. The
+    //! argument `val` determines the specific presentation which is returned.
+    //! The options are:
+    //! * `author::Guralnick + author::Kantor + author::Kassabov +
+    //! author::Lubotzky` [doi.org/10.1090/S0894-0347-08-00590-0][]
+    //!
+    //! The default for `val` is the only option above.
+    //!
+    //! \param n the claimed degree of the symmetric group
+    //! \param val the author of the presentation
+    //!
+    //! \returns A `std::vector<relation_type>`
+    //!
+    //! \throws LibsemigroupsException if `val` is not listed above (modulo
+    //! order of author)
+    //! \throws LibsemigroupsException if `n < 4`
+    //!
+    //! [doi.org/10.1090/S0894-0347-08-00590-0]:
+    //! https://doi.org/10.1090/S0894-0347-08-00590-0
+    std::vector<relation_type>
+    not_symmetric_group(size_t n,
+                        author val = author::Guralnick + author::Kantor
+                                     + author::Kassabov + author::Lubotzky);
+
     // The following block of 7 functions remains undocumented, as we are not
     // entirely sure what they are.
     std::vector<relation_type> rook_monoid(size_t l, int q);

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -1278,6 +1278,58 @@ namespace libsemigroups {
       return result;
     }
 
+    std::vector<relation_type> not_symmetric_group(size_t n, author val) {
+      if (n < 4) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 1st argument to be at least 4, found %llu", uint64_t(n));
+      }
+      if (val
+          == author::Guralnick + author::Kantor + author::Kassabov
+                 + author::Lubotzky) {
+        // See Section 2.2 of 'Presentations of finite simple groups: A
+        // quantitative approach' J. Amer. Math. Soc. 21 (2008), 711-774
+        std::vector<word_type> a;
+        for (size_t i = 0; i <= n - 2; ++i) {
+          a.push_back({i});
+        }
+
+        std::vector<relation_type> result;
+
+        for (size_t i = 0; i <= n - 2; ++i) {
+          result.emplace_back(a[i] ^ 2, word_type({}));
+        }
+
+        for (size_t i = 0; i <= n - 2; ++i) {
+          for (size_t j = 0; j <= n - 2; ++j) {
+            if (i != j) {
+              result.emplace_back((a[i] * a[j]) ^ 3, word_type({}));
+            }
+          }
+        }
+
+        for (size_t i = 0; i <= n - 2; ++i) {
+          for (size_t j = 0; j <= n - 2; ++j) {
+            if (i == j) {
+              continue;
+            }
+            for (size_t k = 0; k <= n - 2; ++k) {
+              if (k != i && k != j) {
+                result.emplace_back((a[i] * a[j] * a[k]) ^ 4, word_type({}));
+              }
+            }
+          }
+        }
+
+        return result;
+
+      } else {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Guralnick + author::Kantor",
+            " + author::Kassabov + author::Lubotzky found %s",
+            detail::to_string(val).c_str());
+      }
+    }
+
     // The remaining presentation functions are currently undocumented, as we
     // are not completely sure what they are.
 

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-// This file is the first of two containing tests for the fpsemi-examples
+// This file is the first of three containing tests for the fpsemi-examples
 // functions. The presentations here define finite semigroups, and we use
 // ToddCoxeter in testing them. Exceptions and defaults are also checked in this
 // file.
@@ -731,5 +731,29 @@ namespace libsemigroups {
       }
       REQUIRE(tc.number_of_classes() == 256);
     }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                            "051",
+                            "not_symmetric_group(4)",
+                            "[fpsemi-examples][standard]") {
+      auto   rg = ReportGuard(REPORT);
+      size_t n  = 4;
+      auto   s  = not_symmetric_group(n,
+                                   author::Guralnick + author::Kantor
+                                       + author::Kassabov + author::Lubotzky);
+      auto   p  = make<Presentation<word_type>>(s);
+      p.alphabet(n);
+      presentation::replace_word(p, word_type({}), {n - 1});
+      presentation::add_identity_rules(p, n - 1);
+      p.validate();
+
+      ToddCoxeter tc(congruence_kind::twosided);
+      tc.set_number_of_generators(n);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+      REQUIRE(tc.number_of_classes() == 72);
+    }
+
   }  // namespace congruence
 }  // namespace libsemigroups

--- a/tests/test-fpsemi-examples-2.cpp
+++ b/tests/test-fpsemi-examples-2.cpp
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-// This file is the second of two containing tests for the fpsemi-examples
+// This file is the second of three containing tests for the fpsemi-examples
 // functions. The presentations here define not necessarily finite semigroups,
 // and we use KnuthBendix in testing them.
 

--- a/tests/test-fpsemi-examples-3.cpp
+++ b/tests/test-fpsemi-examples-3.cpp
@@ -1,0 +1,71 @@
+// libsemigroups - C++ library for semigroups and monoids
+// Copyright (C) 2022 Murray T. Whyte
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+// This file is the third of three containing tests for the fpsemi-examples
+// functions. The tests in this file use Sims1.
+
+// #define CATCH_CONFIG_ENABLE_PAIR_STRINGMAKER
+
+#include "catch.hpp"      // for REQUIRE, REQUIRE_NOTHROW, REQUIRE_THROWS_AS
+#include "test-main.hpp"  // for LIBSEMIGROUPS_TEST_CASE
+
+#include "libsemigroups/fpsemi-examples.hpp"  // for the presentations
+#include "libsemigroups/report.hpp"           // for ReportGuard
+#include "libsemigroups/sims1.hpp"            // for Sims1
+#include "libsemigroups/types.hpp"            // for word_type
+
+namespace libsemigroups {
+
+  using Sims1_ = Sims1<uint32_t>;
+
+  using fpsemigroup::author;
+  using fpsemigroup::make;
+
+  using fpsemigroup::not_symmetric_group;
+
+  LIBSEMIGROUPS_TEST_CASE(
+      "fpsemi-examples",
+      "052",
+      "not_symmetric_group(5) Guralnick + Kantor + Kassabov + Lubotzky",
+      "[fpsemi-examples][quick]") {
+    auto   rg = ReportGuard(false);
+    size_t n  = 5;
+
+    auto p = make<Presentation<word_type>>(
+        not_symmetric_group(n,
+                            author::Guralnick + author::Kantor
+                                + author::Kassabov + author::Lubotzky));
+    p.alphabet(n);
+    presentation::replace_word(p, word_type({}), {n - 1});
+    presentation::add_identity_rules(p, n - 1);
+    p.validate();
+    Sims1_ C(congruence_kind::right);
+    C.short_rules(p);
+
+    auto q
+        = make<Presentation<word_type>>(symmetric_group(n, author::Carmichael));
+    q.alphabet(n);
+    presentation::replace_word(q, word_type({}), {n - 1});
+    presentation::add_identity_rules(q, n - 1);
+    q.validate();
+    Sims1_ D(congruence_kind::right);
+    D.short_rules(q);
+
+    REQUIRE(C.number_of_congruences(3) == 43);
+    REQUIRE(D.number_of_congruences(3) == 4);
+  }
+}  // namespace libsemigroups


### PR DESCRIPTION
**Note: This should be merged after #419**

This PR adds a function `not_symmetric_group` presentation, which returns a presentation claiming to define the symmetric group (but it does not).

This relates to #411.