### PR TITLE
Add presentations for the cyclic inverse monoid, and its order-preserving part

### DIFF
--- a/docs/source/api/fpsemi-examples.rst
+++ b/docs/source/api/fpsemi-examples.rst
@@ -22,7 +22,8 @@ Presentations from the following sources are implemented: :cite:`Gay1999aa`;
 :cite:`Abram2022aa`; :cite:`Easdown2007aa`; :cite:`FitzGerald2003aa`;
 :cite:`East2011aa`; :cite:`Ayik2000aa`; :cite:`Ruskuc1995aa`;
 :cite:`Aizenstat1958aa`; :cite:`Coxeter1979aa`; :cite:`Knuth1970aa`;
-:cite:`Lascoux1981aa`; :cite:`Moore1897aa`; :cite:`Aizenstat1962aa`.
+:cite:`Lascoux1981aa`; :cite:`Moore1897aa`; :cite:`Aizenstat1962aa`;
+:cite:`Fernandes2022aa`.
 
 .. cpp:type:: libsemigroups::fpsemigroup::author
 
@@ -112,6 +113,12 @@ Contents
      - A presentation for the monoid of order preserving
        mappings.
 
+   * - :cpp:any:`cyclic_inverse_monoid`
+     - A presentation for the cyclic inverse monoid.
+
+   * - :cpp:any:`order_preserving_cyclic_inverse_monoid`
+     - A presentation for the order-preserving part of the cyclic inverse monoid.
+
    * - :cpp:any:`not_symmetric_group`
      - A non-presentation for the symmetric group.
 .. cpp:namespace-pop::
@@ -180,6 +187,12 @@ Full API
    :project: libsemigroups
 
 .. doxygenfunction:: libsemigroups::fpsemigroup::order_preserving_monoid
+   :project: libsemigroups
+
+.. doxygenfunction:: libsemigroups::fpsemigroup::cyclic_inverse_monoid
+   :project: libsemigroups
+
+.. doxygenfunction:: libsemigroups::fpsemigroup::order_preserving_cyclic_inverse_monoid
    :project: libsemigroups
 
 .. doxygenfunction:: libsemigroups::fpsemigroup::not_symmetric_group

--- a/docs/source/libsemigroups.bib
+++ b/docs/source/libsemigroups.bib
@@ -127,6 +127,13 @@
     doi         = {10.1093/qmath/haab001},
     url         = {https://doi.org/10.1093/qmath/haab001},
 }
+@misc{Fernandes2022aa,
+    title       = {On the cyclic inverse monoid on a finite set},
+    author      = {Fernandes, Vitor Hugo},
+    year        = 2022,
+    published   = {arXiv},
+    doi         = {10.48550/ARXIV.2211.02155},
+}
 @article{FitzGerald2003aa,
     title       = {A presentation for the monoid of uniform block permutations.},
     author      = {FitzGerald, D.G.},

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -45,17 +45,18 @@ namespace libsemigroups {
       Coxeter    = 8,
       Easdown    = 16,
       East       = 32,
-      FitzGerald = 64,
-      Godelle    = 128,
-      Guralnick  = 256,
-      Iwahori    = 512,
-      Kantor     = 1024,
-      Kassabov   = 2048,
-      Lubotzky   = 4096,
-      Miller     = 8192,
-      Moore      = 16384,
-      Moser      = 32768,
-      Sutov      = 65536
+      Fernandes  = 64,
+      FitzGerald = 128,
+      Godelle    = 256,
+      Guralnick  = 512,
+      Iwahori    = 1024,
+      Kantor     = 2048,
+      Kassabov   = 4096,
+      Lubotzky   = 8192,
+      Miller     = 16'384,
+      Moore      = 32'768,
+      Moser      = 65'536,
+      Sutov      = 131'072
     };
 
     //! This operator can be used arbitrarily to combine author values (see \ref
@@ -465,6 +466,59 @@ namespace libsemigroups {
     //!
     //! [10.1007/s10012-000-0001-1]: https://doi.org/10.1007/s10012-000-0001-1
     std::vector<relation_type> order_preserving_monoid(size_t n);
+
+    //! A presentation for the cyclic inverse monoid.
+    //!
+    //! Returns a vector of relations giving a monoid presentation defining
+    //! the cyclic inverse monoid of degree `n`.
+    //!
+    //! The combination of `val` and `index` determines the specific
+    //! presentation which is returned. The options for these are:
+    //! * `val = author::Fernandes`
+    //!    * `index = 0` (see Theorem 2.6 of [10.48550/arxiv.2211.02155][])
+    //!    * `index = 1` (see Theorem 2.7 of [10.48550/arxiv.2211.02155][])
+    //!
+    //! \param n the degree
+    //! \param val the author
+    //! \param index the index
+    //!
+    //! \returns A `std::vector<relation_type>`
+    //!
+    //! \throws LibsemigroupsException if `n < 3`
+    //! \throws LibsemigroupsException if `val` is not `author::Fernandes`
+    //! \throws LibsemigroupsException if `val = author::Fernandes` and `index`
+    //! is not `0` or `1`
+    //!
+    //! The presentation with `val = author::Fernandes` and `index = 0` has
+    //! \f$n + 1\f$ generators and \f$\frac{1}{2} \left(n^2 + 3n + 4\right)\f$
+    //! relations.
+    //!
+    //! The presentation with `val = author::Fernandes` and `index = 1` has
+    //! \f$2\f$ generators and \f$\frac{1}{2}\left(n^2 - n + 6\right)\f$
+    //! relations.
+    //!
+    //! [10.48550/arxiv.2211.02155]: https://doi.org/10.48550/arxiv.2211.02155
+    std::vector<relation_type> cyclic_inverse_monoid(size_t n,
+                                                     author val
+                                                     = author::Fernandes,
+                                                     size_t index = 1);
+
+    //! A presentation for the order-preserving part of the cyclic inverse
+    //! monoid.
+    //!
+    //! Returns a vector of relations giving a semigroup presentation defining
+    //! the order-preserving part of the cyclic inverse monoid of degree `n`, as
+    //! described in Theorem 2.17 of
+    //! the paper [10.48550/arxiv.2211.02155][].
+    //!
+    //! \param n the degree
+    //!
+    //! \returns A `std::vector<relation_type>`
+    //!
+    //! \throws LibsemigroupsException if `n < 3`
+    //!
+    //! [10.48550/arxiv.2211.02155]: https://doi.org/10.48550/arxiv.2211.02155
+    std::vector<relation_type> order_preserving_cyclic_inverse_monoid(size_t n);
 
     //! A non-presentation for the symmetric group.
     //!

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -1331,6 +1331,148 @@ namespace libsemigroups {
       return result;
     }
 
+    std::vector<relation_type> cyclic_inverse_monoid(size_t n,
+                                                     author val,
+                                                     size_t index) {
+      if (val == author::Fernandes) {
+        if (n < 3) {
+          LIBSEMIGROUPS_EXCEPTION(
+              "the 1st argument must be at least 3 where the 2nd argument is "
+              "author::Fernandes, found %llu",
+              uint64_t(n));
+        }
+        // See Theorem 2.6 of https://arxiv.org/pdf/2211.02155.pdf
+        if (index == 0) {
+          word_type              g = {0};
+          std::vector<word_type> e(n, {0});
+          size_t                 inc = 1;
+          std::for_each(e.begin(), e.end(), [&inc](auto& w) { w[0] += inc++; });
+          std::vector<relation_type> result;
+
+          // R1
+          result.emplace_back(g ^ n, word_type({}));
+          // R2
+          for (size_t i = 0; i < n; ++i) {
+            result.emplace_back(e[i] ^ 2, e[i]);
+          }
+          // R3
+          for (size_t i = 0; i < n - 1; ++i) {
+            for (size_t j = i + 1; j < n; ++j) {
+              result.emplace_back(e[i] * e[j], e[j] * e[i]);
+            }
+          }
+
+          // R4
+          result.emplace_back(g * e[0], e[n - 1] * g);
+          for (size_t i = 0; i < n - 1; ++i) {
+            result.emplace_back(g * e[i + 1], e[i] * g);
+          }
+
+          // R5
+          word_type prod(n, 0);
+          std::iota(prod.begin(), prod.end(), size_t(1));
+          result.emplace_back(g * prod, prod);
+
+          return result;
+        }
+        // See Theorem 2.7 of https://arxiv.org/pdf/2211.02155.pdf
+        if (index == 1) {
+          word_type g = {0};
+          word_type e = {1};
+
+          std::vector<relation_type> result;
+
+          result.emplace_back(g ^ n, word_type({}));  // relation Q1
+          result.emplace_back(e ^ 2, e);              // relation Q2
+
+          // relations Q3
+          for (size_t j = 2; j <= n; ++j)
+            for (size_t i = 1; i < j; ++i) {
+              result.emplace_back(e * (g ^ (n - j + i)) * e * (g ^ (n - i + j)),
+                                  (g ^ (n - j + i)) * e * (g ^ (n - i + j))
+                                      * e);
+            }
+
+          result.emplace_back(g * (e * (g ^ (n - 1)) ^ n),
+                              (e * (g ^ (n - 1))) ^ n);  // relation Q4
+
+          return result;
+        }
+        LIBSEMIGROUPS_EXCEPTION("3rd argument must be 0 or 1 where 2nd "
+                                "argument is author::Fernandes, found %llu",
+                                uint64_t(n));
+      }
+      LIBSEMIGROUPS_EXCEPTION(
+          "expected 2nd argument to be author::Fernandes, found %s",
+          detail::to_string(val).c_str());
+    }
+
+    // See Theorem 2.17 of https://arxiv.org/pdf/2211.02155.pdf
+    std::vector<relation_type>
+    order_preserving_cyclic_inverse_monoid(size_t n) {
+      if (n < 3) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected argument to be at least 3, found %llu", uint64_t(n));
+      }
+      word_type x = {0};
+      word_type y = {1};
+
+      std::vector<word_type> e;
+
+      for (size_t i = 2; i <= n - 1; ++i) {
+        e.push_back({i});
+      }
+
+      std::vector<relation_type> result;
+
+      // relations V1
+      for (size_t i = 0; i <= n - 3; ++i) {
+        result.emplace_back(e[i] ^ 2, e[i]);
+      }
+      // relations V2
+      result.emplace_back(x * y * x, x);
+      result.emplace_back(y * x * y, y);
+
+      // relations V3
+      result.emplace_back(y * (x ^ 2) * y, x * (y ^ 2) * x);
+
+      // relations V4
+      for (size_t j = 1; j <= n - 3; ++j) {
+        for (size_t i = 0; i < j; ++i) {
+          result.emplace_back(e[i] * e[j], e[j] * e[i]);
+        }
+      }
+
+      // relations V5
+      for (size_t i = 0; i <= n - 3; ++i) {
+        result.emplace_back(x * y * e[i], e[i] * x * y);
+        result.emplace_back(y * x * e[i], e[i] * y * x);
+      }
+
+      // relations V6
+      for (size_t i = 0; i <= n - 4; ++i) {
+        result.emplace_back(x * e[i + 1], e[i] * x);
+      }
+
+      // relations V7
+      result.emplace_back((x ^ 2) * y, e[n - 3] * x);
+      result.emplace_back(y * (x ^ 2), x * e[0]);
+
+      // relations V8
+      word_type lhs = y * x;
+      word_type rhs = x;
+      for (size_t i = 0; i <= n - 3; ++i) {
+        lhs = lhs * e[i];
+        rhs = rhs * e[i];
+      }
+      lhs = lhs * x * y;
+      rhs = rhs * x * y;
+
+      result.emplace_back(lhs, rhs);
+
+      return result;
+    }
+
     std::vector<relation_type> not_symmetric_group(size_t n, author val) {
       if (n < 4) {
         LIBSEMIGROUPS_EXCEPTION(

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -39,10 +39,12 @@ namespace libsemigroups {
 
   using fpsemigroup::alternating_group;
   using fpsemigroup::chinese_monoid;
+  using fpsemigroup::cyclic_inverse_monoid;
   using fpsemigroup::dual_symmetric_inverse_monoid;
   using fpsemigroup::fibonacci_semigroup;
   using fpsemigroup::full_transformation_monoid;
   using fpsemigroup::monogenic_semigroup;
+  using fpsemigroup::order_preserving_cyclic_inverse_monoid;
   using fpsemigroup::order_preserving_monoid;
   using fpsemigroup::orientation_preserving_monoid;
   using fpsemigroup::orientation_reversing_monoid;
@@ -309,6 +311,46 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "055",
+                          "order_preserving_monoid degree except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(order_preserving_monoid(0), LibsemigroupsException);
+    REQUIRE_THROWS_AS(order_preserving_monoid(1), LibsemigroupsException);
+    REQUIRE_THROWS_AS(order_preserving_monoid(2), LibsemigroupsException);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "061",
+                          "cyclic_inverse_monoid degree except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(cyclic_inverse_monoid(0, author::Fernandes, 0),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(cyclic_inverse_monoid(1, author::Fernandes, 0),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(cyclic_inverse_monoid(2, author::Fernandes, 0),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(cyclic_inverse_monoid(0, author::Fernandes, 1),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(cyclic_inverse_monoid(1, author::Fernandes, 1),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(cyclic_inverse_monoid(2, author::Fernandes, 1),
+                      LibsemigroupsException);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "062",
+                          "cyclic_inverse_monoid author except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(cyclic_inverse_monoid(5, author::Burnside, 0),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(cyclic_inverse_monoid(5, author::Fernandes, 3),
+                      LibsemigroupsException);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "063",
                           "order_preserving_monoid degree except",
                           "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
@@ -781,6 +823,114 @@ namespace libsemigroups {
         tc.add_pair(p.rules[i], p.rules[i + 1]);
       }
       REQUIRE(tc.number_of_classes() == 92'378);
+    }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                            "056",
+                            "cyclic_inverse_monoid(4) Fernandes 1",
+                            "[fpsemi-examples][quick]") {
+      auto   rg = ReportGuard(REPORT);
+      size_t n  = 4;
+      auto   s  = cyclic_inverse_monoid(n, author::Fernandes, 1);
+      auto   p  = make<Presentation<word_type>>(s);
+      p.alphabet(3);
+      presentation::replace_word(p, word_type({}), {2});
+      presentation::add_identity_rules(p, 2);
+      p.validate();
+
+      ToddCoxeter tc(congruence_kind::twosided);
+      tc.set_number_of_generators(3);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+      REQUIRE(tc.number_of_classes() == 61);
+    }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                            "057",
+                            "cyclic_inverse_monoid(8) Fernandes index 1",
+                            "[fpsemi-examples][quick]") {
+      auto   rg = ReportGuard(REPORT);
+      size_t n  = 8;
+      auto   s  = cyclic_inverse_monoid(n, author::Fernandes, 1);
+      auto   p  = make<Presentation<word_type>>(s);
+      p.alphabet(3);
+      presentation::replace_word(p, word_type({}), {2});
+      presentation::add_identity_rules(p, 2);
+      p.validate();
+
+      ToddCoxeter tc(congruence_kind::twosided);
+      tc.set_number_of_generators(3);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+      REQUIRE(tc.number_of_classes() == 2041);
+    }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                            "058",
+                            "cyclic_inverse_monoid Fernandes index 0",
+                            "[fpsemi-examples][quick]") {
+      auto rg = ReportGuard(REPORT);
+      for (size_t n = 3; n < 10; ++n) {
+        auto p = make<Presentation<word_type>>(
+            fpsemigroup::cyclic_inverse_monoid(n, author::Fernandes, 0));
+        REQUIRE(p.rules.size() == (n * n + 3 * n + 4));
+        p.alphabet(n + 2);
+        presentation::replace_word(p, word_type({}), {n + 1});
+        presentation::add_identity_rules(p, n + 1);
+        p.alphabet_from_rules();
+        p.validate();
+
+        ToddCoxeter tc(congruence_kind::twosided);
+        tc.set_number_of_generators(n + 2);
+        for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+          tc.add_pair(p.rules[i], p.rules[i + 1]);
+        }
+        REQUIRE(tc.number_of_classes() == n * std::pow(2, n) - n + 1);
+      }
+    }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                            "059",
+                            "order_preserving_cyclic_inverse_monoid(4)",
+                            "[fpsemi-examples][quick]") {
+      auto   rg = ReportGuard(REPORT);
+      size_t n  = 4;
+      auto   s  = order_preserving_cyclic_inverse_monoid(n);
+      auto   p  = make<Presentation<word_type>>(s);
+      p.alphabet(n + 1);
+      presentation::replace_word(p, word_type({}), {n});
+      presentation::add_identity_rules(p, n);
+      p.validate();
+
+      ToddCoxeter tc(congruence_kind::twosided);
+      tc.set_number_of_generators(n + 1);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+      REQUIRE(tc.number_of_classes() == 38);
+    }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                            "060",
+                            "order_preserving_cyclic_inverse_monoid(10)",
+                            "[fpsemi-examples][quick]") {
+      auto   rg = ReportGuard(REPORT);
+      size_t n  = 11;
+      auto   s  = order_preserving_cyclic_inverse_monoid(n);
+      auto   p  = make<Presentation<word_type>>(s);
+      p.alphabet(n + 1);
+      presentation::replace_word(p, word_type({}), {n});
+      presentation::add_identity_rules(p, n);
+      p.validate();
+
+      ToddCoxeter tc(congruence_kind::twosided);
+      tc.set_number_of_generators(n + 1);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+      REQUIRE(tc.number_of_classes() == 6120);
     }
 
     LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",


### PR DESCRIPTION
This PR adds to `fpsemi-examples` a presentation for the cyclic inverse monoid (`cyclic_inverse_monoid`), addressing issue #405. It also implements a presentation for its order-preserving part (`order_preserving_cyclic_inverse_monoid`).

Both presentations are given [here](https://arxiv.org/pdf/2211.02155.pdf).