### PR TITLE
Add `order_preserving_monoid` presentation

### DIFF
--- a/docs/source/api/fpsemi-examples.rst
+++ b/docs/source/api/fpsemi-examples.rst
@@ -22,7 +22,7 @@ Presentations from the following sources are implemented: :cite:`Gay1999aa`;
 :cite:`Abram2022aa`; :cite:`Easdown2007aa`; :cite:`FitzGerald2003aa`;
 :cite:`East2011aa`; :cite:`Ayik2000aa`; :cite:`Ruskuc1995aa`;
 :cite:`Aizenstat1958aa`; :cite:`Coxeter1979aa`; :cite:`Knuth1970aa`;
-:cite:`Lascoux1981aa`; :cite:`Moore1897aa`.
+:cite:`Lascoux1981aa`; :cite:`Moore1897aa`; :cite:`Aizenstat1962aa`.
 
 .. cpp:type:: libsemigroups::fpsemigroup::author
 
@@ -108,6 +108,10 @@ Contents
      - A presentation for the monoid of orientation reversing
        mappings.
 
+   * - :cpp:any:`order_preserving_monoid`
+     - A presentation for the monoid of order preserving
+       mappings.
+
    * - :cpp:any:`not_symmetric_group`
      - A non-presentation for the symmetric group.
 .. cpp:namespace-pop::
@@ -173,6 +177,9 @@ Full API
    :project: libsemigroups
 
 .. doxygenfunction:: libsemigroups::fpsemigroup::orientation_reversing_monoid
+   :project: libsemigroups
+
+.. doxygenfunction:: libsemigroups::fpsemigroup::order_preserving_monoid
    :project: libsemigroups
 
 .. doxygenfunction:: libsemigroups::fpsemigroup::not_symmetric_group

--- a/docs/source/libsemigroups.bib
+++ b/docs/source/libsemigroups.bib
@@ -27,6 +27,15 @@
     number      = 87,
     pages       = {261--280},
 }
+@article{Aizenstat1962aa,
+    title       = {Generating relations of an endomorphism semigroup of a finite linearly ordered chain},
+    author      = {Aizenstat, A.},
+    year        = 1962,
+    journal     = {Sibirsk. Mat. Z.},
+    volume      = 2,
+    pages       = {9-11},
+}
+
 @article{Arthur2000aa,
     title       = {Presentations for Two Extensions of the Monoid of Order-Preserving Mappings on a Finite Chain},
     author      = {Arthur, Robert E. and Ruškuc, N.},

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -454,6 +454,8 @@ namespace libsemigroups {
     //! the monoid of order-preserving transformations of degree `n`, as
     //! described in Section 2 of the paper [10.1007/s10012-000-0001-1][].
     //!
+    //! This presentation has \f$2n - 2\f$ generators and \f$n^2\f$ relations.
+    //!
     //! \param n the degree
     //! \param val the author
     //!

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -448,6 +448,22 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `r = 0`
     std::vector<relation_type> monogenic_semigroup(size_t m, size_t r);
 
+    //! A presentation for the monoid of order-preserving mappings.
+    //!
+    //! Returns a vector of relations giving a semigroup presentation defining
+    //! the monoid of order-preserving transformations of degree `n`, as
+    //! described in Section 2 of the paper [10.1007/s10012-000-0001-1][].
+    //!
+    //! \param n the degree
+    //! \param val the author
+    //!
+    //! \returns A `std::vector<relation_type>`
+    //!
+    //! \throws LibsemigroupsException if `n < 3`
+    //!
+    //! [10.1007/s10012-000-0001-1]: https://doi.org/10.1007/s10012-000-0001-1
+    std::vector<relation_type> order_preserving_monoid(size_t n);
+
     //! A non-presentation for the symmetric group.
     //!
     //! Returns a vector of relations giving a monoid presentation which is

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -1278,6 +1278,59 @@ namespace libsemigroups {
       return result;
     }
 
+    std::vector<relation_type> order_preserving_monoid(size_t n) {
+      if (n < 3) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected argument to be at least 3, found %llu", uint64_t(n));
+      }
+      std::vector<word_type> u;
+      std::vector<word_type> v;
+
+      for (size_t i = 0; i <= n - 2; ++i) {
+        u.push_back({i});
+        v.push_back({n - 1 + i});
+      }
+
+      std::vector<relation_type> result;
+
+      // relations 1
+      for (size_t i = 1; i <= n - 2; ++i) {
+        result.emplace_back(v[n - 2 - i] * u[i], u[i] * v[n - 1 - i]);
+      }
+
+      // relations 2
+      for (size_t i = 1; i <= n - 2; ++i) {
+        result.emplace_back(u[n - 2 - i] * v[i], v[i] * u[n - 1 - i]);
+      }
+
+      // relations 3
+      for (size_t i = 0; i <= n - 2; ++i) {
+        result.emplace_back(v[n - 2 - i] * u[i], u[i]);
+      }
+
+      // relations 4
+      for (size_t i = 0; i <= n - 2; ++i) {
+        result.emplace_back(u[n - 2 - i] * v[i], v[i]);
+      }
+
+      // relations 5
+      for (size_t i = 0; i <= n - 2; ++i) {
+        for (size_t j = 0; j <= n - 2; ++j) {
+          if (j != (n - 2) - i && j != n - i - 1) {
+            result.emplace_back(u[i] * v[j], v[j] * u[i]);
+          }
+        }
+      }
+
+      // relation 6
+      result.emplace_back(u[0] * u[1] * u[0], u[0] * u[1]);
+
+      // relation 7
+      result.emplace_back(v[0] * v[1] * v[0], v[0] * v[1]);
+
+      return result;
+    }
+
     std::vector<relation_type> not_symmetric_group(size_t n, author val) {
       if (n < 4) {
         LIBSEMIGROUPS_EXCEPTION(

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -43,6 +43,7 @@ namespace libsemigroups {
   using fpsemigroup::fibonacci_semigroup;
   using fpsemigroup::full_transformation_monoid;
   using fpsemigroup::monogenic_semigroup;
+  using fpsemigroup::order_preserving_monoid;
   using fpsemigroup::orientation_preserving_monoid;
   using fpsemigroup::orientation_reversing_monoid;
   using fpsemigroup::partial_transformation_monoid;
@@ -304,6 +305,16 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(orientation_reversing_monoid(0), LibsemigroupsException);
     REQUIRE_THROWS_AS(orientation_reversing_monoid(1), LibsemigroupsException);
     REQUIRE_THROWS_AS(orientation_reversing_monoid(2), LibsemigroupsException);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "055",
+                          "order_preserving_monoid degree except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(order_preserving_monoid(0), LibsemigroupsException);
+    REQUIRE_THROWS_AS(order_preserving_monoid(1), LibsemigroupsException);
+    REQUIRE_THROWS_AS(order_preserving_monoid(2), LibsemigroupsException);
   }
 
   namespace congruence {
@@ -730,6 +741,46 @@ namespace libsemigroups {
         tc.add_pair(p.rules[i], p.rules[i + 1]);
       }
       REQUIRE(tc.number_of_classes() == 256);
+    }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                            "053",
+                            "order_preserving_monoid(5)",
+                            "[fpsemi-examples][quick]") {
+      auto   rg = ReportGuard(REPORT);
+      size_t n  = 5;
+      auto   s  = order_preserving_monoid(n);
+      auto   p  = make<Presentation<word_type>>(s);
+      p.alphabet(2 * n - 1);
+      presentation::add_identity_rules(p, 2 * n - 2);
+      p.validate();
+
+      ToddCoxeter tc(congruence_kind::twosided);
+      tc.set_number_of_generators(2 * n - 1);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+      REQUIRE(tc.number_of_classes() == 126);
+    }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                            "054",
+                            "order_preserving_monoid(10)",
+                            "[fpsemi-examples][standard]") {
+      auto   rg = ReportGuard(REPORT);
+      size_t n  = 10;
+      auto   s  = order_preserving_monoid(n);
+      auto   p  = make<Presentation<word_type>>(s);
+      p.alphabet(2 * n - 1);
+      presentation::add_identity_rules(p, 2 * n - 2);
+      p.validate();
+
+      ToddCoxeter tc(congruence_kind::twosided);
+      tc.set_number_of_generators(2 * n - 1);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+      REQUIRE(tc.number_of_classes() == 92'378);
     }
 
     LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -299,7 +299,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "048",
-                          "orientation_preserving_monoid degree except",
+                          "orientation_reversing_monoid degree except",
                           "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
     REQUIRE_THROWS_AS(orientation_reversing_monoid(0), LibsemigroupsException);


### PR DESCRIPTION
This PR adds a presentation for the monoid of order-preserving transformations on a finite chain, due to Aizenstat and described in Section 2 of [this paper](https://link.springer.com/article/10.1007/s10012-000-0001-1).

It also corrects the name of an existing test case in `tests/test-fpsemi-examples-1.cpp`.