### PR TITLE
Add a second symmetric group presentation due to Moore

### DIFF
--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -285,36 +285,35 @@ namespace libsemigroups {
     //! Returns a vector of relations giving a monoid presentation for the
     //! symmetric group. The argument `val` determines the specific presentation
     //! which is returned. The options are:
-    //! * `author::Burnside + author::Miller` (given on p.464 of
-    //! [10.1017/CBO9781139237253][])
-    //! * `author::Carmichael` (given in comment 9.5.2 of
-    //! [10.1007/978-1-84800-281-4])
-    //! * `author::Coxeter + author::Moser` (see Ch. 3, Prop 1.2 of
-    //! [hdl.handle.net/10023/2821])
-    //! * `author::Moore`
-    //!    * `index = 0` (given Ch. 3, Prop 1.1 of
-    //!    [hdl.handle.net/10023/2821][])
-    //!    * `index = 1` (given in comment 9.5.3 of
-    //!    [10.1007/978-1-84800-281-4][])
+    //!
+    // clang-format off
+    //!
+    //! Author | Index | No. generators  | No. relations | Reference
+    //! ------ | ----- | --------------- | ------------- | ----------
+    //! `author::Burnside + author::Miller`| `0` | \f$n - 1\f$ | \f$n^3 - 5n^2 + 9n - 5\f$ | p.464 of [10.1017/CBO9781139237253][]   <!-- NOLINT -->
+    //! `author::Carmichael`               | `0` | \f$n - 1\f$ | \f$(n - 1)^2\f$  | Comment 9.5.2 of [10.1007/978-1-84800-281-4][]   <!-- NOLINT -->
+    //! `author::Coxeter + author::Moser`  | `0` | \f$n - 1\f$ | \f$n(n + 1)/2\f$ | Ch.3, Prop 1.2 of [hdl.handle.net/10023/2821][]  <!-- NOLINT --> 
+    //! `author::Moore`                    | `0` | \f$2\f$     | \f$n + 1\f$      | Ch. 3, Prop 1.1 of [hdl.handle.net/10023/2821][] <!-- NOLINT -->
+    //! ^                                  | `1` | \f$n - 1\f$ | \f$n(n + 1)/2\f$ | Comment 9.5.3 of [10.1007/978-1-84800-281-4][]   <!-- NOLINT --> 
+    //!
+    //! [10.1017/CBO9781139237253]: https://doi.org/10.1017/CBO9781139237253
+    //! [10.1007/978-1-84800-281-4]: https://doi.org/10.1007/978-1-84800-281-4
+    //! [hdl.handle.net/10023/2821]: http://hdl.handle.net/10023/2821
+    //!
+    // clang-format on
     //!
     //! The default for `val` is `author::Carmichael`. The default for `index`
-    //! is `0`. If no `index` is listed above for an author, the only accepted
-    //! index for that author is `0`.
+    //! is `0`.
     //!
     //! \param n the degree of the symmetric group
     //! \param val the author of the presentation
     //!
     //! \returns A `std::vector<relation_type>`
     //!
-    //! \throws LibsemigroupsException if `val` is not listed above (modulo
-    //! order of author)
     //! \throws LibsemigroupsException if `n < 4`
-    //! \throws LibsemigroupsException if `index` is not given above for the
-    //! author `val`
+    //! \throws LibsemigroupsException if the author-index combination is
+    //! invalid
     //!
-    //! [10.1017/CBO9781139237253]: https://doi.org/10.1017/CBO9781139237253
-    //! [10.1007/978-1-84800-281-4]: https://doi.org/10.1007/978-1-84800-281-4
-    //! [hdl.handle.net/10023/2821]: http://hdl.handle.net/10023/2821
     std::vector<relation_type> symmetric_group(size_t n,
                                                author val = author::Carmichael,
                                                size_t index = 0);

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -291,10 +291,15 @@ namespace libsemigroups {
     //! [10.1007/978-1-84800-281-4])
     //! * `author::Coxeter + author::Moser` (see Ch. 3, Prop 1.2 of
     //! [hdl.handle.net/10023/2821])
-    //! * `author::Moore` (given in comment 9.5.3 of
-    //! [10.1007/978-1-84800-281-4])
+    //! * `author::Moore`
+    //!    * `index = 0` (given Ch. 3, Prop 1.1 of
+    //!    [hdl.handle.net/10023/2821][])
+    //!    * `index = 1` (given in comment 9.5.3 of
+    //!    [10.1007/978-1-84800-281-4][])
     //!
-    //! The default for `val` is `author::Carmichael`.
+    //! The default for `val` is `author::Carmichael`. The default for `index`
+    //! is `0`. If no `index` is listed above for an author, the only accepted
+    //! index for that author is `0`.
     //!
     //! \param n the degree of the symmetric group
     //! \param val the author of the presentation
@@ -302,13 +307,17 @@ namespace libsemigroups {
     //! \returns A `std::vector<relation_type>`
     //!
     //! \throws LibsemigroupsException if `val` is not listed above (modulo
-    //! order of author) \throws LibsemigroupsException if `n < 4`
+    //! order of author)
+    //! \throws LibsemigroupsException if `n < 4`
+    //! \throws LibsemigroupsException if `index` is not given above for the
+    //! author `val`
     //!
     //! [10.1017/CBO9781139237253]: https://doi.org/10.1017/CBO9781139237253
     //! [10.1007/978-1-84800-281-4]: https://doi.org/10.1007/978-1-84800-281-4
     //! [hdl.handle.net/10023/2821]: http://hdl.handle.net/10023/2821
     std::vector<relation_type> symmetric_group(size_t n,
-                                               author val = author::Carmichael);
+                                               author val = author::Carmichael,
+                                               size_t index = 0);
 
     //! A presentation for the alternating group.
     //!

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -280,12 +280,19 @@ namespace libsemigroups {
       return result;
     }
 
-    std::vector<relation_type> symmetric_group(size_t n, author val) {
+    std::vector<relation_type> symmetric_group(size_t n,
+                                               author val,
+                                               size_t index) {
       if (n < 4) {
         LIBSEMIGROUPS_EXCEPTION(
             "expected 1st argument to be at least 4, found %llu", uint64_t(n));
       }
       if (val == author::Carmichael) {
+        if (index != 0) {
+          LIBSEMIGROUPS_EXCEPTION("expected 3rd argument to be 0 when 2nd "
+                                  "argument is author::Carmichael, found %llu",
+                                  uint64_t(index));
+        }
         // Exercise 9.5.2, p172 of
         // https://link.springer.com/book/10.1007/978-1-84800-281-4
         std::vector<word_type> pi;
@@ -319,6 +326,12 @@ namespace libsemigroups {
       } else if (val == author::Coxeter + author::Moser) {
         // From Chapter 3, Proposition 1.2 in https://bit.ly/3R5ZpKW (Ruskuc
         // thesis)
+        if (index != 0) {
+          LIBSEMIGROUPS_EXCEPTION(
+              "expected 3rd argument to be 0 when 2nd argument is "
+              "author::Coxeter + author::Moser, found %llu",
+              uint64_t(index));
+        }
 
         std::vector<word_type> a;
         for (size_t i = 0; i < n - 1; ++i) {
@@ -341,24 +354,61 @@ namespace libsemigroups {
         return result;
 
       } else if (val == author::Moore) {
-        // From Chapter 3, Proposition 1.1 in https://bit.ly/3R5ZpKW (Ruskuc
-        // thesis)
-        word_type const e = {};
-        word_type const a = {0};
-        word_type const b = {1};
+        if (index == 0) {
+          // From Chapter 3, Proposition 1.1 in https://bit.ly/3R5ZpKW (Ruskuc
+          // thesis)
+          word_type const e = {};
+          word_type const a = {0};
+          word_type const b = {1};
 
-        std::vector<relation_type> result;
-        result.emplace_back(a ^ 2, e);
-        result.emplace_back(b ^ n, e);
-        result.emplace_back((a * b) ^ (n - 1), e);
-        result.emplace_back((a * (b ^ (n - 1)) * a * b) ^ 3, e);
-        for (size_t j = 2; j <= n - 2; ++j) {
-          result.emplace_back((a * ((b ^ (n - 1)) ^ j) * a * (b ^ j)) ^ 2, e);
+          std::vector<relation_type> result;
+          result.emplace_back(a ^ 2, e);
+          result.emplace_back(b ^ n, e);
+          result.emplace_back((a * b) ^ (n - 1), e);
+          result.emplace_back((a * (b ^ (n - 1)) * a * b) ^ 3, e);
+          for (size_t j = 2; j <= n - 2; ++j) {
+            result.emplace_back((a * ((b ^ (n - 1)) ^ j) * a * (b ^ j)) ^ 2, e);
+          }
+          return result;
+        } else if (index == 1) {
+          // From https://core.ac.uk/download/pdf/82378951.pdf
+          // TODO: Get proper DOI of this paper
+
+          std::vector<relation_type> result;
+          std::vector<word_type>     s;
+
+          for (size_t i = 0; i <= n - 2; ++i) {
+            s.push_back({i});
+          }
+
+          for (size_t i = 0; i <= n - 2; ++i) {
+            result.emplace_back(s[i] ^ 2, word_type({}));
+          }
+
+          for (size_t i = 0; i <= n - 4; ++i) {
+            for (size_t j = i + 2; j <= n - 2; ++j) {
+              result.emplace_back(s[i] * s[j], s[j] * s[i]);
+            }
+          }
+
+          for (size_t i = 1; i <= n - 2; ++i) {
+            result.emplace_back(s[i] * s[i - 1] * s[i],
+                                s[i - 1] * s[i] * s[i - 1]);
+          }
+          return result;
         }
-        return result;
+        LIBSEMIGROUPS_EXCEPTION("expected 3rd argument to be 0 or 1 when 2nd "
+                                "argument is author::Moore, found %llu",
+                                uint64_t(index));
       } else if (val == author::Burnside + author::Miller) {
         // See Eq 2.6 of 'Presentations of finite simple groups: A quantitative
         // approach' J. Amer. Math. Soc. 21 (2008), 711-774
+        if (index != 0) {
+          LIBSEMIGROUPS_EXCEPTION(
+              "expected 3rd argument to be 0 when 2nd argument is "
+              "author::Burnside + author::Miller, found %llu",
+              uint64_t(index));
+        }
         std::vector<word_type> a;
         for (size_t i = 0; i <= n - 2; ++i) {
           a.push_back({i});

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -65,6 +65,7 @@ namespace libsemigroups {
                           "049",
                           "test default values",
                           "[fpsemi-examples][quick]") {
+    // author defaults
     REQUIRE(symmetric_group(4) == symmetric_group(4, author::Carmichael));
     REQUIRE(alternating_group(4) == alternating_group(4, author::Moore));
     REQUIRE(full_transformation_monoid(4)
@@ -79,6 +80,9 @@ namespace libsemigroups {
     REQUIRE(uniform_block_bijection_monoid(4)
             == uniform_block_bijection_monoid(4, author::FitzGerald));
     REQUIRE(partition_monoid(4) == partition_monoid(4, author::East));
+
+    // index defaults
+    REQUIRE(symmetric_group(4, author::Moore) == symmetric_group(4, author::Moore, 0));
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
@@ -132,6 +136,17 @@ namespace libsemigroups {
                           "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
     REQUIRE_THROWS_AS(symmetric_group(3, author::Carmichael),
+                      LibsemigroupsException);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "064",
+                          "symmetric_group index except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(symmetric_group(5, author::Moore, 2),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(symmetric_group(5, author::Carmichael, 1),
                       LibsemigroupsException);
   }
 
@@ -487,7 +502,7 @@ namespace libsemigroups {
 
     LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                             "032",
-                            "symmetric_group(6) Moore",
+                            "symmetric_group(6) Moore index 0",
                             "[fpsemi-examples][quick]") {
       auto   rg = ReportGuard(REPORT);
       size_t n  = 6;
@@ -504,6 +519,27 @@ namespace libsemigroups {
         tc.add_pair(p.rules[i], p.rules[i + 1]);
       }
       REQUIRE(tc.number_of_classes() == 720);
+    }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                            "065",
+                            "symmetric_group(7) Moore index 1",
+                            "[fpsemi-examples][quick]") {
+      auto   rg = ReportGuard(REPORT);
+      size_t n  = 7;
+      auto   s  = symmetric_group(n, author::Moore, 1);
+      auto   p  = make<Presentation<word_type>>(s);
+      p.alphabet(n);
+      presentation::replace_word(p, word_type({}), {n - 1});
+      presentation::add_identity_rules(p, n - 1);
+      p.validate();
+
+      ToddCoxeter tc(congruence_kind::twosided);
+      tc.set_number_of_generators(n);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+      REQUIRE(tc.number_of_classes() == 5040);
     }
 
     LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -80,9 +80,14 @@ namespace libsemigroups {
     REQUIRE(uniform_block_bijection_monoid(4)
             == uniform_block_bijection_monoid(4, author::FitzGerald));
     REQUIRE(partition_monoid(4) == partition_monoid(4, author::East));
+    REQUIRE(cyclic_inverse_monoid(4)
+            == cyclic_inverse_monoid(4, author::Fernandes));
 
     // index defaults
-    REQUIRE(symmetric_group(4, author::Moore) == symmetric_group(4, author::Moore, 0));
+    REQUIRE(symmetric_group(4, author::Moore)
+            == symmetric_group(4, author::Moore, 0));
+    REQUIRE(cyclic_inverse_monoid(4, author::Fernandes)
+            == cyclic_inverse_monoid(4, author::Fernandes, 1));
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",


### PR DESCRIPTION
This PR adds a second symmetric group presentation due to Moore, and therefore sets up the `symmetric_group` function to receive a third argument called `index` which can be used to choose between presentations of the same author.

In a separate commit, default value tests for the function `cyclic_inverse_monoid` are added.