### PR TITLE
Add presentation for the monoid of partial isometries of a cycle graph

### DIFF
--- a/docs/source/api/fpsemi-examples.rst
+++ b/docs/source/api/fpsemi-examples.rst
@@ -23,7 +23,7 @@ Presentations from the following sources are implemented: :cite:`Gay1999aa`;
 :cite:`East2011aa`; :cite:`Ayik2000aa`; :cite:`Ruskuc1995aa`;
 :cite:`Aizenstat1958aa`; :cite:`Coxeter1979aa`; :cite:`Knuth1970aa`;
 :cite:`Lascoux1981aa`; :cite:`Moore1897aa`; :cite:`Aizenstat1962aa`;
-:cite:`Fernandes2022aa`.
+:cite:`Fernandes2022aa`; :cite:`Fernandes2022ab`.
 
 .. cpp:type:: libsemigroups::fpsemigroup::author
 
@@ -119,6 +119,9 @@ Contents
    * - :cpp:any:`order_preserving_cyclic_inverse_monoid`
      - A presentation for the order-preserving part of the cyclic inverse monoid.
 
+   * - :cpp:any:`partial_isometries_cycle_graph_monoid`
+     - A presentation for the monoid of partial isometries of a cycle graph.
+
    * - :cpp:any:`not_symmetric_group`
      - A non-presentation for the symmetric group.
 .. cpp:namespace-pop::
@@ -193,6 +196,9 @@ Full API
    :project: libsemigroups
 
 .. doxygenfunction:: libsemigroups::fpsemigroup::order_preserving_cyclic_inverse_monoid
+   :project: libsemigroups
+
+.. doxygenfunction:: libsemigroups::fpsemigroup::partial_isometries_cycle_graph_monoid
    :project: libsemigroups
 
 .. doxygenfunction:: libsemigroups::fpsemigroup::not_symmetric_group

--- a/docs/source/libsemigroups.bib
+++ b/docs/source/libsemigroups.bib
@@ -134,6 +134,13 @@
     published   = {arXiv},
     doi         = {10.48550/ARXIV.2211.02155},
 }
+@misc{Fernandes2022ab,
+    title       = {On the monoid of partial isometries of a cycle graph},
+    author      = {Fernandes, Vítor H. and Paulista, Tânia},
+    year        = 2022,
+    published   = {arXiv},
+    doi         = {10.48550/ARXIV.2205.02196},
+}
 @article{FitzGerald2003aa,
     title       = {A presentation for the monoid of uniform block permutations.},
     author      = {FitzGerald, D.G.},

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -528,6 +528,21 @@ namespace libsemigroups {
     //! [10.48550/arxiv.2211.02155]: https://doi.org/10.48550/arxiv.2211.02155
     std::vector<relation_type> order_preserving_cyclic_inverse_monoid(size_t n);
 
+    //! A presentation for the monoid of partial isometries of a cycle graph.
+    //!
+    //! Returns a vector of relations giving a monoid presentation defining
+    //! the monoid of partial isometries of an \f$n\f$-cycle graph, as described
+    //! in Theorem 2.8 of [10.48550/arxiv.2205.02196][].
+    //!
+    //! \param n the number of vertices of the cycle graph
+    //!
+    //! \returns A `std::vector<relation_type>`
+    //!
+    //! \throws LibsemigroupsException if `n < 3`
+    //!
+    //! [10.48550/arxiv.2205.02196]: https://doi.org/10.48550/arxiv.2205.02196
+    std::vector<relation_type> partial_isometries_cycle_graph_monoid(size_t n);
+
     //! A non-presentation for the symmetric group.
     //!
     //! Returns a vector of relations giving a monoid presentation which is

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -1523,6 +1523,53 @@ namespace libsemigroups {
       return result;
     }
 
+    // See Theorem 2.8 of https://arxiv.org/pdf/2205.02196.pdf
+    std::vector<relation_type> partial_isometries_cycle_graph_monoid(size_t n) {
+      if (n < 3) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected argument to be at least 3, found %llu", uint64_t(n));
+      }
+
+      std::vector<relation_type> result;
+
+      word_type g = {0};
+      word_type h = {1};
+      word_type e = {2};
+
+      // Q1
+      result.emplace_back(g ^ n, word_type({}));
+      result.emplace_back(h ^ 2, word_type({}));
+      result.emplace_back(h * g, (g ^ (n - 1)) * h);
+
+      // Q2
+      result.emplace_back(e ^ 2, e);
+      result.emplace_back(g * h * e * g * h, e);
+
+      // Q3
+
+      for (size_t j = 2; j <= n; ++j) {
+        for (size_t i = 1; i < j; ++i) {
+          result.emplace_back(e * (g ^ (j - i)) * e * (g ^ (n - j + i)),
+                              (g ^ (j - i)) * e * (g ^ (n - j + i)) * e);
+        }
+      }
+
+      if (n % 2 == 1) {
+        // Q4
+        result.emplace_back(h * g * ((e * g) ^ (n - 2)) * e,
+                            ((e * g) ^ (n - 2)) * e);
+      } else {
+        // Q5
+        result.emplace_back(
+            h * g * ((e * g) ^ (n / 2 - 1)) * g * ((e * g) ^ (n / 2 - 2)) * e,
+            ((e * g) ^ (n / 2 - 1)) * g * ((e * g) ^ (n / 2 - 2)) * e);
+        result.emplace_back(h * ((e * g) ^ (n - 1)) * e,
+                            ((e * g) ^ (n - 1)) * e);
+      }
+
+      return result;
+    }
+
     std::vector<relation_type> not_symmetric_group(size_t n, author val) {
       if (n < 4) {
         LIBSEMIGROUPS_EXCEPTION(

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -48,6 +48,7 @@ namespace libsemigroups {
   using fpsemigroup::order_preserving_monoid;
   using fpsemigroup::orientation_preserving_monoid;
   using fpsemigroup::orientation_reversing_monoid;
+  using fpsemigroup::partial_isometries_cycle_graph_monoid;
   using fpsemigroup::partial_transformation_monoid;
   using fpsemigroup::partition_monoid;
   using fpsemigroup::plactic_monoid;
@@ -377,6 +378,19 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(order_preserving_monoid(0), LibsemigroupsException);
     REQUIRE_THROWS_AS(order_preserving_monoid(1), LibsemigroupsException);
     REQUIRE_THROWS_AS(order_preserving_monoid(2), LibsemigroupsException);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "069",
+                          "partial_isometries_cycle_graph_monoid degree except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(partial_isometries_cycle_graph_monoid(0),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(partial_isometries_cycle_graph_monoid(1),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(partial_isometries_cycle_graph_monoid(2),
+                      LibsemigroupsException);
   }
 
   namespace congruence {
@@ -972,6 +986,71 @@ namespace libsemigroups {
         tc.add_pair(p.rules[i], p.rules[i + 1]);
       }
       REQUIRE(tc.number_of_classes() == 6120);
+    }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                            "066",
+                            "order_preserving_cyclic_inverse_monoid(10)",
+                            "[fpsemi-examples][quick]") {
+      auto   rg = ReportGuard(REPORT);
+      size_t n  = 11;
+      auto   s  = order_preserving_cyclic_inverse_monoid(n);
+      auto   p  = make<Presentation<word_type>>(s);
+      p.alphabet(n + 1);
+      presentation::replace_word(p, word_type({}), {n});
+      presentation::add_identity_rules(p, n);
+      p.validate();
+
+      ToddCoxeter tc(congruence_kind::twosided);
+      tc.set_number_of_generators(n + 1);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+      REQUIRE(tc.number_of_classes() == 6120);
+    }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                            "067",
+                            "partial_isometries_cycle_graph_monoid(5)",
+                            "[fpsemi-examples][quick]") {
+      auto   rg = ReportGuard(REPORT);
+      size_t n  = 5;
+      auto   s  = partial_isometries_cycle_graph_monoid(n);
+      REQUIRE(s.size() == 16);
+      auto p = make<Presentation<word_type>>(s);
+      p.alphabet(4);
+      presentation::replace_word(p, word_type({}), {3});
+      presentation::add_identity_rules(p, 3);
+      p.validate();
+
+      ToddCoxeter tc(congruence_kind::twosided);
+      tc.set_number_of_generators(4);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+      REQUIRE(tc.number_of_classes() == 286);
+    }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                            "068",
+                            "partial_isometries_cycle_graph_monoid(10)",
+                            "[fpsemi-examples][quick]") {
+      auto   rg = ReportGuard(REPORT);
+      size_t n  = 10;
+      auto   s  = partial_isometries_cycle_graph_monoid(n);
+      REQUIRE(s.size() == 52);
+      auto p = make<Presentation<word_type>>(s);
+      p.alphabet(4);
+      presentation::replace_word(p, word_type({}), {3});
+      presentation::add_identity_rules(p, 3);
+      p.validate();
+
+      ToddCoxeter tc(congruence_kind::twosided);
+      tc.set_number_of_generators(4);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+      REQUIRE(tc.number_of_classes() == 20'311);
     }
 
     LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -1034,7 +1034,7 @@ namespace libsemigroups {
     LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                             "068",
                             "partial_isometries_cycle_graph_monoid(10)",
-                            "[fpsemi-examples][quick]") {
+                            "[fpsemi-examples][quick][no-valgrind]") {
       auto   rg = ReportGuard(REPORT);
       size_t n  = 10;
       auto   s  = partial_isometries_cycle_graph_monoid(n);

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -925,7 +925,7 @@ namespace libsemigroups {
     LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                             "058",
                             "cyclic_inverse_monoid Fernandes index 0",
-                            "[fpsemi-examples][quick]") {
+                            "[fpsemi-examples][quick][no-valgrind]") {
       auto rg = ReportGuard(REPORT);
       for (size_t n = 3; n < 10; ++n) {
         auto p = make<Presentation<word_type>>(
@@ -970,7 +970,7 @@ namespace libsemigroups {
     LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                             "060",
                             "order_preserving_cyclic_inverse_monoid(10)",
-                            "[fpsemi-examples][quick]") {
+                            "[fpsemi-examples][quick][no-valgrind]") {
       auto   rg = ReportGuard(REPORT);
       size_t n  = 11;
       auto   s  = order_preserving_cyclic_inverse_monoid(n);
@@ -991,7 +991,7 @@ namespace libsemigroups {
     LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                             "066",
                             "order_preserving_cyclic_inverse_monoid(10)",
-                            "[fpsemi-examples][quick]") {
+                            "[fpsemi-examples][quick][no-valgrind]") {
       auto   rg = ReportGuard(REPORT);
       size_t n  = 11;
       auto   s  = order_preserving_cyclic_inverse_monoid(n);

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -1032,9 +1032,32 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
-                            "068",
-                            "partial_isometries_cycle_graph_monoid(10)",
-                            "[fpsemi-examples][quick][no-valgrind]") {
+                            "070",
+                            "partial_isometries_cycle_graph_monoid(4)",
+                            "[fpsemi-examples][quick]") {
+      auto   rg = ReportGuard(REPORT);
+      size_t n  = 4;
+      auto   s  = partial_isometries_cycle_graph_monoid(n);
+      REQUIRE(s.size() == 13);
+      auto p = make<Presentation<word_type>>(s);
+      p.alphabet(4);
+      presentation::replace_word(p, word_type({}), {3});
+      presentation::add_identity_rules(p, 3);
+      p.validate();
+
+      ToddCoxeter tc(congruence_kind::twosided);
+      tc.set_number_of_generators(4);
+      for (size_t i = 0; i < p.rules.size() - 1; i += 2) {
+        tc.add_pair(p.rules[i], p.rules[i + 1]);
+      }
+      REQUIRE(tc.number_of_classes() == 97);
+    }
+
+    LIBSEMIGROUPS_TEST_CASE(
+        "fpsemi-examples",
+        "068",
+        "partial_isometries_cycle_graph_monoid(10)",
+        "[fpsemi-examples][quick][no-valgrind][no-coverage]") {
       auto   rg = ReportGuard(REPORT);
       size_t n  = 10;
       auto   s  = partial_isometries_cycle_graph_monoid(n);


### PR DESCRIPTION
This PR adds a presentation for the monoid of partial isometries of a cycle graph, as described in Theorem 2.8 [here](https://arxiv.org/pdf/2205.02196.pdf).