### PR TITLE
word: remove `detail::StringToWord`

### DIFF
--- a/ci/run-gap-tests-in-docker-container.sh
+++ b/ci/run-gap-tests-in-docker-container.sh
@@ -4,7 +4,7 @@ set -e
 sudo apt-get --yes update
 
 sudo apt-get install git --yes
-sudo apt-get install libtool-bin --yes 
+sudo apt-get install libtool-bin --yes
 
 # Next commands executed in the container...
 GAP_SEMIGROUPS_BRANCH=main
@@ -30,13 +30,13 @@ git clone -b $GAP_SEMIGROUPS_BRANCH --depth=1 https://github.com/$GAP_SEMIGROUPS
 cd semigroups
 
 # Move the libsemigroups to the correct location
-mv $HOME/libsemigroups . 
+mv $HOME/libsemigroups .
 ./autogen.sh
 ./configure --disable-hpcombi
 make -j4
 
 cd ..
-git clone -b master --depth=1 https://github.com/gap-packages/PackageManager.git 
+git clone -b master --depth=1 https://github.com/gap-packages/PackageManager.git
 
 INSTALL_PKGS="if not InstallPackage(\"https://digraphs.github.io/Digraphs/PackageInfo.g\", false) then QuitGap(1); fi;"
 INSTALL_PKGS+="if not InstallPackage(\"io\", false) then QuitGap(1); fi;"

--- a/docs/source/api/present-helper.rst
+++ b/docs/source/api/present-helper.rst
@@ -51,7 +51,7 @@ Contents
 
    * - :cpp:any:`change_alphabet`
      - change or re-order the alphabet.
-   
+
    * - :cpp:any:`character`
      - Return a `char` by index (ordered for readability).
 
@@ -124,6 +124,9 @@ Contents
    * - :cpp:any:`sort_rules`
      - Sort the rules :math:`u_1 = v_1, \ldots, u_n = v_n` so that
        :math:`u_1v_1 < \cdots < u_nv_n`.
+
+   * - :cpp:any:`make`
+     - Make a string or word from a word or string.
 
 .. cpp:namespace-pop::
 

--- a/include/libsemigroups/make-present.hpp
+++ b/include/libsemigroups/make-present.hpp
@@ -27,7 +27,6 @@
 
 #include "froidure-pin-base.hpp"  // for FroidurePinBase::const_rule_i...
 #include "present.hpp"            // for Presentation
-#include "word.hpp"               // for word_to_string
 
 namespace libsemigroups {
   //! Make presentation from a FroidurePin object.

--- a/include/libsemigroups/present.hpp
+++ b/include/libsemigroups/present.hpp
@@ -1252,7 +1252,119 @@ namespace libsemigroups {
     template <typename W>
     void greedy_reduce_length(Presentation<W>& p);
 
+    //! Construct a `word_type` from a presentation and iterators pointing to a
+    //! `std::string`.
+    //!
+    //! This function returns the `word_type` corresponding to the presentation
+    //! \p p and iterators \p first and \p last. More precisely, if \p first and
+    //! \p last point at a string \c s of length \c n, then the `word_type`
+    //! returned by this function is `{p.index(s[0]), p.index(s[1]), ...,
+    //! p.index(s[n - 1])}`.
+    //!
+    //! \tparam W the return type `word_type`.
+    //! \tparam Iterator the type of the iterators
+    //!
+    //! \param p the presentation
+    //! \param first iterator pointing to the start of the string to convert.
+    //! \param last iterator pointing one past the end of the string to convert.
+    //!
+    //! \throws LibsemigroupsException if Presentation::validate_letter throws
+    //! on any value between \p first and \p last.
+    template <typename W,
+              typename Iterator,
+              typename = std::enable_if_t<std::is_same<W, word_type>::value>>
+    word_type make(Presentation<std::string> const& p,
+                   Iterator                         first,
+                   Iterator                         last);
+
+    //! Construct a `word_type` from a presentation and string.
+    //!
+    //! This function returns the `word_type` corresponding to the presentation
+    //! \p p and \p s. More precisely, if \p s has length \c n, then the
+    //! `word_type` returned by this function is `{p.index(s[0]), p.index(s[1]),
+    //! ..., p.index(s[n - 1])}`.
+    //!
+    //! \tparam W the return type `word_type`.
+    //!
+    //! \param p the presentation
+    //! \param s the string
+    //!
+    //! \throws LibsemigroupsException if Presentation::validate_letter throws
+    //! on any value between \p s.
+    template <typename W,
+              typename = std::enable_if_t<std::is_same<W, word_type>::value>>
+    word_type make(Presentation<std::string> const& p, std::string const& s) {
+      return make<word_type>(p, s.cbegin(), s.cend());
+    }
+
+    //! Construct a `word_type` from a presentation and string.
+    //!
+    //! This function returns the `word_type` corresponding to the presentation
+    //! \p p and \p s. More precisely, if \p s has length \c n, then the
+    //! `word_type` returned by this function is `{p.index(s[0]), p.index(s[1]),
+    //! ..., p.index(s[n - 1])}`.
+    //!
+    //! \tparam W the return type `word_type`.
+    //!
+    //! \param p the presentation
+    //! \param s the string
+    //!
+    //! \throws LibsemigroupsException if Presentation::validate_letter throws
+    //! on any value between \p s.
+    template <typename W,
+              typename = std::enable_if_t<std::is_same<W, word_type>::value>>
+    word_type make(Presentation<std::string> const& p, char const* s) {
+      return make<word_type>(p, s, s + std::strlen(s));
+    }
+
+    //! Construct a `std::string` from a presentation and iterators pointing to
+    //! a `word_type`.
+    //!
+    //! This function returns the `std::string` corresponding to the
+    //! presentation \p p and iterators \p first and \p last. More precisely, if
+    //! \p first and \p last point at a `word_type` \c w of length \c n, then
+    //! the `std::string` returned by this function is `{p.letter(w[0]),
+    //! p.letter(w[1]), ..., p.letter(w[n - 1])}`.
+    //!
+    //! \tparam W the return type `std::string`.
+    //! \tparam Iterator the type of the iterators.
+    //!
+    //! \param p the presentation
+    //! \param first iterator pointing to the start of the word to convert.
+    //! \param last iterator pointing one past the end of the word to convert.
+    //!
+    //! \throws LibsemigroupsException if any value between \p first and \p last
+    //! exceeds `p.alphabet().size()`.
+    template <typename W,
+              typename Iterator,
+              typename = std::enable_if_t<std::is_same<W, std::string>::value>>
+    std::string make(Presentation<std::string> const& p,
+                     Iterator                         first,
+                     Iterator                         last);
+
+    //! Construct a `std::string` from a presentation and iterators pointing to
+    //! a `word_type`.
+    //!
+    //! This function returns the `std::string` corresponding to the
+    //! presentation \p p and word \p w. More precisely, if \p w has length \c
+    //! n, then the `std::string` returned by this function is
+    //! `{p.letter(w[0]), p.letter(w[1]), ..., p.letter(w[n - 1])}`.
+    //!
+    //! \tparam W the return type `std::string`.
+    //!
+    //! \param p the presentation
+    //! \param w the word
+    //!
+    //! \throws LibsemigroupsException if any value in \p w exceeds
+    //! `p.alphabet().size()`.
+    template <typename W,
+              typename = std::enable_if_t<std::is_same<W, std::string>::value>>
+    std::string make(Presentation<std::string> const& p, word_type const& w) {
+      return make<std::string>(p, w.cbegin(), w.cend());
+    }
+
   }  // namespace presentation
+
 }  // namespace libsemigroups
 
 #include "present.tpp"

--- a/include/libsemigroups/present.tpp
+++ b/include/libsemigroups/present.tpp
@@ -160,6 +160,7 @@ namespace libsemigroups {
     if (_alphabet.empty()) {
       LIBSEMIGROUPS_EXCEPTION("no alphabet has been defined");
     } else if (_alphabet_map.find(c) == _alphabet_map.cend()) {
+      // TODO(v3) constexpr
       if (std::is_same<letter_type, char>::value) {
         LIBSEMIGROUPS_EXCEPTION("invalid letter %c, valid letters are %s",
                                 c,
@@ -771,5 +772,39 @@ namespace libsemigroups {
       }
     }
 
+    template <typename W, typename Iterator, typename>
+    word_type make(Presentation<std::string> const& p,
+                   Iterator                         first,
+                   Iterator                         last) {
+      for (auto it = first; it != last; ++it) {
+        // Validate because otherwise index can fail . . .
+        // Don't use validate_word because we don't care if s is empty or not.
+        p.validate_letter(*it);
+      }
+      word_type result(std::distance(first, last), 0);
+      std::transform(
+          first, last, result.begin(), [&p](auto val) { return p.index(val); });
+      return result;
+    }
+
+    template <typename W, typename Iterator, typename>
+    std::string make(Presentation<std::string> const& p,
+                     Iterator                         first,
+                     Iterator                         last) {
+      for (auto it = first; it != last; ++it) {
+        auto const c = *it;
+        if (static_cast<size_t>(c) >= p.alphabet().size()) {
+          LIBSEMIGROUPS_EXCEPTION("invalid letter %llu, valid letter are %s",
+                                  uint64_t(c),
+                                  detail::to_string(p.alphabet()).c_str());
+        }
+      }
+      std::string result(std::distance(first, last), 0);
+      std::transform(first, last, result.begin(), [&p](auto val) {
+        return p.letter(val);
+      });
+      return result;
+    }
   }  // namespace presentation
+
 }  // namespace libsemigroups

--- a/include/libsemigroups/stephen.hpp
+++ b/include/libsemigroups/stephen.hpp
@@ -285,6 +285,62 @@ namespace libsemigroups {
     //! function may never terminate.
     bool accepts(Stephen& s, word_type const& w);
 
+    //! Check if a word is equivalent to Stephen::word.
+    //!
+    //! This function triggers the algorithm implemented in this class (if it
+    //! hasn't been triggered already), and then returns \c true if the input
+    //! word \p w is equivalent to Stephen::word in the semigroup defined by
+    //! Stephen::presentation. A word is equivalent to Stephen::word if it
+    //! labels a path in Stephen::word_graph with source \c 0 and target
+    //! Stephen::accept_state.
+    //!
+    //! \param s the Stephen instance
+    //! \param w an rvalue reference to the input word.
+    //!
+    //! \returns A \c bool.
+    //!
+    //! \throws LibsemigroupsException if no presentation was set at
+    //! the construction of \p s or with Stephen::init.
+    //!
+    //! \warning The problem of determining whether two words are equal in
+    //! a finitely presented semigroup is undecidable in general, and this
+    //! function may never terminate.
+    // TODO uncomment or delete!
+    // bool accepts(Stephen& s, word_type&& w);
+
+    //! Check if a word is equivalent to Stephen::word.
+    //!
+    //! This function triggers the algorithm implemented in this class (if it
+    //! hasn't been triggered already), and then returns \c true if the input
+    //! word \p w is equivalent to Stephen::word in the semigroup defined by
+    //! Stephen::presentation. A word is equivalent to Stephen::word if it
+    //! labels a path in Stephen::word_graph with source \c 0 and target
+    //! Stephen::accept_state.
+    //!
+    //! \tparam Iterator the type of the 2nd and 3rd arguments
+    //!
+    //! \param s the Stephen instance
+    //! \param first an iterator pointing at the first letter of the word to
+    //! check
+    //! \param last an iterator pointing one past the last letter of the word
+    //! to check
+    //!
+    //! \returns A \c bool.
+    //!
+    //! \throws LibsemigroupsException if no presentation was set at
+    //! the construction of \p s or with Stephen::init.
+    //!
+    //! \warning The problem of determining whether two words are equal in
+    //! a finitely presented semigroup is undecidable in general, and this
+    //! function may never terminate.
+    template <typename Iterator>
+    bool accepts(Stephen& s, Iterator first, Iterator last) {
+      using action_digraph_helper::last_node_on_path;
+      s.run();
+      return s.accept_state()
+             == last_node_on_path(s.word_graph(), 0, first, last).first;
+    }
+
     //! Check if a word is a left factor of Stephen::word.
     //!
     //! This function triggers the algorithm implemented in this class (if it

--- a/src/make-present.cpp
+++ b/src/make-present.cpp
@@ -23,7 +23,6 @@
 #include "libsemigroups/exception.hpp"          // for LIBSEMIGROUPS_EXCEPTION
 #include "libsemigroups/froidure-pin-base.hpp"  // for FroidurePinBase::cons...
 #include "libsemigroups/present.hpp"            // for Presentation<>::word_...
-#include "libsemigroups/word.hpp"               // for word_to_string
 
 namespace libsemigroups {
   Presentation<std::string> make(FroidurePinBase&   fp,
@@ -37,12 +36,9 @@ namespace libsemigroups {
     Presentation<std::string> p;
     p.alphabet(alphabet);
     for (auto it = fp.cbegin_rules(); it != fp.cend_rules(); ++it) {
-      presentation::add_rule(
-          p,
-          detail::word_to_string(
-              alphabet, it->first.cbegin(), it->first.cend()),
-          detail::word_to_string(
-              alphabet, it->second.cbegin(), it->second.cend()));
+      presentation::add_rule(p,
+                             presentation::make<std::string>(p, it->first),
+                             presentation::make<std::string>(p, it->second));
     }
 
     return p;

--- a/src/stephen.cpp
+++ b/src/stephen.cpp
@@ -213,11 +213,7 @@ namespace libsemigroups {
   namespace stephen {
 
     bool accepts(Stephen& s, word_type const& w) {
-      using action_digraph_helper::last_node_on_path;
-      s.run();
-      return s.accept_state()
-             == last_node_on_path(s.word_graph(), 0, w.cbegin(), w.cend())
-                    .first;
+      return accepts(s, w.cbegin(), w.cend());
     }
 
     bool is_left_factor(Stephen& s, word_type const& w) {

--- a/tests/test-present.cpp
+++ b/tests/test-present.cpp
@@ -32,8 +32,10 @@
 #include "libsemigroups/present.hpp"       // for Presentation
 #include "libsemigroups/siso.hpp"          // for Sislo
 #include "libsemigroups/types.hpp"         // for word_type
+#include "libsemigroups/word.hpp"          // for operator""_w
 
 namespace libsemigroups {
+  using namespace literals;
 
   struct LibsemigroupsException;  // forward decl
 
@@ -1374,7 +1376,6 @@ namespace libsemigroups {
                           "[quick][presentation]") {
     Presentation<std::string> p;
     p.alphabet("ab");
-    p.rules.clear();
     presentation::add_rule_and_check(p, "aaaaaaaaaaaaaaaa", "a");
     presentation::add_rule_and_check(p, "bbbbbbbbbbbbbbbb", "b");
     presentation::add_rule_and_check(p, "abb", "baa");
@@ -1393,6 +1394,34 @@ namespace libsemigroups {
                                          "d",
                                          "aaaa"}));
     REQUIRE(presentation::longest_common_subword(p) == "");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "039",
+                          "make<word_type>",
+                          "[quick][presentation]") {
+    Presentation<std::string> p;
+    p.alphabet("ab");
+    REQUIRE(presentation::make<word_type>(p, "ab") == 01_w);
+    REQUIRE(presentation::make<word_type>(p, "ba") == 10_w);
+    REQUIRE_THROWS_AS(presentation::make<word_type>(p, "bax"),
+                      LibsemigroupsException);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "041",
+                          "make<std::string>",
+                          "[quick][presentation]") {
+    Presentation<std::string> p;
+    p.alphabet("ab");
+    REQUIRE(presentation::make<std::string>(p, 01_w) == "ab");
+    REQUIRE(presentation::make<std::string>(p, 10_w) == "ba");
+    REQUIRE_THROWS_AS(presentation::make<std::string>(p, 02_w),
+                      LibsemigroupsException);
+    p.alphabet("ab");
+
+    std::vector<char> s = {1, 0};
+    REQUIRE(presentation::make<std::string>(p, s.cbegin(), s.cend()) == "ba");
   }
 
 }  // namespace libsemigroups

--- a/tests/test-stephen.cpp
+++ b/tests/test-stephen.cpp
@@ -48,7 +48,6 @@
 #include "libsemigroups/stephen.hpp"               // for Stephen, Stephen::...
 #include "libsemigroups/todd-coxeter-digraph.hpp"  // for ToddCoxeterDigraph
 #include "libsemigroups/types.hpp"                 // for word_type
-#include "libsemigroups/word.hpp"                  // for StringToWord, word...
 
 namespace libsemigroups {
   namespace {
@@ -96,9 +95,8 @@ namespace libsemigroups {
     void verify_c4_normal_form(Presentation<std::string> const& p,
                                std::string const&               word,
                                std::string const&               nf) {
-      detail::StringToWord string_to_word(p.alphabet());
-      Stephen              S(p);
-      S.set_word(string_to_word(word)).run();
+      Stephen S(p);
+      S.set_word(presentation::make<word_type>(p, word)).run();
 
       auto words = std::vector<word_type>(stephen::cbegin_words_accepted(S),
                                           stephen::cend_words_accepted(S));
@@ -106,7 +104,7 @@ namespace libsemigroups {
 
       std::transform(
           words.cbegin(), words.cend(), strings.begin(), [&p](auto const& w) {
-            return detail::word_to_string(p.alphabet(), w.cbegin(), w.cend());
+            return presentation::make<std::string>(p, w);
           });
 
       std::sort(strings.begin(),
@@ -114,34 +112,31 @@ namespace libsemigroups {
                 LexicographicalCompare<std::string>());
       REQUIRE(strings.front() == nf);
 
-      REQUIRE(std::all_of(strings.cbegin(),
-                          strings.cend(),
-                          [&S, &string_to_word](auto const& w) {
-                            return stephen::accepts(S, string_to_word(w));
-                          }));
+      REQUIRE(std::all_of(
+          strings.cbegin(), strings.cend(), [&S, &p](auto const& w) {
+            return stephen::accepts(S, presentation::make<word_type>(p, w));
+          }));
       REQUIRE(stephen::number_of_words_accepted(S) == strings.size());
     }
 
     void verify_c4_equal_to(Presentation<std::string> const& p,
                             std::string const&               word1,
                             std::string const&               word2) {
-      detail::StringToWord string_to_word(p.alphabet());
-      Stephen              S(p);
-      S.set_word(string_to_word(word1)).run();
-      REQUIRE(stephen::accepts(S, string_to_word(word2)));
-      S.set_word(string_to_word(word2)).run();
-      REQUIRE(stephen::accepts(S, string_to_word(word1)));
+      Stephen S(p);
+      S.set_word(presentation::make<word_type>(p, word1)).run();
+      REQUIRE(stephen::accepts(S, presentation::make<word_type>(p, word2)));
+      S.set_word(presentation::make<word_type>(p, word2)).run();
+      REQUIRE(stephen::accepts(S, presentation::make<word_type>(p, word1)));
     }
 
     void verify_c4_not_equal_to(Presentation<std::string> const& p,
                                 std::string const&               word1,
                                 std::string const&               word2) {
-      detail::StringToWord string_to_word(p.alphabet());
-      Stephen              S(p);
-      S.set_word(string_to_word(word1)).run();
-      REQUIRE(!stephen::accepts(S, string_to_word(word2)));
-      S.set_word(string_to_word(word2)).run();
-      REQUIRE(!stephen::accepts(S, string_to_word(word1)));
+      Stephen S(p);
+      S.set_word(presentation::make<word_type>(p, word1)).run();
+      REQUIRE(!stephen::accepts(S, presentation::make<word_type>(p, word2)));
+      S.set_word(presentation::make<word_type>(p, word2)).run();
+      REQUIRE(!stephen::accepts(S, presentation::make<word_type>(p, word1)));
     }
 
   }  // namespace
@@ -407,24 +402,24 @@ namespace libsemigroups {
     presentation::add_rule_and_check(p, "bbb", "b");
     presentation::add_rule_and_check(p, "abab", "aa");
 
-    Stephen              S(p);
-    detail::StringToWord string_to_word("ab");
-    S.set_word(string_to_word("bbab"));
+    Stephen S(p);
+    S.set_word(presentation::make<word_type>(p, "bbab"));
 
-    REQUIRE(stephen::accepts(S, string_to_word("bbaaba")));
-    REQUIRE(!stephen::accepts(S, string_to_word("")));
-    REQUIRE(!stephen::accepts(S, string_to_word("aaaaaaaaaa")));
-    REQUIRE(!stephen::accepts(S, string_to_word("bbb")));
+    REQUIRE(stephen::accepts(S, presentation::make<word_type>(p, "bbaaba")));
+    REQUIRE(!stephen::accepts(S, presentation::make<word_type>(p, "")));
+    REQUIRE(
+        !stephen::accepts(S, presentation::make<word_type>(p, "aaaaaaaaaa")));
+    REQUIRE(!stephen::accepts(S, presentation::make<word_type>(p, "bbb")));
 
-    S.set_word(string_to_word("bba"));
-    REQUIRE(stephen::accepts(S, string_to_word("bbabb")));
-    REQUIRE(stephen::accepts(S, string_to_word("bba")));
-    REQUIRE(!stephen::accepts(S, string_to_word("bbb")));
-    REQUIRE(!stephen::accepts(S, string_to_word("a")));
-    REQUIRE(!stephen::accepts(S, string_to_word("ab")));
+    S.set_word(presentation::make<word_type>(p, "bba"));
+    REQUIRE(stephen::accepts(S, presentation::make<word_type>(p, "bbabb")));
+    REQUIRE(stephen::accepts(S, presentation::make<word_type>(p, "bba")));
+    REQUIRE(!stephen::accepts(S, presentation::make<word_type>(p, "bbb")));
+    REQUIRE(!stephen::accepts(S, presentation::make<word_type>(p, "a")));
+    REQUIRE(!stephen::accepts(S, presentation::make<word_type>(p, "ab")));
 
-    S.set_word(string_to_word("bbaab"));
-    REQUIRE(stephen::accepts(S, string_to_word("bbaba")));
+    S.set_word(presentation::make<word_type>(p, "bbaab"));
+    REQUIRE(stephen::accepts(S, presentation::make<word_type>(p, "bbaba")));
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
@@ -436,11 +431,11 @@ namespace libsemigroups {
     presentation::add_rule_and_check(p, "aaaeaa", "abcd");
     presentation::add_rule_and_check(p, "ef", "dg");
 
-    Stephen              S(p);
-    detail::StringToWord string_to_word("abcdefg");
+    Stephen S(p);
 
-    S.set_word(string_to_word("abcef")).run();
-    REQUIRE(string_to_word("abcef") == word_type({0, 1, 2, 4, 5}));
+    S.set_word(presentation::make<word_type>(p, "abcef")).run();
+    REQUIRE(presentation::make<word_type>(p, "abcef")
+            == word_type({0, 1, 2, 4, 5}));
     REQUIRE(S.word_graph()
             == action_digraph_helper::make<size_t>(
                 11,
@@ -509,11 +504,11 @@ namespace libsemigroups {
                   UNDEFINED,
                   UNDEFINED,
                   UNDEFINED}}));
-    auto rule = string_to_word(p.rules[0]);
+    auto rule = presentation::make<word_type>(p, p.rules[0]);
     auto m    = action_digraph_helper::last_node_on_path(
                  S.word_graph(), 0, rule.cbegin(), rule.cend())
                  .first;
-    rule   = string_to_word(p.rules[1]);
+    rule   = presentation::make<word_type>(p, p.rules[1]);
     auto n = action_digraph_helper::last_node_on_path(
                  S.word_graph(), 0, rule.cbegin(), rule.cend())
                  .first;
@@ -521,25 +516,25 @@ namespace libsemigroups {
     REQUIRE(n != UNDEFINED);
     REQUIRE(m == n);
     REQUIRE(S.word_graph().number_of_nodes() == 11);
-    REQUIRE(stephen::accepts(S, string_to_word("aaaeaag")));
+    REQUIRE(stephen::accepts(S, presentation::make<word_type>(p, "aaaeaag")));
     REQUIRE(stephen::number_of_words_accepted(S) == 3);
     REQUIRE(std::vector<word_type>(stephen::cbegin_words_accepted(S),
                                    stephen::cend_words_accepted(S))
             == std::vector<word_type>(
                 {{0, 1, 2, 3, 6}, {0, 1, 2, 4, 5}, {0, 0, 0, 4, 0, 0, 6}}));
 
-    S.set_word(string_to_word("aaaeaaaeaa")).run();
+    S.set_word(presentation::make<word_type>(p, "aaaeaaaeaa")).run();
 
     REQUIRE(S.word_graph().number_of_nodes() == 15);
     REQUIRE(stephen::number_of_words_accepted(S) == 3);
-    REQUIRE(stephen::accepts(S, string_to_word("aaaeabcd")));
+    REQUIRE(stephen::accepts(S, presentation::make<word_type>(p, "aaaeabcd")));
     REQUIRE(std::vector<word_type>(stephen::cbegin_words_accepted(S),
                                    stephen::cend_words_accepted(S))
             == std::vector<word_type>({{0, 0, 0, 4, 0, 1, 2, 3},
                                        {0, 1, 2, 3, 0, 4, 0, 0},
                                        {0, 0, 0, 4, 0, 0, 0, 4, 0, 0}}));
 
-    S.set_word(string_to_word("aaaeaag")).run();
+    S.set_word(presentation::make<word_type>(p, "aaaeaag")).run();
     REQUIRE(S.word_graph().number_of_nodes() == 11);
     REQUIRE(stephen::number_of_words_accepted(S) == 3);
     REQUIRE(std::vector<word_type>(stephen::cbegin_words_accepted(S),
@@ -564,10 +559,9 @@ namespace libsemigroups {
     presentation::add_rule_and_check(p, "cc", "b");
     presentation::add_rule_and_check(p, "a", "b");
 
-    Stephen              S(p);
-    detail::StringToWord string_to_word("abc");
-    S.set_word(string_to_word("abcc")).run();
-    REQUIRE(stephen::accepts(S, string_to_word("baac")));
+    Stephen S(p);
+    S.set_word(presentation::make<word_type>(p, "abcc")).run();
+    REQUIRE(stephen::accepts(S, presentation::make<word_type>(p, "baac")));
     REQUIRE(S.word_graph().number_of_nodes() == 3);
     REQUIRE(stephen::number_of_words_accepted(S) == POSITIVE_INFINITY);
   }
@@ -590,10 +584,9 @@ namespace libsemigroups {
     presentation::add_rule_and_check(p, "cd", "c");
     presentation::add_rule_and_check(p, "dc", "c");
 
-    Stephen              S(p);
-    detail::StringToWord string_to_word("abcd");
-    S.set_word(string_to_word("dabdaaadabab")).run();
-    REQUIRE(stephen::accepts(S, string_to_word("abdadcaca")));
+    Stephen S(p);
+    S.set_word(presentation::make<word_type>(p, "dabdaaadabab")).run();
+    REQUIRE(stephen::accepts(S, presentation::make<word_type>(p, "abdadcaca")));
     REQUIRE(S.word_graph().number_of_nodes() == 25);
     REQUIRE(stephen::number_of_words_accepted(S) == POSITIVE_INFINITY);
   }
@@ -621,9 +614,8 @@ namespace libsemigroups {
     presentation::add_rule_and_check(p, "abcd", "ce");
     presentation::add_rule_and_check(p, "df", "dg");
 
-    detail::StringToWord string_to_word("abcdefg");
-    Stephen              S(p);
-    S.set_word(string_to_word("dfabcdf")).run();
+    Stephen S(p);
+    S.set_word(presentation::make<word_type>(p, "dfabcdf")).run();
 
     REQUIRE(S.word_graph().number_of_nodes() == 9);
     REQUIRE(stephen::number_of_words_accepted(S) == 8);
@@ -634,7 +626,7 @@ namespace libsemigroups {
 
     std::transform(
         words.cbegin(), words.cend(), strings.begin(), [&p](auto const& w) {
-          return detail::word_to_string(p.alphabet(), w.cbegin(), w.cend());
+          return presentation::make<std::string>(p, w);
         });
 
     REQUIRE(strings
@@ -650,13 +642,13 @@ namespace libsemigroups {
         strings.begin(), strings.end(), LexicographicalCompare<std::string>());
     REQUIRE(strings.front() == "dfabcdf");
 
-    REQUIRE(std::all_of(
-        strings.cbegin(), strings.cend(), [&S, &string_to_word](auto const& w) {
-          return stephen::accepts(S, string_to_word(w));
+    REQUIRE(
+        std::all_of(strings.cbegin(), strings.cend(), [&S, &p](auto const& w) {
+          return stephen::accepts(S, presentation::make<word_type>(p, w));
         }));
     REQUIRE(stephen::number_of_words_accepted(S) == strings.size());
 
-    S.set_word(string_to_word("abcdfceg")).run();
+    S.set_word(presentation::make<word_type>(p, "abcdfceg")).run();
     REQUIRE(stephen::number_of_words_accepted(S) == 16);
     words = std::vector<word_type>(stephen::cbegin_words_accepted(S),
                                    stephen::cend_words_accepted(S));
@@ -664,7 +656,7 @@ namespace libsemigroups {
 
     std::transform(
         words.cbegin(), words.cend(), strings.begin(), [&p](auto const& w) {
-          return detail::word_to_string(p.alphabet(), w.cbegin(), w.cend());
+          return presentation::make<std::string>(p, w);
         });
 
     std::sort(
@@ -688,7 +680,8 @@ namespace libsemigroups {
                                          "cegceg"}));
 
     REQUIRE(strings.front() == "abcdfabcdf");
-    REQUIRE(stephen::accepts(S, string_to_word("abcdfabcdf")));
+    REQUIRE(
+        stephen::accepts(S, presentation::make<word_type>(p, "abcdfabcdf")));
   }
 
   LIBSEMIGROUPS_TEST_CASE(
@@ -701,25 +694,24 @@ namespace libsemigroups {
     p.alphabet("cab");
     presentation::add_rule_and_check(p, "aabc", "acba");
 
-    detail::StringToWord string_to_word("cab");
-    Stephen              S(p);
-    S.set_word(string_to_word("a")).run();
-    REQUIRE(!stephen::accepts(S, string_to_word("b")));
+    Stephen S(p);
+    S.set_word(presentation::make<word_type>(p, "a")).run();
+    REQUIRE(!stephen::accepts(S, presentation::make<word_type>(p, "b")));
 
-    S.set_word(string_to_word("aabcabc")).run();
-    REQUIRE(stephen::accepts(S, string_to_word("aabccba")));
+    S.set_word(presentation::make<word_type>(p, "aabcabc")).run();
+    REQUIRE(stephen::accepts(S, presentation::make<word_type>(p, "aabccba")));
 
-    S.set_word(string_to_word("aabccba")).run();
-    REQUIRE(stephen::accepts(S, string_to_word("aabcabc")));
+    S.set_word(presentation::make<word_type>(p, "aabccba")).run();
+    REQUIRE(stephen::accepts(S, presentation::make<word_type>(p, "aabcabc")));
 
-    S.set_word(string_to_word("acba")).run();
+    S.set_word(presentation::make<word_type>(p, "acba")).run();
     auto words = std::vector<word_type>(stephen::cbegin_words_accepted(S),
                                         stephen::cend_words_accepted(S));
     std::vector<std::string> strings(words.size(), "");
 
     std::transform(
         words.cbegin(), words.cend(), strings.begin(), [&p](auto const& w) {
-          return detail::word_to_string(p.alphabet(), w.cbegin(), w.cend());
+          return presentation::make<std::string>(p, w);
         });
 
     REQUIRE(strings == std::vector<std::string>({"acba", "aabc"}));
@@ -735,48 +727,47 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(Stephen(p), LibsemigroupsException);
     p.alphabet("abcdefg");
 
-    detail::StringToWord string_to_word("abcdefg");
-    Stephen              S(p);
-    auto                 w = string_to_word("abbbddbcbcbc");
+    Stephen S(p);
+    auto    w = presentation::make<word_type>(p, "abbbddbcbcbc");
     S.set_word(w);
     S.run();
     REQUIRE(S.finished());
     S.run();
-    S.set_word(string_to_word("abbbddbcbcbc"));  // resets
+    S.set_word(presentation::make<word_type>(p, "abbbddbcbcbc"));  // resets
     S.report_every(std::chrono::microseconds(10));
 
     S.run();
 
     Stephen T(S);
     REQUIRE(stephen::accepts(T, w));
-    REQUIRE(!stephen::accepts(T, string_to_word("abbbd")));
+    REQUIRE(!stephen::accepts(T, presentation::make<word_type>(p, "abbbd")));
     REQUIRE(stephen::number_of_words_accepted(T) == 1);
     REQUIRE(stephen::number_of_left_factors(T) == w.size() + 1);
     REQUIRE(stephen::accepts(S, w));
-    REQUIRE(!stephen::accepts(S, string_to_word("abbbd")));
+    REQUIRE(!stephen::accepts(S, presentation::make<word_type>(p, "abbbd")));
     REQUIRE(stephen::number_of_words_accepted(S) == 1);
     REQUIRE(stephen::number_of_left_factors(S) == w.size() + 1);
 
     Stephen U(std::move(S));
     REQUIRE(stephen::accepts(U, w));
-    REQUIRE(!stephen::accepts(U, string_to_word("abbbd")));
+    REQUIRE(!stephen::accepts(U, presentation::make<word_type>(p, "abbbd")));
     REQUIRE(stephen::number_of_words_accepted(U) == 1);
     REQUIRE(stephen::number_of_left_factors(U) == w.size() + 1);
 
     S = T;
     REQUIRE(stephen::accepts(T, w));
-    REQUIRE(!stephen::accepts(T, string_to_word("abbbd")));
+    REQUIRE(!stephen::accepts(T, presentation::make<word_type>(p, "abbbd")));
     REQUIRE(stephen::number_of_words_accepted(T) == 1);
     REQUIRE(stephen::number_of_left_factors(T) == w.size() + 1);
     REQUIRE(stephen::accepts(S, w));
-    REQUIRE(!stephen::accepts(S, string_to_word("abbbd")));
+    REQUIRE(!stephen::accepts(S, presentation::make<word_type>(p, "abbbd")));
     REQUIRE(stephen::number_of_words_accepted(S) == 1);
     REQUIRE(stephen::number_of_left_factors(S) == w.size() + 1);
 
     Stephen V;
     V = std::move(S);
     REQUIRE(stephen::accepts(V, w));
-    REQUIRE(!stephen::accepts(V, string_to_word("abbbd")));
+    REQUIRE(!stephen::accepts(V, presentation::make<word_type>(p, "abbbd")));
     REQUIRE(stephen::number_of_words_accepted(V) == 1);
     REQUIRE(stephen::number_of_left_factors(V) == w.size() + 1);
     REQUIRE(V.word() == w);
@@ -833,7 +824,7 @@ namespace libsemigroups {
     presentation::add_rule_and_check(p, "ei", "j");
 
     verify_c4_equal_to(p, "afdj", "bgdj");
-    verify_c4_not_equal_to(p, "xxxxxxxxxxxxxxxxxxxxxxx", "b");
+    verify_c4_not_equal_to(p, "jjjjjjjjjjj", "b");
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",

--- a/tests/test-word.cpp
+++ b/tests/test-word.cpp
@@ -33,14 +33,6 @@ namespace libsemigroups {
     REQUIRE(number_of_words(2, 4, 2) == 0);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("string_to_word", "002", "", "[quick]") {
-    detail::StringToWord string_to_word("BCA");
-    REQUIRE(string_to_word("BCABACB") == word_type({0, 1, 2, 0, 2, 1, 0}));
-    REQUIRE(string_to_word("B") == word_type({0}));
-    REQUIRE(string_to_word("C") == word_type({1}));
-    REQUIRE(string_to_word("A") == word_type({2}));
-  }
-
   LIBSEMIGROUPS_TEST_CASE("operator\"\" _w", "003", "literal", "[quick]") {
     using namespace literals;
     REQUIRE(0120210_w == word_type({0, 1, 2, 0, 2, 1, 0}));


### PR DESCRIPTION
This is only partially done, I'd like to actually remove/rename `StringToWord` and `word_to_string` and replace them with `make`