### PR TITLE
Add `congruence_kind` argument check to `ToddCoxeter` function `to_gap_string`

### DIFF
--- a/include/libsemigroups/todd-coxeter.hpp
+++ b/include/libsemigroups/todd-coxeter.hpp
@@ -1706,8 +1706,9 @@ namespace libsemigroups {
       //! \returns
       //! A \c std::string.
       //!
-      //! \throws LibsemigroupsException if the number of generators exceeds
-      //! 49.
+      //! \throws LibsemigroupsException if the ToddCoxeter instance does not
+      //! have kind `twosided`.
+      //! \throws LibsemigroupsException if the number of generators exceeds 49.
       std::string to_gap_string();
 
      private:

--- a/src/todd-coxeter.cpp
+++ b/src/todd-coxeter.cpp
@@ -1502,6 +1502,11 @@ namespace libsemigroups {
     std::string ToddCoxeter::to_gap_string() {
       std::string const alphabet
           = "abcdefghijklmnopqrstuvwxyzABCDFGHIJKLMNOPQRSTUVWY";
+      if (kind() != congruence_kind::twosided) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected congruence kind to be twosided, found "
+            + congruence_kind_to_string(kind()));
+      }
       if (number_of_generators() > 49) {
         LIBSEMIGROUPS_EXCEPTION("expected at most 49 generators, found %llu!",
                                 uint64_t(number_of_generators()));

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -2735,6 +2735,26 @@ namespace libsemigroups {
       REQUIRE(tc.number_of_classes() == 823543);
     }
 
+    LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                            "110",
+                            "to_gap_string",
+                            "[todd-coxeter][quick]") {
+      ToddCoxeter tc1(congruence_kind::right);
+      tc1.set_number_of_generators(2);
+      tc1.add_pair({0, 1}, {1, 0});
+      REQUIRE_THROWS_AS(tc1.to_gap_string(), LibsemigroupsException);
+
+      ToddCoxeter tc2(congruence_kind::left);
+      tc2.set_number_of_generators(2);
+      tc2.add_pair({0, 1}, {1, 0});
+      REQUIRE_THROWS_AS(tc2.to_gap_string(), LibsemigroupsException);
+
+      ToddCoxeter tc3(congruence_kind::twosided);
+      tc3.set_number_of_generators(2);
+      tc3.add_pair({0, 1}, {1, 0});
+      REQUIRE(tc3.to_gap_string().size() > 0);
+    }
+
   }  // namespace congruence
 
   namespace fpsemigroup {
@@ -4284,5 +4304,6 @@ namespace libsemigroups {
       REQUIRE(tc.size() == 1'451'520);
       std::cout << tc.congruence().stats_string();
     }
+
   }  // namespace fpsemigroup
 }  // namespace libsemigroups


### PR DESCRIPTION
This PR adds an argument check to the `ToddCoxeter` function `to_gap_string`, to require that this only be done where the `ToddCoxeter` instance is `twosided`.