### PR TITLE
Remove auto return type from `first_unused_letter`

### DIFF
--- a/include/libsemigroups/present.hpp
+++ b/include/libsemigroups/present.hpp
@@ -1211,7 +1211,8 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if \p p already has an alphabet of
     //! the maximum possible size supported by `letter_type`.
     template <typename W>
-    auto first_unused_letter(Presentation<W> const& p);
+    typename Presentation<W>::letter_type
+    first_unused_letter(Presentation<W> const& p);
 
     //! Convert a monoid presentation to a semigroup presentation.
     //!

--- a/include/libsemigroups/present.tpp
+++ b/include/libsemigroups/present.tpp
@@ -720,7 +720,8 @@ namespace libsemigroups {
     }
 
     template <typename W>
-    auto first_unused_letter(Presentation<W> const& p) {
+    typename Presentation<W>::letter_type
+    first_unused_letter(Presentation<W> const& p) {
       using letter_type = typename Presentation<W>::letter_type;
       using size_type   = typename W::size_type;
 


### PR DESCRIPTION
This is an attempt to resolve the issues building wheels in, for example,

https://github.com/libsemigroups/libsemigroups_pybind11/actions/runs/4263330603/jobs/7419929200