### PR TITLE
Remove a pessimizing move

### DIFF
--- a/include/libsemigroups/sims1.tpp
+++ b/include/libsemigroups/sims1.tpp
@@ -1000,7 +1000,7 @@ namespace libsemigroups {
     }
 
     hi                    = best.number_of_nodes();
-    ActionDigraph<T> next = std::move(cr.max_nodes(hi - 1).digraph());
+    ActionDigraph<T> next = cr.max_nodes(hi - 1).digraph();
     while (next.number_of_nodes() != 0) {
       hi   = next.number_of_nodes();
       best = std::move(next);


### PR DESCRIPTION
A call to `std::move` requires that 2 copies of an object exist, the source and the target of the move.  In this case, the compiler knows how to eliminate 1 copy entirely, but is prevented from doing so by the move.  GCC says:
```
In file included from /builddir/build/BUILD/libsemigroups-2.6.1/include/libsemigroups/sims1.hpp:1269,
                 from tests/test-sims1.cpp:36:
/builddir/build/BUILD/libsemigroups-2.6.1/include/libsemigroups/sims1.tpp: In instantiation of 'libsemigroups::ActionDigraph<T> libsemigroups::MinimalRepOrc::digraph() const [with T = unsigned int]':
tests/test-sims1.cpp:759:26:   required from here
/builddir/build/BUILD/libsemigroups-2.6.1/include/libsemigroups/sims1.tpp:1003:22: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
 1003 |     ActionDigraph<T> next = std::move(cr.max_nodes(hi - 1).digraph());
      |                      ^~~~
/builddir/build/BUILD/libsemigroups-2.6.1/include/libsemigroups/sims1.tpp:1003:22: note: remove 'std::move' call
```