### PR TITLE
Fix some compiler warnings when using GCC

### DIFF
--- a/benchmarks/bench-konieczny.cpp
+++ b/benchmarks/bench-konieczny.cpp
@@ -58,7 +58,7 @@ namespace libsemigroups {
 
     template <typename Mat>
     T operator()(Mat const& x) const {
-      T     res;
+      T res;
       this->operator()(res, x);
       return res;
     }
@@ -89,7 +89,7 @@ namespace libsemigroups {
 
     template <typename Mat>
     T operator()(Mat const& x) const {
-      T     res;
+      T res;
       this->operator()(res, x);
       return res;
     }

--- a/include/libsemigroups/digraph-with-sources.hpp
+++ b/include/libsemigroups/digraph-with-sources.hpp
@@ -67,6 +67,7 @@ namespace libsemigroups {
     DigraphWithSources(DigraphWithSources const&)            = default;
     DigraphWithSources& operator=(DigraphWithSources const&) = default;
     DigraphWithSources& operator=(DigraphWithSources&&)      = default;
+    ~DigraphWithSources();
 
     void init(size_type m, size_type n);
 

--- a/include/libsemigroups/digraph-with-sources.tpp
+++ b/include/libsemigroups/digraph-with-sources.tpp
@@ -21,6 +21,9 @@
 
 namespace libsemigroups {
 
+  template <typename T>
+  DigraphWithSources<T>::~DigraphWithSources() = default;
+
   // number of nodes, out-degree
   template <typename T>
   void DigraphWithSources<T>::init(size_type m, size_type n) {

--- a/include/libsemigroups/int-range.hpp
+++ b/include/libsemigroups/int-range.hpp
@@ -116,7 +116,7 @@ namespace libsemigroups {
       }
 
       const_iterator operator--(int) noexcept {
-        const_iterator  tmp(*this);
+        const_iterator tmp(*this);
         const_iterator::operator--();
         return tmp;
       }

--- a/include/libsemigroups/kambites.hpp
+++ b/include/libsemigroups/kambites.hpp
@@ -309,7 +309,7 @@ namespace libsemigroups {
       // init_XYZ_data is split into the function that really does the work
       // (really_init_XYZ_data) which is called once, and init_XYZ_data which
       // can be called very often.
-      inline void init_XYZ_data(size_t i) const {
+      void init_XYZ_data(size_t i) const {
         LIBSEMIGROUPS_ASSERT(i < _relation_words.size());
         if (_XYZ_data.empty()) {
           _XYZ_data.resize(_relation_words.size());
@@ -557,6 +557,7 @@ namespace libsemigroups {
       // Data structure for caching the regularly accessed parts of the
       // relation words.
       struct RelationWords {
+        ~RelationWords();
         using internal_type          = Kambites::internal_type;
         bool          is_initialized = false;
         internal_type X;
@@ -616,6 +617,9 @@ namespace libsemigroups {
 
     template <typename T>
     Kambites<T>::~Kambites() = default;
+
+    template <typename T>
+    Kambites<T>::RelationWords::~RelationWords() = default;
 
     ////////////////////////////////////////////////////////////////////////
     // FpSemigroupInterface - pure virtual functions impl - public

--- a/include/libsemigroups/present.hpp
+++ b/include/libsemigroups/present.hpp
@@ -110,6 +110,8 @@ namespace libsemigroups {
     //! Default move assignment operator.
     Presentation& operator=(Presentation&&) = default;
 
+    ~Presentation();
+
     //! Returns the alphabet of the presentation.
     //!
     //! \returns A const reference to Presentation::word_type

--- a/include/libsemigroups/present.tpp
+++ b/include/libsemigroups/present.tpp
@@ -129,6 +129,9 @@ namespace libsemigroups {
       : _alphabet(), _alphabet_map(), _contains_empty_word(false), rules() {}
 
   template <typename W>
+  Presentation<W>::~Presentation() = default;
+
+  template <typename W>
   void Presentation<W>::clear() {
     _alphabet.clear();
     _alphabet_map.clear();

--- a/include/libsemigroups/report.hpp
+++ b/include/libsemigroups/report.hpp
@@ -438,6 +438,8 @@ namespace libsemigroups {
       explicit PrintTable(size_t width = 72)
           : _rows(), _header(), _footer(), _width(width) {}
 
+      ~PrintTable();
+
       std::string emit() {
         std::string result = lineohash() + _header + lineohash();
         for (auto const& row : _rows) {

--- a/include/libsemigroups/stephen.hpp
+++ b/include/libsemigroups/stephen.hpp
@@ -328,10 +328,10 @@ namespace libsemigroups {
     //!
     //! \sa ActionDigraph::cbegin_pstislo for more information about the
     //! iterators returned by this function.
-    const_iterator_words_accepted cbegin_words_accepted(Stephen& s,
-                                                        size_t   min = 0,
-                                                        size_t   max
-                                                        = POSITIVE_INFINITY) {
+    inline const_iterator_words_accepted
+    cbegin_words_accepted(Stephen& s,
+                          size_t   min = 0,
+                          size_t   max = POSITIVE_INFINITY) {
       s.run();
       return s.word_graph().cbegin_pstislo(0, s.accept_state(), min, max);
     }
@@ -341,7 +341,7 @@ namespace libsemigroups {
     //!
     //! \sa \ref cbegin_words_accepted for more information.
     // Not noexcept because cend_pstislo isn't
-    const_iterator_words_accepted cend_words_accepted(Stephen& s) {
+    inline const_iterator_words_accepted cend_words_accepted(Stephen& s) {
       s.run();
       return s.word_graph().cend_pstislo();
     }
@@ -369,10 +369,10 @@ namespace libsemigroups {
     //! \sa ActionDigraph::cbegin_pislo for more information about the
     //! iterators returned by this function.
     // Not noexcept because cbegin_pislo isn't
-    const_iterator_left_factors cbegin_left_factors(Stephen& s,
-                                                    size_t   min = 0,
-                                                    size_t   max
-                                                    = POSITIVE_INFINITY) {
+    inline const_iterator_left_factors
+    cbegin_left_factors(Stephen& s,
+                        size_t   min = 0,
+                        size_t   max = POSITIVE_INFINITY) {
       s.run();
       return s.word_graph().cbegin_pislo(0, min, max);
     }
@@ -382,7 +382,7 @@ namespace libsemigroups {
     //!
     //! \sa \ref cbegin_left_factors for more information.
     // Not noexcept because cend_pislo isn't
-    const_iterator_left_factors cend_left_factors(Stephen& s) {
+    inline const_iterator_left_factors cend_left_factors(Stephen& s) {
       s.run();
       return s.word_graph().cend_pislo();
     }
@@ -408,9 +408,9 @@ namespace libsemigroups {
     //!
     //! \sa ActionDigraph::number_of_paths.
     // Not noexcept because number_of_paths isn't
-    uint64_t number_of_words_accepted(Stephen& s,
-                                      size_t   min = 0,
-                                      size_t   max = POSITIVE_INFINITY) {
+    inline uint64_t number_of_words_accepted(Stephen& s,
+                                             size_t   min = 0,
+                                             size_t   max = POSITIVE_INFINITY) {
       s.run();
       return s.word_graph().number_of_paths(0, s.accept_state(), min, max);
     }
@@ -438,9 +438,9 @@ namespace libsemigroups {
     //! construction or with Stephen::init.
     // Number of words that represent left factors of word()
     // Not noexcept because number_of_paths isn't
-    uint64_t number_of_left_factors(Stephen& s,
-                                    size_t   min = 0,
-                                    size_t   max = POSITIVE_INFINITY) {
+    inline uint64_t number_of_left_factors(Stephen& s,
+                                           size_t   min = 0,
+                                           size_t   max = POSITIVE_INFINITY) {
       s.run();
       return s.word_graph().number_of_paths(0, min, max);
     }

--- a/include/libsemigroups/todd-coxeter.hpp
+++ b/include/libsemigroups/todd-coxeter.hpp
@@ -2002,7 +2002,7 @@ namespace libsemigroups {
       }
 
       template <typename TStackDeduct>
-      inline void def_edge(coset_type c, letter_type x, coset_type d) noexcept {
+      void def_edge(coset_type c, letter_type x, coset_type d) noexcept {
         LIBSEMIGROUPS_ASSERT(is_valid_coset(c));
         LIBSEMIGROUPS_ASSERT(x < number_of_generators());
         LIBSEMIGROUPS_ASSERT(is_valid_coset(d));

--- a/include/libsemigroups/ukkonen.hpp
+++ b/include/libsemigroups/ukkonen.hpp
@@ -283,6 +283,12 @@ namespace libsemigroups {
     Ukkonen& operator=(Ukkonen&&) = default;
 
     ////////////////////////////////////////////////////////////////////////
+    // Ukkonen - destructors - public
+    ////////////////////////////////////////////////////////////////////////
+
+    ~Ukkonen();
+
+    ////////////////////////////////////////////////////////////////////////
     // Ukkonen - initialisation - public
     ////////////////////////////////////////////////////////////////////////
 
@@ -1785,6 +1791,7 @@ namespace libsemigroups {
         GreedyReduceHelper(GreedyReduceHelper&&)                 = delete;
         GreedyReduceHelper& operator=(GreedyReduceHelper const&) = delete;
         GreedyReduceHelper& operator=(GreedyReduceHelper&&)      = delete;
+        ~GreedyReduceHelper();
 
         void pre_order(Ukkonen const& u, size_t v);
         void post_order(Ukkonen const& u, size_t v);

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -145,6 +145,8 @@ namespace libsemigroups {
         _options.resize(n);
       }
     }
+
+    PrintTable::~PrintTable() = default;
   }  // namespace detail
 
   namespace report {

--- a/src/ukkonen.cpp
+++ b/src/ukkonen.cpp
@@ -79,6 +79,12 @@ namespace libsemigroups {
         _word() {}
 
   ////////////////////////////////////////////////////////////////////////
+  // Ukkonen - destructors - public
+  ////////////////////////////////////////////////////////////////////////
+
+  Ukkonen::~Ukkonen() = default;
+
+  ////////////////////////////////////////////////////////////////////////
   // Ukkonen - initialisation - public
   ////////////////////////////////////////////////////////////////////////
 
@@ -110,10 +116,10 @@ namespace libsemigroups {
     }
 
     for (node_index_type i = old_nr_nodes; i < _nodes.size(); ++i) {
-      auto& n = _nodes[i];
-      for (auto const& child : n.children) {
+      auto& node = _nodes[i];
+      for (auto const& child : node.children) {
         if (is_unique_letter(child.first)) {
-          n.is_real_suffix = true;
+          node.is_real_suffix = true;
           break;
         }
       }
@@ -581,6 +587,8 @@ namespace libsemigroups {
             _num_leafs(st.nodes().size(), 0),
             _scratch(),
             _suffix_index() {}
+
+      GreedyReduceHelper::~GreedyReduceHelper() = default;
 
       void GreedyReduceHelper::pre_order(Ukkonen const& st, size_t v) {
         auto const& nodes = st.nodes();

--- a/src/word.cpp
+++ b/src/word.cpp
@@ -64,14 +64,14 @@ namespace libsemigroups {
 
   word_type detail::StringToWord::operator()(std::string const& input) const {
     word_type output;
-              operator()(input, output);
+    operator()(input, output);
     return output;
   }
 
   namespace literals {
     word_type operator"" _w(const char* w, size_t n) {
       word_type result;
-#if LIBSEMIGROUPS_DEBUG
+#ifdef LIBSEMIGROUPS_DEBUG
       static const std::string valid_chars = "0123456789";
 #endif
       for (size_t i = 0; i < n; ++i) {

--- a/tests/test-containers.cpp
+++ b/tests/test-containers.cpp
@@ -612,7 +612,7 @@ namespace libsemigroups {
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(10, 10, 3);
       DynamicArray2<size_t> rv2 = DynamicArray2<size_t>(9, 9, 2);
-      rv1.                  operator=(rv2);
+      rv1.operator=(rv2);
       REQUIRE(rv1.number_of_cols() == 9);
       REQUIRE(rv1.number_of_rows() == 9);
       REQUIRE(std::all_of(
@@ -624,7 +624,7 @@ namespace libsemigroups {
 
       DynamicArray2<bool> rv3 = DynamicArray2<bool>(10, 10, false);
       DynamicArray2<bool> rv4 = DynamicArray2<bool>(9, 9, true);
-      rv3.                operator=(rv4);
+      rv3.operator=(rv4);
       REQUIRE(rv3.number_of_cols() == 9);
       REQUIRE(rv3.number_of_rows() == 9);
       REQUIRE(std::all_of(


### PR DESCRIPTION
This PR implements some fixes for warnings arising when compiling with GCC (`gcc version 13.2.1 20230728 (Red Hat 13.2.1-1) (GCC)`).

The libsemigroups library itself now compiles without errors, however some warnings still crop up when compiling the tests:
```
In file included from tests/test-make-present.cpp:29:
In member function ‘void libsemigroups::detail::StaticVector1<T, N>::push_back(T) [with T = unsigned char; long unsigned int N = 3]’,
    inlined from ‘libsemigroups::detail::StaticVector1<T, N>::StaticVector1(const It&, const It&) [with It = const int*; T = unsigned char; long unsigned int N = 3]’ at /home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/containers.hpp:766:20,
    inlined from ‘void std::__new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = libsemigroups::detail::StaticVector1<unsigned char, 3>; _Args = {const int*&, const int*&}; _Tp = libsemigroups::detail::StaticVector1<unsigned char, 3>]’ at /usr/include/c++/13/bits/new_allocator.h:187:4,
    inlined from ‘static void std::allocator_traits<std::allocator<_CharT> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = libsemigroups::detail::StaticVector1<unsigned char, 3>; _Args = {const int*&, const int*&}; _Tp = libsemigroups::detail::StaticVector1<unsigned char, 3>]’ at /usr/include/c++/13/bits/alloc_traits.h:537:17,
    inlined from ‘void std::vector<_Tp, _Alloc>::_M_realloc_insert(iterator, _Args&& ...) [with _Args = {const int*&, const int*&}; _Tp = libsemigroups::detail::StaticVector1<unsigned char, 3>; _Alloc = std::allocator<libsemigroups::detail::StaticVector1<unsigned char, 3> >]’ at /usr/include/c++/13/bits/vector.tcc:468:28:
/home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/containers.hpp:796:23: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  796 |         _array[_size] = x;
      |         ~~~~~~~~~~~~~~^~~
In file included from /home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/string.hpp:25,
                 from /home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/exception.hpp:26,
                 from /home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/bipart.hpp:40,
                 from tests/test-make-present.cpp:28:
/usr/include/c++/13/array: In member function ‘void std::vector<_Tp, _Alloc>::_M_realloc_insert(iterator, _Args&& ...) [with _Args = {const int*&, const int*&}; _Tp = libsemigroups::detail::StaticVector1<unsigned char, 3>; _Alloc = std::allocator<libsemigroups::detail::StaticVector1<unsigned char, 3> >]’:
/usr/include/c++/13/array:109:55: note: at offset 3 into destination object ‘std::array<unsigned char, 3>::_M_elems’ of size 3
  109 |       typename __array_traits<_Tp, _Nm>::_Type        _M_elems;
      |                                                       ^~~~~~~~
In member function ‘void libsemigroups::detail::StaticVector1<T, N>::push_back(T) [with T = unsigned char; long unsigned int N = 3]’,
    inlined from ‘libsemigroups::detail::StaticVector1<T, N>::StaticVector1(const It&, const It&) [with It = const int*; T = unsigned char; long unsigned int N = 3]’ at /home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/containers.hpp:766:20,
    inlined from ‘void std::__new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = libsemigroups::detail::StaticVector1<unsigned char, 3>; _Args = {const int*&, const int*&}; _Tp = libsemigroups::detail::StaticVector1<unsigned char, 3>]’ at /usr/include/c++/13/bits/new_allocator.h:187:4,
    inlined from ‘static void std::allocator_traits<std::allocator<_CharT> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = libsemigroups::detail::StaticVector1<unsigned char, 3>; _Args = {const int*&, const int*&}; _Tp = libsemigroups::detail::StaticVector1<unsigned char, 3>]’ at /usr/include/c++/13/bits/alloc_traits.h:537:17,
    inlined from ‘void std::vector<_Tp, _Alloc>::emplace_back(_Args&& ...) [with _Args = {const int*&, const int*&}; _Tp = libsemigroups::detail::StaticVector1<unsigned char, 3>; _Alloc = std::allocator<libsemigroups::detail::StaticVector1<unsigned char, 3> >]’ at /usr/include/c++/13/bits/vector.tcc:117:30,
    inlined from ‘libsemigroups::Presentation<W>& libsemigroups::Presentation<W>::add_rule(S, S, T, T) [with S = const int*; T = const int*; W = libsemigroups::detail::StaticVector1<unsigned char, 3>]’ at /home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/present.hpp:273:25,
    inlined from ‘void libsemigroups::presentation::add_rule(libsemigroups::Presentation<W>&, std::initializer_list<_Value>, std::initializer_list<_Value>) [with W = libsemigroups::detail::StaticVector1<unsigned char, 3>; T = int]’ at /home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/present.hpp:534:17:
/home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/containers.hpp:796:23: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  796 |         _array[_size] = x;
      |         ~~~~~~~~~~~~~~^~~
/usr/include/c++/13/array: In function ‘void libsemigroups::presentation::add_rule(libsemigroups::Presentation<W>&, std::initializer_list<_Value>, std::initializer_list<_Value>) [with W = libsemigroups::detail::StaticVector1<unsigned char, 3>; T = int]’:
/usr/include/c++/13/array:109:55: note: at offset 3 into destination object ‘std::array<unsigned char, 3>::_M_elems’ of size 3
  109 |       typename __array_traits<_Tp, _Nm>::_Type        _M_elems;
      |                                                       ^~~~~~~~
In member function ‘void libsemigroups::detail::StaticVector1<T, N>::push_back(T) [with T = unsigned char; long unsigned int N = 3]’,
    inlined from ‘libsemigroups::detail::StaticVector1<T, N>::StaticVector1(const It&, const It&) [with It = const int*; T = unsigned char; long unsigned int N = 3]’ at /home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/containers.hpp:766:20,
    inlined from ‘void std::__new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = libsemigroups::detail::StaticVector1<unsigned char, 3>; _Args = {const int*&, const int*&}; _Tp = libsemigroups::detail::StaticVector1<unsigned char, 3>]’ at /usr/include/c++/13/bits/new_allocator.h:187:4,
    inlined from ‘static void std::allocator_traits<std::allocator<_CharT> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = libsemigroups::detail::StaticVector1<unsigned char, 3>; _Args = {const int*&, const int*&}; _Tp = libsemigroups::detail::StaticVector1<unsigned char, 3>]’ at /usr/include/c++/13/bits/alloc_traits.h:537:17,
    inlined from ‘void std::vector<_Tp, _Alloc>::emplace_back(_Args&& ...) [with _Args = {const int*&, const int*&}; _Tp = libsemigroups::detail::StaticVector1<unsigned char, 3>; _Alloc = std::allocator<libsemigroups::detail::StaticVector1<unsigned char, 3> >]’ at /usr/include/c++/13/bits/vector.tcc:117:30,
    inlined from ‘libsemigroups::Presentation<W>& libsemigroups::Presentation<W>::add_rule(S, S, T, T) [with S = const int*; T = const int*; W = libsemigroups::detail::StaticVector1<unsigned char, 3>]’ at /home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/present.hpp:274:25,
    inlined from ‘void libsemigroups::presentation::add_rule(libsemigroups::Presentation<W>&, std::initializer_list<_Value>, std::initializer_list<_Value>) [with W = libsemigroups::detail::StaticVector1<unsigned char, 3>; T = int]’ at /home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/present.hpp:534:17:
/home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/containers.hpp:796:23: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  796 |         _array[_size] = x;
      |         ~~~~~~~~~~~~~~^~~
/usr/include/c++/13/array: In function ‘void libsemigroups::presentation::add_rule(libsemigroups::Presentation<W>&, std::initializer_list<_Value>, std::initializer_list<_Value>) [with W = libsemigroups::detail::StaticVector1<unsigned char, 3>; T = int]’:
/usr/include/c++/13/array:109:55: note: at offset 3 into destination object ‘std::array<unsigned char, 3>::_M_elems’ of size 3
  109 |       typename __array_traits<_Tp, _Nm>::_Type        _M_elems;
      |
In file included from /usr/include/c++/13/algorithm:61,
                 from tests/test-matrix.cpp:17:
In function ‘void std::__final_insertion_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = libsemigroups::StaticRowView<libsemigroups::BooleanPlus, libsemigroups::BooleanProd, libsemigroups::BooleanZero, libsemigroups::BooleanOne, 2, int>*; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<libsemigroups::{anonymous}::test_BMat000<libsemigroups::StaticMatrix<libsemigroups::BooleanPlus, libsemigroups::BooleanProd, libsemigroups::BooleanZero, libsemigroups::BooleanOne, 2, 2, int> >()::<lambda(const RowView&, const RowView&)> >]’,
    inlined from ‘void std::__sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = libsemigroups::StaticRowView<libsemigroups::BooleanPlus, libsemigroups::BooleanProd, libsemigroups::BooleanZero, libsemigroups::BooleanOne, 2, int>*; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<libsemigroups::{anonymous}::test_BMat000<libsemigroups::StaticMatrix<libsemigroups::BooleanPlus, libsemigroups::BooleanProd, libsemigroups::BooleanZero, libsemigroups::BooleanOne, 2, 2, int> >()::<lambda(const RowView&, const RowView&)> >]’ at /usr/include/c++/13/bits/stl_algo.h:1950:31,
    inlined from ‘void std::sort(_RAIter, _RAIter, _Compare) [with _RAIter = libsemigroups::StaticRowView<libsemigroups::BooleanPlus, libsemigroups::BooleanProd, libsemigroups::BooleanZero, libsemigroups::BooleanOne, 2, int>*; _Compare = libsemigroups::{anonymous}::test_BMat000<libsemigroups::StaticMatrix<libsemigroups::BooleanPlus, libsemigroups::BooleanProd, libsemigroups::BooleanZero, libsemigroups::BooleanOne, 2, 2, int> >()::<lambda(const RowView&, const RowView&)>]’ at /usr/include/c++/13/bits/stl_algo.h:4894:18,
    inlined from ‘void libsemigroups::{anonymous}::test_BMat000() [with Mat = libsemigroups::StaticMatrix<libsemigroups::BooleanPlus, libsemigroups::BooleanProd, libsemigroups::BooleanZero, libsemigroups::BooleanOne, 2, 2, int>]’ at tests/test-matrix.cpp:166:18:
/usr/include/c++/13/bits/stl_algo.h:1859:32: warning: array subscript 16 is outside array bounds of ‘libsemigroups::detail::StaticVector1<libsemigroups::StaticRowView<libsemigroups::BooleanPlus, libsemigroups::BooleanProd, libsemigroups::BooleanZero, libsemigroups::BooleanOne, 2, int>, 2> [1]’ [-Warray-bounds=]
 1859 |           std::__insertion_sort(__first, __first + int(_S_threshold), __comp);
      |           ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tests/test-matrix.cpp: In function ‘void libsemigroups::{anonymous}::test_BMat000() [with Mat = libsemigroups::StaticMatrix<libsemigroups::BooleanPlus, libsemigroups::BooleanProd, libsemigroups::BooleanZero, libsemigroups::BooleanOne, 2, 2, int>]’:
tests/test-matrix.cpp:160:14: note: at offset 128 into object ‘r’ of size 24
  160 |         auto r        = matrix_helpers::rows(m);
      |              ^
```
I was unable to fix these, any help appreciated!
