### PR TITLE
V3 work on `fpsemi-examples`

### DIFF
--- a/benchmarks/bench-todd-coxeter.cpp
+++ b/benchmarks/bench-todd-coxeter.cpp
@@ -268,7 +268,7 @@ namespace libsemigroups {
         "OP_n",
         3,
         9,
-        orientation_preserving_monoid,
+        [](size_t n) { return orientation_preserving_monoid(n); },
         "orientation_preserving_monoid",
         strategies,
         DoNothing);
@@ -334,7 +334,7 @@ namespace libsemigroups {
         "OR_n",
         3,
         8,
-        orientation_preserving_reversing_monoid,
+        [](size_t n) { return orientation_preserving_reversing_monoid(n); },
         "orientation_preserving_reversing_monoid",
         strategies,
         DoNothing);
@@ -530,7 +530,7 @@ namespace libsemigroups {
         "J_n",
         3,
         14,
-        temperley_lieb_monoid,
+        [](size_t n) { return temperley_lieb_monoid(n); },
         "temperley_lieb_monoid",
         strategies,
         DoNothing);
@@ -576,7 +576,7 @@ namespace libsemigroups {
         "B_n\\setminus S_n",
         3,
         7,
-        singular_brauer_monoid,
+        [](size_t n) { return singular_brauer_monoid(n); },
         "singular_brauer_monoid",
         strategies,
         DoNothing);
@@ -642,7 +642,7 @@ namespace libsemigroups {
         "\\operatorname{Stylic}(n)",
         3,
         10,
-        stylic_monoid,
+        [](size_t n) { return stylic_monoid(n); },
         "stylic_monoid",
         strategies,
         DoNothing);
@@ -697,7 +697,7 @@ namespace libsemigroups {
         "\\operatorname{Stellar}(n)",
         3,
         9,
-        stellar_monoid,
+        [](size_t n) { return stellar_monoid(n); },
         "stellar_monoid",
         strategies,
         DoNothing);

--- a/benchmarks/bench-todd-coxeter.cpp
+++ b/benchmarks/bench-todd-coxeter.cpp
@@ -343,7 +343,8 @@ namespace libsemigroups {
   // Approx 9s (2021 - MacBook Air M1 - 8GB RAM)
   TEST_CASE("orientation_preserving_reversing_monoid(9) - hlt",
             "[paper][orientation_preserving_reversing_monoid][n=9][hlt]") {
-    benchmark_todd_coxeter_single(434'835, orientation_preserving_reversing_monoid(9), 9);
+    benchmark_todd_coxeter_single(
+        434'835, orientation_preserving_reversing_monoid(9), 9);
   }
 
   // Approx 90s (2021 - MacBook Air M1 - 8GB RAM)

--- a/benchmarks/bench-todd-coxeter.cpp
+++ b/benchmarks/bench-todd-coxeter.cpp
@@ -230,7 +230,7 @@ namespace libsemigroups {
 
   using fpsemigroup::dual_symmetric_inverse_monoid;
   using fpsemigroup::orientation_preserving_monoid;
-  using fpsemigroup::orientation_reversing_monoid;
+  using fpsemigroup::orientation_preserving_reversing_monoid;
   using fpsemigroup::partition_monoid;
   using fpsemigroup::singular_brauer_monoid;
   using fpsemigroup::stellar_monoid;
@@ -305,7 +305,7 @@ namespace libsemigroups {
   }
 
   ////////////////////////////////////////////////////////////////////////
-  // 2. orientation_reversing_monoid
+  // 2. orientation_preserving_reversing_monoid
   ////////////////////////////////////////////////////////////////////////
 
   namespace orientation_reversing {
@@ -334,44 +334,44 @@ namespace libsemigroups {
         "OR_n",
         3,
         8,
-        orientation_reversing_monoid,
-        "orientation_reversing_monoid",
+        orientation_preserving_reversing_monoid,
+        "orientation_preserving_reversing_monoid",
         strategies,
         DoNothing);
   }  // namespace orientation_reversing
 
   // Approx 9s (2021 - MacBook Air M1 - 8GB RAM)
-  TEST_CASE("orientation_reversing_monoid(9) - hlt",
-            "[paper][orientation_reversing_monoid][n=9][hlt]") {
-    benchmark_todd_coxeter_single(434'835, orientation_reversing_monoid(9), 9);
+  TEST_CASE("orientation_preserving_reversing_monoid(9) - hlt",
+            "[paper][orientation_preserving_reversing_monoid][n=9][hlt]") {
+    benchmark_todd_coxeter_single(434'835, orientation_preserving_reversing_monoid(9), 9);
   }
 
   // Approx 90s (2021 - MacBook Air M1 - 8GB RAM)
-  TEST_CASE("orientation_reversing_monoid(10) - hlt",
-            "[paper][orientation_reversing_monoid][n=10][hlt]") {
+  TEST_CASE("orientation_preserving_reversing_monoid(10) - hlt",
+            "[paper][orientation_preserving_reversing_monoid][n=10][hlt]") {
     benchmark_todd_coxeter_single(
-        1'843'320, orientation_reversing_monoid(10), 10);
+        1'843'320, orientation_preserving_reversing_monoid(10), 10);
   }
 
   // ?? (2021 - MacBook Air M1 - 8GB RAM)
-  TEST_CASE("orientation_reversing_monoid(11) - hlt",
-            "[paper][orientation_reversing_monoid][n=11][hlt]") {
+  TEST_CASE("orientation_preserving_reversing_monoid(11) - hlt",
+            "[paper][orientation_preserving_reversing_monoid][n=11][hlt]") {
     benchmark_todd_coxeter_single(
-        7'753'471, orientation_reversing_monoid(11), 11);
+        7'753'471, orientation_preserving_reversing_monoid(11), 11);
   }
 
   // ?? (2021 - MacBook Air M1 - 8GB RAM)
-  TEST_CASE("orientation_reversing_monoid(12) - hlt",
-            "[paper][orientation_reversing_monoid][n=12][hlt]") {
+  TEST_CASE("orientation_preserving_reversing_monoid(12) - hlt",
+            "[paper][orientation_preserving_reversing_monoid][n=12][hlt]") {
     benchmark_todd_coxeter_single(
-        32'440'884, orientation_reversing_monoid(12), 12);
+        32'440'884, orientation_preserving_reversing_monoid(12), 12);
   }
 
   // ?? (2021 - MacBook Air M1 - 8GB RAM)
-  // TEST_CASE("orientation_reversing_monoid(13) - hlt",
-  //           "[paper][orientation_reversing_monoid][n=13][hlt]") {
+  // TEST_CASE("orientation_preserving_reversing_monoid(13) - hlt",
+  //           "[paper][orientation_preserving_reversing_monoid][n=13][hlt]") {
   //   benchmark_todd_coxeter_single(
-  //       135'195'307, orientation_reversing_monoid(13), 13);
+  //       135'195'307, orientation_preserving_reversing_monoid(13), 13);
   // }
 
   ////////////////////////////////////////////////////////////////////////

--- a/benchmarks/bench-todd-coxeter.sh
+++ b/benchmarks/bench-todd-coxeter.sh
@@ -2,7 +2,7 @@
 set -e
 
 for monoid in orientation_preserving_monoid \
-              orientation_reversing_monoid \
+              orientation_preserving_reversing_monoid \
               partition_monoid \
               dual_symmetric_inverse_monoid \
               uniform_block_bijection_monoid \

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -954,7 +954,12 @@ WARN_LOGFILE           =
 
 INPUT = "../include/libsemigroups" \
         "../README.md"             \
-        "install.md"
+        "install.md"               \
+        "Congruences.md"           \
+        "Words.md"                 \
+        "WordGraphs.md"            \
+        "KnuthBendix.md" \
+        "fpsemi-examples.md"
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -33,6 +33,7 @@
       <!-- TODO: Figure out a way to avoid this hack -->
       <tab type="user" visible="yes" url="group__congruences__group.html#func-members" title="Functions" />
     </tab>
+    <tab type="user" visible="yes" url="@ref md_fpsemi-examples" title="Examples of presentations" />
     <tab type="usergroup" visible="yes" url="@ref misc_group" title="Miscellaneous" >
       <tab type="usergroup" visible="yes" url="@ref constants_group" title="Constants" />
       <tab type="user" visible="yes" url="@ref libsemigroups::Reporter" title="Reporter" />

--- a/docs/fpsemi-examples.md
+++ b/docs/fpsemi-examples.md
@@ -1,0 +1,14 @@
+<!--
+Distributed under the terms of the GPL license version 3.
+
+The full license is in the file LICENSE, distributed with this
+software.
+-->
+
+This file contains documentation for functions which return Presentations
+(TODO: link this) for various semigroups and monoids.
+
+It would be nice to get rid of this 'intermediate' page,
+but I don't know how so we can deal with that later.
+
+* \ref libsemigroups::fpsemigroup "Helper functions"

--- a/docs/source-old/api/fpsemi-examples.rst
+++ b/docs/source-old/api/fpsemi-examples.rst
@@ -105,7 +105,7 @@ Contents
      - A presentation for the monoid of orientation preserving
        mappings.
 
-   * - :cpp:any:`orientation_reversing_monoid`
+   * - :cpp:any:`orientation_preserving_reversing_monoid`
      - A presentation for the monoid of orientation reversing
        mappings.
 
@@ -186,7 +186,7 @@ Full API
 .. doxygenfunction:: libsemigroups::fpsemigroup::orientation_preserving_monoid
    :project: libsemigroups
 
-.. doxygenfunction:: libsemigroups::fpsemigroup::orientation_reversing_monoid
+.. doxygenfunction:: libsemigroups::fpsemigroup::orientation_preserving_reversing_monoid
    :project: libsemigroups
 
 .. doxygenfunction:: libsemigroups::fpsemigroup::order_preserving_monoid

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -51,7 +51,7 @@ namespace libsemigroups {
       East       = 64,
       Fernandes  = 128,
       FitzGerald = 256,
-      Gay        = 521,
+      Gay        = 512,
       Godelle    = 1024,
       Guralnick  = 2048,
       Iwahori    = 4096,

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -191,10 +191,10 @@ namespace libsemigroups {
                                                           author val
                                                           = author::Any);
 
-    //! A presentation for the monoid of orientation reversing mappings.
+    //! A presentation for the monoid of orientation preserving or reversing mappings.
     //!
     //! Returns a monoid presentation defining
-    //! the monoid of orientation reversing mappings on a finite chain of order
+    //! the monoid of orientation preserving or reversing mappings on a finite chain of order
     //! `n`, as described in [10.1007/s10012-000-0001-1][].
     //
     // TODO: This really should say preserving and reversing
@@ -206,7 +206,7 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 3`
     //!
     //! [10.1007/s10012-000-0001-1]: https://doi.org/10.1007/s10012-000-0001-1
-    Presentation<word_type> orientation_reversing_monoid(size_t n,
+    Presentation<word_type> orientation_preserving_reversing_monoid(size_t n,
                                                          author val
                                                          = author::Any);
 

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -30,8 +30,8 @@
 
 namespace libsemigroups {
 
- //! This namespace contains functions which give presentations for some
- //! finitely presented semigroups and monoids.
+  //! This namespace contains functions which give presentations for some
+  //! finitely presented semigroups and monoids.
   namespace fpsemigroup {
 
     // The values in this enum class are used to specify the authors of a
@@ -39,26 +39,27 @@ namespace libsemigroups {
     // authors, values of this type can be passed as an argument to disambiguate
     // which presentation is wanted.
     enum class author : uint64_t {
-      Machine    = 0,
-      Aizenstat  = 1,
-      Burnside   = 2,
-      Carmichael = 4,
-      Coxeter    = 8,
-      Easdown    = 16,
-      East       = 32,
-      Fernandes  = 64,
-      FitzGerald = 128,
-      Gay        = 262'144,
-      Godelle    = 256,
-      Guralnick  = 512,
-      Iwahori    = 1024,
-      Kantor     = 2048,
-      Kassabov   = 4096,
-      Lubotzky   = 8192,
-      Miller     = 16'384,
-      Moore      = 32'768,
-      Moser      = 65'536,
-      Sutov      = 131'072,
+      Any        = 0,
+      Machine    = 1,
+      Aizenstat  = 2,
+      Burnside   = 4,
+      Carmichael = 8,
+      Coxeter    = 16,
+      Easdown    = 32,
+      East       = 64,
+      Fernandes  = 128,
+      FitzGerald = 256,
+      Gay        = 521,
+      Godelle    = 1024,
+      Guralnick  = 2048,
+      Iwahori    = 4096,
+      Kantor     = 8192,
+      Kassabov   = 16'384,
+      Lubotzky   = 32'768,
+      Miller     = 65'536,
+      Moore      = 131'072,
+      Moser      = 262'144,
+      Sutov      = 524'288,
     };
 
     //! This operator can be used arbitrarily to combine author values (see \ref
@@ -81,7 +82,7 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `l < 2`
     //!
     //! [10.48550/arXiv.1910.11740]: https://doi.org/10.48550/arXiv.1910.11740
-    Presentation<word_type> stellar_monoid(size_t l);
+    Presentation<word_type> stellar_monoid(size_t l, author val = author::Any);
 
     //! A presentation for the dual symmetric inverse monoid.
     //!
@@ -169,7 +170,8 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 3`
     //!
     //! [10.21136/MB.2007.134125]: https://doi.org/10.21136/MB.2007.134125
-    Presentation<word_type> singular_brauer_monoid(size_t n);
+    Presentation<word_type> singular_brauer_monoid(size_t n,
+                                                   author val = author::Any);
 
     //! A presentation for the monoid of orientation preserving
     //! mappings.
@@ -185,7 +187,9 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 3`
     //!
     //! [10.1007/s10012-000-0001-1]: https://doi.org/10.1007/s10012-000-0001-1
-    Presentation<word_type> orientation_preserving_monoid(size_t n);
+    Presentation<word_type> orientation_preserving_monoid(size_t n,
+                                                          author val
+                                                          = author::Any);
 
     //! A presentation for the monoid of orientation reversing mappings.
     //!
@@ -202,7 +206,9 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 3`
     //!
     //! [10.1007/s10012-000-0001-1]: https://doi.org/10.1007/s10012-000-0001-1
-    Presentation<word_type> orientation_reversing_monoid(size_t n);
+    Presentation<word_type> orientation_reversing_monoid(size_t n,
+                                                         author val
+                                                         = author::Any);
 
     //! A presentation for the Temperley-Lieb monoid.
     //!
@@ -217,7 +223,8 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 3`
     //!
     //! [10.1093/qmath/haab001]: https://doi.org/10.1093/qmath/haab001
-    Presentation<word_type> temperley_lieb_monoid(size_t n);
+    Presentation<word_type> temperley_lieb_monoid(size_t n,
+                                                  author val = author::Any);
 
     //! A presentation for the Brauer monoid.
     //!
@@ -233,10 +240,11 @@ namespace libsemigroups {
     //!
     //! [10.2478/s11533-006-0017-6]:
     //! https://doi.org/10.2478/s11533-006-0017-6
-    Presentation<word_type> brauer_monoid(size_t n);
+    Presentation<word_type> brauer_monoid(size_t n, author val = author::Any);
 
     // THIS IS UNDOCUMENTED
-    Presentation<word_type> partial_brauer_monoid(size_t n);
+    Presentation<word_type> partial_brauer_monoid(size_t n,
+                                                  author val = author::Any);
 
     //! A presentation for a Fibonacci semigroup.
     //!
@@ -254,7 +262,9 @@ namespace libsemigroups {
     //!
     //! [10.1016/0022-4049(94)90005-1]:
     //! https://doi.org/10.1016/0022-4049(94)90005-1
-    Presentation<word_type> fibonacci_semigroup(size_t r, size_t n);
+    Presentation<word_type> fibonacci_semigroup(size_t r,
+                                                size_t n,
+                                                author val = author::Any);
 
     //! A presentation for the plactic monoid.
     //!
@@ -269,7 +279,7 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 2`
     //!
     //! [10.1007/s00233-022-10285-3]: https://doi.org/10.1007/s00233-022-10285-3
-    Presentation<word_type> plactic_monoid(size_t n);
+    Presentation<word_type> plactic_monoid(size_t n, author val = author::Any);
 
     //! A presentation for the stylic monoid.
     //!
@@ -284,7 +294,7 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 2`
     //!
     //! [10.1007/s00233-022-10285-3]: https://doi.org/10.1007/s00233-022-10285-3
-    Presentation<word_type> stylic_monoid(size_t n);
+    Presentation<word_type> stylic_monoid(size_t n, author val = author::Any);
 
     //! A presentation for the symmetric group.
     //!
@@ -360,7 +370,9 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n = 0`
     //!
     //! [10.1007/s002339910016]: https://doi.org/10.1007/s002339910016
-    Presentation<word_type> rectangular_band(size_t m, size_t n);
+    Presentation<word_type> rectangular_band(size_t m,
+                                             size_t n,
+                                             author val = author::Any);
 
     //! A presentation for the full transformation monoid.
     //!
@@ -456,7 +468,7 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 2`
     //!
     //! [10.1142/S0218196701000425]: https://doi.org/10.1142/S0218196701000425
-    Presentation<word_type> chinese_monoid(size_t n);
+    Presentation<word_type> chinese_monoid(size_t n, author val = author::Any);
 
     //! A presentation for a monogenic semigroup.
     //!
@@ -474,7 +486,9 @@ namespace libsemigroups {
     //!
     //! \throws LibsemigroupsException if `m < 0`
     //! \throws LibsemigroupsException if `r = 0`
-    Presentation<word_type> monogenic_semigroup(size_t m, size_t r);
+    Presentation<word_type> monogenic_semigroup(size_t m,
+                                                size_t r,
+                                                author val = author::Any);
 
     //! A presentation for the monoid of order-preserving mappings.
     //!
@@ -492,7 +506,8 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 3`
     //!
     //! [10.1007/s10012-000-0001-1]: https://doi.org/10.1007/s10012-000-0001-1
-    Presentation<word_type> order_preserving_monoid(size_t n);
+    Presentation<word_type> order_preserving_monoid(size_t n,
+                                                    author val = author::Any);
 
     //! A presentation for the cyclic inverse monoid.
     //!
@@ -545,7 +560,8 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 3`
     //!
     //! [10.48550/arxiv.2211.02155]: https://doi.org/10.48550/arxiv.2211.02155
-    Presentation<word_type> order_preserving_cyclic_inverse_monoid(size_t n);
+    Presentation<word_type>
+    order_preserving_cyclic_inverse_monoid(size_t n, author val = author::Any);
 
     //! A presentation for the monoid of partial isometries of a cycle graph.
     //!
@@ -560,7 +576,8 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 3`
     //!
     //! [10.48550/arxiv.2205.02196]: https://doi.org/10.48550/arxiv.2205.02196
-    Presentation<word_type> partial_isometries_cycle_graph_monoid(size_t n);
+    Presentation<word_type>
+    partial_isometries_cycle_graph_monoid(size_t n, author val = author::Any);
 
     //! A non-presentation for the symmetric group.
     //!
@@ -589,13 +606,16 @@ namespace libsemigroups {
                         author val = author::Guralnick + author::Kantor
                                      + author::Kassabov + author::Lubotzky);
 
-    Presentation<word_type> special_linear_group_2(size_t n);
+    Presentation<word_type> special_linear_group_2(size_t n,
+                                                   author val = author::Any);
 
     // TODO (doc)
-    Presentation<word_type> hypo_plactic_monoid(size_t n);
+    Presentation<word_type> hypo_plactic_monoid(size_t n,
+                                                author val = author::Any);
 
     Presentation<word_type>
-    sigma_stylic_monoid(std::vector<size_t> const& sigma);
+    sigma_stylic_monoid(std::vector<size_t> const& sigma,
+                        author                     val = author::Any);
 
     // TODO add okada_monoid
     // TODO add free_semilattice
@@ -607,7 +627,8 @@ namespace libsemigroups {
     // https://theses.hal.science/tel-01861199
     //
     //  This could also be called the RennerTypeAMonoid
-    Presentation<word_type> zero_rook_monoid(size_t n);
+    Presentation<word_type> zero_rook_monoid(size_t n,
+                                             author val = author::Any);
 
     // TODO rename renner_type_b_monoid:
     // when q = 0: Definition 8.4.1 + Example 8.4.2 in Joel's thesis.
@@ -615,7 +636,9 @@ namespace libsemigroups {
     // with pi_i ^ 2 = 1 (usual Renner monoid) (q is the Iwahori-Hecke
     // deformation of the Renner monoid). q = 1From Joel's thesis,
     // Theorem 8.4.19.
-    Presentation<word_type> renner_type_B_monoid(size_t l, int q);
+    Presentation<word_type> renner_type_B_monoid(size_t l,
+                                                 int    q,
+                                                 author val = author::Any);
 
     // not_renner_type_b_monoid
     // when q = 0, Example 7.1.2, of Joel's thesis
@@ -623,17 +646,23 @@ namespace libsemigroups {
     // https://www.cambridge.org/core/services/aop-cambridge-core/content/view/B6BAB75BD3463916FEDEC15BEDA724FF/S0004972710000365a.pdf/presentation_for_renner_monoids.pdf
     // or
     // https://arxiv.org/abs/0904.0926
-    Presentation<word_type> not_renner_type_B_monoid(size_t l, int q);
+    Presentation<word_type> not_renner_type_B_monoid(size_t l,
+                                                     int    q,
+                                                     author val = author::Any);
 
     // See Theorem 8.4.43 in Joel's thesis q = 1,
     // for q = 0, Definition 8.4.22 (author = Gay)
-    Presentation<word_type> renner_type_D_monoid(size_t l, int q);
+    Presentation<word_type> renner_type_D_monoid(size_t l,
+                                                 int    q,
+                                                 author val = author::Any);
 
     // Godelle's:
     // when q = 1, p41 of
     // https://www.cambridge.org/core/services/aop-cambridge-core/content/view/B6BAB75BD3463916FEDEC15BEDA724FF/S0004972710000365a.pdf/presentation_for_renner_monoids.pdf
     // q = 0, no reference
-    Presentation<word_type> not_renner_type_D_monoid(size_t l, int q);
+    Presentation<word_type> not_renner_type_D_monoid(size_t l,
+                                                     int    q,
+                                                     author val = author::Any);
 
   }  // namespace fpsemigroup
 }  // namespace libsemigroups

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -29,6 +29,9 @@
 #include "types.hpp"         // for relation_type
 
 namespace libsemigroups {
+
+ //! This namespace contains functions which give presentations for some
+ //! finitely presented semigroups and monoids.
   namespace fpsemigroup {
 
     // The values in this enum class are used to specify the authors of a
@@ -67,7 +70,7 @@ namespace libsemigroups {
 
     //! A presentation for the stellar monoid.
     //!
-    //! Returns a vector of relations giving a semigroup presentation defining
+    //! Returns a monoid presentation defining
     //! the stellar monoid with `l` generators, as in Theorem 4.39 of
     //! [10.48550/arXiv.1910.11740][].
     //!
@@ -82,7 +85,7 @@ namespace libsemigroups {
 
     //! A presentation for the dual symmetric inverse monoid.
     //!
-    //! Returns a vector of relations giving a semigroup presentation defining
+    //! Returns a monoid presentation defining
     //! the dual symmetric inverse monoid of degree `n`. The argument `val`
     //! determines the specific presentation which is returned. The options are:
     //! * `author::Easdown + author::East + author::FitzGerald` (from Section 3
@@ -106,7 +109,7 @@ namespace libsemigroups {
 
     //! A presentation for the uniform block bijection monoid.
     //!
-    //! Returns a vector of relations giving a semigroup presentation defining
+    //! Returns a monoid presentation defining
     //! the uniform block bijection monoid of degree `n`. The argument `val`
     //! determines the specific presentation which is returned. The only option
     //! is:
@@ -128,7 +131,7 @@ namespace libsemigroups {
 
     //! A presentation for the partition monoid.
     //!
-    //! Returns a vector of relations giving a semigroup presentation defining
+    //! Returns a presentation defining
     //! the partition monoid of degree `n`. The argument `val` determines the
     //! specific presentation which is returned. The options are:
     //! * `author::Machine`
@@ -136,6 +139,9 @@ namespace libsemigroups {
     //! [10.1016/j.jalgebra.2011.04.008][])
     //!
     //! The default for `val` is `author::East`.
+    //!
+    //! Note that `author::East` returns a monoid presentation, and
+    //! `author::Machine` returns a semigroup presentation.
     //!
     //! \param n the degree
     //! \param val the author of the presentation
@@ -152,7 +158,7 @@ namespace libsemigroups {
 
     //! A presentation for the singular part of the Brauer monoid.
     //!
-    //! Returns a vector of relations giving a semigroup presentation for the
+    //! Returns a monoid presentation for the
     //! singular part of the Brauer monoid of degree `n`, as in Theorem 5 of
     //! [10.21136/MB.2007.134125][]).
     //!
@@ -168,7 +174,7 @@ namespace libsemigroups {
     //! A presentation for the monoid of orientation preserving
     //! mappings.
     //!
-    //! Returns a vector of relations giving a monoid presentation defining
+    //! Returns a monoid presentation defining
     //! the monoid of orientation preserving mappings on a finite chain of order
     //! `n`, as described in [10.1007/s10012-000-0001-1][].
     //!
@@ -183,9 +189,11 @@ namespace libsemigroups {
 
     //! A presentation for the monoid of orientation reversing mappings.
     //!
-    //! Returns a vector of relations giving a monoid presentation defining
+    //! Returns a monoid presentation defining
     //! the monoid of orientation reversing mappings on a finite chain of order
     //! `n`, as described in [10.1007/s10012-000-0001-1][].
+    //
+    // TODO: This really should say preserving and reversing
     //!
     //! \param n the order of the chain
     //!
@@ -198,7 +206,7 @@ namespace libsemigroups {
 
     //! A presentation for the Temperley-Lieb monoid.
     //!
-    //! Returns a vector of relations giving a semigroup presentation defining
+    //! Returns a monoid presentation defining
     //! the Temperley-Lieb monoid with `n` generators, as described in
     //! Theorem 2.2 of [10.1093/qmath/haab001][].
     //!
@@ -213,7 +221,7 @@ namespace libsemigroups {
 
     //! A presentation for the Brauer monoid.
     //!
-    //! Returns a vector of relations giving a semigroup presentation defining
+    //! Returns a monoid presentation defining
     //! the Brauer monoid of degree `n`, as described in Theorem 3.1 of the
     //! paper [10.2478/s11533-006-0017-6][].
     //!
@@ -227,11 +235,12 @@ namespace libsemigroups {
     //! https://doi.org/10.2478/s11533-006-0017-6
     Presentation<word_type> brauer_monoid(size_t n);
 
+    // THIS IS UNDOCUMENTED
     Presentation<word_type> partial_brauer_monoid(size_t n);
 
     //! A presentation for a Fibonacci semigroup.
     //!
-    //! Returns a vector of relations giving a semigroup presentation defining
+    //! Returns a semigroup presentation defining
     //! the Fibonacci semigroup \f$F(r, n)\f$, as described in
     //! [10.1016/0022-4049(94)90005-1][].
     //!
@@ -249,7 +258,7 @@ namespace libsemigroups {
 
     //! A presentation for the plactic monoid.
     //!
-    //! Returns a vector of relations giving a semigroup presentation defining
+    //! Returns a monoid presentation defining
     //! the plactic monoid with `n` generators (see Section 3 of
     //! [10.1007/s00233-022-10285-3][]).
     //!
@@ -264,7 +273,7 @@ namespace libsemigroups {
 
     //! A presentation for the stylic monoid.
     //!
-    //! Returns a vector of relations giving a semigroup presentation defining
+    //! Returns a monoid presentation defining
     //! the stylic monoid with `n` generators (see Theorem 8.1 of
     //! [10.1007/s00233-022-10285-3]).
     //!
@@ -279,7 +288,7 @@ namespace libsemigroups {
 
     //! A presentation for the symmetric group.
     //!
-    //! Returns a vector of relations giving a monoid presentation for the
+    //! Returns a monoid presentation for the
     //! symmetric group. The argument `val` determines the specific presentation
     //! which is returned. The options are:
     //!
@@ -317,7 +326,7 @@ namespace libsemigroups {
 
     //! A presentation for the alternating group.
     //!
-    //! Returns a vector of relations giving a monoid presentation defining the
+    //! Returns a monoid presentation defining the
     //! alternating group of degree `n`. The argument `val` determines the
     //! specific presentation which is returned. The options are:
     //! * `author::Moore` (see Ch. 3, Prop 1.3 of [hdl.handle.net/10023/2821][])
@@ -338,7 +347,7 @@ namespace libsemigroups {
 
     //! A presentation for a rectangular band.
     //!
-    //! Returns a vector of relations giving a semigroup presentation defining
+    //! Returns a semigroup presentation defining
     //! the `m` by `n` rectangular band, as given in Proposition 4.2 of
     //! [10.1007/s002339910016][].
     //!
@@ -355,7 +364,7 @@ namespace libsemigroups {
 
     //! A presentation for the full transformation monoid.
     //!
-    //! Returns a vector of relations giving a monoid presentation defining the
+    //! Returns a monoid presentation defining the
     //! full transformation monoid. The argument `val` determines the specific
     //! presentation which is returned. The options are:
     //! * `author::Aizenstat` (see Ch. 3, Prop 1.7 of
@@ -381,7 +390,7 @@ namespace libsemigroups {
 
     //! A presentation for the partial transformation monoid.
     //!
-    //! Returns a vector of relations giving a monoid presentation defining the
+    //! Returns a monoid presentation defining the
     //! partial transformation monoid. The argument `val` determines the
     //! specific presentation which is returned. The options are:
     //! * `author::Machine`
@@ -405,7 +414,7 @@ namespace libsemigroups {
 
     //! A presentation for the symmetric inverse monoid.
     //!
-    //! Returns a vector of relations giving a monoid presentation defining the
+    //! Returns a monoid presentation defining the
     //! symmetric inverse monoid. The argument `val` determines the specific
     //! presentation which is returned. The options are:
     //! * `author::Sutov` (see Theorem 9.2.2 of
@@ -437,7 +446,7 @@ namespace libsemigroups {
 
     //! A presentation for the Chinese monoid.
     //!
-    //! Returns a vector of relations giving a semigroup presentation defining
+    //! Returns a monoid presentation defining
     //! the Chinese monoid, as described in [10.1142/S0218196701000425][].
     //!
     //! \param n the number of generators
@@ -451,21 +460,25 @@ namespace libsemigroups {
 
     //! A presentation for a monogenic semigroup.
     //!
-    //! Returns a vector of relations giving a semigroup presentation defining
+    //! Returns a presentation defining
     //! the monogenic semigroup defined by the presentation \f$\langle a \mid
     //! a^{m + r} = a^m \rangle\f$.
+    //!
+    //! If \param m = 0, the presentation returned is a monoid presentation;
+    //! otherwise, a semigroup presentation is returned.
     //!
     //! \param m the index
     //! \param r the period
     //!
     //! \returns A `std::vector<relation_type>`
     //!
+    //! \throws LibsemigroupsException if `m < 0`
     //! \throws LibsemigroupsException if `r = 0`
     Presentation<word_type> monogenic_semigroup(size_t m, size_t r);
 
     //! A presentation for the monoid of order-preserving mappings.
     //!
-    //! Returns a vector of relations giving a semigroup presentation defining
+    //! Returns a monoid presentation defining
     //! the monoid of order-preserving transformations of degree `n`, as
     //! described in Section 2 of the paper [10.1007/s10012-000-0001-1][].
     //!
@@ -483,7 +496,7 @@ namespace libsemigroups {
 
     //! A presentation for the cyclic inverse monoid.
     //!
-    //! Returns a vector of relations giving a monoid presentation defining
+    //! Returns a monoid presentation defining
     //! the cyclic inverse monoid of degree `n`.
     //!
     //! The combination of `val` and `index` determines the specific
@@ -520,7 +533,7 @@ namespace libsemigroups {
     //! A presentation for the order-preserving part of the cyclic inverse
     //! monoid.
     //!
-    //! Returns a vector of relations giving a semigroup presentation defining
+    //! Returns a monoid presentation defining
     //! the order-preserving part of the cyclic inverse monoid of degree `n`, as
     //! described in Theorem 2.17 of
     //! the paper [10.48550/arxiv.2211.02155][].
@@ -536,7 +549,7 @@ namespace libsemigroups {
 
     //! A presentation for the monoid of partial isometries of a cycle graph.
     //!
-    //! Returns a vector of relations giving a monoid presentation defining
+    //! Returns a monoid presentation defining
     //! the monoid of partial isometries of an \f$n\f$-cycle graph, as described
     //! in Theorem 2.8 of [10.48550/arxiv.2205.02196][].
     //!
@@ -551,7 +564,7 @@ namespace libsemigroups {
 
     //! A non-presentation for the symmetric group.
     //!
-    //! Returns a vector of relations giving a monoid presentation which is
+    //! Returns a monoid presentation which is
     //! claimed to define the symmetric group of degree `n`, but does not. The
     //! argument `val` determines the specific presentation which is returned.
     //! The options are:

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -236,8 +236,6 @@ namespace libsemigroups {
     //!
     //! \returns A `std::vector<relation_type>`
     //!
-    //! \noexcept
-    //!
     //! [10.2478/s11533-006-0017-6]:
     //! https://doi.org/10.2478/s11533-006-0017-6
     Presentation<word_type> brauer_monoid(size_t n, author val = author::Any);

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -203,8 +203,6 @@ namespace libsemigroups {
     //! the monoid of orientation preserving or reversing mappings on a finite
     //! chain of order `n`, as described in [10.1007/s10012-000-0001-1][].
     //
-    // TODO: This really should say preserving and reversing
-    //!
     //! \param n the order of the chain
     //!
     //! \returns A `std::vector<relation_type>`

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -28,6 +28,8 @@
 #include "presentation.hpp"  // for Presentation
 #include "types.hpp"         // for relation_type
 
+// TODO: Run include-what-you-use on this file (I (Murray) couldn't)
+
 namespace libsemigroups {
 
   //! This namespace contains functions which give presentations for some
@@ -64,7 +66,7 @@ namespace libsemigroups {
 
     //! This operator can be used arbitrarily to combine author values (see \ref
     //! author).
-    inline author operator+(author auth1, author auth2) {
+    [[nodiscard]] inline author operator+(author auth1, author auth2) {
       return static_cast<author>(static_cast<uint64_t>(auth1)
                                  + static_cast<uint64_t>(auth2));
     }
@@ -82,7 +84,9 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `l < 2`
     //!
     //! [10.48550/arXiv.1910.11740]: https://doi.org/10.48550/arXiv.1910.11740
-    Presentation<word_type> stellar_monoid(size_t l, author val = author::Any);
+    [[nodiscard]] Presentation<word_type> stellar_monoid(size_t l,
+                                                         author val
+                                                         = author::Any);
 
     //! A presentation for the dual symmetric inverse monoid.
     //!
@@ -104,7 +108,7 @@ namespace libsemigroups {
     //! `author::Easdown + author::East + author::FitzGerald`
     //!
     //! [10.48550/arxiv.0707.2439]: https://doi.org/10.48550/arxiv.0707.2439
-    Presentation<word_type> dual_symmetric_inverse_monoid(
+    [[nodiscard]] Presentation<word_type> dual_symmetric_inverse_monoid(
         size_t n,
         author val = author::Easdown + author::East + author::FitzGerald);
 
@@ -127,7 +131,7 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `val` is not `author::FitzGerald`
     //!
     //! [10.1017/s0004972700037692]: https://doi.org/10.1017/s0004972700037692
-    Presentation<word_type>
+    [[nodiscard]] Presentation<word_type>
     uniform_block_bijection_monoid(size_t n, author val = author::FitzGerald);
 
     //! A presentation for the partition monoid.
@@ -154,8 +158,9 @@ namespace libsemigroups {
     //!
     //! [10.1016/j.jalgebra.2011.04.008]:
     //! https://doi.org/10.1016/j.jalgebra.2011.04.008
-    Presentation<word_type> partition_monoid(size_t n,
-                                             author val = author::East);
+    [[nodiscard]] Presentation<word_type> partition_monoid(size_t n,
+                                                           author val
+                                                           = author::East);
 
     //! A presentation for the singular part of the Brauer monoid.
     //!
@@ -170,8 +175,9 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 3`
     //!
     //! [10.21136/MB.2007.134125]: https://doi.org/10.21136/MB.2007.134125
-    Presentation<word_type> singular_brauer_monoid(size_t n,
-                                                   author val = author::Any);
+    [[nodiscard]] Presentation<word_type> singular_brauer_monoid(size_t n,
+                                                                 author val
+                                                                 = author::Any);
 
     //! A presentation for the monoid of orientation preserving
     //! mappings.
@@ -187,15 +193,15 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 3`
     //!
     //! [10.1007/s10012-000-0001-1]: https://doi.org/10.1007/s10012-000-0001-1
-    Presentation<word_type> orientation_preserving_monoid(size_t n,
-                                                          author val
-                                                          = author::Any);
+    [[nodiscard]] Presentation<word_type>
+    orientation_preserving_monoid(size_t n, author val = author::Any);
 
-    //! A presentation for the monoid of orientation preserving or reversing mappings.
+    //! A presentation for the monoid of orientation preserving or reversing
+    //! mappings.
     //!
     //! Returns a monoid presentation defining
-    //! the monoid of orientation preserving or reversing mappings on a finite chain of order
-    //! `n`, as described in [10.1007/s10012-000-0001-1][].
+    //! the monoid of orientation preserving or reversing mappings on a finite
+    //! chain of order `n`, as described in [10.1007/s10012-000-0001-1][].
     //
     // TODO: This really should say preserving and reversing
     //!
@@ -206,9 +212,8 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 3`
     //!
     //! [10.1007/s10012-000-0001-1]: https://doi.org/10.1007/s10012-000-0001-1
-    Presentation<word_type> orientation_preserving_reversing_monoid(size_t n,
-                                                         author val
-                                                         = author::Any);
+    [[nodiscard]] Presentation<word_type>
+    orientation_preserving_reversing_monoid(size_t n, author val = author::Any);
 
     //! A presentation for the Temperley-Lieb monoid.
     //!
@@ -223,8 +228,9 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 3`
     //!
     //! [10.1093/qmath/haab001]: https://doi.org/10.1093/qmath/haab001
-    Presentation<word_type> temperley_lieb_monoid(size_t n,
-                                                  author val = author::Any);
+    [[nodiscard]] Presentation<word_type> temperley_lieb_monoid(size_t n,
+                                                                author val
+                                                                = author::Any);
 
     //! A presentation for the Brauer monoid.
     //!
@@ -238,11 +244,14 @@ namespace libsemigroups {
     //!
     //! [10.2478/s11533-006-0017-6]:
     //! https://doi.org/10.2478/s11533-006-0017-6
-    Presentation<word_type> brauer_monoid(size_t n, author val = author::Any);
+    [[nodiscard]] Presentation<word_type> brauer_monoid(size_t n,
+                                                        author val
+                                                        = author::Any);
 
     // THIS IS UNDOCUMENTED
-    Presentation<word_type> partial_brauer_monoid(size_t n,
-                                                  author val = author::Any);
+    [[nodiscard]] Presentation<word_type> partial_brauer_monoid(size_t n,
+                                                                author val
+                                                                = author::Any);
 
     //! A presentation for a Fibonacci semigroup.
     //!
@@ -260,9 +269,8 @@ namespace libsemigroups {
     //!
     //! [10.1016/0022-4049(94)90005-1]:
     //! https://doi.org/10.1016/0022-4049(94)90005-1
-    Presentation<word_type> fibonacci_semigroup(size_t r,
-                                                size_t n,
-                                                author val = author::Any);
+    [[nodiscard]] Presentation<word_type>
+    fibonacci_semigroup(size_t r, size_t n, author val = author::Any);
 
     //! A presentation for the plactic monoid.
     //!
@@ -277,7 +285,9 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 2`
     //!
     //! [10.1007/s00233-022-10285-3]: https://doi.org/10.1007/s00233-022-10285-3
-    Presentation<word_type> plactic_monoid(size_t n, author val = author::Any);
+    [[nodiscard]] Presentation<word_type> plactic_monoid(size_t n,
+                                                         author val
+                                                         = author::Any);
 
     //! A presentation for the stylic monoid.
     //!
@@ -292,7 +302,9 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 2`
     //!
     //! [10.1007/s00233-022-10285-3]: https://doi.org/10.1007/s00233-022-10285-3
-    Presentation<word_type> stylic_monoid(size_t n, author val = author::Any);
+    [[nodiscard]] Presentation<word_type> stylic_monoid(size_t n,
+                                                        author val
+                                                        = author::Any);
 
     //! A presentation for the symmetric group.
     //!
@@ -328,9 +340,10 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if the author-index combination is
     //! invalid
     //!
-    Presentation<word_type> symmetric_group(size_t n,
-                                            author val   = author::Carmichael,
-                                            size_t index = 0);
+    [[nodiscard]] Presentation<word_type> symmetric_group(size_t n,
+                                                          author val
+                                                          = author::Carmichael,
+                                                          size_t index = 0);
 
     //! A presentation for the alternating group.
     //!
@@ -350,8 +363,9 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 4`
     //!
     //! [hdl.handle.net/10023/2821]: http://hdl.handle.net/10023/2821
-    Presentation<word_type> alternating_group(size_t n,
-                                              author val = author::Moore);
+    [[nodiscard]] Presentation<word_type> alternating_group(size_t n,
+                                                            author val
+                                                            = author::Moore);
 
     //! A presentation for a rectangular band.
     //!
@@ -368,9 +382,8 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n = 0`
     //!
     //! [10.1007/s002339910016]: https://doi.org/10.1007/s002339910016
-    Presentation<word_type> rectangular_band(size_t m,
-                                             size_t n,
-                                             author val = author::Any);
+    [[nodiscard]] Presentation<word_type>
+    rectangular_band(size_t m, size_t n, author val = author::Any);
 
     //! A presentation for the full transformation monoid.
     //!
@@ -394,9 +407,8 @@ namespace libsemigroups {
     //!
     //! [http://hdl.handle.net/10023/2821]: http://hdl.handle.net/10023/2821
     //! [10.1007/978-1-84800-281-4]: https://doi.org/10.1007/978-1-84800-281-4
-    Presentation<word_type> full_transformation_monoid(size_t n,
-                                                       author val
-                                                       = author::Iwahori);
+    [[nodiscard]] Presentation<word_type>
+    full_transformation_monoid(size_t n, author val = author::Iwahori);
 
     //! A presentation for the partial transformation monoid.
     //!
@@ -418,9 +430,8 @@ namespace libsemigroups {
     //! order of author)
     //!
     //! [10.1007/978-1-84800-281-4]: https://doi.org/10.1007/978-1-84800-281-4
-    Presentation<word_type> partial_transformation_monoid(size_t n,
-                                                          author val
-                                                          = author::Sutov);
+    [[nodiscard]] Presentation<word_type>
+    partial_transformation_monoid(size_t n, author val = author::Sutov);
 
     //! A presentation for the symmetric inverse monoid.
     //!
@@ -450,9 +461,8 @@ namespace libsemigroups {
     //! order of author)
     //!
     //! [10.1007/978-1-84800-281-4]: https://doi.org/10.1007/978-1-84800-281-4
-    Presentation<word_type> symmetric_inverse_monoid(size_t n,
-                                                     author val
-                                                     = author::Sutov);
+    [[nodiscard]] Presentation<word_type>
+    symmetric_inverse_monoid(size_t n, author val = author::Sutov);
 
     //! A presentation for the Chinese monoid.
     //!
@@ -466,7 +476,9 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 2`
     //!
     //! [10.1142/S0218196701000425]: https://doi.org/10.1142/S0218196701000425
-    Presentation<word_type> chinese_monoid(size_t n, author val = author::Any);
+    [[nodiscard]] Presentation<word_type> chinese_monoid(size_t n,
+                                                         author val
+                                                         = author::Any);
 
     //! A presentation for a monogenic semigroup.
     //!
@@ -484,9 +496,8 @@ namespace libsemigroups {
     //!
     //! \throws LibsemigroupsException if `m < 0`
     //! \throws LibsemigroupsException if `r = 0`
-    Presentation<word_type> monogenic_semigroup(size_t m,
-                                                size_t r,
-                                                author val = author::Any);
+    [[nodiscard]] Presentation<word_type>
+    monogenic_semigroup(size_t m, size_t r, author val = author::Any);
 
     //! A presentation for the monoid of order-preserving mappings.
     //!
@@ -504,8 +515,8 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 3`
     //!
     //! [10.1007/s10012-000-0001-1]: https://doi.org/10.1007/s10012-000-0001-1
-    Presentation<word_type> order_preserving_monoid(size_t n,
-                                                    author val = author::Any);
+    [[nodiscard]] Presentation<word_type>
+    order_preserving_monoid(size_t n, author val = author::Any);
 
     //! A presentation for the cyclic inverse monoid.
     //!
@@ -538,10 +549,10 @@ namespace libsemigroups {
     //! relations.
     //!
     //! [10.48550/arxiv.2211.02155]: https://doi.org/10.48550/arxiv.2211.02155
-    Presentation<word_type> cyclic_inverse_monoid(size_t n,
-                                                  author val
-                                                  = author::Fernandes,
-                                                  size_t index = 1);
+    [[nodiscard]] Presentation<word_type>
+    cyclic_inverse_monoid(size_t n,
+                          author val   = author::Fernandes,
+                          size_t index = 1);
 
     //! A presentation for the order-preserving part of the cyclic inverse
     //! monoid.
@@ -558,7 +569,7 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 3`
     //!
     //! [10.48550/arxiv.2211.02155]: https://doi.org/10.48550/arxiv.2211.02155
-    Presentation<word_type>
+    [[nodiscard]] Presentation<word_type>
     order_preserving_cyclic_inverse_monoid(size_t n, author val = author::Any);
 
     //! A presentation for the monoid of partial isometries of a cycle graph.
@@ -574,7 +585,7 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if `n < 3`
     //!
     //! [10.48550/arxiv.2205.02196]: https://doi.org/10.48550/arxiv.2205.02196
-    Presentation<word_type>
+    [[nodiscard]] Presentation<word_type>
     partial_isometries_cycle_graph_monoid(size_t n, author val = author::Any);
 
     //! A non-presentation for the symmetric group.
@@ -599,19 +610,21 @@ namespace libsemigroups {
     //!
     //! [doi.org/10.1090/S0894-0347-08-00590-0]:
     //! https://doi.org/10.1090/S0894-0347-08-00590-0
-    Presentation<word_type>
+    [[nodiscard]] Presentation<word_type>
     not_symmetric_group(size_t n,
                         author val = author::Guralnick + author::Kantor
                                      + author::Kassabov + author::Lubotzky);
 
-    Presentation<word_type> special_linear_group_2(size_t n,
-                                                   author val = author::Any);
+    [[nodiscard]] Presentation<word_type> special_linear_group_2(size_t n,
+                                                                 author val
+                                                                 = author::Any);
 
     // TODO (doc)
-    Presentation<word_type> hypo_plactic_monoid(size_t n,
-                                                author val = author::Any);
+    [[nodiscard]] Presentation<word_type> hypo_plactic_monoid(size_t n,
+                                                              author val
+                                                              = author::Any);
 
-    Presentation<word_type>
+    [[nodiscard]] Presentation<word_type>
     sigma_stylic_monoid(std::vector<size_t> const& sigma,
                         author                     val = author::Any);
 
@@ -625,8 +638,9 @@ namespace libsemigroups {
     // https://theses.hal.science/tel-01861199
     //
     //  This could also be called the RennerTypeAMonoid
-    Presentation<word_type> zero_rook_monoid(size_t n,
-                                             author val = author::Any);
+    [[nodiscard]] Presentation<word_type> zero_rook_monoid(size_t n,
+                                                           author val
+                                                           = author::Any);
 
     // TODO rename renner_type_b_monoid:
     // when q = 0: Definition 8.4.1 + Example 8.4.2 in Joel's thesis.
@@ -634,9 +648,8 @@ namespace libsemigroups {
     // with pi_i ^ 2 = 1 (usual Renner monoid) (q is the Iwahori-Hecke
     // deformation of the Renner monoid). q = 1From Joel's thesis,
     // Theorem 8.4.19.
-    Presentation<word_type> renner_type_B_monoid(size_t l,
-                                                 int    q,
-                                                 author val = author::Any);
+    [[nodiscard]] Presentation<word_type>
+    renner_type_B_monoid(size_t l, int q, author val = author::Any);
 
     // not_renner_type_b_monoid
     // when q = 0, Example 7.1.2, of Joel's thesis
@@ -644,23 +657,20 @@ namespace libsemigroups {
     // https://www.cambridge.org/core/services/aop-cambridge-core/content/view/B6BAB75BD3463916FEDEC15BEDA724FF/S0004972710000365a.pdf/presentation_for_renner_monoids.pdf
     // or
     // https://arxiv.org/abs/0904.0926
-    Presentation<word_type> not_renner_type_B_monoid(size_t l,
-                                                     int    q,
-                                                     author val = author::Any);
+    [[nodiscard]] Presentation<word_type>
+    not_renner_type_B_monoid(size_t l, int q, author val = author::Any);
 
     // See Theorem 8.4.43 in Joel's thesis q = 1,
     // for q = 0, Definition 8.4.22 (author = Gay)
-    Presentation<word_type> renner_type_D_monoid(size_t l,
-                                                 int    q,
-                                                 author val = author::Any);
+    [[nodiscard]] Presentation<word_type>
+    renner_type_D_monoid(size_t l, int q, author val = author::Any);
 
     // Godelle's:
     // when q = 1, p41 of
     // https://www.cambridge.org/core/services/aop-cambridge-core/content/view/B6BAB75BD3463916FEDEC15BEDA724FF/S0004972710000365a.pdf/presentation_for_renner_monoids.pdf
     // q = 0, no reference
-    Presentation<word_type> not_renner_type_D_monoid(size_t l,
-                                                     int    q,
-                                                     author val = author::Any);
+    [[nodiscard]] Presentation<word_type>
+    not_renner_type_D_monoid(size_t l, int q, author val = author::Any);
 
   }  // namespace fpsemigroup
 }  // namespace libsemigroups

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -367,6 +367,7 @@ namespace libsemigroups {
         t.insert(t.begin(), i);
         presentation::add_rule_no_checks(p, t + word_type({i}), t);
       }
+      p.contains_empty_word(true);
       return p;
     }
 
@@ -414,6 +415,7 @@ namespace libsemigroups {
           presentation::add_rule_no_checks(p, {b, b, a}, {b, a, b});
         }
       }
+      p.contains_empty_word(true);
       return p;
     }
 
@@ -1354,7 +1356,7 @@ namespace libsemigroups {
       return p;
     }
 
-    Presentation<word_type> monogenic_semigroup(size_t m, size_t r) {
+    Presentation<word_type> monogenic_semigroup(size_t m, size_t r) { 
       if (r == 0) {
         LIBSEMIGROUPS_EXCEPTION(
             "expected 2nd argument to be strictly positive, found {}", r);
@@ -1362,6 +1364,12 @@ namespace libsemigroups {
       Presentation<word_type> p;
       presentation::add_rule_no_checks(p, pow(0_w, m + r), pow(0_w, m));
       p.alphabet_from_rules();
+      if (m == 0) {
+        p.contains_empty_word(true);
+      }
+      else {
+        p.contains_empty_word(false);
+      }
       return p;
     }
 

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -21,21 +21,24 @@
 
 #include "libsemigroups/fpsemi-examples.hpp"
 
-#include <algorithm>  // for for_each
-#include <cmath>      // for abs
-#include <cstdint>    // for int64_t
-#include <cstdlib>    // for abs
-#include <numeric>    // for iota
-#include <utility>    // for move
+#include <algorithm>         // for max, for_each
+#include <cmath>             // for abs
+#include <cstdint>           // for int64_t
+#include <cstdlib>           // for abs
+#include <initializer_list>  // for initializer_list
+#include <numeric>           // for iota
+#include <string>            // for basic_string
+#include <utility>           // for move, swap
 
-#include "libsemigroups/debug.hpp"      // for LIBSEMIGROUPS_ASSERT
-#include "libsemigroups/exception.hpp"  // for LIBSEMIGROUPS_EXCEPTION, Libs...
-#include "libsemigroups/presentation.hpp"  // for operator+, add_rule, operator+=
-#include "libsemigroups/ranges.hpp"  // for seq, Inner, operator|, to_vector
-#include "libsemigroups/types.hpp"   // for word_type, relation_type, let...
-#include "libsemigroups/words.hpp"   // for operator""_w
-
-#include "libsemigroups/detail/report.hpp"  // for magic_enum formatting
+#include "libsemigroups/constants.hpp"     // for operator==
+#include "libsemigroups/debug.hpp"         // for LIBSEMIGROUPS_ASSERT
+#include "libsemigroups/detail/fmt.hpp"    // for format
+#include "libsemigroups/exception.hpp"     // for LIBSEMIGROUPS_EXCEPTION
+#include "libsemigroups/order.hpp"         // for shortlex_compare
+#include "libsemigroups/presentation.hpp"  // for add_rule_no_checks, Presen...
+#include "libsemigroups/ranges.hpp"        // for operator|, to_vector, enum...
+#include "libsemigroups/types.hpp"         // for word_type, letter_type
+#include "libsemigroups/words.hpp"         // for operator""_w, operator+, pow
 
 namespace libsemigroups {
   using literals::operator""_w;
@@ -971,7 +974,8 @@ namespace libsemigroups {
     }
 
     // Also from https://doi.org/10.1007/s10012-000-0001-1
-    Presentation<word_type> orientation_preserving_reversing_monoid(size_t n, author val) {
+    Presentation<word_type>
+    orientation_preserving_reversing_monoid(size_t n, author val) {
       if (n < 3) {
         LIBSEMIGROUPS_EXCEPTION(
             "expected 1st argument to be at least 3, found {}", n);

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -75,7 +75,7 @@ namespace libsemigroups {
       // For the partial transformation monoid presentation, we want e12_value =
       // n.
 
-      LIBSEMIGROUPS_ASSERT(n >= 5);
+      LIBSEMIGROUPS_ASSERT(n >= 4);
       LIBSEMIGROUPS_ASSERT(e12_value < pi_start
                            | e12_value >= pi_start + n - 2);
 

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -76,7 +76,8 @@ namespace libsemigroups {
       // n.
 
       LIBSEMIGROUPS_ASSERT(n >= 5);
-      LIBSEMIGROUPS_ASSERT(e12_value < pi_start | e12_value >= pi_start + n - 2)
+      LIBSEMIGROUPS_ASSERT(e12_value < pi_start
+                           | e12_value >= pi_start + n - 2);
 
       word_type              e12 = {e12_value};
       std::vector<word_type> pi;

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -72,15 +72,8 @@ namespace libsemigroups {
       // For the partial transformation monoid presentation, we want e12_value =
       // n.
 
-      if (n < 4) {
-        LIBSEMIGROUPS_EXCEPTION(
-            "expected 1st argument to be at least 4, found {}", n);
-      } else if (e12_value >= pi_start && e12_value <= pi_start + n - 2) {
-        // TODO improve the error message
-        LIBSEMIGROUPS_EXCEPTION("e12 must not lie in the range [pi_start, "
-                                "pi_start + n - 2], found {}",
-                                e12_value);
-      }
+      LIBSEMIGROUPS_ASSERT(n >= 5);
+      LIBSEMIGROUPS_ASSERT(e12_value < pi_start | e12_value >= pi_start + n - 2)
 
       word_type              e12 = {e12_value};
       std::vector<word_type> pi;

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -971,7 +971,7 @@ namespace libsemigroups {
     }
 
     // Also from https://doi.org/10.1007/s10012-000-0001-1
-    Presentation<word_type> orientation_reversing_monoid(size_t n, author val) {
+    Presentation<word_type> orientation_preserving_reversing_monoid(size_t n, author val) {
       if (n < 3) {
         LIBSEMIGROUPS_EXCEPTION(
             "expected 1st argument to be at least 3, found {}", n);

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -355,10 +355,13 @@ namespace libsemigroups {
     using words::operator+;
     using words::operator+=;
 
-    Presentation<word_type> stellar_monoid(size_t l) {
+    Presentation<word_type> stellar_monoid(size_t l, author val) {
       if (l < 2) {
-        LIBSEMIGROUPS_EXCEPTION("expected argument to be at least 2, found {}",
-                                l);
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 1st argument to be at least 2, found {}", l);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
       }
       auto p = zero_rook_monoid(l);
 
@@ -371,13 +374,18 @@ namespace libsemigroups {
       return p;
     }
 
-    Presentation<word_type> fibonacci_semigroup(size_t r, size_t n) {
+    Presentation<word_type> fibonacci_semigroup(size_t r,
+                                                size_t n,
+                                                author val) {
       if (r == 0) {
         LIBSEMIGROUPS_EXCEPTION(
             "expected 1st argument to be strictly positive, found {}", r);
       } else if (n == 0) {
         LIBSEMIGROUPS_EXCEPTION(
             "expected 2nd argument to be strictly positive, found {}", n);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 3rd argument to be author::Any, found {}", val);
       }
       Presentation<word_type> p;
 
@@ -391,10 +399,13 @@ namespace libsemigroups {
       return p;
     }
 
-    Presentation<word_type> plactic_monoid(size_t n) {
+    Presentation<word_type> plactic_monoid(size_t n, author val) {
       if (n < 1) {
-        LIBSEMIGROUPS_EXCEPTION("expected argument to be at least 1, found {}",
-                                n);
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 1st argument to be at least 1, found {}", n);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
       }
       Presentation<word_type> p;
       p.alphabet(n);
@@ -419,10 +430,13 @@ namespace libsemigroups {
       return p;
     }
 
-    Presentation<word_type> stylic_monoid(size_t n) {
+    Presentation<word_type> stylic_monoid(size_t n, author val) {
       if (n < 2) {
-        LIBSEMIGROUPS_EXCEPTION("expected argument to be at least 2, found {}",
-                                n);
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 1st argument to be at least 2, found {}", n);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
       }
       auto p = plactic_monoid(n);
       presentation::add_idempotent_rules_no_checks(p, range(n));
@@ -864,19 +878,22 @@ namespace libsemigroups {
 
     // From Theorem 5 in 10.21136/MB.2007.134125
     // https://dml.cz/bitstream/handle/10338.dmlcz/134125/MathBohem_132-2007-3_6.pdf
-    Presentation<word_type> singular_brauer_monoid(size_t n) {
+    Presentation<word_type> singular_brauer_monoid(size_t n, author val) {
       if (n < 3) {
-        LIBSEMIGROUPS_EXCEPTION("expected argument to be at least 3, found {}",
-                                n);
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 1st argument to be at least 3, found {}", n);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
       }
       std::vector<std::vector<word_type>> t;
-      size_t                              val = 0;
+      size_t                              value = 0;
       for (size_t i = 0; i < n; ++i) {
         t.push_back({});
         for (size_t j = 0; j < n; ++j) {
           if (i != j) {
-            t.back().push_back({val});
-            val++;
+            t.back().push_back({value});
+            value++;
           } else {
             t.back().push_back({0});
           }
@@ -932,10 +949,14 @@ namespace libsemigroups {
     }
 
     // From https://doi.org/10.1007/s10012-000-0001-1
-    Presentation<word_type> orientation_preserving_monoid(size_t n) {
+    Presentation<word_type> orientation_preserving_monoid(size_t n,
+                                                          author val) {
       if (n < 3) {
-        LIBSEMIGROUPS_EXCEPTION("expected argument to be at least 3, found {}",
-                                n);
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 1st argument to be at least 3, found {}", n);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
       }
       Presentation<word_type> p;
       p.alphabet(2);
@@ -957,10 +978,13 @@ namespace libsemigroups {
     }
 
     // Also from https://doi.org/10.1007/s10012-000-0001-1
-    Presentation<word_type> orientation_reversing_monoid(size_t n) {
+    Presentation<word_type> orientation_reversing_monoid(size_t n, author val) {
       if (n < 3) {
-        LIBSEMIGROUPS_EXCEPTION("expected argument to be at least 3, found {}",
-                                n);
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 1st argument to be at least 3, found {}", n);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
       }
       Presentation<word_type> p;
       p.alphabet(3);
@@ -992,10 +1016,13 @@ namespace libsemigroups {
     }
 
     // From Theorem 2.2 in https://doi.org/10.1093/qmath/haab001
-    Presentation<word_type> temperley_lieb_monoid(size_t n) {
+    Presentation<word_type> temperley_lieb_monoid(size_t n, author val) {
       if (n < 3) {
-        LIBSEMIGROUPS_EXCEPTION("expected argument to be at least 3, found {}",
-                                n);
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 1st argument to be at least 3, found {}", n);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
       }
 
       Presentation<word_type> p;
@@ -1022,7 +1049,11 @@ namespace libsemigroups {
 
     // From Theorem 3.1 in
     // https://link.springer.com/content/pdf/10.2478/s11533-006-0017-6.pdf
-    Presentation<word_type> brauer_monoid(size_t n) {
+    Presentation<word_type> brauer_monoid(size_t n, author val) {
+      if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
+      }
       std::vector<word_type> s(n), t(n);
       for (size_t i = 0; i < n - 1; ++i) {
         s[i] = {i};
@@ -1065,9 +1096,13 @@ namespace libsemigroups {
       return p;
     }
 
-    Presentation<word_type> partial_brauer_monoid(size_t n) {
+    Presentation<word_type> partial_brauer_monoid(size_t n, author val) {
       if (n == 0) {
         LIBSEMIGROUPS_EXCEPTION("TODO");
+      }
+      if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
       }
 
       std::vector<word_type> s(n), t(n), v(n);
@@ -1129,7 +1164,7 @@ namespace libsemigroups {
 
     // From Proposition 4.2 in
     // https://link.springer.com/content/pdf/10.1007/s002339910016.pdf
-    Presentation<word_type> rectangular_band(size_t m, size_t n) {
+    Presentation<word_type> rectangular_band(size_t m, size_t n, author val) {
       if (m == 0) {
         LIBSEMIGROUPS_EXCEPTION(
             "expected 1st argument to be strictly positive, found {}", m);
@@ -1137,6 +1172,9 @@ namespace libsemigroups {
       if (n == 0) {
         LIBSEMIGROUPS_EXCEPTION(
             "expected 2nd argument to be strictly positive, found {}", n);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 3rd argument to be author::Any, found {}", val);
       }
 
       std::vector<word_type> a(m);
@@ -1331,10 +1369,13 @@ namespace libsemigroups {
     // Chinese monoid
     // See: The Chinese Monoid - Cassaigne, Espie, Krob, Novelli and Hivert,
     // 2001
-    Presentation<word_type> chinese_monoid(size_t n) {
+    Presentation<word_type> chinese_monoid(size_t n, author val) {
       if (n < 2) {
-        LIBSEMIGROUPS_EXCEPTION("expected argument to be at least 2, found {}",
-                                n);
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 1st argument to be at least 2, found {}", n);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
       }
       Presentation<word_type> p;
       p.alphabet(n);
@@ -1356,27 +1397,34 @@ namespace libsemigroups {
       return p;
     }
 
-    Presentation<word_type> monogenic_semigroup(size_t m, size_t r) { 
+    Presentation<word_type> monogenic_semigroup(size_t m,
+                                                size_t r,
+                                                author val) {
       if (r == 0) {
         LIBSEMIGROUPS_EXCEPTION(
             "expected 2nd argument to be strictly positive, found {}", r);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 3rd argument to be author::Any, found {}", val);
       }
       Presentation<word_type> p;
       presentation::add_rule_no_checks(p, pow(0_w, m + r), pow(0_w, m));
       p.alphabet_from_rules();
       if (m == 0) {
         p.contains_empty_word(true);
-      }
-      else {
+      } else {
         p.contains_empty_word(false);
       }
       return p;
     }
 
-    Presentation<word_type> order_preserving_monoid(size_t n) {
+    Presentation<word_type> order_preserving_monoid(size_t n, author val) {
       if (n < 3) {
-        LIBSEMIGROUPS_EXCEPTION("expected argument to be at least 3, found {}",
-                                n);
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 1st argument to be at least 3, found {}", n);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
       }
       std::vector<word_type> u, v;
 
@@ -1493,10 +1541,14 @@ namespace libsemigroups {
     }
 
     // See Theorem 2.17 of https://arxiv.org/pdf/2211.02155.pdf
-    Presentation<word_type> order_preserving_cyclic_inverse_monoid(size_t n) {
+    Presentation<word_type> order_preserving_cyclic_inverse_monoid(size_t n,
+                                                                   author val) {
       if (n < 3) {
-        LIBSEMIGROUPS_EXCEPTION("expected argument to be at least 3, found {}",
-                                n);
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 1st argument to be at least 3, found {}", n);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
       }
 
       Presentation<word_type> p;
@@ -1538,10 +1590,14 @@ namespace libsemigroups {
     }
 
     // See Theorem 2.8 of https://arxiv.org/pdf/2205.02196.pdf
-    Presentation<word_type> partial_isometries_cycle_graph_monoid(size_t n) {
+    Presentation<word_type> partial_isometries_cycle_graph_monoid(size_t n,
+                                                                  author val) {
       if (n < 3) {
-        LIBSEMIGROUPS_EXCEPTION("expected argument to be at least 3, found {}",
-                                n);
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 1st argument to be at least 3, found {}", n);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
       }
 
       Presentation<word_type> p;
@@ -1632,7 +1688,11 @@ namespace libsemigroups {
 
     // n should be prime for this presentation to actually defined the claimed
     // group.
-    Presentation<word_type> special_linear_group_2(size_t n) {
+    Presentation<word_type> special_linear_group_2(size_t n, author val) {
+      if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
+      }
       Presentation<word_type> p;
       p.alphabet(4);
       p.contains_empty_word(true);
@@ -1646,7 +1706,11 @@ namespace libsemigroups {
       return p;
     }
 
-    Presentation<word_type> hypo_plactic_monoid(size_t n) {
+    Presentation<word_type> hypo_plactic_monoid(size_t n, author val) {
+      if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
+      }
       auto result = plactic_monoid(n);
 
       for (letter_type a = 0; a < n; ++a) {
@@ -1673,7 +1737,11 @@ namespace libsemigroups {
     }
 
     Presentation<word_type>
-    sigma_stylic_monoid(std::vector<size_t> const& sigma) {
+    sigma_stylic_monoid(std::vector<size_t> const& sigma, author val) {
+      if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
+      }
       auto p = plactic_monoid(sigma.size());
       p.contains_empty_word(true);
       for (auto [a, e] : rx::enumerate(sigma)) {
@@ -1682,10 +1750,13 @@ namespace libsemigroups {
       return p;
     }
 
-    Presentation<word_type> zero_rook_monoid(size_t n) {
+    Presentation<word_type> zero_rook_monoid(size_t n, author val) {
       if (n < 2) {
         LIBSEMIGROUPS_EXCEPTION(
             "the 1st argument (degree) must at least 2, found {}", n);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 2nd argument to be author::Any, found {}", val);
       }
 
       Presentation<word_type> p;
@@ -1696,9 +1767,14 @@ namespace libsemigroups {
       return p;
     }
 
-    Presentation<word_type> not_renner_type_B_monoid(size_t l, int q) {
+    Presentation<word_type> not_renner_type_B_monoid(size_t l,
+                                                     int    q,
+                                                     author val) {
       if (q != 0 && q != 1) {
         LIBSEMIGROUPS_EXCEPTION("the 2nd argument must be 0 or 1, found {}", q);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 3rd argument to be author::Any, found {}", val);
       }
 
       Presentation<word_type> p;
@@ -1714,9 +1790,12 @@ namespace libsemigroups {
       return p;
     }
 
-    Presentation<word_type> renner_type_B_monoid(size_t l, int q) {
+    Presentation<word_type> renner_type_B_monoid(size_t l, int q, author val) {
       if (q != 0 && q != 1) {
         LIBSEMIGROUPS_EXCEPTION("the 2nd argument must be 0 or 1, found {}", q);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 3rd argument to be author::Any, found {}", val);
       }
 
       Presentation<word_type> p;
@@ -1735,9 +1814,14 @@ namespace libsemigroups {
       return p;
     }
 
-    Presentation<word_type> not_renner_type_D_monoid(size_t l, int q) {
+    Presentation<word_type> not_renner_type_D_monoid(size_t l,
+                                                     int    q,
+                                                     author val) {
       if (q != 0 && q != 1) {
         LIBSEMIGROUPS_EXCEPTION("the 2nd argument must be 0 or 1, found {}", q);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 3rd argument to be author::Any, found {}", val);
       }
       Presentation<word_type> p;
       add_renner_type_D_common(p, l, q);
@@ -1756,9 +1840,12 @@ namespace libsemigroups {
       return p;
     }
 
-    Presentation<word_type> renner_type_D_monoid(size_t l, int q) {
+    Presentation<word_type> renner_type_D_monoid(size_t l, int q, author val) {
       if (q != 0 && q != 1) {
         LIBSEMIGROUPS_EXCEPTION("the 2nd argument must be 0 or 1, found {}", q);
+      } else if (val != author::Any) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 3rd argument to be author::Any, found {}", val);
       }
       Presentation<word_type> p;
       add_renner_type_D_common(p, l, q);

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -22,15 +22,29 @@
 
 // #define CATCH_CONFIG_ENABLE_PAIR_STRINGMAKER
 
-#include "catch.hpp"  // for REQUIRE, REQUIRE_NOTHROW, REQUIRE_THROWS_AS
-#include "libsemigroups/to-froidure-pin.hpp"
-#include "test-main.hpp"  // for LIBSEMIGROUPS_TEST_CASE
-
-#include "libsemigroups/detail/report.hpp"    // for ReportGuard
-#include "libsemigroups/fpsemi-examples.hpp"  // for the presentations
+#include <cmath>                              // for pow
+#include <cmath>                              // for pow
+#include <cstddef>                            // for size_t
+#include <unordered_map>                      // for operator!=
+#include <vector>                             // for vector, allocator, oper...
+                                              //
+#include "catch.hpp"                          // for StringRef, SourceLineInfo
+#include "test-main.hpp"                      // for LIBSEMIGROUPS_TEST_CASE
+                                              //
+#include "libsemigroups/constants.hpp"        // for operator!=
+#include "libsemigroups/exception.hpp"        // for LibsemigroupsException
+#include "libsemigroups/fpsemi-examples.hpp"  // for author, symmetric_group
+#include "libsemigroups/froidure-pin.hpp"     // for FroidurePin
+#include "libsemigroups/obvinf.hpp"           // for is_obviously_infinite
+#include "libsemigroups/presentation.hpp"     // for Presentation, operator==
+#include "libsemigroups/ranges.hpp"           // for operator|, chain
+#include "libsemigroups/to-froidure-pin.hpp"  // for to_froidure_pin
 #include "libsemigroups/todd-coxeter.hpp"     // for ToddCoxeter
-#include "libsemigroups/types.hpp"            // for word_type
-#include "libsemigroups/words.hpp"
+#include "libsemigroups/types.hpp"            // for congruence_kind, word_type
+#include "libsemigroups/words.hpp"            // for operator""_w
+
+#include "libsemigroups/detail/fmt.hpp"  // for format, print                                           //
+#include "libsemigroups/detail/report.hpp"  // for ReportGuard
 
 namespace libsemigroups {
   using literals::operator""_w;
@@ -98,30 +112,43 @@ namespace libsemigroups {
 
     // author::Any defaults
     REQUIRE(stellar_monoid(4, author::Any) == stellar_monoid(4));
-    REQUIRE(singular_brauer_monoid(4, author::Any) == singular_brauer_monoid(4));
-    REQUIRE(orientation_preserving_monoid(4, author::Any) == orientation_preserving_monoid(4));
-    REQUIRE(orientation_preserving_reversing_monoid(4, author::Any) == orientation_preserving_reversing_monoid(4));
+    REQUIRE(singular_brauer_monoid(4, author::Any)
+            == singular_brauer_monoid(4));
+    REQUIRE(orientation_preserving_monoid(4, author::Any)
+            == orientation_preserving_monoid(4));
+    REQUIRE(orientation_preserving_reversing_monoid(4, author::Any)
+            == orientation_preserving_reversing_monoid(4));
     REQUIRE(temperley_lieb_monoid(4, author::Any) == temperley_lieb_monoid(4));
     REQUIRE(brauer_monoid(4, author::Any) == brauer_monoid(4));
     REQUIRE(partial_brauer_monoid(4, author::Any) == partial_brauer_monoid(4));
-    REQUIRE(fibonacci_semigroup(5, 2, author::Any) == fibonacci_semigroup(5, 2));
+    REQUIRE(fibonacci_semigroup(5, 2, author::Any)
+            == fibonacci_semigroup(5, 2));
     REQUIRE(plactic_monoid(4, author::Any) == plactic_monoid(4));
     REQUIRE(stylic_monoid(4, author::Any) == stylic_monoid(4));
     REQUIRE(rectangular_band(5, 3, author::Any) == rectangular_band(5, 3));
     REQUIRE(chinese_monoid(5, author::Any) == chinese_monoid(5));
-    REQUIRE(monogenic_semigroup(6, 3, author::Any) == monogenic_semigroup(6, 3));
-    REQUIRE(order_preserving_monoid(4, author::Any) == order_preserving_monoid(4));
-    REQUIRE(order_preserving_cyclic_inverse_monoid(4, author::Any) == order_preserving_cyclic_inverse_monoid(4));
-    REQUIRE(partial_isometries_cycle_graph_monoid(4, author::Any) == partial_isometries_cycle_graph_monoid(4));
-    REQUIRE(special_linear_group_2(5, author::Any) == special_linear_group_2(5));
+    REQUIRE(monogenic_semigroup(6, 3, author::Any)
+            == monogenic_semigroup(6, 3));
+    REQUIRE(order_preserving_monoid(4, author::Any)
+            == order_preserving_monoid(4));
+    REQUIRE(order_preserving_cyclic_inverse_monoid(4, author::Any)
+            == order_preserving_cyclic_inverse_monoid(4));
+    REQUIRE(partial_isometries_cycle_graph_monoid(4, author::Any)
+            == partial_isometries_cycle_graph_monoid(4));
+    REQUIRE(special_linear_group_2(5, author::Any)
+            == special_linear_group_2(5));
     REQUIRE(hypo_plactic_monoid(4, author::Any) == hypo_plactic_monoid(4));
-    REQUIRE(sigma_stylic_monoid({3, 4}, author::Any) == sigma_stylic_monoid({3, 4}));
+    REQUIRE(sigma_stylic_monoid({3, 4}, author::Any)
+            == sigma_stylic_monoid({3, 4}));
     REQUIRE(zero_rook_monoid(4, author::Any) == zero_rook_monoid(4));
-    REQUIRE(renner_type_B_monoid(4, 1, author::Any) == renner_type_B_monoid(4, 1));
-    REQUIRE(not_renner_type_B_monoid(4, 1, author::Any) == not_renner_type_B_monoid(4, 1));
-    REQUIRE(renner_type_D_monoid(4, 1, author::Any) == renner_type_D_monoid(4, 1));
-    REQUIRE(not_renner_type_D_monoid(4, 1, author::Any) == not_renner_type_D_monoid(4, 1));
-
+    REQUIRE(renner_type_B_monoid(4, 1, author::Any)
+            == renner_type_B_monoid(4, 1));
+    REQUIRE(not_renner_type_B_monoid(4, 1, author::Any)
+            == not_renner_type_B_monoid(4, 1));
+    REQUIRE(renner_type_D_monoid(4, 1, author::Any)
+            == renner_type_D_monoid(4, 1));
+    REQUIRE(not_renner_type_D_monoid(4, 1, author::Any)
+            == not_renner_type_D_monoid(4, 1));
 
     // index defaults
     REQUIRE(symmetric_group(4, author::Moore)
@@ -149,16 +176,22 @@ namespace libsemigroups {
     REQUIRE(not fibonacci_semigroup(5, 2).contains_empty_word());
     REQUIRE(plactic_monoid(5).contains_empty_word());
     REQUIRE(stylic_monoid(5).contains_empty_word());
-    REQUIRE(symmetric_group(5, author::Burnside + author::Miller).contains_empty_word());
+    REQUIRE(symmetric_group(5, author::Burnside + author::Miller)
+                .contains_empty_word());
     REQUIRE(symmetric_group(5, author::Carmichael).contains_empty_word());
-    REQUIRE(symmetric_group(5, author::Coxeter + author::Moser).contains_empty_word());
+    REQUIRE(symmetric_group(5, author::Coxeter + author::Moser)
+                .contains_empty_word());
     REQUIRE(symmetric_group(5, author::Moore).contains_empty_word());
     REQUIRE(alternating_group(5).contains_empty_word());
     REQUIRE(not rectangular_band(5, 5).contains_empty_word());
-    REQUIRE(full_transformation_monoid(5, author::Iwahori).contains_empty_word());
-    REQUIRE(full_transformation_monoid(5, author::Aizenstat).contains_empty_word());
-    REQUIRE(partial_transformation_monoid(5, author::Sutov).contains_empty_word());
-    REQUIRE(partial_transformation_monoid(3, author::Machine).contains_empty_word());
+    REQUIRE(
+        full_transformation_monoid(5, author::Iwahori).contains_empty_word());
+    REQUIRE(
+        full_transformation_monoid(5, author::Aizenstat).contains_empty_word());
+    REQUIRE(
+        partial_transformation_monoid(5, author::Sutov).contains_empty_word());
+    REQUIRE(partial_transformation_monoid(3, author::Machine)
+                .contains_empty_word());
     REQUIRE(symmetric_inverse_monoid(5).contains_empty_word());
     REQUIRE(chinese_monoid(5).contains_empty_word());
     REQUIRE(monogenic_semigroup(0, 5).contains_empty_word());
@@ -351,7 +384,7 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(stellar_monoid(1), LibsemigroupsException);
   }
 
-    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "103",
                           "stellar_monoid auth except",
                           "[fpsemi-examples][quick]") {
@@ -369,12 +402,13 @@ namespace libsemigroups {
     REQUIRE_NOTHROW(plactic_monoid(2));
   }
 
-    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "104",
                           "plactic_monoid auth except",
                           "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
-    REQUIRE_THROWS_AS(plactic_monoid(5, author::Iwahori), LibsemigroupsException);
+    REQUIRE_THROWS_AS(plactic_monoid(5, author::Iwahori),
+                      LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
@@ -386,7 +420,7 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(stylic_monoid(1), LibsemigroupsException);
   }
 
-    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "105",
                           "stylic_monoid auth except",
                           "[fpsemi-examples][quick]") {
@@ -404,13 +438,14 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(temperley_lieb_monoid(2), LibsemigroupsException);
   }
 
-    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "106",
                           "temperley_lieb_monoid auth except",
                           "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
-    REQUIRE_THROWS_AS(temperley_lieb_monoid(5, author::Sutov), LibsemigroupsException);
-    }
+    REQUIRE_THROWS_AS(temperley_lieb_monoid(5, author::Sutov),
+                      LibsemigroupsException);
+  }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "023",
@@ -422,12 +457,13 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(singular_brauer_monoid(2), LibsemigroupsException);
   }
 
-    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "107",
                           "singular_brauer_monoid auth except",
                           "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
-    REQUIRE_THROWS_AS(singular_brauer_monoid(5, author::Sutov), LibsemigroupsException);
+    REQUIRE_THROWS_AS(singular_brauer_monoid(5, author::Sutov),
+                      LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
@@ -440,30 +476,36 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(orientation_preserving_monoid(2), LibsemigroupsException);
   }
 
-    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "107",
                           "orientation_preserving_monoid auth except",
                           "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
-    REQUIRE_THROWS_AS(orientation_preserving_monoid(5, author::Sutov), LibsemigroupsException);
+    REQUIRE_THROWS_AS(orientation_preserving_monoid(5, author::Sutov),
+                      LibsemigroupsException);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE(
+      "fpsemi-examples",
+      "025",
+      "orientation_preserving_reversing_monoid degree except",
+      "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(orientation_preserving_reversing_monoid(0),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(orientation_preserving_reversing_monoid(1),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(orientation_preserving_reversing_monoid(2),
+                      LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
-                          "025",
-                          "orientation_preserving_reversing_monoid degree except",
-                          "[fpsemi-examples][quick]") {
-    auto rg = ReportGuard(REPORT);
-    REQUIRE_THROWS_AS(orientation_preserving_reversing_monoid(0), LibsemigroupsException);
-    REQUIRE_THROWS_AS(orientation_preserving_reversing_monoid(1), LibsemigroupsException);
-    REQUIRE_THROWS_AS(orientation_preserving_reversing_monoid(2), LibsemigroupsException);
-  }
-
-    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "108",
                           "orientation_preserving_reversing_monoid auth except",
                           "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
-    REQUIRE_THROWS_AS(orientation_preserving_reversing_monoid(0, author::Sutov), LibsemigroupsException);
+    REQUIRE_THROWS_AS(orientation_preserving_reversing_monoid(0, author::Sutov),
+                      LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
@@ -476,12 +518,13 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(order_preserving_monoid(2), LibsemigroupsException);
   }
 
-    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "109",
                           "order_preserving_monoid auth except",
                           "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
-    REQUIRE_THROWS_AS(order_preserving_monoid(5, author::Sutov), LibsemigroupsException);
+    REQUIRE_THROWS_AS(order_preserving_monoid(5, author::Sutov),
+                      LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
@@ -514,22 +557,28 @@ namespace libsemigroups {
                       LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
-                          "029",
-                          "order_preserving_cyclic_inverse_monoid degree except",
-                          "[fpsemi-examples][quick]") {
+  LIBSEMIGROUPS_TEST_CASE(
+      "fpsemi-examples",
+      "029",
+      "order_preserving_cyclic_inverse_monoid degree except",
+      "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
-    REQUIRE_THROWS_AS(order_preserving_cyclic_inverse_monoid(0), LibsemigroupsException);
-    REQUIRE_THROWS_AS(order_preserving_cyclic_inverse_monoid(1), LibsemigroupsException);
-    REQUIRE_THROWS_AS(order_preserving_cyclic_inverse_monoid(2), LibsemigroupsException);
+    REQUIRE_THROWS_AS(order_preserving_cyclic_inverse_monoid(0),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(order_preserving_cyclic_inverse_monoid(1),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(order_preserving_cyclic_inverse_monoid(2),
+                      LibsemigroupsException);
   }
 
-   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
-                          "110",
-                          "order_preserving_cyclic_inverse_monoid author except",
-                          "[fpsemi-examples][quick]") {
+  LIBSEMIGROUPS_TEST_CASE(
+      "fpsemi-examples",
+      "110",
+      "order_preserving_cyclic_inverse_monoid author except",
+      "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
-    REQUIRE_THROWS_AS(order_preserving_cyclic_inverse_monoid(2, author::Sutov), LibsemigroupsException);
+    REQUIRE_THROWS_AS(order_preserving_cyclic_inverse_monoid(2, author::Sutov),
+                      LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
@@ -545,12 +594,13 @@ namespace libsemigroups {
                       LibsemigroupsException);
   }
 
-    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "111",
                           "partial_isometries_cycle_graph_monoid auth except",
                           "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
-    REQUIRE_THROWS_AS(partial_isometries_cycle_graph_monoid(5, author::Sutov), LibsemigroupsException);
+    REQUIRE_THROWS_AS(partial_isometries_cycle_graph_monoid(5, author::Sutov),
+                      LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
@@ -637,7 +687,8 @@ namespace libsemigroups {
                           "[fpsemi-examples][quick]") {
     auto        rg = ReportGuard(REPORT);
     size_t      n  = 5;
-    ToddCoxeter tc(congruence_kind::twosided, orientation_preserving_reversing_monoid(n));
+    ToddCoxeter tc(congruence_kind::twosided,
+                   orientation_preserving_reversing_monoid(n));
     REQUIRE(tc.number_of_classes() == 1'015);
   }
 

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -52,6 +52,7 @@ namespace libsemigroups {
   using fpsemigroup::order_preserving_monoid;
   using fpsemigroup::orientation_preserving_monoid;
   using fpsemigroup::orientation_reversing_monoid;
+  using fpsemigroup::partial_brauer_monoid;
   using fpsemigroup::partial_isometries_cycle_graph_monoid;
   using fpsemigroup::partial_transformation_monoid;
   using fpsemigroup::partition_monoid;
@@ -93,6 +94,46 @@ namespace libsemigroups {
             == symmetric_group(4, author::Moore, 0));
     REQUIRE(cyclic_inverse_monoid(4, author::Fernandes)
             == cyclic_inverse_monoid(4, author::Fernandes, 1));
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "102",
+                          "test semigroup/monoid status",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE(stellar_monoid(5).contains_empty_word());
+    REQUIRE(dual_symmetric_inverse_monoid(5).contains_empty_word());
+    REQUIRE(uniform_block_bijection_monoid(5).contains_empty_word());
+    REQUIRE(partition_monoid(5, author::East).contains_empty_word());
+    REQUIRE(not partition_monoid(3, author::Machine).contains_empty_word());
+    REQUIRE(not singular_brauer_monoid(5).contains_empty_word());
+    REQUIRE(orientation_preserving_monoid(5).contains_empty_word());
+    REQUIRE(orientation_reversing_monoid(5).contains_empty_word());
+    REQUIRE(temperley_lieb_monoid(5).contains_empty_word());
+    REQUIRE(brauer_monoid(5).contains_empty_word());
+    REQUIRE(partial_brauer_monoid(5).contains_empty_word());
+    REQUIRE(not fibonacci_semigroup(5, 2).contains_empty_word());
+    REQUIRE(plactic_monoid(5).contains_empty_word());
+    REQUIRE(stylic_monoid(5).contains_empty_word());
+    REQUIRE(symmetric_group(5, author::Burnside + author::Miller).contains_empty_word());
+    REQUIRE(symmetric_group(5, author::Carmichael).contains_empty_word());
+    REQUIRE(symmetric_group(5, author::Coxeter + author::Moser).contains_empty_word());
+    REQUIRE(symmetric_group(5, author::Moore).contains_empty_word());
+    REQUIRE(alternating_group(5).contains_empty_word());
+    REQUIRE(not rectangular_band(5, 5).contains_empty_word());
+    REQUIRE(full_transformation_monoid(5, author::Iwahori).contains_empty_word());
+    REQUIRE(full_transformation_monoid(5, author::Aizenstat).contains_empty_word());
+    REQUIRE(partial_transformation_monoid(5, author::Sutov).contains_empty_word());
+    REQUIRE(partial_transformation_monoid(3, author::Machine).contains_empty_word());
+    REQUIRE(symmetric_inverse_monoid(5).contains_empty_word());
+    REQUIRE(chinese_monoid(5).contains_empty_word());
+    REQUIRE(monogenic_semigroup(0, 5).contains_empty_word());
+    REQUIRE(not monogenic_semigroup(2, 6).contains_empty_word());
+    REQUIRE(order_preserving_monoid(5).contains_empty_word());
+    REQUIRE(cyclic_inverse_monoid(5).contains_empty_word());
+    REQUIRE(order_preserving_cyclic_inverse_monoid(5).contains_empty_word());
+    REQUIRE(partial_isometries_cycle_graph_monoid(5).contains_empty_word());
+    REQUIRE(not_symmetric_group(5).contains_empty_word());
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -54,7 +54,7 @@ namespace libsemigroups {
   using fpsemigroup::order_preserving_cyclic_inverse_monoid;
   using fpsemigroup::order_preserving_monoid;
   using fpsemigroup::orientation_preserving_monoid;
-  using fpsemigroup::orientation_reversing_monoid;
+  using fpsemigroup::orientation_preserving_reversing_monoid;
   using fpsemigroup::partial_brauer_monoid;
   using fpsemigroup::partial_isometries_cycle_graph_monoid;
   using fpsemigroup::partial_transformation_monoid;
@@ -100,7 +100,7 @@ namespace libsemigroups {
     REQUIRE(stellar_monoid(4, author::Any) == stellar_monoid(4));
     REQUIRE(singular_brauer_monoid(4, author::Any) == singular_brauer_monoid(4));
     REQUIRE(orientation_preserving_monoid(4, author::Any) == orientation_preserving_monoid(4));
-    REQUIRE(orientation_reversing_monoid(4, author::Any) == orientation_reversing_monoid(4));
+    REQUIRE(orientation_preserving_reversing_monoid(4, author::Any) == orientation_preserving_reversing_monoid(4));
     REQUIRE(temperley_lieb_monoid(4, author::Any) == temperley_lieb_monoid(4));
     REQUIRE(brauer_monoid(4, author::Any) == brauer_monoid(4));
     REQUIRE(partial_brauer_monoid(4, author::Any) == partial_brauer_monoid(4));
@@ -142,7 +142,7 @@ namespace libsemigroups {
     REQUIRE(not partition_monoid(3, author::Machine).contains_empty_word());
     REQUIRE(not singular_brauer_monoid(5).contains_empty_word());
     REQUIRE(orientation_preserving_monoid(5).contains_empty_word());
-    REQUIRE(orientation_reversing_monoid(5).contains_empty_word());
+    REQUIRE(orientation_preserving_reversing_monoid(5).contains_empty_word());
     REQUIRE(temperley_lieb_monoid(5).contains_empty_word());
     REQUIRE(brauer_monoid(5).contains_empty_word());
     REQUIRE(partial_brauer_monoid(5).contains_empty_word());
@@ -450,20 +450,20 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "025",
-                          "orientation_reversing_monoid degree except",
+                          "orientation_preserving_reversing_monoid degree except",
                           "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
-    REQUIRE_THROWS_AS(orientation_reversing_monoid(0), LibsemigroupsException);
-    REQUIRE_THROWS_AS(orientation_reversing_monoid(1), LibsemigroupsException);
-    REQUIRE_THROWS_AS(orientation_reversing_monoid(2), LibsemigroupsException);
+    REQUIRE_THROWS_AS(orientation_preserving_reversing_monoid(0), LibsemigroupsException);
+    REQUIRE_THROWS_AS(orientation_preserving_reversing_monoid(1), LibsemigroupsException);
+    REQUIRE_THROWS_AS(orientation_preserving_reversing_monoid(2), LibsemigroupsException);
   }
 
     LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "108",
-                          "orientation_reversing_monoid auth except",
+                          "orientation_preserving_reversing_monoid auth except",
                           "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
-    REQUIRE_THROWS_AS(orientation_reversing_monoid(0, author::Sutov), LibsemigroupsException);
+    REQUIRE_THROWS_AS(orientation_preserving_reversing_monoid(0, author::Sutov), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
@@ -633,11 +633,11 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "038",
-                          "orientation_reversing_monoid(5)",
+                          "orientation_preserving_reversing_monoid(5)",
                           "[fpsemi-examples][quick]") {
     auto        rg = ReportGuard(REPORT);
     size_t      n  = 5;
-    ToddCoxeter tc(congruence_kind::twosided, orientation_reversing_monoid(n));
+    ToddCoxeter tc(congruence_kind::twosided, orientation_preserving_reversing_monoid(n));
     REQUIRE(tc.number_of_classes() == 1'015);
   }
 

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -46,7 +46,10 @@ namespace libsemigroups {
   using fpsemigroup::dual_symmetric_inverse_monoid;
   using fpsemigroup::fibonacci_semigroup;
   using fpsemigroup::full_transformation_monoid;
+  using fpsemigroup::hypo_plactic_monoid;
   using fpsemigroup::monogenic_semigroup;
+  using fpsemigroup::not_renner_type_B_monoid;
+  using fpsemigroup::not_renner_type_D_monoid;
   using fpsemigroup::not_symmetric_group;
   using fpsemigroup::order_preserving_cyclic_inverse_monoid;
   using fpsemigroup::order_preserving_monoid;
@@ -58,7 +61,11 @@ namespace libsemigroups {
   using fpsemigroup::partition_monoid;
   using fpsemigroup::plactic_monoid;
   using fpsemigroup::rectangular_band;
+  using fpsemigroup::renner_type_B_monoid;
+  using fpsemigroup::renner_type_D_monoid;
+  using fpsemigroup::sigma_stylic_monoid;
   using fpsemigroup::singular_brauer_monoid;
+  using fpsemigroup::special_linear_group_2;
   using fpsemigroup::stellar_monoid;
   using fpsemigroup::stylic_monoid;
   using fpsemigroup::symmetric_group;
@@ -88,6 +95,33 @@ namespace libsemigroups {
     REQUIRE(partition_monoid(4) == partition_monoid(4, author::East));
     REQUIRE(cyclic_inverse_monoid(4)
             == cyclic_inverse_monoid(4, author::Fernandes));
+
+    // author::Any defaults
+    REQUIRE(stellar_monoid(4, author::Any) == stellar_monoid(4));
+    REQUIRE(singular_brauer_monoid(4, author::Any) == singular_brauer_monoid(4));
+    REQUIRE(orientation_preserving_monoid(4, author::Any) == orientation_preserving_monoid(4));
+    REQUIRE(orientation_reversing_monoid(4, author::Any) == orientation_reversing_monoid(4));
+    REQUIRE(temperley_lieb_monoid(4, author::Any) == temperley_lieb_monoid(4));
+    REQUIRE(brauer_monoid(4, author::Any) == brauer_monoid(4));
+    REQUIRE(partial_brauer_monoid(4, author::Any) == partial_brauer_monoid(4));
+    REQUIRE(fibonacci_semigroup(5, 2, author::Any) == fibonacci_semigroup(5, 2));
+    REQUIRE(plactic_monoid(4, author::Any) == plactic_monoid(4));
+    REQUIRE(stylic_monoid(4, author::Any) == stylic_monoid(4));
+    REQUIRE(rectangular_band(5, 3, author::Any) == rectangular_band(5, 3));
+    REQUIRE(chinese_monoid(5, author::Any) == chinese_monoid(5));
+    REQUIRE(monogenic_semigroup(6, 3, author::Any) == monogenic_semigroup(6, 3));
+    REQUIRE(order_preserving_monoid(4, author::Any) == order_preserving_monoid(4));
+    REQUIRE(order_preserving_cyclic_inverse_monoid(4, author::Any) == order_preserving_cyclic_inverse_monoid(4));
+    REQUIRE(partial_isometries_cycle_graph_monoid(4, author::Any) == partial_isometries_cycle_graph_monoid(4));
+    REQUIRE(special_linear_group_2(5, author::Any) == special_linear_group_2(5));
+    REQUIRE(hypo_plactic_monoid(4, author::Any) == hypo_plactic_monoid(4));
+    REQUIRE(sigma_stylic_monoid({3, 4}, author::Any) == sigma_stylic_monoid({3, 4}));
+    REQUIRE(zero_rook_monoid(4, author::Any) == zero_rook_monoid(4));
+    REQUIRE(renner_type_B_monoid(4, 1, author::Any) == renner_type_B_monoid(4, 1));
+    REQUIRE(not_renner_type_B_monoid(4, 1, author::Any) == not_renner_type_B_monoid(4, 1));
+    REQUIRE(renner_type_D_monoid(4, 1, author::Any) == renner_type_D_monoid(4, 1));
+    REQUIRE(not_renner_type_D_monoid(4, 1, author::Any) == not_renner_type_D_monoid(4, 1));
+
 
     // index defaults
     REQUIRE(symmetric_group(4, author::Moore)

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -351,6 +351,14 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(stellar_monoid(1), LibsemigroupsException);
   }
 
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "103",
+                          "stellar_monoid auth except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(stellar_monoid(5, author::Sutov), LibsemigroupsException);
+  }
+
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "020",
                           "plactic_monoid degree except",
@@ -361,6 +369,14 @@ namespace libsemigroups {
     REQUIRE_NOTHROW(plactic_monoid(2));
   }
 
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "104",
+                          "plactic_monoid auth except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(plactic_monoid(5, author::Iwahori), LibsemigroupsException);
+  }
+
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "021",
                           "stylic_monoid degree except",
@@ -368,6 +384,14 @@ namespace libsemigroups {
     auto rg = ReportGuard(REPORT);
     REQUIRE_THROWS_AS(stylic_monoid(0), LibsemigroupsException);
     REQUIRE_THROWS_AS(stylic_monoid(1), LibsemigroupsException);
+  }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "105",
+                          "stylic_monoid auth except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(stylic_monoid(5, author::Sutov), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
@@ -380,6 +404,14 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(temperley_lieb_monoid(2), LibsemigroupsException);
   }
 
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "106",
+                          "temperley_lieb_monoid auth except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(temperley_lieb_monoid(5, author::Sutov), LibsemigroupsException);
+    }
+
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "023",
                           "singular_brauer_monoid degree except",
@@ -388,6 +420,14 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(singular_brauer_monoid(0), LibsemigroupsException);
     REQUIRE_THROWS_AS(singular_brauer_monoid(1), LibsemigroupsException);
     REQUIRE_THROWS_AS(singular_brauer_monoid(2), LibsemigroupsException);
+  }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "107",
+                          "singular_brauer_monoid auth except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(singular_brauer_monoid(5, author::Sutov), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
@@ -400,6 +440,14 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(orientation_preserving_monoid(2), LibsemigroupsException);
   }
 
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "107",
+                          "orientation_preserving_monoid auth except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(orientation_preserving_monoid(5, author::Sutov), LibsemigroupsException);
+  }
+
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "025",
                           "orientation_reversing_monoid degree except",
@@ -410,6 +458,14 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(orientation_reversing_monoid(2), LibsemigroupsException);
   }
 
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "108",
+                          "orientation_reversing_monoid auth except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(orientation_reversing_monoid(0, author::Sutov), LibsemigroupsException);
+  }
+
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "026",
                           "order_preserving_monoid degree except",
@@ -418,6 +474,14 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(order_preserving_monoid(0), LibsemigroupsException);
     REQUIRE_THROWS_AS(order_preserving_monoid(1), LibsemigroupsException);
     REQUIRE_THROWS_AS(order_preserving_monoid(2), LibsemigroupsException);
+  }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "109",
+                          "order_preserving_monoid auth except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(order_preserving_monoid(5, author::Sutov), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
@@ -452,12 +516,20 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "029",
-                          "order_preserving_monoid degree except",
+                          "order_preserving_cyclic_inverse_monoid degree except",
                           "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
-    REQUIRE_THROWS_AS(order_preserving_monoid(0), LibsemigroupsException);
-    REQUIRE_THROWS_AS(order_preserving_monoid(1), LibsemigroupsException);
-    REQUIRE_THROWS_AS(order_preserving_monoid(2), LibsemigroupsException);
+    REQUIRE_THROWS_AS(order_preserving_cyclic_inverse_monoid(0), LibsemigroupsException);
+    REQUIRE_THROWS_AS(order_preserving_cyclic_inverse_monoid(1), LibsemigroupsException);
+    REQUIRE_THROWS_AS(order_preserving_cyclic_inverse_monoid(2), LibsemigroupsException);
+  }
+
+   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "110",
+                          "order_preserving_cyclic_inverse_monoid author except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(order_preserving_cyclic_inverse_monoid(2, author::Sutov), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
@@ -471,6 +543,14 @@ namespace libsemigroups {
                       LibsemigroupsException);
     REQUIRE_THROWS_AS(partial_isometries_cycle_graph_monoid(2),
                       LibsemigroupsException);
+  }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "111",
+                          "partial_isometries_cycle_graph_monoid auth except",
+                          "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+    REQUIRE_THROWS_AS(partial_isometries_cycle_graph_monoid(5, author::Sutov), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -23,7 +23,6 @@
 // #define CATCH_CONFIG_ENABLE_PAIR_STRINGMAKER
 
 #include <cmath>                              // for pow
-#include <cmath>                              // for pow
 #include <cstddef>                            // for size_t
 #include <unordered_map>                      // for operator!=
 #include <vector>                             // for vector, allocator, oper...
@@ -166,14 +165,14 @@ namespace libsemigroups {
     REQUIRE(dual_symmetric_inverse_monoid(5).contains_empty_word());
     REQUIRE(uniform_block_bijection_monoid(5).contains_empty_word());
     REQUIRE(partition_monoid(5, author::East).contains_empty_word());
-    REQUIRE(not partition_monoid(3, author::Machine).contains_empty_word());
-    REQUIRE(not singular_brauer_monoid(5).contains_empty_word());
+    REQUIRE(!partition_monoid(3, author::Machine).contains_empty_word());
+    REQUIRE(!singular_brauer_monoid(5).contains_empty_word());
     REQUIRE(orientation_preserving_monoid(5).contains_empty_word());
     REQUIRE(orientation_preserving_reversing_monoid(5).contains_empty_word());
     REQUIRE(temperley_lieb_monoid(5).contains_empty_word());
     REQUIRE(brauer_monoid(5).contains_empty_word());
     REQUIRE(partial_brauer_monoid(5).contains_empty_word());
-    REQUIRE(not fibonacci_semigroup(5, 2).contains_empty_word());
+    REQUIRE(!fibonacci_semigroup(5, 2).contains_empty_word());
     REQUIRE(plactic_monoid(5).contains_empty_word());
     REQUIRE(stylic_monoid(5).contains_empty_word());
     REQUIRE(symmetric_group(5, author::Burnside + author::Miller)
@@ -183,7 +182,7 @@ namespace libsemigroups {
                 .contains_empty_word());
     REQUIRE(symmetric_group(5, author::Moore).contains_empty_word());
     REQUIRE(alternating_group(5).contains_empty_word());
-    REQUIRE(not rectangular_band(5, 5).contains_empty_word());
+    REQUIRE(!rectangular_band(5, 5).contains_empty_word());
     REQUIRE(
         full_transformation_monoid(5, author::Iwahori).contains_empty_word());
     REQUIRE(
@@ -195,7 +194,7 @@ namespace libsemigroups {
     REQUIRE(symmetric_inverse_monoid(5).contains_empty_word());
     REQUIRE(chinese_monoid(5).contains_empty_word());
     REQUIRE(monogenic_semigroup(0, 5).contains_empty_word());
-    REQUIRE(not monogenic_semigroup(2, 6).contains_empty_word());
+    REQUIRE(!monogenic_semigroup(2, 6).contains_empty_word());
     REQUIRE(order_preserving_monoid(5).contains_empty_word());
     REQUIRE(cyclic_inverse_monoid(5).contains_empty_word());
     REQUIRE(order_preserving_cyclic_inverse_monoid(5).contains_empty_word());

--- a/tests/test-fpsemi-examples-2.cpp
+++ b/tests/test-fpsemi-examples-2.cpp
@@ -19,21 +19,37 @@
 // functions. The presentations here define not necessarily finite semigroups,
 // and we use KnuthBendix in testing them.
 
-#include "libsemigroups/constants.hpp"
 #define CATCH_CONFIG_ENABLE_PAIR_STRINGMAKER
 
-#include "catch.hpp"      // for REQUIRE, REQUIRE_NOTHROW, REQUIRE_THROWS_AS
+#include <algorithm>      // for max, next_permutation
+#include <chrono>         // for operator-
+#include <cstddef>        // for size_t
+#include <list>           // for operator!=
+#include <string>         // for basic_string, operator+
+#include <unordered_map>  // for unordered_map, operator==
+#include <utility>        // for pair
+#include <vector>         // for vector, operator==
+
+#include "catch.hpp"      // for StringRef, SourceLineInfo
 #include "test-main.hpp"  // for LIBSEMIGROUPS_TEST_CASE
 
-#include "libsemigroups/fpsemi-examples.hpp"  // for the presentations
-#include "libsemigroups/knuth-bendix.hpp"     // for KnuthBendix
+#include "libsemigroups/constants.hpp"        // for operator==, operator!=
+#include "libsemigroups/fpsemi-examples.hpp"  // for not_renner_type_D_monoid
+#include "libsemigroups/knuth-bendix.hpp"     // for KnuthBendix, to_present...
 #include "libsemigroups/obvinf.hpp"           // for is_obviously_infinite
-#include "libsemigroups/types.hpp"            // for word_type
-#include "libsemigroups/words.hpp"            // for literals
+#include "libsemigroups/paths.hpp"            // for ReversiblePaths
+#include "libsemigroups/presentation.hpp"     // for longest_rule_length
+#include "libsemigroups/ranges.hpp"           // for operator|, to_vector
+#include "libsemigroups/rewriters.hpp"        // for RewriteTrie
+#include "libsemigroups/to-presentation.hpp"  // for to_presentation
+#include "libsemigroups/types.hpp"            // for congruence_kind, word_type
+#include "libsemigroups/word-graph.hpp"       // for is_complete
+#include "libsemigroups/words.hpp"            // for operator""_w, to_string
 
-#include "libsemigroups/detail/report.hpp"  // for ReportGuard
-
-#include "libsemigroups/ranges.hpp"
+#include "libsemigroups/detail/eigen.hpp"  // // for DenseBase::row, DenseBa...
+#include "libsemigroups/detail/fmt.hpp"    // for format, print
+#include "libsemigroups/detail/iterator.hpp"  // for operator+
+#include "libsemigroups/detail/report.hpp"    // for ReportGuard
 
 namespace libsemigroups {
 

--- a/tests/test-fpsemi-examples-3.cpp
+++ b/tests/test-fpsemi-examples-3.cpp
@@ -20,13 +20,16 @@
 
 // #define CATCH_CONFIG_ENABLE_PAIR_STRINGMAKER
 
-#include "catch.hpp"      // for REQUIRE, REQUIRE_NOTHROW, REQUIRE_THROWS_AS
+#include <cstddef>  // for size_t
+
+#include "catch.hpp"      // for StringRef, SourceLineInfo
 #include "test-main.hpp"  // for LIBSEMIGROUPS_TEST_CASE
 
-#include "libsemigroups/fpsemi-examples.hpp"  // for the presentations
+#include "libsemigroups/fpsemi-examples.hpp"  // for not_symmetric_group
 #include "libsemigroups/sims.hpp"             // for Sims1
-#include "libsemigroups/types.hpp"            // for word_type
+#include "libsemigroups/types.hpp"            // for tril
 
+#include "libsemigroups/detail/fmt.hpp"     // for format, print
 #include "libsemigroups/detail/report.hpp"  // for ReportGuard
 
 namespace libsemigroups {

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -1983,10 +1983,11 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 128);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "052",
-                          "orientation_preserving_reversing_monoid(5) (Ruskuc + Arthur)",
-                          "[todd-coxeter][quick][no-valgrind][no-coverage]") {
+  LIBSEMIGROUPS_TEST_CASE(
+      "ToddCoxeter",
+      "052",
+      "orientation_preserving_reversing_monoid(5) (Ruskuc + Arthur)",
+      "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     using fpsemigroup::orientation_preserving_reversing_monoid;
     auto         rg = ReportGuard(false);
     size_t const n  = 5;

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -1985,12 +1985,12 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "052",
-                          "orientation_reversing_monoid(5) (Ruskuc + Arthur)",
+                          "orientation_preserving_reversing_monoid(5) (Ruskuc + Arthur)",
                           "[todd-coxeter][quick][no-valgrind][no-coverage]") {
-    using fpsemigroup::orientation_reversing_monoid;
+    using fpsemigroup::orientation_preserving_reversing_monoid;
     auto         rg = ReportGuard(false);
     size_t const n  = 5;
-    auto         p  = orientation_reversing_monoid(n);
+    auto         p  = orientation_preserving_reversing_monoid(n);
     ToddCoxeter  tc(congruence_kind::twosided, p);
 
     section_hlt(tc);
@@ -2128,11 +2128,11 @@ namespace libsemigroups {
                           "060",
                           "Generate GAP benchmarks for OR_n",
                           "[todd-coxeter][fail]") {
-    using fpsemigroup::orientation_reversing_monoid;
+    using fpsemigroup::orientation_preserving_reversing_monoid;
 
     auto rg = ReportGuard(true);
     for (size_t n = 3; n <= 8; ++n) {
-      auto        p = orientation_reversing_monoid(n);
+      auto        p = orientation_preserving_reversing_monoid(n);
       ToddCoxeter tc(congruence_kind::twosided, p);
       output_gap_benchmark_file("orient-reverse-" + std::to_string(n) + ".g",
                                 tc);


### PR DESCRIPTION
So far this checks each function in the file for whether it returns a semigroup or monoid presentation, updates the documentation to reflect this, and makes tests for this.