### PR TITLE
v3 Fix bug in `SimsRefinerIdeals` when dealing with complete graphs

### DIFF
--- a/include/libsemigroups/sims.hpp
+++ b/include/libsemigroups/sims.hpp
@@ -324,7 +324,7 @@ namespace libsemigroups {
     //! * \ref number_of_threads to set the number of threads;
     //! * \ref include to set the pairs to be included;
     //! * \ref exclude to set the pairs to be excluded;
-    //! * \ref add_pruner to add a pruninf function;
+    //! * \ref add_pruner to add a pruner;
     //! * \ref long_rule_length to set the length of long rules;
     //! * \ref idle_thread_restarts to set the number of idle thread restarts.
     //!
@@ -3119,6 +3119,13 @@ namespace libsemigroups {
           if (t != UNDEFINED && t != sink) {
             return false;
           }
+        }
+      } else {
+        auto const N     = wg.number_of_active_nodes();
+        auto       first = wg.cbegin_nodes();
+        auto       last  = wg.cbegin_nodes() + N;
+        if (word_graph::is_complete(wg, first, last)) {
+          return false;
         }
       }
       return true;

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -18,6 +18,7 @@
 
 #include "libsemigroups/detail/stl.hpp"
 #include "libsemigroups/word-graph.hpp"
+#include <cstdint>
 #define CATCH_CONFIG_ENABLE_PAIR_STRINGMAKER
 #define CATCH_CONFIG_ENABLE_TUPLE_STRINGMAKER
 
@@ -4005,6 +4006,99 @@ namespace libsemigroups {
     REQUIRE(s.number_of_congruences(12) == 41);  // computed using GAP
     s.add_pruner(ip);
     REQUIRE(s.number_of_congruences(12) == 12);  // computed using GAP
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Sims1",
+                          "124",
+                          "Right congruence checking",
+                          "[quick][low-index]") {
+    Presentation<word_type> p;
+    p.alphabet(01_w);
+    p.contains_empty_word(true);
+    presentation::add_rule(p, 000_w, 11_w);
+    presentation::add_rule(p, 001_w, 10_w);
+
+    word_graph_type wg;
+
+    // Wrong alphabet size
+    wg = to_word_graph<node_type>(3, {{1, 1, 1}, {2, 2, 2}, {2, 2, 2}});
+    wg.number_of_active_nodes(3);
+    REQUIRE(!sims::is_right_congruence(p, wg));
+
+    // Incomplete
+    wg = to_word_graph<node_type>(2, {{1, 1}, {1, UNDEFINED}});
+    wg.number_of_active_nodes(2);
+    REQUIRE(!sims::is_right_congruence(p, wg));
+
+    // Incompatible
+    wg = to_word_graph<node_type>(2, {{1, 1}, {1, 0}});
+    wg.number_of_active_nodes(2);
+    REQUIRE(!sims::is_right_congruence(p, wg));
+    REQUIRE_THROWS_AS(sims::validate_right_congruence(p, wg),
+                      LibsemigroupsException);
+
+    // Works
+    wg = to_word_graph<node_type>(4, {{1, 2}, {2, 2}, {3, 3}, {3, 3}});
+    wg.number_of_active_nodes(4);
+    REQUIRE(sims::is_right_congruence(p, wg));
+
+    // Non maximal
+    wg = to_word_graph<node_type>(2, {{1, 1}, {1, 0}});
+    wg.number_of_active_nodes(2);
+    REQUIRE(!sims::is_maximal_right_congruence(p, wg));
+    wg = to_word_graph<node_type>(4, {{1, 2}, {2, 2}, {3, 3}, {3, 3}});
+    wg.number_of_active_nodes(4);
+    REQUIRE(!sims::is_maximal_right_congruence(p, wg));
+    wg = to_word_graph<node_type>(1, {{0, 0}});
+    wg.number_of_active_nodes(1);
+    REQUIRE(!sims::is_maximal_right_congruence(p, wg));
+
+    // Is maximal
+    wg = to_word_graph<node_type>(2, {{1, 1}, {1, 1}});
+    wg.number_of_active_nodes(2);
+    REQUIRE(sims::is_maximal_right_congruence(p, wg));
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Sims2",
+                          "125",
+                          "Two-sided congruence checking",
+                          "[quick][low-index]") {
+    Presentation<word_type> p;
+    p.alphabet(01_w);
+    p.contains_empty_word(true);
+    presentation::add_rule(p, 000_w, 11_w);
+    presentation::add_rule(p, 001_w, 10_w);
+
+    word_graph_type wg;
+
+    // Wrong alphabet size
+    wg = to_word_graph<node_type>(3, {{1, 1, 1}, {2, 2, 2}, {2, 2, 2}});
+    wg.number_of_active_nodes(3);
+    REQUIRE(!sims::is_two_sided_congruence(p, wg));
+
+    // Incomplete
+    wg = to_word_graph<node_type>(2, {{1, 1}, {1, UNDEFINED}});
+    wg.number_of_active_nodes(2);
+    REQUIRE(!sims::is_two_sided_congruence(p, wg));
+
+    // Incompatible
+    wg = to_word_graph<node_type>(2, {{1, 1}, {1, 0}});
+    wg.number_of_active_nodes(2);
+    REQUIRE(!sims::is_two_sided_congruence(p, wg));
+    REQUIRE_THROWS_AS(sims::validate_two_sided_congruence(p, wg),
+                      LibsemigroupsException);
+
+    // Not compatible with X_Gamma
+    wg = to_word_graph<node_type>(4, {{1, 2}, {2, 2}, {3, 3}, {3, 3}});
+    wg.number_of_active_nodes(4);
+    REQUIRE(!sims::is_two_sided_congruence(p, wg));
+    REQUIRE_THROWS_AS(sims::validate_two_sided_congruence(p, wg),
+                      LibsemigroupsException);
+
+    // Works
+    wg = to_word_graph<node_type>(2, {{1, 1}, {1, 1}});
+    wg.number_of_active_nodes(2);
+    REQUIRE(sims::is_two_sided_congruence(p, wg));
   }
 }  // namespace libsemigroups
 

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -3859,24 +3859,15 @@ namespace libsemigroups {
     SimsRefinerIdeals ip(s.presentation());
     s.add_pruner(ip);
 
-    REQUIRE(s.number_of_congruences(1) == 1);      // computed using GAP
-    REQUIRE(s.number_of_congruences(2) == 3);      // computed using GAP
-    REQUIRE(s.number_of_congruences(3) == 5);      // computed using GAP
-    REQUIRE(s.number_of_congruences(4) == 7);      // computed using GAP
-    REQUIRE(s.number_of_congruences(5) == 9);      // computed using GAP
-    REQUIRE(s.number_of_congruences(6) == 11);     // computed using GAP
-    REQUIRE(s.number_of_congruences(7) == 12);     // computed using GAP
-    REQUIRE(s.number_of_congruences(8) == 12);     // computed using GAP
-    REQUIRE(s.number_of_congruences(9) == 12);     // computed using GAP
-    REQUIRE(s.number_of_congruences(10) == 12);    // computed using GAP
-    REQUIRE(s.number_of_congruences(11) == 12);    // computed using GAP
-    REQUIRE(s.number_of_congruences(12) == 12);    // computed using GAP
-    REQUIRE(s.number_of_congruences(13) == 12);    // computed using GAP
-    REQUIRE(s.number_of_congruences(14) == 12);    // computed using GAP
-    REQUIRE(s.number_of_congruences(15) == 12);    // computed using GAP
-    REQUIRE(s.number_of_congruences(50) == 12);    // computed using GAP
-    REQUIRE(s.number_of_congruences(100) == 12);   // computed using GAP
-    REQUIRE(s.number_of_congruences(1000) == 12);  // computed using GAP
+    REQUIRE(s.number_of_congruences(1) == 1);   // computed using GAP
+    REQUIRE(s.number_of_congruences(2) == 3);   // computed using GAP
+    REQUIRE(s.number_of_congruences(3) == 5);   // computed using GAP
+    REQUIRE(s.number_of_congruences(4) == 7);   // computed using GAP
+    REQUIRE(s.number_of_congruences(5) == 9);   // computed using GAP
+    REQUIRE(s.number_of_congruences(6) == 11);  // computed using GAP
+    REQUIRE(s.number_of_congruences(7) == 12);  // computed using GAP
+    for (size_t nr_classes = 8; nr_classes < 16; ++nr_classes)
+      REQUIRE(s.number_of_congruences(nr_classes) == 12);  // computed using GAP
   }
 
   // about 2 seconds

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -3848,6 +3848,7 @@ namespace libsemigroups {
                           "[quick][sims1]") {
     Presentation<std::string> p;
     p.alphabet("ab");
+    p.contains_empty_word(false);
     presentation::add_rule(p, "aaa", "bb");
     presentation::add_rule(p, "aab", "ba");
 
@@ -3858,61 +3859,24 @@ namespace libsemigroups {
     SimsRefinerIdeals ip(s.presentation());
     s.add_pruner(ip);
 
-    // size_t result = 0;
-    // s.for_each(3, [&ip, &result](auto const& wg) {
-    //   if (ip(wg)) {
-    //     result++;
-    //   }
-    // });
-    // REQUIRE(result == 5);
-    // result = 0;
-    // s.for_each(4, [&ip, &result](auto const& wg) {
-    //   if (ip(wg)) {
-    //     result++;
-    //   }
-    // });
-    // REQUIRE(result == 7);
-    //
-    // result = 0;
-    // s.for_each(5, [&ip, &result](auto const& wg) {
-    //   if (ip(wg)) {
-    //     result++;
-    //   }
-    // });
-    // REQUIRE(result == 9);
-    //
-    // result = 0;
-    // s.for_each(6, [&ip, &result](auto const& wg) {
-    //   if (ip(wg)) {
-    //     result++;
-    //   }
-    // });
-    // REQUIRE(result == 11);
-    //
-    // result = 0;
-    // s.for_each(7, [&ip, &result](auto const& wg) {
-    //   if (ip(wg)) {
-    //     result++;
-    //   }
-    // });
-    // REQUIRE(result == 12);
-    //
-    // result = 0;
-    // s.for_each(8, [&ip, &result](auto const& wg) {
-    //   if (ip(wg)) {
-    //     result++;
-    //   }
-    // });
-    // REQUIRE(result == 12);
-
-    REQUIRE(s.number_of_congruences(1) == 1);   // computed using GAP
-    REQUIRE(s.number_of_congruences(2) == 3);   // computed using GAP
-    REQUIRE(s.number_of_congruences(3) == 5);   // computed using GAP
-    REQUIRE(s.number_of_congruences(4) == 7);   // computed using GAP
-    REQUIRE(s.number_of_congruences(5) == 9);   // computed using GAP
-    REQUIRE(s.number_of_congruences(6) == 11);  // computed using GAP
-    REQUIRE(s.number_of_congruences(7) == 12);  // computed using GAP
-    REQUIRE(s.number_of_congruences(8) == 12);  // computed using GAP
+    REQUIRE(s.number_of_congruences(1) == 1);      // computed using GAP
+    REQUIRE(s.number_of_congruences(2) == 3);      // computed using GAP
+    REQUIRE(s.number_of_congruences(3) == 5);      // computed using GAP
+    REQUIRE(s.number_of_congruences(4) == 7);      // computed using GAP
+    REQUIRE(s.number_of_congruences(5) == 9);      // computed using GAP
+    REQUIRE(s.number_of_congruences(6) == 11);     // computed using GAP
+    REQUIRE(s.number_of_congruences(7) == 12);     // computed using GAP
+    REQUIRE(s.number_of_congruences(8) == 12);     // computed using GAP
+    REQUIRE(s.number_of_congruences(9) == 12);     // computed using GAP
+    REQUIRE(s.number_of_congruences(10) == 12);    // computed using GAP
+    REQUIRE(s.number_of_congruences(11) == 12);    // computed using GAP
+    REQUIRE(s.number_of_congruences(12) == 12);    // computed using GAP
+    REQUIRE(s.number_of_congruences(13) == 12);    // computed using GAP
+    REQUIRE(s.number_of_congruences(14) == 12);    // computed using GAP
+    REQUIRE(s.number_of_congruences(15) == 12);    // computed using GAP
+    REQUIRE(s.number_of_congruences(50) == 12);    // computed using GAP
+    REQUIRE(s.number_of_congruences(100) == 12);   // computed using GAP
+    REQUIRE(s.number_of_congruences(1000) == 12);  // computed using GAP
   }
 
   // about 2 seconds
@@ -4030,6 +3994,26 @@ namespace libsemigroups {
     // });
     // REQUIRE(result == 6);
     // REQUIRE(s.number_of_congruences(15) == 0);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Sims2",
+                          "123",
+                          "Adding and removing pruners",
+                          "[quick][low-index]") {
+    Presentation<std::string> p;
+    p.alphabet("ab");
+    p.contains_empty_word(false);
+    presentation::add_rule(p, "aaa", "bb");
+    presentation::add_rule(p, "aab", "ba");
+
+    Sims2             s(p);
+    SimsRefinerIdeals ip(s.presentation());
+    s.add_pruner(ip);
+    REQUIRE(s.number_of_congruences(12) == 12);  // computed using GAP
+    s.clear_pruners();
+    REQUIRE(s.number_of_congruences(12) == 41);  // computed using GAP
+    s.add_pruner(ip);
+    REQUIRE(s.number_of_congruences(12) == 12);  // computed using GAP
   }
 }  // namespace libsemigroups
 


### PR DESCRIPTION
This PR fixes a bug, which causes ideal finding to return the wrong answer. In particular, `SimsRefinerIdeals` returned `true` if the input word graph is complete and no sink is found. Due to the way we implement pruning in the current implementation of `Sims`, pruners should always correctly accept or reject a complete word graph (whereas for incomplete word graphs we only need to correctly reject).

To fix this, `SimsRefinerIdeals` will now return `false` when given as input a complete word graph without a nontrivial sink. Note that when given a complete word graph with a nontrivial sink, the remaining checks of the function guarantee that the word graph is accepted if and only if it represents a nontrivial right Rees congruence.