### PR TITLE
Update the minimum g++ version

### DIFF
--- a/include/libsemigroups/debug.hpp
+++ b/include/libsemigroups/debug.hpp
@@ -30,9 +30,9 @@
 #define LIBSEMIGROUPS_ASSERT(x)
 #endif
 
-#if (defined(__GNUC__) && __GNUC__ < 6 \
+#if (defined(__GNUC__) && __GNUC__ < 9 \
      && !(defined(__clang__) || defined(__INTEL_COMPILER)))
-#error "GCC version 6.0 or higher is required"
+#error "GCC version 9.0 or higher is required"
 #endif
 
 #endif  // LIBSEMIGROUPS_DEBUG_HPP_

--- a/include/libsemigroups/debug.hpp
+++ b/include/libsemigroups/debug.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2024 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/froidure-pin.hpp
+++ b/include/libsemigroups/froidure-pin.hpp
@@ -324,6 +324,7 @@ namespace libsemigroups {
                           state_type*     stt,
                           size_t          tid = 0) const {
       if constexpr (std::is_void_v<state_type>) {
+        (void) stt;  // To silence warnings in g++-9
         Product()(xy, x, y, tid);
       } else {
         Product()(xy, x, y, stt, tid);


### PR DESCRIPTION
For libsemigroups to compile with g++, the g++ version needs to be 9 or greater. This is not caught with `./configure`, so an error is thrown if necessary.

One reason for g++ 9 to be required is to meet the [compiler dependencies of Magic Enum](https://github.com/Neargye/magic_enum/tree/8bd403f888955fc9133b4bc79ffc3740c4f44034?tab=readme-ov-file#compiler-compatibility).