### PR TITLE
Add new presentations for transformation monoids

### DIFF
--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -59,9 +59,11 @@ namespace libsemigroups {
       Kassabov   = 16'384,
       Lubotzky   = 32'768,
       Miller     = 65'536,
-      Moore      = 131'072,
-      Moser      = 262'144,
-      Sutov      = 524'288,
+      Mitchell   = 131'072,
+      Moore      = 262'144,
+      Moser      = 524'288,
+      Sutov      = 1'048'576,
+      Whyte      = 2'097'152
     };
 
     //! This operator can be used arbitrarily to combine author values (see \ref
@@ -73,7 +75,7 @@ namespace libsemigroups {
 
     //! A presentation for the stellar monoid.
     //!
-    //! Returns a monoid presentation defining
+
     //! the stellar monoid with `l` generators, as in Theorem 4.39 of
     //! [10.48550/arXiv.1910.11740][].
     //!
@@ -392,6 +394,7 @@ namespace libsemigroups {
     //! [http://hdl.handle.net/10023/2821][])
     //! * `author::Iwahori` (see Theorem 9.3.1 of
     //! [10.1007/978-1-84800-281-4][])
+    //! * `author::Mitchell + author::Whyte` (see Theorem 1.5 of [10.48550/arXiv.2406.19294][])
     //!
     //! The default for `val` is `author::Iwahori`.
     //!
@@ -405,6 +408,7 @@ namespace libsemigroups {
     //!
     //! [http://hdl.handle.net/10023/2821]: http://hdl.handle.net/10023/2821
     //! [10.1007/978-1-84800-281-4]: https://doi.org/10.1007/978-1-84800-281-4
+    //! [10.48550/arXiv.2406.19294]: https://doi.org/10.48550/arXiv.2406.19294
     [[nodiscard]] Presentation<word_type>
     full_transformation_monoid(size_t n, author val = author::Iwahori);
 
@@ -416,6 +420,7 @@ namespace libsemigroups {
     //! * `author::Machine`
     //! * `author::Sutov` (see Theorem 9.4.1 of
     //! [10.1007/978-1-84800-281-4][])
+    //! * `author::Mitchell + author::Whyte`  (See Theorem 1.5 of [10.48550/arXiv.2406.19294])
     //!
     //! The default for `val` is `author::Sutov`.
     //!
@@ -428,6 +433,7 @@ namespace libsemigroups {
     //! order of author)
     //!
     //! [10.1007/978-1-84800-281-4]: https://doi.org/10.1007/978-1-84800-281-4
+    //! [10.48550/arXiv.2406.19294]: https://doi.org/10.48550/arXiv.2406.19294
     [[nodiscard]] Presentation<word_type>
     partial_transformation_monoid(size_t n, author val = author::Sutov);
 
@@ -438,7 +444,8 @@ namespace libsemigroups {
     //! presentation which is returned. The options are:
     //! * `author::Sutov` (see Theorem 9.2.2 of
     //! [10.1007/978-1-84800-281-4][])
-
+    //! * `author::Mitchell + author::Whyte` (see Theorem 1.4 of [10.48550/arXiv.2406.19294][])
+    //!
     // When val == author::Gay, this is just a presentation for the symmetric
     // inverse monoid, a slightly modified version from Solomon (so that
     // contains the Coxeter+Moser presentation for the symmetric group),
@@ -448,7 +455,7 @@ namespace libsemigroups {
     // Maybe should be Solomon:
     // https://www.sciencedirect.com/science/article/pii/S0021869303005933/pdf
     //!
-    //! The default for `val` is the only option above.
+    //! The default value for `val` is `author::Sutov`.
     //!
     //! \param n the degree of the symmetric inverse monoid
     //! \param val the author of the presentation
@@ -459,6 +466,7 @@ namespace libsemigroups {
     //! order of author)
     //!
     //! [10.1007/978-1-84800-281-4]: https://doi.org/10.1007/978-1-84800-281-4
+    //! [10.48550/arXiv.2406.19294]: https://doi.org/10.48550/arXiv.2406.19294
     [[nodiscard]] Presentation<word_type>
     symmetric_inverse_monoid(size_t n, author val = author::Sutov);
 

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -397,7 +397,7 @@ namespace libsemigroups {
     //! * `author::Mitchell + author::Whyte` (see Theorem 1.5 of
     //! [10.48550/arXiv.2406.19294][])
     //!
-    //! The default for `val` is `author::Iwahori`.
+    //! The default for `val` is `author::Mitchell + author::Whyte`.
     //!
     //! \param n the degree of the full transformation monoid
     //! \param val the author of the presentation
@@ -411,7 +411,8 @@ namespace libsemigroups {
     //! [10.1007/978-1-84800-281-4]: https://doi.org/10.1007/978-1-84800-281-4
     //! [10.48550/arXiv.2406.19294]: https://doi.org/10.48550/arXiv.2406.19294
     [[nodiscard]] Presentation<word_type>
-    full_transformation_monoid(size_t n, author val = author::Iwahori);
+    full_transformation_monoid(size_t n,
+                               author val = author::Mitchell + author::Whyte);
 
     //! A presentation for the partial transformation monoid.
     //!
@@ -424,7 +425,7 @@ namespace libsemigroups {
     //! * `author::Mitchell + author::Whyte`  (See Theorem 1.5 of
     //! [10.48550/arXiv.2406.19294])
     //!
-    //! The default for `val` is `author::Sutov`.
+    //! The default for `val` is `author::Mitchell + author::Whyte`.
     //!
     //! \param n the degree of the partial transformation monoid
     //! \param val the author of the presentation
@@ -436,8 +437,9 @@ namespace libsemigroups {
     //!
     //! [10.1007/978-1-84800-281-4]: https://doi.org/10.1007/978-1-84800-281-4
     //! [10.48550/arXiv.2406.19294]: https://doi.org/10.48550/arXiv.2406.19294
-    [[nodiscard]] Presentation<word_type>
-    partial_transformation_monoid(size_t n, author val = author::Sutov);
+    [[nodiscard]] Presentation<word_type> partial_transformation_monoid(
+        size_t n,
+        author val = author::Mitchell + author::Whyte);
 
     //! A presentation for the symmetric inverse monoid.
     //!
@@ -458,7 +460,7 @@ namespace libsemigroups {
     // Maybe should be Solomon:
     // https://www.sciencedirect.com/science/article/pii/S0021869303005933/pdf
     //!
-    //! The default value for `val` is `author::Sutov`.
+    //! The default value for `val` is `author::Mitchell + author::Whyte`.
     //!
     //! \param n the degree of the symmetric inverse monoid
     //! \param val the author of the presentation
@@ -471,7 +473,8 @@ namespace libsemigroups {
     //! [10.1007/978-1-84800-281-4]: https://doi.org/10.1007/978-1-84800-281-4
     //! [10.48550/arXiv.2406.19294]: https://doi.org/10.48550/arXiv.2406.19294
     [[nodiscard]] Presentation<word_type>
-    symmetric_inverse_monoid(size_t n, author val = author::Sutov);
+    symmetric_inverse_monoid(size_t n,
+                             author val = author::Mitchell + author::Whyte);
 
     //! A presentation for the Chinese monoid.
     //!

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -394,7 +394,8 @@ namespace libsemigroups {
     //! [http://hdl.handle.net/10023/2821][])
     //! * `author::Iwahori` (see Theorem 9.3.1 of
     //! [10.1007/978-1-84800-281-4][])
-    //! * `author::Mitchell + author::Whyte` (see Theorem 1.5 of [10.48550/arXiv.2406.19294][])
+    //! * `author::Mitchell + author::Whyte` (see Theorem 1.5 of
+    //! [10.48550/arXiv.2406.19294][])
     //!
     //! The default for `val` is `author::Iwahori`.
     //!
@@ -420,7 +421,8 @@ namespace libsemigroups {
     //! * `author::Machine`
     //! * `author::Sutov` (see Theorem 9.4.1 of
     //! [10.1007/978-1-84800-281-4][])
-    //! * `author::Mitchell + author::Whyte`  (See Theorem 1.5 of [10.48550/arXiv.2406.19294])
+    //! * `author::Mitchell + author::Whyte`  (See Theorem 1.5 of
+    //! [10.48550/arXiv.2406.19294])
     //!
     //! The default for `val` is `author::Sutov`.
     //!
@@ -444,7 +446,8 @@ namespace libsemigroups {
     //! presentation which is returned. The options are:
     //! * `author::Sutov` (see Theorem 9.2.2 of
     //! [10.1007/978-1-84800-281-4][])
-    //! * `author::Mitchell + author::Whyte` (see Theorem 1.4 of [10.48550/arXiv.2406.19294][])
+    //! * `author::Mitchell + author::Whyte` (see Theorem 1.4 of
+    //! [10.48550/arXiv.2406.19294][])
     //!
     // When val == author::Gay, this is just a presentation for the symmetric
     // inverse monoid, a slightly modified version from Solomon (so that

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -396,6 +396,10 @@ namespace libsemigroups {
     //! [10.1007/978-1-84800-281-4][])
     //! * `author::Mitchell + author::Whyte` (see Theorem 1.5 of
     //! [10.48550/arXiv.2406.19294][])
+    //!    * `index = 0` for the presentation with five non-symmetric-group
+    //!    relations
+    //!    * `index = 1` for the presentation with four non-symmetric-group
+    //!    relations, valid for odd degree
     //!
     //! The default for `val` is `author::Mitchell + author::Whyte`.
     //!
@@ -412,7 +416,8 @@ namespace libsemigroups {
     //! [10.48550/arXiv.2406.19294]: https://doi.org/10.48550/arXiv.2406.19294
     [[nodiscard]] Presentation<word_type>
     full_transformation_monoid(size_t n,
-                               author val = author::Mitchell + author::Whyte);
+                               author val   = author::Mitchell + author::Whyte,
+                               size_t index = 0);
 
     //! A presentation for the partial transformation monoid.
     //!

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -456,14 +456,6 @@ namespace libsemigroups {
     //! * `author::Mitchell + author::Whyte` (see Theorem 1.4 of
     //! [10.48550/arXiv.2406.19294][])
     //!
-    // When val == author::Gay, this is just a presentation for the symmetric
-    // inverse monoid, a slightly modified version from Solomon (so that
-    // contains the Coxeter+Moser presentation for the symmetric group),
-    // Example 7.1.2 in Joel gay's thesis (JDM the presentation in Example 7.1.2
-    // seems to have 2n - 1 generators whereas this function returns a monoid on
-    // n generators. TODO ask Florent again if this reference is correct
-    // Maybe should be Solomon:
-    // https://www.sciencedirect.com/science/article/pii/S0021869303005933/pdf
     //!
     //! The default value for `val` is `author::Mitchell + author::Whyte`.
     //!
@@ -477,6 +469,15 @@ namespace libsemigroups {
     //!
     //! [10.1007/978-1-84800-281-4]: https://doi.org/10.1007/978-1-84800-281-4
     //! [10.48550/arXiv.2406.19294]: https://doi.org/10.48550/arXiv.2406.19294
+    //
+    // When val == author::Gay, this is just a presentation for the symmetric
+    // inverse monoid, a slightly modified version from Solomon (so that
+    // contains the Coxeter+Moser presentation for the symmetric group),
+    // Example 7.1.2 in Joel gay's thesis (JDM the presentation in Example 7.1.2
+    // seems to have 2n - 1 generators whereas this function returns a monoid on
+    // n generators. TODO ask Florent again if this reference is correct
+    // Maybe should be Solomon:
+    // https://www.sciencedirect.com/science/article/pii/S0021869303005933/pdf
     [[nodiscard]] Presentation<word_type>
     symmetric_inverse_monoid(size_t n,
                              author val = author::Mitchell + author::Whyte);

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -1214,10 +1214,11 @@ namespace libsemigroups {
       if (n < 4) {
         LIBSEMIGROUPS_EXCEPTION(
             "the 1st argument (degree) must be at least 4, found {}", n);
-      } else if (val != author::Aizenstat && val != author::Iwahori) {
+      } else if (val != author::Aizenstat && val != author::Iwahori
+              && val != author::Mitchell + author::Whyte) {
         LIBSEMIGROUPS_EXCEPTION(
-            "expected 2nd argument to be author::Aizenstat or "
-            "author::Iwahori, found {}",
+            "expected 2nd argument to be author::Aizenstat, or "
+            "author::Iwahori, or author::Mitchell + author::Whyte found {}",
             val);
       }
 
@@ -1245,13 +1246,38 @@ namespace libsemigroups {
             p,
             pow(210_w + pow(1_w, n - 2) + 01_w, 2),
             pow(10_w + (pow(1_w, n - 2)) + 012_w, 2));
-      } else {
+      } else if (val == author::Iwahori) {
         // From Theorem 9.3.1, p161-162, (Ganyushkin + Mazorchuk)
         // using Theorem 9.1.4 to express presentation in terms
         // of the pi_i and e_12.
         // https://link.springer.com/book/10.1007/978-1-84800-281-4
         p = symmetric_group(n, author::Carmichael);
         add_full_transformation_monoid_relations(p, n, 0, n - 1);
+      }
+      else {
+        p = symmetric_group(n, author::Carmichael);
+        // From Theorem 1.5 of arXiv:2406.19294
+
+        // Relation T1
+        presentation::add_rule_no_checks(p, {n - 1, 1, n - 1, 1}, {n - 1});
+
+        // Relation T3
+        presentation::add_rule_no_checks(p, {1, 2, 1, n - 1}, {n - 1, 1, 2, 1});
+
+        // Relation T7
+        presentation::add_rule_no_checks(p, {n - 2, 0, 1, 0, n - 1, n - 2, 0, 1, 0, n - 1},
+            {n - 1, n - 2, 0, 1, 0, n - 1, n - 2, 0, 1, 0});
+
+        // Relation T8
+        std::vector<size_t> gens(n - 1);  // list of generators to use prod on
+        std::iota(gens.begin(), gens.end(), 0);
+        presentation::add_rule_no_checks(p, prod(gens, 1, n - 1, 1) + word_type({1, 0, n - 1}),
+            word_type({n - 1}) + prod(gens, 1, n - 1, 1) + word_type({1}));
+        
+        // Relation T9
+        presentation::add_rule_no_checks(p, {0, 1, 0, n - 1, 0, 1, 0, n - 1, 0, 1, 0, n - 1, 0, 1, 0},
+            {n - 1, 0, 1, 0, n - 1});
+
       }
       p.alphabet_from_rules();
       return p;
@@ -1262,10 +1288,10 @@ namespace libsemigroups {
       if (n < 3) {
         LIBSEMIGROUPS_EXCEPTION(
             "the 1st argument (size_t) must be at least 3, found {}", n);
-      } else if (val != author::Machine && val != author::Sutov) {
+      } else if (val != author::Machine && val != author::Sutov && val != author::Mitchell + author::Whyte) {
         LIBSEMIGROUPS_EXCEPTION(
-            "expected 2nd argument to be author::Machine or "
-            "author::Sutov, found {}",
+            "expected 2nd argument to be author::Machine, or "
+            "author::Sutov, or author::Mitchell + author::Whyte, found {}",
             val);
       } else if (val == author::Machine && n != 3) {
         LIBSEMIGROUPS_EXCEPTION("the 1st argument must be 3 where the 2nd "
@@ -1297,7 +1323,7 @@ namespace libsemigroups {
                2102_w,  21301_w, 13112_w,  31021_w, 31020_w, 31120_w, 3112_w,
                31121_w, 3102_w,  121202_w, 21202_w};
 
-      } else {
+      } else if (val == author::Sutov) {
         // From Theorem 9.4.1, p169, (Ganyushkin + Mazorchuk)
         // https://link.springer.com/book/10.1007/978-1-84800-281-4
         p = symmetric_inverse_monoid(n, author::Sutov);
@@ -1309,6 +1335,46 @@ namespace libsemigroups {
             p, {n, n - 1}, {0, n - 1, 0, n - 1, n});
         presentation::add_rule_no_checks(p, {n, 1, n - 1, 1}, {1, n - 1, 1, n});
       }
+      else {
+        // From Theorem 1.6 of https://doi.org/10.48550/arXiv.2406.19294
+        // val == author::Mitchell + author::Whyte
+        p = symmetric_group(n, author::Carmichael);
+       
+
+        // Relation I3
+        std::vector<size_t> gens(n - 1);  // list of generators to use prod on
+        std::iota(gens.begin(), gens.end(), 0);
+        presentation::add_rule_no_checks(p, prod(gens, 0, n - 1, 1) + word_type({0, n - 1}),
+            word_type({n - 1}) + prod(gens, 0, n - 1, 1) + word_type({0}));
+
+        // Relation T3
+        presentation::add_rule_no_checks(p, {1, 2, 1, n}, {n, 1, 2, 1});
+
+        // Relation T7
+        presentation::add_rule_no_checks(p, {n - 2, 0, 1, 0, n, n - 2, 0, 1, 0, n},
+            {n, n - 2, 0, 1, 0, n, n - 2, 0, 1, 0});
+
+        // Relation T8
+        presentation::add_rule_no_checks(p, prod(gens, 1, n - 1, 1) + word_type({1, 0, n}),
+            word_type({n}) + prod(gens, 1, n - 1, 1) + word_type({1}));
+        
+        // Relation T9
+        presentation::add_rule_no_checks(p, {0, 1, 0, n, 0, 1, 0, n, 0, 1, 0, n, 0, 1, 0},
+            {n, 0, 1, 0, n});
+       
+        // Relation P1
+        presentation::add_rule_no_checks(p, {n, 0, n - 1, 0}, {n});
+
+         // Relation P5
+        presentation::add_rule_no_checks(p, {1, n - 1, 1, n}, {n, 1, n - 1, 1}); 
+
+         // Relation P6
+        presentation::add_rule_no_checks(p, {0, 1, 0, n - 1, 0, 1, 0}, {n - 1, 0, n, 0});
+
+         // Relation P7
+        presentation::add_rule_no_checks(p, {0, n - 1, 0, n - 1, 0}, {n, n - 1});
+      }
+      p.alphabet_from_rules();
       return p;
     }
 
@@ -1316,9 +1382,9 @@ namespace libsemigroups {
     // https://link.springer.com/book/10.1007/978-1-84800-281-4 (Ganyushkin +
     // Mazorchuk)
     Presentation<word_type> symmetric_inverse_monoid(size_t n, author val) {
-      if (val != author::Sutov && val != author::Gay) {
-        LIBSEMIGROUPS_EXCEPTION("expected 2nd argument to be author::Sutov or "
-                                "author::Gay, found {}",
+      if (val != author::Sutov && val != author::Gay && val != author::Mitchell + author::Whyte) {
+        LIBSEMIGROUPS_EXCEPTION("expected 2nd argument to be author::Sutov, or "
+                                "author::Gay, or author::Mitchell + author::Whyte, found {}",
                                 val);
       } else if (val == author::Sutov && n < 4) {
         LIBSEMIGROUPS_EXCEPTION("the 1st argument must be at least 4 when the "
@@ -1327,6 +1393,10 @@ namespace libsemigroups {
       } else if (val == author::Gay && n < 2) {
         LIBSEMIGROUPS_EXCEPTION("the 1st argument must be at least 2 when the "
                                 "2nd argument is author::Gay, found {}",
+                                n);
+      } else if (val == author::Mitchell + author::Whyte && n < 4) {
+        LIBSEMIGROUPS_EXCEPTION("the 1st argument must be at least 4 when the "
+                                "2nd argument is author::Mitchell + author::Whyte, found {}",
                                 n);
       }
       Presentation<word_type> p;
@@ -1353,13 +1423,33 @@ namespace libsemigroups {
         presentation::add_rule_no_checks(
             p, epsilon[1] + epsilon[0] + pi[0], epsilon[1] + epsilon[0]);
         p.alphabet_from_rules();
-      } else {
-        // val == author::Gay
+      } else if (val == author::Gay) {
         p = symmetric_group(n, author::Coxeter + author::Moser);
         p.alphabet(n);
         presentation::add_idempotent_rules_no_checks(p, {n - 1});
         add_rook_monoid_common(p, n);
       }
+      else {
+      // val == author::Mitchell + author::Whyte
+      // From Theorem 1.4 of https://doi.org/10.48550/arXiv.2406.19294
+      
+        p = symmetric_group(n, author::Carmichael);
+
+        // Relation I2
+        presentation::add_rule_no_checks(p, {0, 1, 0, n - 1}, {n - 1, 0, 1, 0}); 
+
+        // Relation I6
+        std::vector<size_t> gens(n - 1);  // list of generators to use prod on
+        std::iota(gens.begin(), gens.end(), 0);
+        presentation::add_rule_no_checks(p, prod(gens, 0, n - 1, 1) + word_type({0, n - 1}),
+            word_type({n - 1, n - 1}) + prod(gens, 0, n - 1, 1) + word_type({0}));
+
+           // Relation I7
+      presentation::add_rule_no_checks(p, {0, n - 1, 0, n - 1, 0, n - 1, 0}, {n - 1, 0, n - 1});
+
+      }
+
+      p.alphabet_from_rules();
       p.contains_empty_word(true);
       return p;
     }

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -1232,9 +1232,7 @@ namespace libsemigroups {
       } else if (index > 1) {
         LIBSEMIGROUPS_EXCEPTION(
             "the 3rd argument (index) must be either 0 or 1, found {}", index);
-      }
-
-      else if (index != 0 && val != author::Mitchell + author::Whyte) {
+      } else if (index != 0 && val != author::Mitchell + author::Whyte) {
         LIBSEMIGROUPS_EXCEPTION("the 3rd argument (index) must be 0 when the "
                                 "2nd argument (author) is "
                                 " author::Mitchell + author::Whyte, found {}",

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -1346,7 +1346,7 @@ namespace libsemigroups {
             presentation::add_rule_no_checks(
                 p,
                 word_type({1}) + prod(gens, n - 2, 0, -1)
-                    + word_type({n - 1, 1}) + prod(gens, 1, n - 1, 1)
+                    + word_type({n - 1}) + prod(gens, 1, n - 1, 1)
                     + word_type({1}),
                 {0, n - 1, 1, n - 1, 1});
           }

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -1210,7 +1210,9 @@ namespace libsemigroups {
       return p;
     }
 
-    Presentation<word_type> full_transformation_monoid(size_t n, author val) {
+    Presentation<word_type> full_transformation_monoid(size_t n,
+                                                       author val,
+                                                       size_t index) {
       if (val != author::Aizenstat && val != author::Iwahori
           && val != author::Mitchell + author::Whyte) {
         LIBSEMIGROUPS_EXCEPTION(
@@ -1225,8 +1227,21 @@ namespace libsemigroups {
       } else if (n < 2 && val == author::Mitchell + author::Whyte) {
         LIBSEMIGROUPS_EXCEPTION(
             "the 1st argument must be at least 2 when the 2nd argument is "
-            "author::Mitchell + author::Whyte found {}",
+            "author::Mitchell + author::Whyte, found {}",
             val);
+      } else if (index > 1) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "the 3rd argument (index) must be either 0 or 1, found {}", index);
+      }
+
+      else if (index != 0 && val != author::Mitchell + author::Whyte) {
+        LIBSEMIGROUPS_EXCEPTION("the 3rd argument (index) must be 0 when the "
+                                "2nd argument (author) is "
+                                " author::Mitchell + author::Whyte, found {}",
+                                index);
+      } else if (index == 1 && n % 2 == 0) {
+        LIBSEMIGROUPS_EXCEPTION("the 1st argument (degree) must be odd when "
+                                "the 3rd argument (index) is 1");
       }
 
       Presentation<word_type> p;
@@ -1275,37 +1290,71 @@ namespace libsemigroups {
           presentation::add_rule_no_checks(p, 2121_w, 2_w);
           presentation::add_rule_no_checks(p, pow(0102_w, 3) + 010_w, 20102_w);
         } else {
+          // n >= 4
           p = symmetric_group(n, author::Carmichael);
-          // From Theorem 1.5 of arXiv:2406.19294
+          if (index == 0) {
+            // From Theorem 1.5 of arXiv:2406.19294
 
-          // Relation T1
-          presentation::add_rule_no_checks(p, {n - 1, 1, n - 1, 1}, {n - 1});
+            // Relation T1
+            presentation::add_rule_no_checks(p, {n - 1, 1, n - 1, 1}, {n - 1});
 
-          // Relation T3
-          presentation::add_rule_no_checks(
-              p, {1, 2, 1, n - 1}, {n - 1, 1, 2, 1});
+            // Relation T3
+            presentation::add_rule_no_checks(
+                p, {1, 2, 1, n - 1}, {n - 1, 1, 2, 1});
 
-          // Relation T7
-          presentation::add_rule_no_checks(
-              p,
-              {n - 2, 0, 1, 0, n - 1, n - 2, 0, 1, 0, n - 1},
-              {n - 1, n - 2, 0, 1, 0, n - 1, n - 2, 0, 1, 0});
+            // Relation T7
+            presentation::add_rule_no_checks(
+                p,
+                {n - 2, 0, 1, 0, n - 1, n - 2, 0, 1, 0, n - 1},
+                {n - 1, n - 2, 0, 1, 0, n - 1, n - 2, 0, 1, 0});
 
-          // Relation T8
-          std::vector<size_t> gens(n - 1);  // list of generators to use prod on
-          std::iota(gens.begin(), gens.end(), 0);
-          presentation::add_rule_no_checks(
-              p,
-              prod(gens, 1, n - 1, 1) + word_type({1, 0, n - 1}),
-              word_type({n - 1}) + prod(gens, 1, n - 1, 1) + word_type({1}));
+            // Relation T8
+            std::vector<size_t> gens(n
+                                     - 1);  // list of generators to use prod on
+            std::iota(gens.begin(), gens.end(), 0);
+            presentation::add_rule_no_checks(
+                p,
+                prod(gens, 1, n - 1, 1) + word_type({1, 0, n - 1}),
+                word_type({n - 1}) + prod(gens, 1, n - 1, 1) + word_type({1}));
 
-          // Relation T9
-          presentation::add_rule_no_checks(
-              p,
-              {0, 1, 0, n - 1, 0, 1, 0, n - 1, 0, 1, 0, n - 1, 0, 1, 0},
-              {n - 1, 0, 1, 0, n - 1});
+            // Relation T9
+            presentation::add_rule_no_checks(
+                p,
+                {0, 1, 0, n - 1, 0, 1, 0, n - 1, 0, 1, 0, n - 1, 0, 1, 0},
+                {n - 1, 0, 1, 0, n - 1});
+          } else {
+            // index == 1
+
+            // Relation T7
+            presentation::add_rule_no_checks(
+                p,
+                {n - 2, 0, 1, 0, n - 1, n - 2, 0, 1, 0, n - 1},
+                {n - 1, n - 2, 0, 1, 0, n - 1, n - 2, 0, 1, 0});
+
+            // Relation T9
+            presentation::add_rule_no_checks(
+                p,
+                {0, 1, 0, n - 1, 0, 1, 0, n - 1, 0, 1, 0, n - 1, 0, 1, 0},
+                {n - 1, 0, 1, 0, n - 1});
+
+            // Relation T10
+            presentation::add_rule_no_checks(
+                p, {1, 2, 1, n - 1, 1, 2, 1}, {n - 1, 1, n - 1, 1});
+
+            // Relation T8
+            std::vector<size_t> gens(n
+                                     - 1);  // list of generators to use prod on
+            std::iota(gens.begin(), gens.end(), 0);
+            presentation::add_rule_no_checks(
+                p,
+                word_type({1}) + prod(gens, n - 2, 0, -1)
+                    + word_type({n - 1, 1}) + prod(gens, 1, n - 1, 1)
+                    + word_type({1}),
+                {0, n - 1, 1, n - 1, 1});
+          }
         }
       }
+
       p.alphabet_from_rules();
       p.contains_empty_word(true);
       return p;

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -42,7 +42,7 @@
 
 namespace libsemigroups {
   using literals::operator""_w;
-  using words::operator+;
+  using words::   operator+;
 
   namespace {
 

--- a/src/fpsemi-examples.cpp
+++ b/src/fpsemi-examples.cpp
@@ -1345,9 +1345,8 @@ namespace libsemigroups {
             std::iota(gens.begin(), gens.end(), 0);
             presentation::add_rule_no_checks(
                 p,
-                word_type({1}) + prod(gens, n - 2, 0, -1)
-                    + word_type({n - 1}) + prod(gens, 1, n - 1, 1)
-                    + word_type({1}),
+                word_type({1}) + prod(gens, n - 2, 0, -1) + word_type({n - 1})
+                    + prod(gens, 1, n - 1, 1) + word_type({1}),
                 {0, n - 1, 1, n - 1, 1});
           }
         }

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -188,6 +188,8 @@ namespace libsemigroups {
     REQUIRE(
         full_transformation_monoid(5, author::Aizenstat).contains_empty_word());
     REQUIRE(
+        full_transformation_monoid(5, author::Mitchell + author::Whyte).contains_empty_word());
+    REQUIRE(
         partial_transformation_monoid(5, author::Sutov).contains_empty_word());
     REQUIRE(partial_transformation_monoid(3, author::Machine)
                 .contains_empty_word());
@@ -848,6 +850,30 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 3'125);
   }
 
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "112",
+                          "full_transformation_monoid(5) Mitchell + Whyte",
+                          "[fpsemi-examples][quick]") {
+    auto   rg = ReportGuard(REPORT);
+    size_t n  = 5;
+
+    ToddCoxeter tc(congruence_kind::twosided,
+                   full_transformation_monoid(n, author::Mitchell + author::Whyte));
+    REQUIRE(tc.number_of_classes() == 3'125);
+  }
+
+        LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "113",
+                          "full_transformation_monoid(6) Mitchell + Whyte",
+                          "[fpsemi-examples][quick]") {
+    auto   rg = ReportGuard(REPORT);
+    size_t n  = 6;
+
+    ToddCoxeter tc(congruence_kind::twosided,
+                   full_transformation_monoid(n, author::Mitchell + author::Whyte));
+    REQUIRE(tc.number_of_classes() == 46'656);
+  }
+
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "050",
                           "partial_transformation_monoid(5) Sutov",
@@ -856,6 +882,17 @@ namespace libsemigroups {
     size_t      n  = 5;
     ToddCoxeter tc(congruence_kind::twosided,
                    partial_transformation_monoid(n, author::Sutov));
+    REQUIRE(tc.number_of_classes() == 7'776);
+  }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "116",
+                          "partial_transformation_monoid(5) Mitchell + Whyte",
+                          "[fpsemi-examples][quick]") {
+    auto        rg = ReportGuard(REPORT);
+    size_t      n  = 5;
+    ToddCoxeter tc(congruence_kind::twosided,
+                   partial_transformation_monoid(n, author::Mitchell + author::Whyte));
     REQUIRE(tc.number_of_classes() == 7'776);
   }
 
@@ -878,6 +915,30 @@ namespace libsemigroups {
 
     ToddCoxeter tc(congruence_kind::twosided,
                    symmetric_inverse_monoid(n, author::Sutov));
+    REQUIRE(tc.number_of_classes() == 1'546);
+  }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "114",
+                          "symmetric_inverse_monoid(4) Mitchell + Whyte",
+                          "[fpsemi-examples][quick][no-valgrind]") {
+    auto   rg = ReportGuard(REPORT);
+    size_t n  = 4;
+
+    ToddCoxeter tc(congruence_kind::twosided,
+                   symmetric_inverse_monoid(n, author::Mitchell + author::Whyte));
+    REQUIRE(tc.number_of_classes() == 209);
+  }
+
+    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "115",
+                          "symmetric_inverse_monoid(5) Mitchell + Whyte",
+                          "[fpsemi-examples][quick][no-valgrind]") {
+    auto   rg = ReportGuard(REPORT);
+    size_t n  = 5;
+
+    ToddCoxeter tc(congruence_kind::twosided,
+                   symmetric_inverse_monoid(n, author::Mitchell + author::Whyte));
     REQUIRE(tc.number_of_classes() == 1'546);
   }
 

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -230,7 +230,9 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(full_transformation_monoid(3, author::Iwahori),
                       LibsemigroupsException);
     REQUIRE_THROWS_AS(full_transformation_monoid(1), LibsemigroupsException);
-    REQUIRE_THROWS_AS(full_transformation_monoid(6, author::Mitchell + author::Whyte, 1);
+    REQUIRE_THROWS_AS(
+        full_transformation_monoid(6, author::Mitchell + author::Whyte, 1),
+        LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -233,6 +233,7 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(
         full_transformation_monoid(6, author::Mitchell + author::Whyte, 1),
         LibsemigroupsException);
+    REQUIRE_THROWS_AS(full_transformation_monoid(1), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -95,11 +95,12 @@ namespace libsemigroups {
     REQUIRE(symmetric_group(4) == symmetric_group(4, author::Carmichael));
     REQUIRE(alternating_group(4) == alternating_group(4, author::Moore));
     REQUIRE(full_transformation_monoid(4)
-            == full_transformation_monoid(4, author::Iwahori));
-    REQUIRE(partial_transformation_monoid(4)
-            == partial_transformation_monoid(4, author::Sutov));
+            == full_transformation_monoid(4, author::Mitchell + author::Whyte));
+    REQUIRE(
+        partial_transformation_monoid(4)
+        == partial_transformation_monoid(4, author::Mitchell + author::Whyte));
     REQUIRE(symmetric_inverse_monoid(4)
-            == symmetric_inverse_monoid(4, author::Sutov));
+            == symmetric_inverse_monoid(4, author::Mitchell + author::Whyte));
     REQUIRE(dual_symmetric_inverse_monoid(4)
             == dual_symmetric_inverse_monoid(
                 4, author::Easdown + author::East + author::FitzGerald));
@@ -220,6 +221,7 @@ namespace libsemigroups {
     auto rg = ReportGuard(REPORT);
     REQUIRE_THROWS_AS(full_transformation_monoid(3, author::Iwahori),
                       LibsemigroupsException);
+    REQUIRE_THROWS_AS(full_transformation_monoid(1), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
@@ -238,6 +240,7 @@ namespace libsemigroups {
     auto rg = ReportGuard(REPORT);
     REQUIRE_THROWS_AS(partial_transformation_monoid(3, author::Sutov),
                       LibsemigroupsException);
+    REQUIRE_THROWS_AS(partial_transformation_monoid(1), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -188,8 +188,11 @@ namespace libsemigroups {
         full_transformation_monoid(5, author::Iwahori).contains_empty_word());
     REQUIRE(
         full_transformation_monoid(5, author::Aizenstat).contains_empty_word());
-    REQUIRE(full_transformation_monoid(5, author::Mitchell + author::Whyte)
+    REQUIRE(full_transformation_monoid(5, author::Mitchell + author::Whyte, 0)
                 .contains_empty_word());
+    REQUIRE(full_transformation_monoid(5, author::Mitchell + author::Whyte, 1)
+                .contains_empty_word());
+
     REQUIRE(
         partial_transformation_monoid(5, author::Sutov).contains_empty_word());
     REQUIRE(partial_transformation_monoid(3, author::Machine)
@@ -207,11 +210,16 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "001",
-                          "full_transformation_monoid author except",
+                          "full_transformation_monoid author index except",
                           "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);
     REQUIRE_THROWS_AS(full_transformation_monoid(5, author::Burnside),
                       LibsemigroupsException);
+    REQUIRE_THROWS_AS(full_transformation_monoid(5, author::Iwahori, 1),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(
+        full_transformation_monoid(5, author::Mitchell + author::Whyte, 2),
+        LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
@@ -222,6 +230,7 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(full_transformation_monoid(3, author::Iwahori),
                       LibsemigroupsException);
     REQUIRE_THROWS_AS(full_transformation_monoid(1), LibsemigroupsException);
+    REQUIRE_THROWS_AS(full_transformation_monoid(6, author::Mitchell + author::Whyte, 1);
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
@@ -881,6 +890,20 @@ namespace libsemigroups {
     ToddCoxeter tc(
         congruence_kind::twosided,
         full_transformation_monoid(n, author::Mitchell + author::Whyte));
+    REQUIRE(tc.number_of_classes() == 3'125);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE(
+      "fpsemi-examples",
+      "118",
+      "full_transformation_monoid(5) Mitchell + Whyte index 1",
+      "[fpsemi-examples][quick]") {
+    auto   rg = ReportGuard(REPORT);
+    size_t n  = 5;
+
+    ToddCoxeter tc(
+        congruence_kind::twosided,
+        full_transformation_monoid(n, author::Mitchell + author::Whyte, 1));
     REQUIRE(tc.number_of_classes() == 3'125);
   }
 

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -187,8 +187,8 @@ namespace libsemigroups {
         full_transformation_monoid(5, author::Iwahori).contains_empty_word());
     REQUIRE(
         full_transformation_monoid(5, author::Aizenstat).contains_empty_word());
-    REQUIRE(
-        full_transformation_monoid(5, author::Mitchell + author::Whyte).contains_empty_word());
+    REQUIRE(full_transformation_monoid(5, author::Mitchell + author::Whyte)
+                .contains_empty_word());
     REQUIRE(
         partial_transformation_monoid(5, author::Sutov).contains_empty_word());
     REQUIRE(partial_transformation_monoid(3, author::Machine)
@@ -850,27 +850,47 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 3'125);
   }
 
-    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+  LIBSEMIGROUPS_TEST_CASE(
+      "fpsemi-examples",
+      "117",
+      "full_transformation_monoid(n = 2, 3) Mitchell + Whyte",
+      "[fpsemi-examples][quick]") {
+    auto rg = ReportGuard(REPORT);
+
+    ToddCoxeter tc2(
+        congruence_kind::twosided,
+        full_transformation_monoid(2, author::Mitchell + author::Whyte));
+    REQUIRE(tc2.number_of_classes() == 4);
+
+    ToddCoxeter tc3(
+        congruence_kind::twosided,
+        full_transformation_monoid(3, author::Mitchell + author::Whyte));
+    REQUIRE(tc3.number_of_classes() == 27);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "112",
                           "full_transformation_monoid(5) Mitchell + Whyte",
                           "[fpsemi-examples][quick]") {
     auto   rg = ReportGuard(REPORT);
     size_t n  = 5;
 
-    ToddCoxeter tc(congruence_kind::twosided,
-                   full_transformation_monoid(n, author::Mitchell + author::Whyte));
+    ToddCoxeter tc(
+        congruence_kind::twosided,
+        full_transformation_monoid(n, author::Mitchell + author::Whyte));
     REQUIRE(tc.number_of_classes() == 3'125);
   }
 
-        LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "113",
                           "full_transformation_monoid(6) Mitchell + Whyte",
                           "[fpsemi-examples][quick]") {
     auto   rg = ReportGuard(REPORT);
     size_t n  = 6;
 
-    ToddCoxeter tc(congruence_kind::twosided,
-                   full_transformation_monoid(n, author::Mitchell + author::Whyte));
+    ToddCoxeter tc(
+        congruence_kind::twosided,
+        full_transformation_monoid(n, author::Mitchell + author::Whyte));
     REQUIRE(tc.number_of_classes() == 46'656);
   }
 
@@ -885,14 +905,15 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 7'776);
   }
 
-    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "116",
                           "partial_transformation_monoid(5) Mitchell + Whyte",
                           "[fpsemi-examples][quick]") {
     auto        rg = ReportGuard(REPORT);
     size_t      n  = 5;
-    ToddCoxeter tc(congruence_kind::twosided,
-                   partial_transformation_monoid(n, author::Mitchell + author::Whyte));
+    ToddCoxeter tc(
+        congruence_kind::twosided,
+        partial_transformation_monoid(n, author::Mitchell + author::Whyte));
     REQUIRE(tc.number_of_classes() == 7'776);
   }
 
@@ -918,27 +939,29 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 1'546);
   }
 
-    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "114",
                           "symmetric_inverse_monoid(4) Mitchell + Whyte",
                           "[fpsemi-examples][quick][no-valgrind]") {
     auto   rg = ReportGuard(REPORT);
     size_t n  = 4;
 
-    ToddCoxeter tc(congruence_kind::twosided,
-                   symmetric_inverse_monoid(n, author::Mitchell + author::Whyte));
+    ToddCoxeter tc(
+        congruence_kind::twosided,
+        symmetric_inverse_monoid(n, author::Mitchell + author::Whyte));
     REQUIRE(tc.number_of_classes() == 209);
   }
 
-    LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "115",
                           "symmetric_inverse_monoid(5) Mitchell + Whyte",
                           "[fpsemi-examples][quick][no-valgrind]") {
     auto   rg = ReportGuard(REPORT);
     size_t n  = 5;
 
-    ToddCoxeter tc(congruence_kind::twosided,
-                   symmetric_inverse_monoid(n, author::Mitchell + author::Whyte));
+    ToddCoxeter tc(
+        congruence_kind::twosided,
+        symmetric_inverse_monoid(n, author::Mitchell + author::Whyte));
     REQUIRE(tc.number_of_classes() == 1'546);
   }
 

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -913,7 +913,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
                           "113",
                           "full_transformation_monoid(6) Mitchell + Whyte",
-                          "[fpsemi-examples][quick]") {
+                          "[fpsemi-examples]") {
     auto   rg = ReportGuard(REPORT);
     size_t n  = 6;
 

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -899,7 +899,7 @@ namespace libsemigroups {
       "fpsemi-examples",
       "118",
       "full_transformation_monoid(5) Mitchell + Whyte index 1",
-      "[fpsemi-examples][quick]") {
+      "[fpsemi-examples]") {
     auto   rg = ReportGuard(REPORT);
     size_t n  = 5;
 

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -3121,7 +3121,7 @@ namespace libsemigroups {
                           "2-sided T_4",
                           "[quick][sims2][no-valgrind][no-coverage]") {
     auto  rg = ReportGuard(false);
-    Sims2 S(fpsemigroup::full_transformation_monoid(4));
+    Sims2 S(fpsemigroup::full_transformation_monoid(4, author::Iwahori));
 
     REQUIRE(S.number_of_congruences(256) == 11);  // Verified with GAP
     // sims::dot_poset("example-093-T-4-2-sided", S.cbegin(256), S.cend(256));


### PR DESCRIPTION
This PR adds presentations for the symmetric inverse, full transformation and partial transformation monoids from _[Short presentations for transformation monoids](https://arxiv.org/abs/2406.19294)_.

This is currently a draft, and there are a few things left to do, including:

- Fixing the line break where the default author value is mentioned in the `symmetric_inverse_monoid` documentation. Possibly this has to do with the non-documented comment in the midst of this.

- Adding the presentations for lower degrees -- for mathematical (or in some instances, implementational) reasons, this will need to be done case-by-case.

- Change the default author values for each monoid to use these presentations (seems reasonable!)

- Implement the even-degree-only presentation for the full transformation monoid.