### PR TITLE
Fix some warnings

### DIFF
--- a/include/libsemigroups/detail/containers.hpp
+++ b/include/libsemigroups/detail/containers.hpp
@@ -866,8 +866,18 @@ namespace libsemigroups {
 
       // Not noexcept because std::array::operator[] isn't
       void push_back(T x) {
+        // The below assertions exist to insure that we are not badly assigning
+        // values. The subsequent pragmas exist to suppress the false-positive
+        // warnings produced by g++ 13.2.0
         LIBSEMIGROUPS_ASSERT(_size < N);
+        LIBSEMIGROUPS_ASSERT(_array.size() == N);
+        static_assert(std::is_same_v<typename decltype(_array)::value_type, T>);
+#pragma GCC diagnostic push
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
         _array[_size] = x;
+#pragma GCC diagnostic pop
         _size++;
       }
 

--- a/include/libsemigroups/detail/multi-string-view.hpp
+++ b/include/libsemigroups/detail/multi-string-view.hpp
@@ -572,7 +572,9 @@ namespace libsemigroups {
 
         void destroy_long() {
 #pragma GCC diagnostic push
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
           _long.~Long();
 #pragma GCC diagnostic pop
         }

--- a/include/libsemigroups/detail/multi-string-view.hpp
+++ b/include/libsemigroups/detail/multi-string-view.hpp
@@ -571,7 +571,10 @@ namespace libsemigroups {
         }
 
         void destroy_long() {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
           _long.~Long();
+#pragma GCC diagnostic pop
         }
 
         Short _short;

--- a/include/libsemigroups/paths.hpp
+++ b/include/libsemigroups/paths.hpp
@@ -642,19 +642,20 @@ namespace libsemigroups {
     bool set_iterator_no_checks() const;
 
     // The following init function is private to avoid the case of constructing
-    // a Paths object without setting _word_graph
+    // a Paths object without setting _word_graph. The subsequent default
+    // constructor is protected and still needed (instead of deleting it) to
+    // avoid problems with having uninitialised std::variants with copy
+    // constructors.
+
     Paths& init();
+
+   protected:
+    Paths() = default;
 
    public:
     ////////////////////////////////////////////////////////////////////////
     // Constructors + initialization
     ////////////////////////////////////////////////////////////////////////
-
-    //! \brief Deleted.
-    //!
-    //! Deleted. To avoid the situation where the underlying WordGraph is not
-    //! defined, it is not possible to default construct a Paths object.
-    Paths() = delete;
 
     //! \brief Default copy constructor.
     //!
@@ -688,7 +689,7 @@ namespace libsemigroups {
     //! \warning The Paths object only holds a reference to the underlying
     //! WordGraph \p wg, and so \p wg must outlive any Paths object constructed
     //! from it.
-    explicit Paths(WordGraph<Node> const& wg) {
+    explicit Paths(WordGraph<Node> const& wg) : Paths() {
       init(wg);
     }
 
@@ -1128,6 +1129,8 @@ namespace libsemigroups {
 
     // Private so that we cannot create one of these without the word graph
     // known.
+    ReversiblePaths() = default;
+
     ReversiblePaths& init() {
       _reverse = false;
       return *this;
@@ -1144,9 +1147,6 @@ namespace libsemigroups {
     static constexpr bool is_finite     = Paths<Node>::is_finite;
     static constexpr bool is_idempotent = Paths<Node>::is_idempotent;
 
-    //! \copydoc Paths::Paths()
-    ReversiblePaths() = delete;
-
     //! \copydoc Paths::Paths(Paths const&)
     ReversiblePaths(ReversiblePaths const&) = default;
 
@@ -1160,7 +1160,8 @@ namespace libsemigroups {
     ReversiblePaths& operator=(ReversiblePaths&&) = default;
 
     //! \copydoc Paths::Paths(WordGraph<Node> const&)
-    explicit ReversiblePaths(WordGraph<Node> const& wg) : Paths<Node>(wg) {
+    explicit ReversiblePaths(WordGraph<Node> const& wg) : ReversiblePaths() {
+      Paths<Node>::init(wg);
       init();
     }
 

--- a/include/libsemigroups/presentation.tpp
+++ b/include/libsemigroups/presentation.tpp
@@ -96,9 +96,20 @@ namespace libsemigroups {
       }
     }
     word_type lphbt(n, 0);
+
+    // The below assertions exist to insure that we are not badly assigning
+    // values. The subsequent pragmas exist to suppress the false-positive
+    // warnings produced by g++ 13.2.0
+    static_assert(
+        std::is_same_v<std::decay_t<decltype(*lphbt.begin())>,
+                       decltype(words::human_readable_letter<Word>(0))>);
+#pragma GCC diagnostic push
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
     std::iota(
         lphbt.begin(), lphbt.end(), words::human_readable_letter<Word>(0));
-
+#pragma GCC diagnostic pop
     return alphabet(lphbt);
   }
 
@@ -655,9 +666,21 @@ namespace libsemigroups {
       }
       Word A(p.alphabet().size(), 0);
 
+      // The below assertion exists to insure that we are not badly assigning
+      // values. The subsequent pragmas exist to suppress the false-positive
+      // warnings produced by g++ 13.2.0
+      static_assert(
+          std::is_same_v<typename Word::value_type,
+                         decltype(words::human_readable_letter<Word>(0))>);
+
+#pragma GCC diagnostic push
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
       for (size_t i = 0; i < p.alphabet().size(); ++i) {
         A[i] = words::human_readable_letter<Word>(i);
       }
+#pragma GCC diagnostic pop
       p.alphabet(std::move(A));
 #ifdef LIBSEMIGROUPS_DEBUG
       p.validate();

--- a/include/libsemigroups/to-presentation.tpp
+++ b/include/libsemigroups/to-presentation.tpp
@@ -108,7 +108,15 @@ namespace libsemigroups {
     presentation::normalize_alphabet(result);
     result.alphabet(2 * result.alphabet().size());
     auto invs = result.alphabet();
+
+    // The below pragma exists to suppress the false-positive warnings produced
+    // by g++ 13.2.0
+#pragma GCC diagnostic push
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
     std::rotate(invs.begin(), invs.begin() + invs.size() / 2, invs.end());
+#pragma GCC diagnostic pop
     result.inverses_no_checks(std::move(invs));
     return result;
   }

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -217,13 +217,23 @@ namespace libsemigroups {
     template <typename Iterator>
     explicit PTransfBase(Iterator first, Iterator last) : PTransfBase() {
       using OtherScalar = typename std::iterator_traits<Iterator>::value_type;
+      // The below assertions exist to insure that we are not badly assigning
+      // values. The subsequent pragmas exist to suppress the false-positive
+      // warnings produced by g++ 13.2.0
       static_assert(
           std::is_same_v<OtherScalar, Undefined>
               || std::is_convertible_v<OtherScalar, point_type>,
           "the template parameter Iterator must have "
           "value_type \"Undefined\" or convertible to \"point_type\"!");
+      static_assert(std::is_same_v<std::decay_t<decltype(*_container.begin())>,
+                                   point_type>);
       resize(_container, std::distance(first, last));
+#pragma GCC diagnostic push
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
       std::copy(first, last, _container.begin());
+#pragma GCC diagnostic pop
     }
 
     //! \copydoc PTransfBase::PTransfBase(Container const&)

--- a/tests/test-fpsemi-examples-2.cpp
+++ b/tests/test-fpsemi-examples-2.cpp
@@ -98,8 +98,7 @@ namespace libsemigroups {
                           "068",
                           "plactic_monoid(3)",
                           "[fpsemi-examples][quick]") {
-    using rule_type = KnuthBendix<>::rule_type;
-    auto rg         = ReportGuard(false);
+    auto rg = ReportGuard(false);
     REQUIRE(plactic_monoid(3).rules
             == std::vector<word_type>({102_w,
                                        120_w,
@@ -156,6 +155,7 @@ namespace libsemigroups {
     REQUIRE(kb.presentation().alphabet() == "abc");
     REQUIRE(is_obviously_infinite(kb));
     kb.run();
+    // using rule_type = KnuthBendix<>::rule_type;
     // REQUIRE((kb.active_rules() | to_vector())
     //         == std::vector<rule_type>({{"bca", "bac"},
     //                                    {"cab", "acb"},

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -1785,7 +1785,6 @@ namespace libsemigroups {
     REQUIRE(human_readable_letter<>(0) == 'a');
     REQUIRE(human_readable_letter<>(10) == 'k');
 
-    detail::IntRange          ir(0, 255);
     Presentation<std::string> q;
 
     Presentation<word_type> r;


### PR DESCRIPTION
This PR removes some compiler warnings introduced by `g++ 13.2`, is highlighted in #597.