### PR TITLE
Fix noexcept and no_libsemigroups_except

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -284,8 +284,8 @@ TAB_SIZE = 4
 # @} or use a double escape (\\{ and \\})
 
 ALIASES = exceptions="\par Exceptions"
-ALIASES += noexcept="This function is $(noexcept) and is guaranteed never to throw."
-ALIASES += no_libsemigroups_except="This function guarantees not to throw a $()LibsemigroupsException$()."
+ALIASES += noexcept="This function is `noexcept` and is guaranteed never to throw."
+ALIASES += no_libsemigroups_except="This function guarantees not to throw a `LibsemigroupsException`."
 ALIASES += no_libsemigroups_except_detail="This function guarantees not to throw a \ref libsemigroups::LibsemigroupsException."
 ALIASES += strong_guarantee="If an exception is thrown, \c this is guaranteed not to be modified (strong exception guarantee)."
 ALIASES += basic_guarantee="If an exception is thrown, \c this might be modified but is guaranteed to be in a valid state (basic exception guarantee)."


### PR DESCRIPTION
In the absence of proper language support, my editor thought that the `Doxyfile` was a shell script, and incorrectly formatted the file. This PR reverts it back to the old (correct) version.

I have now installed language support, so this hopefully won't happen again; sorry!