### PR TITLE
Check doc order

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -69,6 +69,18 @@ Some more conventions:
     the namespace would belong to the function name (like
     `words::number_of_words`).
 
+* The documentation for each function may contain the following section
+  indicators in the following order:
+  #. ``\tparam``
+  #. ``\param``
+  #. ``\return``
+  #. ``\exceptions`` or ``\throws``
+  #. ``\complexity``
+  #. ``\note``
+  #. ``\warning``
+  #. ``\sa``
+  This can be checked by running ``etc/check_doc_order.py``.
+
 Debugging and valgrinding
 -------------------------
 

--- a/etc/check_doc_order.py
+++ b/etc/check_doc_order.py
@@ -65,7 +65,7 @@ def process_file(f):
                 highest_level = level
                 break
             print(
-                f"{begin_warn_col}Warning: {command} is not in the correct place in docstring at {file}:{line_no+1}{end_warn_col}"
+                f"{begin_warn_col}warning: {command} is not in the correct place in docstring at {file}:{line_no+1}{end_warn_col}"
             )
 
 

--- a/etc/check_doc_order.py
+++ b/etc/check_doc_order.py
@@ -9,17 +9,18 @@ end_warn_col = "\033[0m"
 
 
 def all_cpp_files(start):
-    files = set()
+    files = []
 
     def dive(path):
         for entry in listdir(path):
             candidate = os.path.join(path, entry)
             if isfile(candidate) and splitext(entry)[1] == ".hpp":
-                files.add(candidate)
+                files.append(candidate)
             elif not isfile(candidate):
                 dive(candidate)
 
     dive(start)
+    files.sort()
     return files
 
 

--- a/etc/check_doc_order.py
+++ b/etc/check_doc_order.py
@@ -4,7 +4,7 @@ import os
 from os import listdir
 from os.path import isfile, splitext
 
-being_warn_col = "\033[93m"
+begin_warn_col = "\033[93m"
 end_warn_col = "\033[0m"
 
 
@@ -64,7 +64,7 @@ def process_file(f):
                 highest_level = level
                 break
             print(
-                f"{being_warn_col}Warning: {command} is not in the correct place in docstring at {file}:{line_no+1}{end_warn_col}"
+                f"{begin_warn_col}Warning: {command} is not in the correct place in docstring at {file}:{line_no+1}{end_warn_col}"
             )
 
 

--- a/etc/check_doc_order.py
+++ b/etc/check_doc_order.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+import re
+import os
+from os import listdir
+from os.path import isfile, splitext
+
+being_warn_col = "\033[93m"
+end_warn_col = "\033[0m"
+
+
+def all_cpp_files(start):
+    files = set()
+
+    def dive(path):
+        for entry in listdir(path):
+            candidate = os.path.join(path, entry)
+            if isfile(candidate) and splitext(entry)[1] == ".hpp":
+                files.add(candidate)
+            elif not isfile(candidate):
+                dive(candidate)
+
+    dive(start)
+    return files
+
+
+include_path = "include"
+files = all_cpp_files(include_path)
+
+commands = {
+    r"\tparam": 1,
+    r"\param": 2,
+    r"\return": 3,
+    r"\exceptions": 4,
+    r"\throws": 4,
+    r"\complexity": 5,
+    r"\note": 6,
+    r"\warning": 7,
+    r"\sa": 8,
+}
+
+
+def process_file(f):
+    check_doc = True
+    in_doc = False
+    for line_no, line in enumerate(f):
+        if check_doc and "/*" in line:
+            check_doc = False
+        if not check_doc and "*/" in line:
+            check_doc = True
+        if not check_doc:
+            continue
+
+        if not in_doc and r"//!" in line:
+            in_doc = True
+            highest_level = 0
+
+        if in_doc and r"//!" not in line:
+            in_doc = False
+
+        for command, level in commands.items():
+            if command not in line:
+                continue
+            if level >= highest_level:
+                highest_level = level
+                break
+            print(
+                f"{being_warn_col}Warning: {command} is not in the correct place in docstring at {file}:{line_no+1}{end_warn_col}"
+            )
+
+
+print("Checking docstring order in .hpp files . . .")
+for file in files:
+    with open(file, "r") as f:
+        process_file(f)

--- a/etc/make-doc.sh
+++ b/etc/make-doc.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+echo "Checking doc order . . ."
+./etc/check_doc_order.py
 mkdir -p docs/build
 cd docs/
 echo "doxygen --version"

--- a/include/libsemigroups/action.hpp
+++ b/include/libsemigroups/action.hpp
@@ -544,12 +544,12 @@ namespace libsemigroups {
     //!
     //! \returns The size of the action, a value of type \c size_t.
     //!
+    //! \exceptions
+    //! \no_libsemigroups_except
+    //!
     //! \complexity
     //! The time complexity is \f$O(mn)\f$ where \f$m\f$ is the total number of
     //! points in the orbit and \f$n\f$ is the number of generators.
-    //!
-    //! \exceptions
-    //! \no_libsemigroups_except
     [[nodiscard]] size_t size() {
       run();
       return _orb.size();
@@ -562,11 +562,11 @@ namespace libsemigroups {
     //! \returns
     //! A value of type \c size_t.
     //!
-    //! \complexity
-    //! Constant.
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant.
     [[nodiscard]] size_t current_size() const noexcept {
       return _orb.size();
     }
@@ -580,11 +580,11 @@ namespace libsemigroups {
     //! \returns
     //! A const iterator to the first point.
     //!
-    //! \complexity
-    //! Constant.
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant.
     [[nodiscard]] const_iterator cbegin() const noexcept {
       return const_iterator(_orb.cbegin());
     }
@@ -599,15 +599,15 @@ namespace libsemigroups {
     //!
     //! Returns a range object containing the current points in the
     //! action.
-    // TODO(1) add a reference to the ranges page when it exists
     //!
     //! \returns A range object.
     //!
-    //! \complexity
-    //! Constant.
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant.
+    // TODO(1) add a reference to the ranges page when it exists
     [[nodiscard]] auto range() const noexcept {
       return rx::iterator_range(_orb.cbegin(), _orb.cend())
              | rx::transform([this](auto const& pt) {
@@ -625,11 +625,11 @@ namespace libsemigroups {
     //! \returns
     //! A const iterator to one past the end.
     //!
-    //! \complexity
-    //! Constant.
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant.
     [[nodiscard]] const_iterator cend() const noexcept {
       return const_iterator(_orb.cend());
     }
@@ -652,11 +652,11 @@ namespace libsemigroups {
     //! \returns
     //! A value of type \c bool.
     //!
-    //! \complexity
-    //! Constant.
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant.
     [[nodiscard]] bool cache_scc_multipliers() const noexcept {
       return _options._cache_scc_multipliers;
     }
@@ -672,11 +672,11 @@ namespace libsemigroups {
     //! \returns
     //! A reference to `*this`.
     //!
-    //! \complexity
-    //! Constant.
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant.
     Action& cache_scc_multipliers(bool val) noexcept {
       _options._cache_scc_multipliers = val;
       return *this;
@@ -693,13 +693,13 @@ namespace libsemigroups {
     //!
     //! \returns An element of type \ref element_type.
     //!
+    //! \throws LibsemigroupsException if there are no generators yet added
+    //! or the index \p pos is out of range.
+    //!
     //! \complexity
     //! At most \f$O(mn)\f$ where \f$m\f$ is the complexity of multiplying
     //! elements of type \ref element_type and \f$n\f$ is the size of the fully
     //! enumerated orbit.
-    //!
-    //! \throws LibsemigroupsException if there are no generators yet added
-    //! or the index \p pos is out of range.
     [[nodiscard]] element_type multiplier_from_scc_root(index_type pos) {
       return multiplier_private<true>(
           _multipliers_from_scc_root, _scc.spanning_forest(), pos);
@@ -716,13 +716,13 @@ namespace libsemigroups {
     //!
     //! \returns An element of type \ref element_type.
     //!
+    //! \throws LibsemigroupsException if there are no generators yet added
+    //! or the index \p pos is out of range.
+    //!
     //! \complexity
     //! At most \f$O(mn)\f$ where \f$m\f$ is the complexity of multiplying
     //! elements of type \ref element_type and \f$n\f$ is the size of the fully
     //! enumerated orbit.
-    //!
-    //! \throws LibsemigroupsException if there are no generators yet added
-    //! or the index \p pos is out of range.
     [[nodiscard]] element_type multiplier_to_scc_root(index_type pos) {
       return multiplier_private<false>(
           _multipliers_to_scc_root, _scc.reverse_spanning_forest(), pos);
@@ -738,13 +738,13 @@ namespace libsemigroups {
     //!
     //! \returns A value of type \ref const_reference_point_type.
     //!
+    //! \throws LibsemigroupsException if the point \p x does not belong to
+    //! the action.
+    //!
     //! \complexity
     //! At most \f$O(mn)\f$ where \f$m\f$ is the complexity of multiplying
     //! elements of type \ref element_type and \f$n\f$ is the size of the fully
     //! enumerated orbit.
-    //!
-    //! \throws LibsemigroupsException if the point \p x does not belong to
-    //! the action.
     [[nodiscard]] const_reference_point_type
     root_of_scc(const_reference_point_type x) {
       // TODO(2) this could be a helper
@@ -762,12 +762,12 @@ namespace libsemigroups {
     //!
     //! \returns A value of type \ref const_reference_point_type.
     //!
+    //! \throws LibsemigroupsException if the index \p pos is out of range.
+    //!
     //! \complexity
     //! At most \f$O(mn)\f$ where \f$m\f$ is the complexity of multiplying
     //! elements of type \ref element_type and \f$n\f$ is the size of the fully
     //! enumerated orbit.
-    //!
-    //! \throws LibsemigroupsException if the index \p pos is out of range.
     [[nodiscard]] const_reference_point_type root_of_scc(index_type pos) {
       return this->to_external_const(_orb[_scc.root_of(pos)]);
     }
@@ -776,13 +776,13 @@ namespace libsemigroups {
     //!
     //! \returns A const reference to a WordGraph<uint32_t>.
     //!
+    //! \exceptions
+    //! \no_libsemigroups_except
+    //!
     //! \complexity
     //! At most \f$O(mn)\f$ where \f$m\f$ is the complexity of multiplying
     //! elements of type \ref element_type and \f$n\f$ is the size of the fully
     //! enumerated orbit.
-    //!
-    //! \exceptions
-    //! \no_libsemigroups_except
     [[nodiscard]] WordGraph<uint32_t> const& word_graph() {
       run();
       return _graph;
@@ -796,13 +796,13 @@ namespace libsemigroups {
     //!
     //! \returns A const reference to a Gabow object.
     //!
+    //! \exceptions
+    //! \no_libsemigroups_except
+    //!
     //! \complexity
     //! At most \f$O(mn)\f$ where \f$m\f$ is the complexity of multiplying
     //! elements of type \ref element_type and \f$n\f$ is the size of the fully
     //! enumerated orbit.
-    //!
-    //! \exceptions
-    //! \no_libsemigroups_except
     [[nodiscard]] Gabow<uint32_t> const& scc() {
       run();
       return _scc;

--- a/include/libsemigroups/bipart.hpp
+++ b/include/libsemigroups/bipart.hpp
@@ -868,9 +868,9 @@ namespace libsemigroups {
     //! * partition the set \f$\{-n, \ldots, -1, 1, \ldots, n\}\f$
     //! for some positive integer \f$n\f$.
     //!
-    //! \warning None of these conditions is checked by the constructor.
-    //!
     //! \param blocks the partition.
+    //!
+    //! \warning None of these conditions is checked by the constructor.
     //!
     //! \sa libsemigroups::validate(Bipartition const&).
     Bipartition(std::initializer_list<std::vector<int32_t>> const& blocks);
@@ -1170,11 +1170,11 @@ namespace libsemigroups {
     //! \param y the second bipartition to multiply
     //! \param thread_id the index of the calling thread (defaults to \c 0)
     //!
-    //! \complexity
-    //! Quadratic in `x.degree()`.
-    //!
     //! \exceptions
     //! \no_libsemigroups_except
+    //!
+    //! \complexity
+    //! Quadratic in `x.degree()`.
     //!
     //! \warning
     //! If different threads call this function concurrently with the same
@@ -1350,11 +1350,11 @@ namespace libsemigroups {
     //!
     //! \param n the number of blocks.
     //!
-    //! \complexity
-    //! Constant.
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant.
     void set_number_of_blocks(size_t n) noexcept;
 
     //! \brief Set the number of left blocks.
@@ -1364,11 +1364,11 @@ namespace libsemigroups {
     //!
     //! \param n the number of blocks.
     //!
-    //! \complexity
-    //! Constant.
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant.
     void set_number_of_left_blocks(size_t n) noexcept;
 
     //! \brief Set the rank.
@@ -1378,11 +1378,11 @@ namespace libsemigroups {
     //!
     //! \param n the rank.
     //!
-    //! \complexity
-    //! Constant.
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant.
     void set_rank(size_t n) noexcept;
 
     //! \brief Return a const iterator pointing to the first transverse

--- a/include/libsemigroups/bmat-adapters.hpp
+++ b/include/libsemigroups/bmat-adapters.hpp
@@ -60,13 +60,13 @@ namespace libsemigroups {
   //! Specialization of the \ref ImageRightAction adapter for \ref BMat and
   //! containers of \ref BitSet.
   //!
-  //! \sa ImageRightAction.
-  //!
   //! \warning
   //! The template type `Mat` must be a \ref BMat type (\ref IsBMat<Mat> must be
   //! true), and the `value_type` of the template type `Container` must be a
   //! bit set (`IsBitSet<typename Container::value_type>>` must be true). If
   //! not, template substitution will fail.
+  //!
+  //! \sa ImageRightAction.
   // T = StaticVector1<BitSet<N>, N> or std::vector<BitSet<N>>
   // Possibly further container when value_type is BitSet.
   template <typename Mat, typename Container>
@@ -111,11 +111,11 @@ namespace libsemigroups {
   //!
   //! Specialization of the ImageLeftAction adapter for \ref BMat
   //!
-  //! \sa ImageLeftAction.
-  //!
   //! \warning
   //! The template type `Mat` must be a \ref BMat type (\ref IsBMat<Mat> must be
   //! true). If not, template substitution will fail.
+  //!
+  //! \sa ImageLeftAction.
   //!
   // TODO(0) doc tparams
   template <typename Mat, typename Container>
@@ -152,8 +152,6 @@ namespace libsemigroups {
   //!
   //! Specialization of the LambdaValue adapter for \ref BMat
   //!
-  //! \sa LambdaValue.
-  //!
   //! \note
   //! The the type chosen here limits the Konieczny algorithm to BMats of degree
   //! at most 64 (or 32 on 32-bit systems).
@@ -161,6 +159,8 @@ namespace libsemigroups {
   //! \warning
   //! The template type `Mat` must be a \ref BMat type (\ref IsBMat<Mat> must be
   //! true). If not, template substitution will fail.
+  //!
+  //! \sa LambdaValue.
   // This currently limits the use of Konieczny to matrices of dimension at
   // most 64 with the default traits class, since we cannot know the
   // dimension of the matrices at compile time, only at run time.
@@ -186,8 +186,6 @@ namespace libsemigroups {
   //!
   //! Specialization of the RhoValue adapter for \ref BMat.
   //!
-  //! \sa RhoValue.
-  //!
   //! \note
   //! The the type chosen here limits the Konieczny algorithm to BMats of degree
   //! at most 64 (or 32 on 32-bit systems).
@@ -195,6 +193,8 @@ namespace libsemigroups {
   //! \warning
   //! The template type `Mat` must be a \ref BMat type (\ref IsBMat<Mat> must be
   //! true). If not, template substitution will fail.
+  //!
+  //! \sa RhoValue.
   // TODO(0) doc tparams
   template <typename Mat>
 #ifndef PARSED_BY_DOXYGEN
@@ -221,11 +221,11 @@ namespace libsemigroups {
   //! Specialization of the Lambda adapter for instances of \ref BMat and
   //! `std::vector<BitSet<N>>` or `detail::StaticVector1<BitSet<N>>`.
   //!
-  //! \sa Lambda.
-  //!
   //! \warning
   //! The template type `Mat` must be a \ref BMat type (\ref IsBMat<Mat> must be
   //! true). If not, template substitution will fail.
+  //!
+  //! \sa Lambda.
   // TODO(0) doc tparameters
   template <typename Mat, typename Container>
 #ifndef PARSED_BY_DOXYGEN
@@ -270,11 +270,11 @@ namespace libsemigroups {
   //! Specialization of the Rho adapter for instances of \ref Transf and
   //! `std::vector<BitSet<N>>` or `StaticVector1<BitSet<N>>`.
   //!
-  //! \sa Rho.
-  //!
   //! \warning
   //! The template type `Mat` must be a \ref BMat type (\ref IsBMat<Mat> must be
   //! true). If not, template substitution will fail.
+  //!
+  //! \sa Rho.
   template <typename Mat, typename Container>
 #ifndef PARSED_BY_DOXYGEN
   struct Rho<Mat, Container, std::enable_if_t<IsBMat<Mat>>>
@@ -305,11 +305,11 @@ namespace libsemigroups {
   //! Specialization of the ImageRightAction adapter for \ref BMat and
   //! ``BitSet``.
   //!
-  //! \sa ImageRightAction.
-  //!
   //! \warning
   //! The template type `Mat` must be a \ref BMat type (\ref IsBMat<Mat> must be
   //! true). If not, template substitution will fail.
+  //!
+  //! \sa ImageRightAction.
   template <size_t N, typename Mat>
 #ifndef PARSED_BY_DOXYGEN
   struct ImageRightAction<Mat, BitSet<N>, std::enable_if_t<IsBMat<Mat>>>
@@ -349,11 +349,11 @@ namespace libsemigroups {
   //!
   //! Specialization of the RankState adapter for \ref BMat.
   //!
-  //! \sa RankState.
-  //!
   //! \warning
   //! The template type `Mat` must be a \ref BMat type (\ref IsBMat<Mat> must be
   //! true). If not, template substitution will fail.
+  //!
+  //! \sa RankState.
   template <typename Mat>
 #ifndef PARSED_BY_DOXYGEN
   class RankState<Mat, std::enable_if_t<IsBMat<Mat>>>
@@ -431,11 +431,11 @@ namespace libsemigroups {
   //!
   //! Specialization of the Rank adapter for instances of \ref BMat
   //!
-  //! \sa Rank.
-  //!
   //! \warning
   //! The template type `Mat` must satisfy \ref IsBMat<Mat>.
   //! If not, template substitution will fail.
+  //!
+  //! \sa Rank.
   template <typename Mat>
 #ifndef PARSED_BY_DOXYGEN
   struct Rank<Mat, RankState<Mat>, std::enable_if_t<IsBMat<Mat>>>

--- a/include/libsemigroups/detail/rewriters.hpp
+++ b/include/libsemigroups/detail/rewriters.hpp
@@ -281,11 +281,11 @@ namespace libsemigroups {
       //! If the right-hand side is greater than the left-hand side of a rule,
       //! with regards to length-lexicographical order, then swap them.
       //!
-      //! \complexity
-      //! The same complexity as \ref shortlex_compare(T* const, T* const)
-      //!
       //! \exceptions
       //! Throws if \ref shortlex_compare(T* const, T* const) does.
+      //!
+      //! \complexity
+      //! The same complexity as \ref shortlex_compare(T* const, T* const)
       //!
       //! \sa
       //! shortlex_compare(T* const, T* const)

--- a/include/libsemigroups/dot.hpp
+++ b/include/libsemigroups/dot.hpp
@@ -322,10 +322,10 @@ namespace libsemigroups {
     //! represented graph.
     //!
     //! \returns A range object.
-    // TODO(0) add a reference to the ranges page when it exists
     //!
     //! \exceptions
     //! \noexcept
+    // TODO(0) add a reference to the ranges page when it exists
     auto nodes() noexcept {
       return rx::iterator_range(_nodes.begin(), _nodes.end())
              | rx::transform([](auto& pair) -> Node& { return pair.second; });
@@ -337,10 +337,10 @@ namespace libsemigroups {
     //! represented graph.
     //!
     //! \returns A range object.
-    // TODO(0) add a reference to the ranges page when it exists
     //!
     //! \exceptions
     //! \noexcept
+    // TODO(0) add a reference to the ranges page when it exists
     auto nodes() const noexcept {
       return rx::iterator_range(_nodes.begin(), _nodes.end())
              | rx::transform(

--- a/include/libsemigroups/forest.hpp
+++ b/include/libsemigroups/forest.hpp
@@ -161,12 +161,12 @@ namespace libsemigroups {
     //! \complexity
     //! Constant
     //!
+    //! \note The value of \p gen can be arbitrary, and so this argument is
+    //! never checked.
+    //!
     //! \warning No checks are performed on the arguments of this function. In
     //! particular, if \p node or \p parent is greater than or equal to \ref
     //! number_of_nodes, then bad things may happen.
-    //!
-    //! \note The value of \p gen can be arbitrary, and so this argument is
-    //! never checked.
     Forest& set_parent_and_label_no_checks(node_type  node,
                                            node_type  parent,
                                            label_type gen) {
@@ -180,9 +180,6 @@ namespace libsemigroups {
     //! This function sets the parent of \p node to be \p parent, and the
     //! associated edge-label to be \p gen.
     //!
-    //! \note The value of \p gen can be arbitrary, and so this argument is
-    //! never checked.
-    //!
     //! \param node   the node whose parent and label to set.
     //! \param parent the parent node.
     //! \param gen    the label of the edge from \p parent to \p node.
@@ -194,6 +191,9 @@ namespace libsemigroups {
     //!
     //! \complexity
     //! Constant
+    //!
+    //! \note The value of \p gen can be arbitrary, and so this argument is
+    //! never checked.
     // not noexcept because std::vector::operator[] isn't.
     Forest& set_parent_and_label(node_type  node,
                                  node_type  parent,

--- a/include/libsemigroups/fpsemi-examples.hpp
+++ b/include/libsemigroups/fpsemi-examples.hpp
@@ -202,7 +202,7 @@ namespace libsemigroups {
     //! Returns a monoid presentation defining
     //! the monoid of orientation preserving or reversing mappings on a finite
     //! chain of order `n`, as described in [10.1007/s10012-000-0001-1][].
-    //
+    //!
     //! \param n the order of the chain
     //!
     //! \returns A `std::vector<relation_type>`

--- a/include/libsemigroups/gabow.hpp
+++ b/include/libsemigroups/gabow.hpp
@@ -115,12 +115,12 @@ namespace libsemigroups {
     //!
     //! This function constructs a Gabow object from the WordGraph \p wg.
     //!
+    //! \note This function does not trigger the computation of the strongly
+    //! connected components.
+    //!
     //! \warning The Gabow object only holds a reference to the underlying
     //! WordGraph \p wg, and so that object must outlive the corresponding Gabow
     //! object.
-    //!
-    //! \note This function does not trigger the computation of the strongly
-    //! connected components.
     explicit Gabow(WordGraph<node_type> const& wg) {
       init(wg);
     }
@@ -135,12 +135,12 @@ namespace libsemigroups {
     //! \exceptions
     //! \no_libsemigroups_except
     //!
+    //! \note This function does not trigger the computation of the strongly
+    //! connected components.
+    //!
     //! \warning The Gabow object only holds a reference to the underlying
     //! WordGraph \p wg, and so that object must outlive the corresponding Gabow
     //! object.
-    //!
-    //! \note This function does not trigger the computation of the strongly
-    //! connected components.
     Gabow& init(WordGraph<node_type> const& wg);
 
     //! \brief Get the id of a strongly connected component of a node.
@@ -155,11 +155,11 @@ namespace libsemigroups {
     //! \exceptions
     //! \no_libsemigroups_except
     //!
-    //! \warning This function does not check that its argument \p n is actually
-    //! a node of the underlying word graph.
-    //!
     //! \note This function triggers the computation of the strongly connected
     //! components (if they are not already known).
+    //!
+    //! \warning This function does not check that its argument \p n is actually
+    //! a node of the underlying word graph.
     [[nodiscard]] size_type id_no_checks(node_type n) const {
       run();
       return _id[n];
@@ -246,10 +246,10 @@ namespace libsemigroups {
     //! \exceptions
     //! \no_libsemigroups_except
     //!
-    //! \warning This function does not check that its argument \p i.
-    //!
     //! \note This function triggers the computation of the strongly connected
     //! components (if they are not already known).
+    //!
+    //! \warning This function does not check that its argument \p i.
     //!
     //! \sa \ref component_of_no_checks to obtain the strongly connected
     //! component of a node.
@@ -267,11 +267,11 @@ namespace libsemigroups {
     //! \returns
     //! A `size_t`.
     //!
-    //! \note This function triggers the computation of the strongly connected
-    //! components (if they are not already known).
-    //!
     //! \exceptions
     //! \no_libsemigroups_except
+    //!
+    //! \note This function triggers the computation of the strongly connected
+    //! components (if they are not already known).
     [[nodiscard]] size_t number_of_components() const {
       run();
       return _comps.size();
@@ -331,17 +331,17 @@ namespace libsemigroups {
     //!
     //! \param n the node.
     //!
-    //! \exceptions
-    //! \no_libsemigroups_except
-    //!
     //! \returns
     //! The root of the strongly connected component containing the node \p n,
     //! a value of \ref WordGraph::node_type.
     //!
-    //! \warning This function does not check that its argument \p n.
+    //! \exceptions
+    //! \no_libsemigroups_except
     //!
     //! \note This function triggers the computation of the strongly connected
     //! components (if they are not already known).
+    //!
+    //! \warning This function does not check that its argument \p n.
     [[nodiscard]] node_type root_of_no_checks(node_type n) const {
       return component_of_no_checks(n)[0];
     }
@@ -380,15 +380,15 @@ namespace libsemigroups {
     //!
     //! \param n the node.
     //!
+    //! \returns A vector of node_type.
+    //!
     //! \exceptions
     //! \no_libsemigroups_except
     //!
-    //! \returns A vector of node_type.
-    //!
-    //! \warning This function does not check that its argument \p n.
-    //!
     //! \note This function triggers the computation of the strongly connected
     //! components (if they are not already known).
+    //!
+    //! \warning This function does not check that its argument \p n.
     [[nodiscard]] std::vector<node_type> const&
     component_of_no_checks(node_type n) const {
       run();

--- a/include/libsemigroups/hpcombi.hpp
+++ b/include/libsemigroups/hpcombi.hpp
@@ -140,10 +140,10 @@ namespace libsemigroups {
   //! Specialization of the Product adapter for subclasses of
   //! ``HPCombi::PTransf16``.
   //!
-  //! \sa Product.
-  //!
   //! \note ``HPCombi`` implements composition of functions from left to right,
   //! whereas ``libsemigroups`` assumes composition is right to left.
+  //!
+  //! \sa Product.
   template <typename TPTransf16Subclass>
   struct Product<TPTransf16Subclass,
                  std::enable_if_t<std::is_base_of_v<HPCombi::PTransf16,

--- a/include/libsemigroups/matrix.hpp
+++ b/include/libsemigroups/matrix.hpp
@@ -1038,10 +1038,6 @@ namespace libsemigroups {
   //! This class is the type of row views into a StaticMatrix; see
   //! the documentation for StaticMatrix for further details.
   //!
-  //! \warning
-  //! If the underlying matrix is destroyed, then any row views for that matrix
-  //! are invalidated.
-  //!
   //! \tparam PlusOp a stateless type with a call operator of signature
   //! `scalar_type operator()(scalar_type, scalar_type)` implementing the
   //! addition of the semiring.
@@ -1062,6 +1058,10 @@ namespace libsemigroups {
   //!
   //! \tparam Scalar the type of the entries in the matrices (the type of
   //! elements in the underlying semiring).
+  //!
+  //! \warning
+  //! If the underlying matrix is destroyed, then any row views for that matrix
+  //! are invalidated.
   template <typename PlusOp,
             typename ProdOp,
             typename ZeroOp,
@@ -1168,11 +1168,11 @@ namespace libsemigroups {
     //!
     //! \returns  A value of type \ref iterator.
     //!
-    //! \complexity
-    //! Constant
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant
     iterator begin() noexcept;
 
     //! \brief Returns a iterator pointing one beyond the last entry of the row.
@@ -1182,11 +1182,11 @@ namespace libsemigroups {
     //!
     //! \returns  A value of type \ref iterator.
     //!
-    //! \complexity
-    //! Constant
-    //!
     //! \exceptions
     //! \no_libsemigroups_except
+    //!
+    //! \complexity
+    //! Constant
     iterator end();
 
     //! \brief Returns a const iterator pointing at the first entry.
@@ -1196,11 +1196,11 @@ namespace libsemigroups {
     //!
     //! \returns  A value of type \ref const_iterator.
     //!
-    //! \complexity
-    //! Constant
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant
     const_iterator cbegin() const noexcept;
 
     //! \brief Returns a const iterator pointing one beyond the last entry of
@@ -1211,11 +1211,11 @@ namespace libsemigroups {
     //!
     //! \returns  A value of type \ref iterator.
     //!
-    //! \complexity
-    //! Constant
-    //!
     //! \exceptions
     //! \no_libsemigroups_except
+    //!
+    //! \complexity
+    //! Constant
     iterator cend();
 
     //! \brief Returns a reference to the specified entry of the row.
@@ -1473,10 +1473,6 @@ namespace libsemigroups {
   //! matrix and is cheap to create and copy. Addition, scalar multiplication,
   //! and other usual vector operations are defined for row views.
   //!
-  //! \warning
-  //! If the underlying matrix is destroyed, then any row views for that
-  //! matrix are invalidated.
-  //!
   //! \tparam PlusOp a stateless type with a call operator of signature
   //! `scalar_type operator()(scalar_type, scalar_type)` implementing the
   //! addition of the semiring
@@ -1495,6 +1491,10 @@ namespace libsemigroups {
   //!
   //! \tparam Scalar the type of the entries in the matrices (the type of
   //! elements in the underlying semiring)
+  //!
+  //! \warning
+  //! If the underlying matrix is destroyed, then any row views for that
+  //! matrix are invalidated.
   template <typename PlusOp,
             typename ProdOp,
             typename ZeroOp,
@@ -1644,16 +1644,16 @@ namespace libsemigroups {
   //! This class is the type of row views into a \ref
   //! DynamicMatrixDynamicArith "DynamicMatrix (run-time arithmetic)".
   //!
-  //! \warning
-  //! If the underlying matrix is destroyed, then any row views for that
-  //! matrix are invalidated.
-  //!
   //! \tparam Semiring the type of a semiring object which defines the semiring
   //! arithmetic (see requirements in \ref DynamicMatrixDynamicArith
   //! "DynamicMatrix (run-time arithmetic)".
   //!
   //! \tparam Scalar the type of the entries in the matrices (the type of
   //! elements in the underlying semiring).
+  //!
+  //! \warning
+  //! If the underlying matrix is destroyed, then any row views for that
+  //! matrix are invalidated.
   template <typename Semiring, typename Scalar>
   class DynamicRowView<Semiring, Scalar>
       : public detail::RowViewCommon<DynamicMatrix<Semiring, Scalar>,
@@ -2114,13 +2114,10 @@ namespace libsemigroups {
     //!
     //! \returns  A value of type \ref scalar_reference.
     //!
-    //! \exceptions
-    //!   this function guarantees not to throw a LibsemigroupsException.
+    //! \throws LibsemigroupsException if \p r or \p c is out of bounds.
     //!
     //! \complexity
     //!   Constant
-    //!
-    //! \throws LibsemigroupsException if \p r or \p c is out of bounds.
     scalar_reference at(size_t r, size_t c);
 
     //! \brief Returns a const reference to the specified entry of the matrix.
@@ -2152,13 +2149,10 @@ namespace libsemigroups {
     //!
     //! \returns  A value of type \ref scalar_const_reference.
     //!
-    //! \exceptions
-    //! \no_libsemigroups_except
+    //! \throws LibsemigroupsException if \p r or \p c is out of bounds.
     //!
     //! \complexity
     //! Constant
-    //!
-    //! \throws LibsemigroupsException if \p r or \p c is out of bounds.
     scalar_const_reference at(size_t r, size_t c) const;
 
     //! \brief Returns an iterator pointing at the first entry.
@@ -2168,11 +2162,11 @@ namespace libsemigroups {
     //!
     //! \returns A value of type \ref StaticMatrix::iterator "iterator".
     //!
-    //! \complexity
-    //! Constant
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant
     //!
     //! \warning
     //! The order in which entries in the matrix are iterated over is not
@@ -2184,11 +2178,11 @@ namespace libsemigroups {
     //!
     //! \returns A value of type \ref StaticMatrix::iterator "iterator".
     //!
-    //! \complexity
-    //! Constant
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant
     //!
     //! \warning
     //! The order in which entries in the matrix are iterated over is not
@@ -2203,11 +2197,11 @@ namespace libsemigroups {
     //! \returns  A value of type \ref StaticMatrix::const_iterator
     //! "const_iterator".
     //!
-    //! \complexity
-    //! Constant
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant
     //!
     //! \warning
     //!   The order in which entries in the matrix are iterated over is not
@@ -2223,11 +2217,11 @@ namespace libsemigroups {
     //! \returns  A value of type \ref StaticMatrix::const_iterator
     //! "const_iterator".
     //!
-    //! \complexity
-    //! Constant
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant
     //!
     //! \warning
     //! The order in which entries in the matrix are iterated over is not
@@ -2311,11 +2305,11 @@ namespace libsemigroups {
     //!
     //! \returns A value of type `std::pair<scalar_type, scalar_type>`.
     //!
-    //! \complexity
-    //! Constant
-    //!
     //! \exceptions
     //! \no_libsemigroups_except
+    //!
+    //! \complexity
+    //! Constant
     std::pair<scalar_type, scalar_type> coords(const_iterator it) const;
 
     //! \brief Returns the number of rows of the matrix.
@@ -2324,11 +2318,11 @@ namespace libsemigroups {
     //!
     //! \returns A value of type `size_t`.
     //!
-    //! \complexity
-    //! Constant
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant
     size_t number_of_rows() const noexcept;
 
     //! \brief Returns the number of columns of the matrix.
@@ -2337,11 +2331,11 @@ namespace libsemigroups {
     //!
     //! \returns A value of type `size_t`.
     //!
-    //! \complexity
-    //! Constant
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant
     size_t number_of_cols() const noexcept;
 
     //! \brief Returns the sum of two matrices.
@@ -2500,11 +2494,11 @@ namespace libsemigroups {
     //!
     //! \param that  the matrix to swap contents with.
     //!
-    //! \complexity
-    //! Constant
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant
     void swap(StaticMatrix& that) noexcept;
 
     //! \brief Transpose a matrix in-place.
@@ -2514,11 +2508,11 @@ namespace libsemigroups {
     //! \exceptions
     //! \no_libsemigroups_except
     //!
+    //! \throws LibsemigroupsException if the matrix isn't square.
+    //!
     //! \complexity
     //! \f$O(mn)\f$ where \f$m\f$ is \ref number_of_rows and
     //! \f$n\f$ is \ref number_of_cols.
-    //!
-    //! \throws LibsemigroupsException if the matrix isn't square.
     void transpose();
 
     //! \brief Transpose a matrix in-place.

--- a/include/libsemigroups/paths.hpp
+++ b/include/libsemigroups/paths.hpp
@@ -820,17 +820,17 @@ namespace libsemigroups {
     //!
     //! \returns A reference to `*this`.
     //!
-    //! \warning The source node must be defined for a Paths object
-    //! to be valid.
-    //!
-    //! \warning This function does not verify that the argument \p n is a node
-    //! in the underlying WordGraph (\ref word_graph).
-    //!
     //! \exceptions
     //! \noexcept
     //!
     //! \note Changing the value of the source node resets the Paths object to
     //! point at the first word in the specified range.
+    //!
+    //! \warning The source node must be defined for a Paths object
+    //! to be valid.
+    //!
+    //! \warning This function does not verify that the argument \p n is a node
+    //! in the underlying WordGraph (\ref word_graph).
     Paths& source_no_checks(node_type n) noexcept {
       return source_no_checks(this, n);
     }
@@ -844,14 +844,14 @@ namespace libsemigroups {
     //!
     //! \returns A reference to `*this`.
     //!
-    //! \warning It is necessary to set the source node using \ref source
-    //! before a Paths object is valid.
-    //!
     //! \throws LibsemigroupsException if \p n is not a node in the underlying
     //! WordGraph (\ref word_graph).
     //!
     //! \note Changing the value of the source node resets the Paths object to
     //! point at the first word in the specified range.
+    //!
+    //! \warning It is necessary to set the source node using \ref source
+    //! before a Paths object is valid.
     Paths& source(node_type n) {
       word_graph::throw_if_node_out_of_bounds(word_graph(), n);
       return source_no_checks(n);
@@ -885,11 +885,11 @@ namespace libsemigroups {
     //! \exceptions
     //! \noexcept
     //!
-    //! \warning This function does not verify that the argument \p n is a node
-    //! in the underlying WordGraph (\ref word_graph).
-    //!
     //! \note Changing the value of the target node resets the Paths object to
     //! point at the first word in the specified range.
+    //!
+    //! \warning This function does not verify that the argument \p n is a node
+    //! in the underlying WordGraph (\ref word_graph).
     Paths& target_no_checks(node_type n) noexcept {
       return target_no_checks(this, n);
     }

--- a/include/libsemigroups/pbr.hpp
+++ b/include/libsemigroups/pbr.hpp
@@ -507,12 +507,12 @@ namespace libsemigroups {
   //! \throws LibsemigroupsException if libsemigroups::throw_if_invalid(PBR
   //! const&) throws when called with the constructed PBR.
   //!
-  //! \sa
-  //! \ref libsemigroups::PBR().
-  //!
   //! \warning
   //! No checks are performed on the validity of \p args prior to the
   //! construction of the PBR object.
+  //!
+  //! \sa
+  //! \ref libsemigroups::PBR().
   template <typename... T>
   PBR to_pbr(T... args) {
     // TODO(later) validate_args
@@ -533,12 +533,12 @@ namespace libsemigroups {
   //! \throws LibsemigroupsException if libsemigroups::throw_if_invalid(PBR
   //! const&) throws when called with the constructed PBR.
   //!
-  //! \sa
-  //! \ref libsemigroups::PBR(initializer_list_type<uint32_t>).
-  //!
   //! \warning
   //! No checks are performed on the validity of \p args prior to the
   //! construction of the PBR object.
+  //!
+  //! \sa
+  //! \ref libsemigroups::PBR(initializer_list_type<uint32_t>).
   inline PBR to_pbr(PBR::initializer_list_type<uint32_t> args) {
     return to_pbr<decltype(args)>(args);
   }
@@ -556,13 +556,13 @@ namespace libsemigroups {
   //! \throws LibsemigroupsException if libsemigroups::throw_if_invalid(PBR
   //! const&) throws when called with the constructed PBR.
   //!
-  //! \sa
-  //! \ref libsemigroups::PBR(initializer_list_type<uint32_t>,
-  //! initializer_list_type<uint32_t>).
-  //!
   //! \warning
   //! No checks are performed on the validity of \p left or \p right prior to
   //! the construction of the PBR object.
+  //!
+  //! \sa
+  //! \ref libsemigroups::PBR(initializer_list_type<uint32_t>,
+  //! initializer_list_type<uint32_t>).
   PBR to_pbr(PBR::initializer_list_type<int32_t> left,
              PBR::initializer_list_type<int32_t> right);
 

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -454,13 +454,14 @@ namespace libsemigroups {
     //! \exceptions
     //! \no_libsemigroups_except
     //!
+    //! \complexity
+    //! Average case: linear in the length of the alphabet, worst case:
+    //! quadratic in the length of the alphabet.
+    //!
     //! \warning This function does no checks on its arguments whatsoever. In
     //! particular, if the letter \p x is not a generator, then bad things will
     //! happen.
     //!
-    //! \complexity
-    //! Average case: linear in the length of the alphabet, worst case:
-    //! quadratic in the length of the alphabet.
     void remove_generator_no_checks(letter_type x);
 
     //! \brief Remove \p x as a generator.

--- a/include/libsemigroups/runner.hpp
+++ b/include/libsemigroups/runner.hpp
@@ -151,12 +151,12 @@ namespace libsemigroups {
     //! \returns
     //! A value of type \c bool.
     //!
-    //! \sa report_every(std::chrono::nanoseconds) and report_every(Time).
+    //! \note This function is thread-safe.
     //!
     //! \warning This function can be somewhat expensive, and so you should
     //! avoid invoking it too often.
     //!
-    //! \note This function is thread-safe.
+    //! \sa report_every(std::chrono::nanoseconds) and report_every(Time).
     // not noexcept because operator- for time_points can throw.
     // TODO(later) remove? Used by Action
     [[nodiscard]] inline bool report() const {
@@ -180,16 +180,16 @@ namespace libsemigroups {
     //!
     //! \param val the amount of time (in nanoseconds) between reports.
     //!
-    //! \exceptions
-    //! \noexcept
-    //!
     //! \returns
     //! A reference to \c this.
     //!
-    //! \sa
-    //! report_every(Time)
+    //! \exceptions
+    //! \noexcept
     //!
     //! \note This function is not thread-safe.
+    //!
+    //! \sa
+    //! report_every(Time)
     Reporter& report_every(nanoseconds val) noexcept {
       _last_report          = std::chrono::high_resolution_clock::now();
       _report_time_interval = val;
@@ -207,11 +207,11 @@ namespace libsemigroups {
     //!
     //! \param t the amount of time (in \c Time) between reports.
     //!
-    //! \exceptions
-    //! \noexcept
-    //!
     //! \returns
     //! A reference to \c this.
+    //!
+    //! \exceptions
+    //! \noexcept
     //!
     //! \note This function is not thread-safe.
     template <typename Time>
@@ -221,11 +221,11 @@ namespace libsemigroups {
 
     //! \brief Get the minimum elapsed time between reports.
     //!
-    //! \exceptions
-    //! \noexcept
-    //!
     //! \returns
     //! The number of nanoseconds between reports.
+    //!
+    //! \exceptions
+    //! \noexcept
     //!
     //! \note This function is thread-safe.
     [[nodiscard]] nanoseconds report_every() const noexcept {
@@ -238,10 +238,10 @@ namespace libsemigroups {
     //!  which is also the time of construction of a Reporter instance if
     //!  reset_start_time() is not explicitly called.
     //!
+    //! \returns The time point representing the start time.
+    //!
     //! \exceptions
     //! \noexcept
-    //!
-    //! \returns The time point representing the start time.
     //!
     //! \note This function is thread-safe.
     [[nodiscard]] time_point start_time() const noexcept {
@@ -269,10 +269,10 @@ namespace libsemigroups {
     //! * report_every(); or
     //! * report().
     //!
+    //! \returns A \ref time_point.
+    //!
     //! \exceptions
     //! \noexcept
-    //!
-    //! \returns A \ref time_point.
     //!
     //! \note This function is thread-safe.
     [[nodiscard]] time_point last_report() const noexcept {
@@ -320,10 +320,10 @@ namespace libsemigroups {
     //! (set via report_prefix(std::string const&)), which is typically
     //! the name of the algorithm being run at the outmost level.
     //!
+    //! \returns A const reference to the prefix string.
+    //!
     //! \exceptions
     //! \noexcept
-    //!
-    //! \returns A const reference to the prefix string.
     //!
     //! \note This function is thread-safe.
     [[nodiscard]] std::string const& report_prefix() const noexcept {
@@ -552,11 +552,11 @@ namespace libsemigroups {
     //! Returns \c true if run() has started to run (it can be running or
     //! not).
     //!
-    //! \exceptions
-    //! \noexcept
-    //!
     //! \returns
     //! A \c bool.
+    //!
+    //! \exceptions
+    //! \noexcept
     //!
     //! \sa finished()
     [[nodiscard]] bool started() const noexcept {
@@ -568,11 +568,11 @@ namespace libsemigroups {
     //! Returns \c true if run() is in the process of running and \c false it is
     //! not.
     //!
-    //! \exceptions
-    //! \noexcept
-    //!
     //! \returns
     //! A \c bool.
+    //!
+    //! \exceptions
+    //! \noexcept
     //!
     //! \sa finished()
     [[nodiscard]] bool running() const noexcept {
@@ -694,14 +694,14 @@ namespace libsemigroups {
     //!
     //! Returns the current state of the Runner as given by \ref state.
     //!
+    //! \returns
+    //! A value of type \c state.
+    //!
     //! \exceptions
     //! \noexcept
     //!
     //! \complexity
     //! Constant.
-    //!
-    //! \returns
-    //! A value of type \c state.
     [[nodiscard]] state current_state() const noexcept {
       return _state;
     }

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -553,11 +553,11 @@ namespace libsemigroups {
     //! \returns
     //! A const iterator to the first image value.
     //!
-    //! \complexity
-    //! Constant.
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant.
     [[nodiscard]] const_iterator cbegin() const noexcept {
       return _container.cbegin();
     }
@@ -568,11 +568,11 @@ namespace libsemigroups {
     //! \returns
     //! A const iterator pointing one past the last image value.
     //!
-    //! \complexity
-    //! Constant.
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant.
     [[nodiscard]] const_iterator cend() const noexcept {
       return _container.cend();
     }
@@ -593,11 +593,11 @@ namespace libsemigroups {
     //! \returns
     //! An iterator to the first image value.
     //!
-    //! \complexity
-    //! Constant.
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant.
     [[nodiscard]] iterator begin() noexcept {
       return _container.begin();
     }
@@ -608,11 +608,11 @@ namespace libsemigroups {
     //! \returns
     //! An iterator pointing one past the last image value.
     //!
-    //! \complexity
-    //! Constant.
-    //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \complexity
+    //! Constant.
     [[nodiscard]] iterator end() noexcept {
       return _container.end();
     }
@@ -1264,14 +1264,14 @@ namespace libsemigroups {
     //! \param ran the range
     //! \param M the degree
     //!
-    //! \complexity
-    //! Linear in the size of \p dom.
-    //!
     //! \throws LibsemigroupsException if any of the following fail to hold:
     //! * the value \p M is not compatible with the template parameter \p N
     //! * \p dom and \p ran do not have the same size
     //! * any value in \p dom or \p ran is greater than \p M
     //! * there are repeated entries in \p dom or \p ran.
+    //!
+    //! \complexity
+    //! Linear in the size of \p dom.
     template <typename OtherScalar>
     [[nodiscard]] static PPerm make(std::vector<OtherScalar> const& dom,
                                     std::vector<OtherScalar> const& ran,
@@ -1968,11 +1968,11 @@ namespace libsemigroups {
     //! \param res the container for the result.
     //! \param x the transf.
     //!
-    //! \complexity
-    //! Linear in `x.degree()`.
-    //!
     //! \exceptions
     //! \no_libsemigroups_except
+    //!
+    //! \complexity
+    //! Linear in `x.degree()`.
     // not noexcept because std::vector::resize isn't (although
     // StaticVector1::resize is).
     void operator()(T& res, Transf<N, Scalar> const& x) const;
@@ -1990,10 +1990,10 @@ namespace libsemigroups {
     //! \returns
     //! A value of type \c size_t.
     //!
-    //! \complexity
+    //! \exceptions
     //! See Transf::rank.
     //!
-    //! \exceptions
+    //! \complexity
     //! See Transf::rank.
     [[nodiscard]] size_t operator()(Transf<N, Scalar> const& x) const {
       return x.rank();

--- a/include/libsemigroups/word-graph.hpp
+++ b/include/libsemigroups/word-graph.hpp
@@ -392,10 +392,10 @@ namespace libsemigroups {
     //!
     //! \returns A reference to `*this`.
     //!
+    //! \throws LibsemigroupsException if \p s or \p a is out of range.
+    //!
     //! \complexity
     //! Constant.
-    //!
-    //! \throws LibsemigroupsException if \p s or \p a is out of range.
     WordGraph& remove_target(node_type s, label_type a);
 
     //! \brief Removes a given label from the word graph.
@@ -480,10 +480,10 @@ namespace libsemigroups {
     //!
     //! \returns A reference to `*this`.
     //!
+    //! \throws LibsemigroupsException if \p m, \p n, or \p a are out of range.
+    //!
     //! \complexity
     //! Constant
-    //!
-    //! \throws LibsemigroupsException if \p m, \p n, or \p a are out of range.
     WordGraph& swap_targets(node_type m, node_type n, label_type a);
 
     //! \brief Check if two word graphs are equal.
@@ -657,11 +657,11 @@ namespace libsemigroups {
     //! Returns the node adjacent to \p s via the edge labelled \p a, or
     //! \ref UNDEFINED; both are values of type \ref node_type.
     //!
-    //! \complexity
-    //! Constant.
-    //!
     //! \exceptions
     //! \no_libsemigroups_except
+    //!
+    //! \complexity
+    //! Constant.
     //!
     //! \warning This function does not verify \p s or \p a is valid.
     // Not noexcept because DynamicArray2::get is not
@@ -687,17 +687,17 @@ namespace libsemigroups {
     //!    is the return value of \ref out_degree); and
     //! If no such value exists, then `{UNDEFINED, UNDEFINED}` is returned.
     //!
-    //! \complexity
-    //! At worst \f$O(n)\f$ where \f$n\f$ equals out_degree().
-    //!
     //! \exceptions
     //! \no_libsemigroups_except
     //!
-    //! \sa next_label_and_target.
+    //! \complexity
+    //! At worst \f$O(n)\f$ where \f$n\f$ equals out_degree().
     //!
     //! \warning This function does not check its arguments, in particular it is
     //! not verified that the parameter \p s represents a node of \c this, or
     //! that \p a is a valid label.
+    //!
+    //! \sa next_label_and_target.
     // Not noexcept because DynamicArray2::get is not
     [[nodiscard]] std::pair<label_type, node_type>
     next_label_and_target_no_checks(node_type s, label_type a) const;
@@ -725,11 +725,11 @@ namespace libsemigroups {
     //!    where \f$n\f$ is the return value of out_degree();
     //! If no such value exists, then `{UNDEFINED, UNDEFINED}` is returned.
     //!
-    //! \complexity
-    //! At worst \f$O(n)\f$ where \f$n\f$ equals out_degree().
-    //!
     //! \throws LibsemigroupsException if \p s does not represent a node in \c
     //! this, or \p a is not a valid edge label.
+    //!
+    //! \complexity
+    //! At worst \f$O(n)\f$ where \f$n\f$ equals out_degree().
     //!
     //! \sa next_label_and_target_no_checks.
     // Not noexcept because next_label_and_target_no_checks is not
@@ -805,11 +805,11 @@ namespace libsemigroups {
     //! \returns
     //! A value of type \c size_type.
     //!
-    //! \warning No checks are performed that the argument \p s is actually a
-    //! node in the word graph.
-    //!
     //! \complexity
     //! \f$O(n)\f$ where \c n is out_degree().
+    //!
+    //! \warning No checks are performed that the argument \p s is actually a
+    //! node in the word graph.
     [[nodiscard]] size_type number_of_edges_no_checks(node_type s) const;
 
     //! \brief Returns the out-degree.
@@ -1661,13 +1661,13 @@ namespace libsemigroups {
     //! \return Whether or not the word graph is compatible with the given rules
     //! at each one of the given nodes.
     //!
-    //! \warning
-    //! No checks on the arguments of this function are performed.
-    //!
     //! \exceptions
     //! \no_libsemigroups_except
     //!
     //! \note This function ignores out of bound targets in \p wg (if any).
+    //!
+    //! \warning
+    //! No checks on the arguments of this function are performed.
     template <typename Node,
               typename Iterator1,
               typename Iterator2,
@@ -1759,9 +1759,9 @@ namespace libsemigroups {
     //! \return Whether or not the word graph is compatible with the given rules
     //! at each one of the given nodes.
     //!
-    //! \warning This function does not check that its arguments are valid.
-    //!
     //! \note This function ignores out of bound targets in \p wg (if any).
+    //!
+    //! \warning This function does not check that its arguments are valid.
     template <typename Node, typename Iterator1, typename Iterator2>
     bool is_compatible_no_checks(WordGraph<Node> const& wg,
                                  Iterator1              first_node,
@@ -1870,12 +1870,12 @@ namespace libsemigroups {
     //! \returns Whether or not the word graph is complete on the given
     //! range of nodes.
     //!
+    //! \throws LibsemigroupsException if any item in the range defined by \p
+    //! first_node and \p last_node is not a node of \p wg.
+    //!
     //! \complexity
     //! \f$O(mn)\f$ where \c m is the number of nodes in the range and \c n is
     //! out_degree().
-    //!
-    //! \throws LibsemigroupsException if any item in the range defined by \p
-    //! first_node and \p last_node is not a node of \p wg.
     template <typename Node, typename Iterator1, typename Iterator2>
     [[nodiscard]] bool is_complete(WordGraph<Node> const& wg,
                                    Iterator1              first_node,
@@ -2098,9 +2098,9 @@ namespace libsemigroups {
     //! \param first iterator into a word.
     //! \param last iterator into a word.
     //!
-    //! \throws LibsemigroupsException if \p source is out of bounds.
-    //!
     //! \returns A pair consisting of WordGraph::node_type and \p S.
+    //!
+    //! \throws LibsemigroupsException if \p source is out of bounds.
     //!
     //! \complexity
     //! At worst the distance from \p first to \p last.
@@ -2342,11 +2342,11 @@ namespace libsemigroups {
     //! \param root the source node.
     //! \param f the Forest object to hold the result.
     //!
-    //! \note If any target of any edge in the word graph \p wg that is out of
-    //! bounds, then this is ignored by this function.
-    //!
     //! \throws LibsemigroupsException if \p root is out of bounds, i.e.
     //! greater than or equal to WordGraph::number_of_nodes.
+    //!
+    //! \note If any target of any edge in the word graph \p wg that is out of
+    //! bounds, then this is ignored by this function.
     template <typename Node1, typename Node2>
     void spanning_tree(WordGraph<Node1> const& wg, Node2 root, Forest& f);
 
@@ -2388,11 +2388,11 @@ namespace libsemigroups {
     //!
     //! \returns A Forest object containing a spanning tree.
     //!
-    //! \note If any target of any edge in the word graph \p wg that is out of
-    //! bounds, then this is ignored by this function.
-    //!
     //! \throws LibsemigroupsException if \p root is out of bounds, i.e.
     //! greater than or equal to WordGraph::number_of_nodes.
+    //!
+    //! \note If any target of any edge in the word graph \p wg that is out of
+    //! bounds, then this is ignored by this function.
     template <typename Node1, typename Node2>
     [[nodiscard]] Forest spanning_tree(WordGraph<Node1> const& wg, Node2 root);
 

--- a/include/libsemigroups/words.hpp
+++ b/include/libsemigroups/words.hpp
@@ -1659,10 +1659,10 @@ namespace libsemigroups {
     //!
     //! \returns A reference to \c *this.
     //!
-    //! \sa \ref min
-    //!
     //! \note Unlike WordRange::first, this function will throw if \p frst
     //! contains letters not belonging to alphabet().
+    //!
+    //! \sa \ref min
     StringRange& first(std::string const& frst) {
       _word_range.first(_to_word(frst));
       _current_valid &= _word_range.valid();
@@ -1694,11 +1694,11 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if \p lst contains letters not belonging
     //! to alphabet().
     //!
-    //! \sa \ref max
-    //!
     //! \note The behaviour of this function is not exactly the same as
     //! ``WordRange::last(word_type const&)``. That function will not throw if a
     //! word contains letters not in the alphabet.
+    //!
+    //! \sa \ref max
     StringRange& last(std::string const& lst) {
       _word_range.last(_to_word(lst));
       _current_valid &= _word_range.valid();


### PR DESCRIPTION
This PR adds a script that scans the doc in the `.hpp` files, and prints a warning whenever the section indicators (like `\exceptions` or `\tparam`) are in the wrong order. Here, the 'correct' order means the order @james-d-mitchell once described to me as a good order.

I'm happy for this order to change, but there should be a consistent order throughout the doc.