### PR TITLE
Fix linting warnings introduced by `cpplint 2.0.0`

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,3 @@
 set noparent
-filter=-build/c++11,-build/include_subdir,-runtime/indentation_namespace,-runtime/references,-build/include,-readability/todo,-runtime/printf
+filter=-build/c++11,-build/include,-build/include_subdir,-readability/todo,-runtime/printf,-runtime/references,-whitespace/indent_namespace
 linelength=80

--- a/include/libsemigroups/bmat8.hpp
+++ b/include/libsemigroups/bmat8.hpp
@@ -88,7 +88,7 @@ namespace libsemigroups {
       // Constructor: takes a reference to a byte and the index of the bit in
       // that byte
       constexpr BitRef(uint64_t& data, size_t index) noexcept
-          : _data(data), _mask(uint64_t(1) << (63 - index)) {}
+          : _data(data), _mask(static_cast<uint64_t>(1) << (63 - index)) {}
 
       // Assignment operator to allow setting the bit through the proxy
       constexpr BitRef& operator=(bool val) noexcept {

--- a/include/libsemigroups/paths.tpp
+++ b/include/libsemigroups/paths.tpp
@@ -93,7 +93,7 @@ namespace libsemigroups {
       for (size_t i = min; i < max; ++i) {
         uint64_t add = std::accumulate(acc.cbegin() + source * N,
                                        acc.cbegin() + source * N + N,
-                                       uint64_t(0));
+                                       static_cast<uint64_t>(0));
         if (add == 0) {
           break;
         }
@@ -223,7 +223,7 @@ namespace libsemigroups {
       return std::accumulate(number_paths.cbegin_row(source) + min,
                              number_paths.cbegin_row(source)
                                  + std::min(topo.size(), max),
-                             uint64_t(0));
+                             static_cast<uint64_t>(0));
     }
 
     template <typename Node1, typename Node2>
@@ -290,7 +290,7 @@ namespace libsemigroups {
       return std::accumulate(number_paths.cbegin_row(source) + min,
                              number_paths.cbegin_row(source)
                                  + std::min(topo.size(), max),
-                             uint64_t(0));
+                             static_cast<uint64_t>(0));
     }
 
   }  // namespace detail

--- a/src/todd-coxeter.cpp
+++ b/src/todd-coxeter.cpp
@@ -830,7 +830,7 @@ namespace libsemigroups {
 
   void ToddCoxeter::report_next_lookahead(size_t old_value) const {
     static const std::string pad(8, ' ');
-    int64_t                  diff = int64_t(lookahead_next()) - old_value;
+    int64_t diff = static_cast<int64_t>(lookahead_next()) - old_value;
     report_default("ToddCoxeter: next lookahead at {} | {:>12} (nodes)  "
                    "| {:>12} (diff)\n",
                    pad,

--- a/tests/test-bmat8.cpp
+++ b/tests/test-bmat8.cpp
@@ -676,7 +676,7 @@ namespace libsemigroups {
     BMat8 zero(0);
     REQUIRE(BMat8({{0, 0}, {0, 0}}) == zero);
     REQUIRE(BMat8({{0, 0}, {0, 1}}) != zero);
-    REQUIRE(BMat8({{0, 0}, {0, 1}}) == BMat8(uint64_t(1) << 54));
+    REQUIRE(BMat8({{0, 0}, {0, 1}}) == BMat8(static_cast<uint64_t>(1) << 54));
 
     REQUIRE_THROWS_AS(BMat8({{0, 0}}), LibsemigroupsException);
     REQUIRE_THROWS_AS(BMat8({{0, 1}}), LibsemigroupsException);

--- a/tests/test-constants.cpp
+++ b/tests/test-constants.cpp
@@ -33,10 +33,10 @@ namespace libsemigroups {
 
     REQUIRE(!(UNDEFINED == 0));
     REQUIRE(!(UNDEFINED == size_t(0)));
-    REQUIRE(!(UNDEFINED == int64_t(0)));
+    REQUIRE(!(UNDEFINED == static_cast<int64_t>((0))));
     REQUIRE(!(0 == UNDEFINED));
     REQUIRE(!(size_t(0) == UNDEFINED));
-    REQUIRE(!(int64_t(0) == UNDEFINED));
+    REQUIRE(!(static_cast<int64_t>((0)) == UNDEFINED));
 
     // operator!=
     REQUIRE(!(UNDEFINED != UNDEFINED));
@@ -46,10 +46,10 @@ namespace libsemigroups {
 
     REQUIRE(UNDEFINED != 0);
     REQUIRE(UNDEFINED != size_t(0));
-    REQUIRE(UNDEFINED != int64_t(0));
+    REQUIRE(UNDEFINED != static_cast<int64_t>((0)));
     REQUIRE(0 != UNDEFINED);
     REQUIRE(size_t(0) != UNDEFINED);
-    REQUIRE(int64_t(0) != UNDEFINED);
+    REQUIRE(static_cast<int64_t>((0)) != UNDEFINED);
 
     // operator>
     REQUIRE(!(UNDEFINED > UNDEFINED));
@@ -85,10 +85,10 @@ namespace libsemigroups {
 
     REQUIRE(!(POSITIVE_INFINITY == 0));
     REQUIRE(!(POSITIVE_INFINITY == size_t(0)));
-    REQUIRE(!(POSITIVE_INFINITY == int64_t(0)));
+    REQUIRE(!(POSITIVE_INFINITY == static_cast<int64_t>((0))));
     REQUIRE(!(0 == POSITIVE_INFINITY));
     REQUIRE(!(size_t(0) == POSITIVE_INFINITY));
-    REQUIRE(!(int64_t(0) == POSITIVE_INFINITY));
+    REQUIRE(!(static_cast<int64_t>((0)) == POSITIVE_INFINITY));
 
     // operator!=
     REQUIRE(!(POSITIVE_INFINITY != POSITIVE_INFINITY));
@@ -98,10 +98,10 @@ namespace libsemigroups {
 
     REQUIRE(!(POSITIVE_INFINITY == 0));
     REQUIRE(POSITIVE_INFINITY != size_t(0));
-    REQUIRE(POSITIVE_INFINITY != int64_t(0));
+    REQUIRE(POSITIVE_INFINITY != static_cast<int64_t>((0)));
     REQUIRE(0 != POSITIVE_INFINITY);
     REQUIRE(size_t(0) != POSITIVE_INFINITY);
-    REQUIRE(int64_t(0) != POSITIVE_INFINITY);
+    REQUIRE(static_cast<int64_t>((0)) != POSITIVE_INFINITY);
 
     // operator<
     REQUIRE(!(POSITIVE_INFINITY < 0));
@@ -110,8 +110,8 @@ namespace libsemigroups {
     REQUIRE(1000 < POSITIVE_INFINITY);
     REQUIRE(size_t(0) < POSITIVE_INFINITY);
     REQUIRE(size_t(1000) < POSITIVE_INFINITY);
-    REQUIRE(int64_t(0) < POSITIVE_INFINITY);
-    REQUIRE(int64_t(1000) < POSITIVE_INFINITY);
+    REQUIRE(static_cast<int64_t>((0)) < POSITIVE_INFINITY);
+    REQUIRE(static_cast<int64_t>((1000)) < POSITIVE_INFINITY);
     REQUIRE(NEGATIVE_INFINITY < POSITIVE_INFINITY);
 
     // operator>
@@ -132,9 +132,9 @@ namespace libsemigroups {
     REQUIRE(!(NEGATIVE_INFINITY == LIMIT_MAX));
 
     REQUIRE(!(NEGATIVE_INFINITY == 0));
-    REQUIRE(!(NEGATIVE_INFINITY == int64_t(0)));
+    REQUIRE(!(NEGATIVE_INFINITY == static_cast<int64_t>((0))));
     REQUIRE(!(0 == NEGATIVE_INFINITY));
-    REQUIRE(!(int64_t(0) == NEGATIVE_INFINITY));
+    REQUIRE(!(static_cast<int64_t>((0)) == NEGATIVE_INFINITY));
 
     // operator!=
     REQUIRE(!(NEGATIVE_INFINITY != NEGATIVE_INFINITY));
@@ -143,17 +143,17 @@ namespace libsemigroups {
     REQUIRE(NEGATIVE_INFINITY != LIMIT_MAX);
 
     REQUIRE(NEGATIVE_INFINITY != 0);
-    REQUIRE(NEGATIVE_INFINITY != int64_t(0));
+    REQUIRE(NEGATIVE_INFINITY != static_cast<int64_t>((0)));
     REQUIRE(0 != NEGATIVE_INFINITY);
-    REQUIRE(int64_t(0) != NEGATIVE_INFINITY);
+    REQUIRE(static_cast<int64_t>((0)) != NEGATIVE_INFINITY);
 
     // operator<
     REQUIRE(NEGATIVE_INFINITY < 0);
     REQUIRE(!(NEGATIVE_INFINITY < NEGATIVE_INFINITY));
     REQUIRE(!(0 < NEGATIVE_INFINITY));
     REQUIRE(!(1000 < NEGATIVE_INFINITY));
-    REQUIRE(!(int64_t(0) < NEGATIVE_INFINITY));
-    REQUIRE(!(int64_t(1000) < NEGATIVE_INFINITY));
+    REQUIRE(!(static_cast<int64_t>((0)) < NEGATIVE_INFINITY));
+    REQUIRE(!(static_cast<int64_t>((1000)) < NEGATIVE_INFINITY));
     REQUIRE(!(POSITIVE_INFINITY < NEGATIVE_INFINITY));
 
     // operator>
@@ -180,9 +180,9 @@ namespace libsemigroups {
     REQUIRE(!(LIMIT_MAX == NEGATIVE_INFINITY));
 
     REQUIRE(!(LIMIT_MAX == -1));
-    REQUIRE(!(LIMIT_MAX == int64_t(0)));
+    REQUIRE(!(LIMIT_MAX == static_cast<int64_t>((0))));
     REQUIRE(!(-1 == LIMIT_MAX));
-    REQUIRE(!(int64_t(0) == LIMIT_MAX));
+    REQUIRE(!(static_cast<int64_t>((0)) == LIMIT_MAX));
 
     // operator!=
     REQUIRE(!(LIMIT_MAX != LIMIT_MAX));
@@ -191,9 +191,9 @@ namespace libsemigroups {
     REQUIRE(LIMIT_MAX != NEGATIVE_INFINITY);
 
     REQUIRE(LIMIT_MAX != -1);
-    REQUIRE(LIMIT_MAX != int64_t(0));
+    REQUIRE(LIMIT_MAX != static_cast<int64_t>((0)));
     REQUIRE(-1 != LIMIT_MAX);
-    REQUIRE(int64_t(0) != LIMIT_MAX);
+    REQUIRE(static_cast<int64_t>((0)) != LIMIT_MAX);
 
     // operator>
     REQUIRE(!(LIMIT_MAX > LIMIT_MAX));

--- a/tests/test-digraph-with-sources.cpp
+++ b/tests/test-digraph-with-sources.cpp
@@ -1854,9 +1854,10 @@ namespace libsemigroups {
     REQUIRE(ad.number_of_paths(1, 1, 0, 10) == 1404);
     REQUIRE_THROWS_AS(ad.number_of_paths(1, 1, 0, 10, algorithm::trivial),
                       LibsemigroupsException);
-    REQUIRE(ad.number_of_paths(1, 1, 0, 10)
-            == uint64_t(std::distance(ad.cbegin_pstilo(1, 1, 0, 10),
-                                      ad.cend_pstilo())));
+    REQUIRE(
+        ad.number_of_paths(1, 1, 0, 10)
+        == static_cast<uint64_t>(
+            (std::distance(ad.cbegin_pstilo(1, 1, 0, 10)), ad.cend_pstilo())));
 
     auto checker2 = [&ad](word_type const& w) {
       return w.size() < 10 && action_digraph_helper::follow_path(ad, 1, w) == 1;

--- a/tests/test-paths.cpp
+++ b/tests/test-paths.cpp
@@ -996,7 +996,8 @@ namespace libsemigroups {
         LibsemigroupsException);
 
     p.source(1).target(1).min(0).max(10);
-    REQUIRE(number_of_paths(wg, 1, 1, 0, 10) == uint64_t((p | count())));
+    REQUIRE(number_of_paths(wg, 1, 1, 0, 10)
+            == static_cast<uint64_t>((p | count())));
 
     auto checker2 = [&wg](word_type const& w) {
       return w.size() < 10 && word_graph::follow_path(wg, 1, w) == 1;


### PR DESCRIPTION
On 06/10/24, `cpplint` released version 2.0.0. Amongst [other changes](https://github.com/cpplint/cpplint/blob/develop/CHANGELOG.rst), this seemingly changed some of the names of the filters, and introduced stricter checking for `C` style casting.

This PR updates the names of our filters, and ensures the consistent usage of new-style casting.