### PR TITLE
Make exceptions appear consistently in the doc

### DIFF
--- a/include/libsemigroups/aho-corasick.hpp
+++ b/include/libsemigroups/aho-corasick.hpp
@@ -725,7 +725,7 @@ namespace libsemigroups {
   //!
   //! \returns A string containing a representation of \p ac.
   //!
-  //! \exception
+  //! \exceptions
   //! \no_libsemigroups_except
   // TODO (now) rename this to_human_readable_repr
   std::string to_string(AhoCorasick& ac);

--- a/include/libsemigroups/detail/rewriters.hpp
+++ b/include/libsemigroups/detail/rewriters.hpp
@@ -98,7 +98,7 @@ namespace libsemigroups {
       //!
       //! \param id the id of the new rule.
       //!
-      //! \exception
+      //! \exceptions
       //! \no_libsemigroups_except
       explicit Rule(int64_t id);
 
@@ -124,7 +124,7 @@ namespace libsemigroups {
       //!
       //! \returns A pointer to the left-hand side.
       //!
-      //! \exception
+      //! \exceptions
       //! \noexcept
       //!
       //! \complexity
@@ -144,7 +144,7 @@ namespace libsemigroups {
       //!
       //! \returns A pointer to the right-hand side.
       //!
-      //! \exception
+      //! \exceptions
       //! \noexcept
       //!
       //! \complexity
@@ -163,7 +163,7 @@ namespace libsemigroups {
       //!
       //! \returns A value of type `bool`.
       //!
-      //! \exception
+      //! \exceptions
       //! \noexcept
       //!
       //! \complexity
@@ -178,7 +178,7 @@ namespace libsemigroups {
       //!
       //! \returns A value of type `bool`.
       //!
-      //! \exception
+      //! \exceptions
       //! \noexcept
       //!
       //! \complexity
@@ -196,7 +196,7 @@ namespace libsemigroups {
       //!
       //! Deactivate a rule, if it is active.
       //!
-      //! \exception
+      //! \exceptions
       //! \noexcept
       //!
       //! \complexity
@@ -210,7 +210,7 @@ namespace libsemigroups {
       //!
       //! Activate a rule, if it is inactive.
       //!
-      //! \exception
+      //! \exceptions
       //! \noexcept
       //!
       //! \complexity
@@ -226,7 +226,7 @@ namespace libsemigroups {
       //!
       //! \param id the id to set.
       //!
-      //! \exception
+      //! \exceptions
       //! \noexcept
       //!
       //! \complexity
@@ -269,7 +269,7 @@ namespace libsemigroups {
       //! \complexity
       //! Constant.
       //!
-      //! \exception
+      //! \exceptions
       //! \noexcept
       [[nodiscard]] int64_t id() const noexcept {
         LIBSEMIGROUPS_ASSERT(_id != 0);

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -149,7 +149,7 @@ namespace libsemigroups {
     //! \returns
     //! A value of type \ref point_type.
     //!
-    //! \exception
+    //! \exceptions
     //! \noexcept
     [[nodiscard]] static point_type undef() noexcept {
       return static_cast<point_type>(UNDEFINED);

--- a/include/libsemigroups/word-graph.hpp
+++ b/include/libsemigroups/word-graph.hpp
@@ -640,7 +640,7 @@ namespace libsemigroups {
     //! \complexity
     //! Constant.
     //!
-    //! \exception LibsemigroupsException if \p source or \p a is not
+    //! \throws LibsemigroupsException if \p source or \p a is not
     //! valid.
     // Not noexcept because throw_if_node_out_of_bounds/label aren't
     [[nodiscard]] node_type target(node_type source, label_type a) const;
@@ -1460,7 +1460,7 @@ namespace libsemigroups {
     //! \param first iterator into a word.
     //! \param last iterator into a word.
     //!
-    //! \exception
+    //! \exceptions
     //! \noexcept
     //!
     //! \returns A value of type \p Node1.
@@ -1492,7 +1492,7 @@ namespace libsemigroups {
     //! \param from the source node.
     //! \param path the word.
     //!
-    //! \exception
+    //! \exceptions
     //! \noexcept
     //!
     //! \returns A value of type \p Node1.
@@ -2065,7 +2065,7 @@ namespace libsemigroups {
     //! \param first iterator into a word.
     //! \param last iterator into a word.
     //!
-    //! \exception
+    //! \exceptions
     //! \noexcept
     //!
     //! \returns A pair consisting of the last node reached and an iterator


### PR DESCRIPTION
This PR makes all exceptions, `noexcept` and `no_libsemigroups_except` render consistently in the doc. Specifically, all occurrences of `noexcept` and `no_libsemigroups_except` are preceded by `\exceptions`, and not `\exception` (note the lack of a trailing s).

Doxygen expects the first word after `\exception` to be an error type and renders it differently. This isn't the case for `\noexcept` and `\no_libsemigroups_except`. The difference is highlighted below.

## Before
![image](https://github.com/user-attachments/assets/b86c6c17-55c5-4046-a55c-306b2261e7a5)
## After
![image](https://github.com/user-attachments/assets/cb92fc9f-4680-46cb-bb66-339f3a7a12f9)