### PR TITLE
Replace `Transf::make` with `to<Transf>`, and same for `Perm` and `PPerm`

### DIFF
--- a/benchmarks/bench-sims1.cpp
+++ b/benchmarks/bench-sims1.cpp
@@ -55,13 +55,13 @@ namespace libsemigroups {
   TEST_CASE("POI(3) from FroidurePin", "[POI3][Sim1][quick][talk]") {
     auto                  rg = ReportGuard(false);
     FroidurePin<PPerm<3>> S;
-    S.add_generator(PPerm<3>::make({0, 1, 2}, {0, 1, 2}, 3));
-    S.add_generator(PPerm<3>::make({1, 2}, {0, 1}, 3));
-    S.add_generator(PPerm<3>::make({0, 1}, {0, 2}, 3));
-    S.add_generator(PPerm<3>::make({0, 2}, {1, 2}, 3));
-    S.add_generator(PPerm<3>::make({0, 1}, {1, 2}, 3));
-    S.add_generator(PPerm<3>::make({0, 2}, {0, 1}, 3));
-    S.add_generator(PPerm<3>::make({1, 2}, {0, 2}, 3));
+    S.add_generator(to_pperm<3>({0, 1, 2}, {0, 1, 2}, 3));
+    S.add_generator(to_pperm<3>({1, 2}, {0, 1}, 3));
+    S.add_generator(to_pperm<3>({0, 1}, {0, 2}, 3));
+    S.add_generator(to_pperm<3>({0, 2}, {1, 2}, 3));
+    S.add_generator(to_pperm<3>({0, 1}, {1, 2}, 3));
+    S.add_generator(to_pperm<3>({0, 2}, {0, 1}, 3));
+    S.add_generator(to_pperm<3>({1, 2}, {0, 2}, 3));
     REQUIRE(S.size() == 20);
 
     auto p = to_presentation<word_type>(S);
@@ -81,15 +81,15 @@ namespace libsemigroups {
   TEST_CASE("POI(4) from FroidurePin", "[POI4][Sim1][standard]") {
     auto                  rg = ReportGuard(false);
     FroidurePin<PPerm<4>> S;
-    S.add_generator(PPerm<4>::make({0, 1, 2, 3}, {0, 1, 2, 3}, 4));
-    S.add_generator(PPerm<4>::make({1, 2, 3}, {0, 1, 2}, 4));
-    S.add_generator(PPerm<4>::make({0, 1, 2}, {0, 1, 3}, 4));
-    S.add_generator(PPerm<4>::make({0, 1, 3}, {0, 2, 3}, 4));
-    S.add_generator(PPerm<4>::make({0, 2, 3}, {1, 2, 3}, 4));
-    S.add_generator(PPerm<4>::make({0, 1, 2}, {1, 2, 3}, 4));
-    S.add_generator(PPerm<4>::make({0, 1, 3}, {0, 1, 2}, 4));
-    S.add_generator(PPerm<4>::make({0, 2, 3}, {0, 1, 3}, 4));
-    S.add_generator(PPerm<4>::make({1, 2, 3}, {0, 2, 3}, 4));
+    S.add_generator(to_pperm<4>({0, 1, 2, 3}, {0, 1, 2, 3}, 4));
+    S.add_generator(to_pperm<4>({1, 2, 3}, {0, 1, 2}, 4));
+    S.add_generator(to_pperm<4>({0, 1, 2}, {0, 1, 3}, 4));
+    S.add_generator(to_pperm<4>({0, 1, 3}, {0, 2, 3}, 4));
+    S.add_generator(to_pperm<4>({0, 2, 3}, {1, 2, 3}, 4));
+    S.add_generator(to_pperm<4>({0, 1, 2}, {1, 2, 3}, 4));
+    S.add_generator(to_pperm<4>({0, 1, 3}, {0, 1, 2}, 4));
+    S.add_generator(to_pperm<4>({0, 2, 3}, {0, 1, 3}, 4));
+    S.add_generator(to_pperm<4>({1, 2, 3}, {0, 2, 3}, 4));
     REQUIRE(S.size() == 70);
 
     auto p = to_presentation<word_type>(S);
@@ -374,9 +374,9 @@ namespace libsemigroups {
             "[full_transf_monoid][length][002]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<4>> S;
-    S.add_generator(Transf<4>::make({1, 2, 3, 0}));
-    S.add_generator(Transf<4>::make({1, 0, 2, 3}));
-    S.add_generator(Transf<4>::make({0, 1, 2, 0}));
+    S.add_generator(to_transf<4>({1, 2, 3, 0}));
+    S.add_generator(to_transf<4>({1, 0, 2, 3}));
+    S.add_generator(to_transf<4>({0, 1, 2, 0}));
     REQUIRE(S.size() == 256);
     auto p = to_presentation<word_type>(S);
     bench_length(p);
@@ -408,26 +408,26 @@ namespace libsemigroups {
     auto rg = ReportGuard(false);
 
     FroidurePin<PPerm<10>> S;
-    S.add_generator(PPerm<10>::make({1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
-    S.add_generator(PPerm<10>::make(
+    S.add_generator(to_pperm<10>({1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
+    S.add_generator(to_pperm<10>(
         {1, 2, 3, 4, 5, 6, 7, 8, 9}, {1, 2, 3, 4, 5, 6, 7, 8, 9}, 10));
-    S.add_generator(PPerm<10>::make(
+    S.add_generator(to_pperm<10>(
         {0, 2, 3, 4, 5, 6, 7, 8, 9}, {0, 2, 3, 4, 5, 6, 7, 8, 9}, 10));
-    S.add_generator(PPerm<10>::make(
+    S.add_generator(to_pperm<10>(
         {0, 1, 3, 4, 5, 6, 7, 8, 9}, {0, 1, 3, 4, 5, 6, 7, 8, 9}, 10));
-    S.add_generator(PPerm<10>::make(
+    S.add_generator(to_pperm<10>(
         {0, 1, 2, 4, 5, 6, 7, 8, 9}, {0, 1, 2, 4, 5, 6, 7, 8, 9}, 10));
-    S.add_generator(PPerm<10>::make(
+    S.add_generator(to_pperm<10>(
         {0, 1, 2, 3, 5, 6, 7, 8, 9}, {0, 1, 2, 3, 5, 6, 7, 8, 9}, 10));
-    S.add_generator(PPerm<10>::make(
+    S.add_generator(to_pperm<10>(
         {0, 1, 2, 3, 4, 6, 7, 8, 9}, {0, 1, 2, 3, 4, 6, 7, 8, 9}, 10));
-    S.add_generator(PPerm<10>::make(
+    S.add_generator(to_pperm<10>(
         {0, 1, 2, 3, 4, 5, 7, 8, 9}, {0, 1, 2, 3, 4, 5, 7, 8, 9}, 10));
-    S.add_generator(PPerm<10>::make(
+    S.add_generator(to_pperm<10>(
         {0, 1, 2, 3, 4, 5, 6, 8, 9}, {0, 1, 2, 3, 4, 5, 6, 8, 9}, 10));
-    S.add_generator(PPerm<10>::make(
+    S.add_generator(to_pperm<10>(
         {0, 1, 2, 3, 4, 5, 6, 7, 9}, {0, 1, 2, 3, 4, 5, 6, 7, 9}, 10));
-    S.add_generator(PPerm<10>::make(
+    S.add_generator(to_pperm<10>(
         {0, 1, 2, 3, 4, 5, 6, 7, 8}, {0, 1, 2, 3, 4, 5, 6, 7, 8}, 10));
 
     size_t n = 10;
@@ -441,8 +441,8 @@ namespace libsemigroups {
     auto rg = ReportGuard(false);
 
     FroidurePin<PPerm<10>> S;
-    S.add_generator(PPerm<10>::make({1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
-    S.add_generator(PPerm<10>::make(
+    S.add_generator(to_pperm<10>({1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
+    S.add_generator(to_pperm<10>(
         {1, 2, 3, 4, 5, 6, 7, 8, 9}, {1, 2, 3, 4, 5, 6, 7, 8, 9}, 10));
 
     size_t n = 10;
@@ -546,7 +546,7 @@ namespace libsemigroups {
   TEST_CASE("Catalan monoid n = 1 - all", "[catalan][n=1]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<1>> S;
-    S.add_generator(Transf<1>::make({0}));
+    S.add_generator(to_transf<1>({0}));
     REQUIRE(S.size() == 1);
     auto p = to_presentation<word_type>(S);
 
@@ -560,8 +560,8 @@ namespace libsemigroups {
   TEST_CASE("Catalan monoid n = 2 - all", "[catalan][n=2]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<2>> S;
-    S.add_generator(Transf<2>::make({0, 1}));
-    S.add_generator(Transf<2>::make({0, 0}));
+    S.add_generator(to_transf<2>({0, 1}));
+    S.add_generator(to_transf<2>({0, 0}));
     REQUIRE(S.size() == 2);
     auto p = to_presentation<word_type>(S);
 
@@ -575,9 +575,9 @@ namespace libsemigroups {
   TEST_CASE("Catalan monoid n = 3 - all", "[catalan][n=3]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<3>> S;
-    S.add_generator(Transf<3>::make({0, 1, 2}));
-    S.add_generator(Transf<3>::make({0, 0, 2}));
-    S.add_generator(Transf<3>::make({0, 1, 1}));
+    S.add_generator(to_transf<3>({0, 1, 2}));
+    S.add_generator(to_transf<3>({0, 0, 2}));
+    S.add_generator(to_transf<3>({0, 1, 1}));
     REQUIRE(S.size() == 5);
     auto p = to_presentation<word_type>(S);
 
@@ -591,10 +591,10 @@ namespace libsemigroups {
   TEST_CASE("Catalan monoid n = 4 - all", "[catalan][n=4]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<4>> S;
-    S.add_generator(Transf<4>::make({0, 1, 2, 3}));
-    S.add_generator(Transf<4>::make({0, 0, 2, 3}));
-    S.add_generator(Transf<4>::make({0, 1, 1, 3}));
-    S.add_generator(Transf<4>::make({0, 1, 2, 2}));
+    S.add_generator(to_transf<4>({0, 1, 2, 3}));
+    S.add_generator(to_transf<4>({0, 0, 2, 3}));
+    S.add_generator(to_transf<4>({0, 1, 1, 3}));
+    S.add_generator(to_transf<4>({0, 1, 2, 2}));
     REQUIRE(S.size() == 14);
     auto p = to_presentation<word_type>(S);
 
@@ -608,11 +608,11 @@ namespace libsemigroups {
   TEST_CASE("Catalan monoid n = 5 - all", "[catalan][n=5]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<5>> S;
-    S.add_generator(Transf<5>::make({0, 1, 2, 3, 4}));
-    S.add_generator(Transf<5>::make({0, 0, 2, 3, 4}));
-    S.add_generator(Transf<5>::make({0, 1, 1, 3, 4}));
-    S.add_generator(Transf<5>::make({0, 1, 2, 2, 4}));
-    S.add_generator(Transf<5>::make({0, 1, 2, 3, 3}));
+    S.add_generator(to_transf<5>({0, 1, 2, 3, 4}));
+    S.add_generator(to_transf<5>({0, 0, 2, 3, 4}));
+    S.add_generator(to_transf<5>({0, 1, 1, 3, 4}));
+    S.add_generator(to_transf<5>({0, 1, 2, 2, 4}));
+    S.add_generator(to_transf<5>({0, 1, 2, 3, 3}));
     REQUIRE(S.size() == 42);
     auto p = to_presentation<word_type>(S);
 
@@ -638,9 +638,9 @@ namespace libsemigroups {
   TEST_CASE("Order endomorphisms n = 2 - all", "[order_endos][n=2]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<2>> S;
-    S.add_generator(Transf<2>::make({0, 1}));
-    S.add_generator(Transf<2>::make({0, 0}));
-    S.add_generator(Transf<2>::make({1, 1}));
+    S.add_generator(to_transf<2>({0, 1}));
+    S.add_generator(to_transf<2>({0, 0}));
+    S.add_generator(to_transf<2>({1, 1}));
     REQUIRE(S.size() == 3);
 
     Sims1 C;

--- a/benchmarks/bench-sims1.cpp
+++ b/benchmarks/bench-sims1.cpp
@@ -55,13 +55,13 @@ namespace libsemigroups {
   TEST_CASE("POI(3) from FroidurePin", "[POI3][Sim1][quick][talk]") {
     auto                  rg = ReportGuard(false);
     FroidurePin<PPerm<3>> S;
-    S.add_generator(to_pperm<3>({0, 1, 2}, {0, 1, 2}, 3));
-    S.add_generator(to_pperm<3>({1, 2}, {0, 1}, 3));
-    S.add_generator(to_pperm<3>({0, 1}, {0, 2}, 3));
-    S.add_generator(to_pperm<3>({0, 2}, {1, 2}, 3));
-    S.add_generator(to_pperm<3>({0, 1}, {1, 2}, 3));
-    S.add_generator(to_pperm<3>({0, 2}, {0, 1}, 3));
-    S.add_generator(to_pperm<3>({1, 2}, {0, 2}, 3));
+    S.add_generator(to<PPerm<3>>({0, 1, 2}, {0, 1, 2}, 3));
+    S.add_generator(to<PPerm<3>>({1, 2}, {0, 1}, 3));
+    S.add_generator(to<PPerm<3>>({0, 1}, {0, 2}, 3));
+    S.add_generator(to<PPerm<3>>({0, 2}, {1, 2}, 3));
+    S.add_generator(to<PPerm<3>>({0, 1}, {1, 2}, 3));
+    S.add_generator(to<PPerm<3>>({0, 2}, {0, 1}, 3));
+    S.add_generator(to<PPerm<3>>({1, 2}, {0, 2}, 3));
     REQUIRE(S.size() == 20);
 
     auto p = to_presentation<word_type>(S);
@@ -81,15 +81,15 @@ namespace libsemigroups {
   TEST_CASE("POI(4) from FroidurePin", "[POI4][Sim1][standard]") {
     auto                  rg = ReportGuard(false);
     FroidurePin<PPerm<4>> S;
-    S.add_generator(to_pperm<4>({0, 1, 2, 3}, {0, 1, 2, 3}, 4));
-    S.add_generator(to_pperm<4>({1, 2, 3}, {0, 1, 2}, 4));
-    S.add_generator(to_pperm<4>({0, 1, 2}, {0, 1, 3}, 4));
-    S.add_generator(to_pperm<4>({0, 1, 3}, {0, 2, 3}, 4));
-    S.add_generator(to_pperm<4>({0, 2, 3}, {1, 2, 3}, 4));
-    S.add_generator(to_pperm<4>({0, 1, 2}, {1, 2, 3}, 4));
-    S.add_generator(to_pperm<4>({0, 1, 3}, {0, 1, 2}, 4));
-    S.add_generator(to_pperm<4>({0, 2, 3}, {0, 1, 3}, 4));
-    S.add_generator(to_pperm<4>({1, 2, 3}, {0, 2, 3}, 4));
+    S.add_generator(to<PPerm<4>>({0, 1, 2, 3}, {0, 1, 2, 3}, 4));
+    S.add_generator(to<PPerm<4>>({1, 2, 3}, {0, 1, 2}, 4));
+    S.add_generator(to<PPerm<4>>({0, 1, 2}, {0, 1, 3}, 4));
+    S.add_generator(to<PPerm<4>>({0, 1, 3}, {0, 2, 3}, 4));
+    S.add_generator(to<PPerm<4>>({0, 2, 3}, {1, 2, 3}, 4));
+    S.add_generator(to<PPerm<4>>({0, 1, 2}, {1, 2, 3}, 4));
+    S.add_generator(to<PPerm<4>>({0, 1, 3}, {0, 1, 2}, 4));
+    S.add_generator(to<PPerm<4>>({0, 2, 3}, {0, 1, 3}, 4));
+    S.add_generator(to<PPerm<4>>({1, 2, 3}, {0, 2, 3}, 4));
     REQUIRE(S.size() == 70);
 
     auto p = to_presentation<word_type>(S);
@@ -374,9 +374,9 @@ namespace libsemigroups {
             "[full_transf_monoid][length][002]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<4>> S;
-    S.add_generator(to_transf<4>({1, 2, 3, 0}));
-    S.add_generator(to_transf<4>({1, 0, 2, 3}));
-    S.add_generator(to_transf<4>({0, 1, 2, 0}));
+    S.add_generator(to<Transf<4>>({1, 2, 3, 0}));
+    S.add_generator(to<Transf<4>>({1, 0, 2, 3}));
+    S.add_generator(to<Transf<4>>({0, 1, 2, 0}));
     REQUIRE(S.size() == 256);
     auto p = to_presentation<word_type>(S);
     bench_length(p);
@@ -408,26 +408,26 @@ namespace libsemigroups {
     auto rg = ReportGuard(false);
 
     FroidurePin<PPerm<10>> S;
-    S.add_generator(to_pperm<10>({1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
-    S.add_generator(to_pperm<10>(
+    S.add_generator(to<PPerm<10>>({1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
+    S.add_generator(to<PPerm<10>>(
         {1, 2, 3, 4, 5, 6, 7, 8, 9}, {1, 2, 3, 4, 5, 6, 7, 8, 9}, 10));
-    S.add_generator(to_pperm<10>(
+    S.add_generator(to<PPerm<10>>(
         {0, 2, 3, 4, 5, 6, 7, 8, 9}, {0, 2, 3, 4, 5, 6, 7, 8, 9}, 10));
-    S.add_generator(to_pperm<10>(
+    S.add_generator(to<PPerm<10>>(
         {0, 1, 3, 4, 5, 6, 7, 8, 9}, {0, 1, 3, 4, 5, 6, 7, 8, 9}, 10));
-    S.add_generator(to_pperm<10>(
+    S.add_generator(to<PPerm<10>>(
         {0, 1, 2, 4, 5, 6, 7, 8, 9}, {0, 1, 2, 4, 5, 6, 7, 8, 9}, 10));
-    S.add_generator(to_pperm<10>(
+    S.add_generator(to<PPerm<10>>(
         {0, 1, 2, 3, 5, 6, 7, 8, 9}, {0, 1, 2, 3, 5, 6, 7, 8, 9}, 10));
-    S.add_generator(to_pperm<10>(
+    S.add_generator(to<PPerm<10>>(
         {0, 1, 2, 3, 4, 6, 7, 8, 9}, {0, 1, 2, 3, 4, 6, 7, 8, 9}, 10));
-    S.add_generator(to_pperm<10>(
+    S.add_generator(to<PPerm<10>>(
         {0, 1, 2, 3, 4, 5, 7, 8, 9}, {0, 1, 2, 3, 4, 5, 7, 8, 9}, 10));
-    S.add_generator(to_pperm<10>(
+    S.add_generator(to<PPerm<10>>(
         {0, 1, 2, 3, 4, 5, 6, 8, 9}, {0, 1, 2, 3, 4, 5, 6, 8, 9}, 10));
-    S.add_generator(to_pperm<10>(
+    S.add_generator(to<PPerm<10>>(
         {0, 1, 2, 3, 4, 5, 6, 7, 9}, {0, 1, 2, 3, 4, 5, 6, 7, 9}, 10));
-    S.add_generator(to_pperm<10>(
+    S.add_generator(to<PPerm<10>>(
         {0, 1, 2, 3, 4, 5, 6, 7, 8}, {0, 1, 2, 3, 4, 5, 6, 7, 8}, 10));
 
     size_t n = 10;
@@ -441,8 +441,8 @@ namespace libsemigroups {
     auto rg = ReportGuard(false);
 
     FroidurePin<PPerm<10>> S;
-    S.add_generator(to_pperm<10>({1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
-    S.add_generator(to_pperm<10>(
+    S.add_generator(to<PPerm<10>>({1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
+    S.add_generator(to<PPerm<10>>(
         {1, 2, 3, 4, 5, 6, 7, 8, 9}, {1, 2, 3, 4, 5, 6, 7, 8, 9}, 10));
 
     size_t n = 10;
@@ -546,7 +546,7 @@ namespace libsemigroups {
   TEST_CASE("Catalan monoid n = 1 - all", "[catalan][n=1]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<1>> S;
-    S.add_generator(to_transf<1>({0}));
+    S.add_generator(to<Transf<1>>({0}));
     REQUIRE(S.size() == 1);
     auto p = to_presentation<word_type>(S);
 
@@ -560,8 +560,8 @@ namespace libsemigroups {
   TEST_CASE("Catalan monoid n = 2 - all", "[catalan][n=2]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<2>> S;
-    S.add_generator(to_transf<2>({0, 1}));
-    S.add_generator(to_transf<2>({0, 0}));
+    S.add_generator(to<Transf<2>>({0, 1}));
+    S.add_generator(to<Transf<2>>({0, 0}));
     REQUIRE(S.size() == 2);
     auto p = to_presentation<word_type>(S);
 
@@ -575,9 +575,9 @@ namespace libsemigroups {
   TEST_CASE("Catalan monoid n = 3 - all", "[catalan][n=3]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<3>> S;
-    S.add_generator(to_transf<3>({0, 1, 2}));
-    S.add_generator(to_transf<3>({0, 0, 2}));
-    S.add_generator(to_transf<3>({0, 1, 1}));
+    S.add_generator(to<Transf<3>>({0, 1, 2}));
+    S.add_generator(to<Transf<3>>({0, 0, 2}));
+    S.add_generator(to<Transf<3>>({0, 1, 1}));
     REQUIRE(S.size() == 5);
     auto p = to_presentation<word_type>(S);
 
@@ -591,10 +591,10 @@ namespace libsemigroups {
   TEST_CASE("Catalan monoid n = 4 - all", "[catalan][n=4]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<4>> S;
-    S.add_generator(to_transf<4>({0, 1, 2, 3}));
-    S.add_generator(to_transf<4>({0, 0, 2, 3}));
-    S.add_generator(to_transf<4>({0, 1, 1, 3}));
-    S.add_generator(to_transf<4>({0, 1, 2, 2}));
+    S.add_generator(to<Transf<4>>({0, 1, 2, 3}));
+    S.add_generator(to<Transf<4>>({0, 0, 2, 3}));
+    S.add_generator(to<Transf<4>>({0, 1, 1, 3}));
+    S.add_generator(to<Transf<4>>({0, 1, 2, 2}));
     REQUIRE(S.size() == 14);
     auto p = to_presentation<word_type>(S);
 
@@ -608,11 +608,11 @@ namespace libsemigroups {
   TEST_CASE("Catalan monoid n = 5 - all", "[catalan][n=5]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<5>> S;
-    S.add_generator(to_transf<5>({0, 1, 2, 3, 4}));
-    S.add_generator(to_transf<5>({0, 0, 2, 3, 4}));
-    S.add_generator(to_transf<5>({0, 1, 1, 3, 4}));
-    S.add_generator(to_transf<5>({0, 1, 2, 2, 4}));
-    S.add_generator(to_transf<5>({0, 1, 2, 3, 3}));
+    S.add_generator(to<Transf<5>>({0, 1, 2, 3, 4}));
+    S.add_generator(to<Transf<5>>({0, 0, 2, 3, 4}));
+    S.add_generator(to<Transf<5>>({0, 1, 1, 3, 4}));
+    S.add_generator(to<Transf<5>>({0, 1, 2, 2, 4}));
+    S.add_generator(to<Transf<5>>({0, 1, 2, 3, 3}));
     REQUIRE(S.size() == 42);
     auto p = to_presentation<word_type>(S);
 
@@ -638,9 +638,9 @@ namespace libsemigroups {
   TEST_CASE("Order endomorphisms n = 2 - all", "[order_endos][n=2]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<2>> S;
-    S.add_generator(to_transf<2>({0, 1}));
-    S.add_generator(to_transf<2>({0, 0}));
-    S.add_generator(to_transf<2>({1, 1}));
+    S.add_generator(to<Transf<2>>({0, 1}));
+    S.add_generator(to<Transf<2>>({0, 0}));
+    S.add_generator(to<Transf<2>>({1, 1}));
     REQUIRE(S.size() == 3);
 
     Sims1 C;

--- a/include/libsemigroups/matrix.hpp
+++ b/include/libsemigroups/matrix.hpp
@@ -7035,7 +7035,7 @@ namespace libsemigroups {
     //! \par Example
     //!
     //! \code
-    //! auto x == ProjMaxPlusMat<>::make({{-2, 2, 0}, {-1, 0, 0}, {1, -3,
+    //! auto x == ProjMaxPlusMat<>::to_matrix({{-2, 2, 0}, {-1, 0, 0}, {1, -3,
     //! 1}}));
     //! // returns {{-1, 0, -1}, {-2, -1, -2}, {-1, 0, -1}}
     //! matrix::pow(x, 100);
@@ -7783,7 +7783,7 @@ namespace libsemigroups {
     //! \par Example
     //!
     //! \code
-    //! auto x = BMat<>::make({{1, 0, 0}, {0, 0, 1}, {0, 1, 0}});
+    //! auto x = BMat<>::to_matrix({{1, 0, 0}, {0, 0, 1}, {0, 1, 0}});
     //! matrix::row_space_size(x); // returns 7
     //! \endcode
     template <typename Mat, typename = std::enable_if_t<IsBMat<Mat>>>

--- a/include/libsemigroups/matrix.hpp
+++ b/include/libsemigroups/matrix.hpp
@@ -7035,13 +7035,14 @@ namespace libsemigroups {
     //! \par Example
     //!
     //! \code
-    //! auto x == ProjMaxPlusMat<>::to_matrix({{-2, 2, 0}, {-1, 0, 0}, {1, -3,
+    //! auto x == ProjMaxPlusMat<>::make({{-2, 2, 0}, {-1, 0, 0}, {1, -3,
     //! 1}}));
     //! // returns {{-1, 0, -1}, {-2, -1, -2}, {-1, 0, -1}}
     //! matrix::pow(x, 100);
     //! \endcode
     // TODO(1) pow_no_checks
     // TODO(2) version that changes x in-place
+    // TODO(0) update the code in the examples
     template <typename Mat>
     Mat pow(Mat const& x, typename Mat::scalar_type e) {
       using scalar_type = typename Mat::scalar_type;
@@ -7783,9 +7784,10 @@ namespace libsemigroups {
     //! \par Example
     //!
     //! \code
-    //! auto x = BMat<>::to_matrix({{1, 0, 0}, {0, 0, 1}, {0, 1, 0}});
+    //! auto x = BMat<>::make({{1, 0, 0}, {0, 0, 1}, {0, 1, 0}});
     //! matrix::row_space_size(x); // returns 7
     //! \endcode
+    // TODO(0) Update the code in the examples
     template <typename Mat, typename = std::enable_if_t<IsBMat<Mat>>>
     size_t row_space_size(Mat const& x) {
       size_t const M                 = detail::BitSetCapacity<Mat>::value;

--- a/include/libsemigroups/to-froidure-pin.hpp
+++ b/include/libsemigroups/to-froidure-pin.hpp
@@ -137,7 +137,7 @@ namespace libsemigroups {
 
   //! Make a FroidurePin object from a WordGraph.
   //!
-  //! Calls `make(ad, 0, ad.number_of_nodes())`; see above.
+  //! Calls `to_froidure_pin(ad, 0, ad.number_of_nodes())`; see above.
   template <typename Element, typename Node>
   FroidurePin<Element> to_froidure_pin(WordGraph<Node> const& ad) {
     return to_froidure_pin<Element>(ad, 0, ad.number_of_nodes());

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -1481,9 +1481,9 @@ namespace libsemigroups {
       typename Scalar
       = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
   class Perm : public Transf<N, Scalar> {
+   public:
     using base_type = PTransf<N, Scalar>;
 
-   public:
     //! \brief Type of the image values.
     //!
     //! Also the template parameter \c Scalar.
@@ -1497,28 +1497,45 @@ namespace libsemigroups {
     using Transf<N, Scalar>::Transf;
     using base_type::degree;
 
-    //! \copydoc Transf::make(OtherContainer&&)
-    //! \throws LibsemigroupsException if there are repeated values in \p cont.
-    template <typename OtherContainer>
-    [[nodiscard]] static Perm make(OtherContainer&& cont) {
-      return base_type::template make<Perm>(std::forward<OtherContainer>(cont));
-    }
-
-    //! \copydoc Transf::make()
-    [[nodiscard]] static Perm make() {
-      return base_type::template make<Perm>();
-    }
-
-    //! \copydoc make(OtherContainer&&)
-    [[nodiscard]] static Perm make(std::initializer_list<point_type> cont) {
-      return make<std::initializer_list<point_type>>(std::move(cont));
-    }
-
     //! \copydoc Transf::one(size_t)
     [[nodiscard]] static Perm one(size_t M) {
       return base_type::template one<Perm>(M);
     }
   };
+
+  //! \copydoc PTransfBase::make(OtherContainer&&)
+  //! \throws LibsemigroupsException if there are repeated values in \p cont.
+  template <
+      size_t N = 0,
+      typename Scalar
+      = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>,
+      typename OtherContainer>
+  [[nodiscard]] Perm<N, Scalar> to_perm(OtherContainer&& cont) {
+    return Perm<N, Scalar>::base_type::template make<Perm<N, Scalar>>(
+        std::forward<OtherContainer>(cont));
+  }
+
+  //! \copydoc PTransfBase::make()
+  template <
+      size_t N = 0,
+      typename Scalar
+      = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
+  [[nodiscard]] Perm<N, Scalar> to_perm() {
+    return Perm<N, Scalar>::base_type::template make<Perm<N, Scalar>>();
+  }
+
+  //! \copydoc to_perm(OtherContainer&&)
+  template <
+      size_t N = 0,
+      typename Scalar
+      = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
+  [[nodiscard]] Perm<N, Scalar>
+  to_perm(std::initializer_list<typename Perm<N, Scalar>::point_type> cont) {
+    return to_perm<N,
+                   Scalar,
+                   std::initializer_list<typename Perm<N, Scalar>::point_type>>(
+        std::move(cont));
+  }
 
   ////////////////////////////////////////////////////////////////////////
   // Perm helpers

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -50,7 +50,7 @@
 #include "debug.hpp"      // for LIBSEMIGROUPS_ASSERT
 #include "exception.hpp"  // for LIBSEMIGROUPS_EXCEPTION
 #include "hpcombi.hpp"    // for HPCombi::Transf16
-#include "types.hpp"      // for SmallestInteger, enable_if_is_same
+#include "types.hpp"      // for SmallestInteger
 
 #include "detail/stl.hpp"  // for is_array_v
 

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -1003,12 +1003,9 @@ namespace libsemigroups {
       typename Scalar
       = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
   class Transf : public PTransf<N, Scalar> {
-   public:
-    //! \brief Type of the parent class.
-    //!
-    //! Type of the parent class.
     using base_type = PTransf<N, Scalar>;
 
+   public:
     //! \brief Type of the image values.
     //!
     //! Also the template parameter \c Scalar.
@@ -1091,7 +1088,7 @@ namespace libsemigroups {
       = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>,
       typename OtherContainer>
   [[nodiscard]] Transf<N, Scalar> to_transf(OtherContainer&& cont) {
-    return Transf<N, Scalar>::base_type::template make<Transf<N, Scalar>>(
+    return Transf<N, Scalar>::template make<Transf<N, Scalar>>(
         std::forward<OtherContainer>(cont));
   }
 
@@ -1198,12 +1195,9 @@ namespace libsemigroups {
       typename Scalar
       = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
   class PPerm : public PTransf<N, Scalar> {
-   public:
-    //! \brief Type of the parent class.
-    //!
-    //! Type of the parent class.
     using base_type = PTransf<N, Scalar>;
 
+   public:
     //! \brief Type of the image values.
     //!
     //! Also the template parameter \c Scalar.
@@ -1312,7 +1306,7 @@ namespace libsemigroups {
       = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>,
       typename OtherContainer>
   [[nodiscard]] PPerm<N, Scalar> to_pperm(OtherContainer&& cont) {
-    return PPerm<N, Scalar>::base_type::template make<PPerm<N, Scalar>>(
+    return PPerm<N, Scalar>::template make<PPerm<N, Scalar>>(
         std::forward<OtherContainer>(cont));
   }
 
@@ -1509,12 +1503,9 @@ namespace libsemigroups {
       typename Scalar
       = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
   class Perm : public Transf<N, Scalar> {
-   public:
-    //! \brief Type of the parent class.
-    //!
-    //! Type of the parent class.
     using base_type = PTransf<N, Scalar>;
 
+   public:
     //! \brief Type of the image values.
     //!
     //! Also the template parameter \c Scalar.
@@ -1565,7 +1556,7 @@ namespace libsemigroups {
       = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>,
       typename OtherContainer>
   [[nodiscard]] Perm<N, Scalar> to_perm(OtherContainer&& cont) {
-    return Perm<N, Scalar>::base_type::template make<Perm<N, Scalar>>(
+    return Perm<N, Scalar>::template make<Perm<N, Scalar>>(
         std::forward<OtherContainer>(cont));
   }
 

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -269,7 +269,8 @@ namespace libsemigroups {
     //! \param cont the container.
     //!
     //! \throw LibsemigroupsException if any of the following hold:
-    //! * the size of \p cont is incompatible with \ref container_type.
+    //! * the size of \p cont is incompatible with \ref
+    //! PTransfBase::container_type.
     //! * any value in \p cont exceeds `cont.size()` and is not equal to
     //!   UNDEFINED.
     //!
@@ -291,7 +292,8 @@ namespace libsemigroups {
     //! \param cont the initializer list.
     //!
     //! \throw LibsemigroupsException if any of the following hold:
-    //! * the size of \p cont is incompatible with \ref container_type.
+    //! * the size of \p cont is incompatible with \ref
+    //! PTransfBase::container_type.
     //! * any value in \p cont exceeds `cont.size()` and is not equal to
     //!   UNDEFINED.
     //!
@@ -909,7 +911,7 @@ namespace libsemigroups {
   //! and the default value of \p Scalar is the smallest integer type able to
   //! hold \c N. See also SmallestInteger.
   //!
-  //! \tparam N  the degree (default: \c 0)
+  //! \tparam N the degree (default: \c 0)
   //! \tparam Scalar an unsigned integer type (the type of the image values)
   template <
       size_t N = 0,
@@ -952,7 +954,7 @@ namespace libsemigroups {
   //! \ingroup transf_group
   //! \brief Validate a partial transformation.
   //!
-  //! \tparam N  the degree
+  //! \tparam N the degree
   //! \tparam Scalar an unsigned integer type (the type of the image values)
   //!
   //! \param f the partial transformation to validate.
@@ -1005,7 +1007,7 @@ namespace libsemigroups {
   //! \p N is not \c 0, then the default value of \p Scalar is the smallest
   //! integer type able to hold \c N. See also SmallestInteger.
   //!
-  //! \tparam N  the degree (default: \c 0)
+  //! \tparam N the degree (default: \c 0)
   //! \tparam Scalar an unsigned integer type (the type of the image values)
   //!
   //! This class inherits from either StaticPTransf or DynamicPTransf, see the
@@ -1017,6 +1019,9 @@ namespace libsemigroups {
       = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
   class Transf : public PTransf<N, Scalar> {
    public:
+    //! \brief Type of the parent class.
+    //!
+    //! Type of the parent class.
     using base_type = PTransf<N, Scalar>;
 
     //! \brief Type of the image values.
@@ -1043,11 +1048,14 @@ namespace libsemigroups {
     //! \no_libsemigroups_except
     //!
     //! \complexity
-    //! Linear in \ref degree.
+    //! Linear in the degree of the transformation.
     //!
     //! \warning
     //! No checks are made on whether or not the parameters are compatible. If
     //! \p f and \p g have different degrees, then bad things will happen.
+    //!
+    //! \sa
+    //! \ref PTransfBase::degree
     void product_inplace(Transf const& f, Transf const& g);
 
     //! \brief Returns the identity transformation on the given number of
@@ -1068,9 +1076,19 @@ namespace libsemigroups {
     }
   };
 
-  //! \copydoc PTransfBase::make()
+  //! \relates Transf
   //!
-  //! \note \c Subclass is \c Transf !!
+  //! \brief Make an instance of \ref Transf with degree \c 0.
+  //!
+  //! This is equivalent to default constructing a \ref Transf instance and is
+  //! here for consistency of interface only. The ``to_...`` functions
+  //! check their arguments, and the constructed  instance for validity, but in
+  //! this case there's nothing to check.
+  //!
+  //! \tparam N the degree (default: \c 0)
+  //! \tparam Scalar an unsigned integer type (the type of the image values)
+  //!
+  //! \returns A \ref Transf instance with degree \c 0.
   template <
       size_t N = 0,
       typename Scalar
@@ -1079,7 +1097,30 @@ namespace libsemigroups {
     return Transf<N, Scalar>::base_type::template make<Transf<N, Scalar>>();
   }
 
-  //! \copydoc PTransfBase::make(OtherContainer&&)
+  //! \relates Transf
+  //!
+  //! \brief Construct from universal reference container and validate.
+  //!
+  //! Constructs a \ref Transf initialized using the container \p cont as
+  //! follows: the image of the point \c i under the transformation is the value
+  //! in position \c i of the container \p cont.
+  //!
+  //! \tparam N the degree (default: \c 0)
+  //! \tparam Scalar an unsigned integer type (the type of the image values)
+  //! \tparam OtherContainer universal reference for the type of the container
+  //! (default: Container).
+  //!
+  //! \param cont the container.
+  //!
+  //! \returns A \ref Transf instance with degree \c N.
+  //!
+  //! \throw LibsemigroupsException if any of the following hold:
+  //! * the size of \p cont is incompatible with \ref container_type.
+  //! * any value in \p cont exceeds `cont.size()` and is not equal to
+  //!   UNDEFINED.
+  //!
+  //! \complexity
+  //! Linear in the size of the container \p cont.
   template <
       size_t N = 0,
       typename Scalar
@@ -1090,7 +1131,10 @@ namespace libsemigroups {
         std::forward<OtherContainer>(cont));
   }
 
+  //! \relates Transf
+  //!
   //! \copydoc to_transf(OtherContainer&&)
+  //!
   //! \throws LibsemigroupsException if the value \ref UNDEFINED belongs to \p
   //! cont.
   template <
@@ -1178,7 +1222,7 @@ namespace libsemigroups {
   //! \p N is not \c 0, then the default value of \p Scalar is the smallest
   //! integer type able to hold \c N. See also SmallestInteger.
   //!
-  //! \tparam N  the degree (default: \c 0)
+  //! \tparam N the degree (default: \c 0)
   //! \tparam Scalar an unsigned integer type (the type of the image values)
   //! (default: \c uint32_t)
   //!
@@ -1191,7 +1235,11 @@ namespace libsemigroups {
       = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
   class PPerm : public PTransf<N, Scalar> {
    public:
+    //! \brief Type of the parent class.
+    //!
+    //! Type of the parent class.
     using base_type = PTransf<N, Scalar>;
+
     //! \brief Type of the image values.
     //!
     //! Also the template parameter \c Scalar.
@@ -1227,7 +1275,7 @@ namespace libsemigroups {
     //! No checks whatsoever are performed on the validity of the arguments.
     //!
     //! \sa
-    //! \ref make.
+    //! \ref to_pperm.
     //
     // Note: we use vectors here not container_type (which might be array),
     // because the length of dom and img might not equal degree().
@@ -1270,9 +1318,19 @@ namespace libsemigroups {
     }
   };
 
-  //! \copydoc PTransfBase::make()
+  //! \relates PPerm
   //!
-  //! \note \c Subclass is \c PPerm !!
+  //! \brief Make an instance of \ref PPerm with degree \c 0.
+  //!
+  //! This is equivalent to default constructing a \ref PPerm instance and is
+  //! here for consistency of interface only. The ``to_...`` functions
+  //! check their arguments, and the constructed  instance for validity, but in
+  //! this case there's nothing to check.
+  //!
+  //! \tparam N the degree (default: \c 0)
+  //! \tparam Scalar an unsigned integer type (the type of the image values)
+  //!
+  //! \returns A \ref PPerm instance with degree \c 0.
   template <
       size_t N = 0,
       typename Scalar
@@ -1281,9 +1339,30 @@ namespace libsemigroups {
     return PPerm<N, Scalar>::base_type::template make<PPerm<N, Scalar>>();
   }
 
-  //! \copydoc PTransfBase::make(OtherContainer&&)
+  //! \relates PPerm
   //!
-  //! \note \c Subclass is \c PPerm !!
+  //! \brief Construct from universal reference container and validate.
+  //!
+  //! Constructs a \ref PPerm initialized using the container \p cont as
+  //! follows: the image of the point \c i under the partial permutation is the
+  //! value in position \c i of the container \p cont.
+  //!
+  //! \tparam N the degree (default: \c 0)
+  //! \tparam Scalar an unsigned integer type (the type of the image values)
+  //! \tparam OtherContainer universal reference for the type of the container
+  //! (default: Container).
+  //!
+  //! \param cont the container.
+  //!
+  //! \returns A \ref PPerm instance with degree \c N.
+  //!
+  //! \throw LibsemigroupsException if any of the following hold:
+  //! * the size of \p cont is incompatible with \ref container_type.
+  //! * any value in \p cont exceeds `cont.size()` and is not equal to
+  //!   UNDEFINED.
+  //!
+  //! \complexity
+  //! Linear in the size of the container \p cont.
   template <
       size_t N = 0,
       typename Scalar
@@ -1294,7 +1373,9 @@ namespace libsemigroups {
         std::forward<OtherContainer>(cont));
   }
 
-  //! \copydoc make(OtherContainer&&)
+  //! \relates PPerm
+  //!
+  //! \copydoc to_pperm(OtherContainer&&)
   template <
       size_t N = 0,
       typename Scalar
@@ -1308,6 +1389,8 @@ namespace libsemigroups {
         std::move(cont));
   }
 
+  //! \relates PPerm
+  //!
   //! \brief Construct from domain, range, and degree, and validate
   //!
   //! Constructs a partial perm of degree \p M such that `f[dom[i]] =
@@ -1335,8 +1418,10 @@ namespace libsemigroups {
            std::vector<typename PPerm<N, Scalar>::point_type> const& ran,
            size_t                                                    M);
 
-  //! \copydoc make(std::vector<OtherScalar> const&, std::vector<OtherScalar>
-  //! const&, size_t const)
+  //! \relates PPerm
+  //!
+  //! \copydoc to_pperm(std::vector<typename PPerm<N, Scalar>::point_type>
+  //! const&,std::vector<typename PPerm<N, Scalar>::point_type> const&,size_t)
   template <
       size_t N = 0,
       typename Scalar
@@ -1470,7 +1555,7 @@ namespace libsemigroups {
   //! \p N is not \c 0, then the default value of \p Scalar is the smallest
   //! integer type able to hold \c N. See also SmallestInteger.
   //!
-  //! \tparam N  the degree (default: \c 0)
+  //! \tparam N the degree (default: \c 0)
   //! \tparam Scalar an unsigned integer type (the type of the image values)
   //!
   //! This class inherits from either StaticPTransf or DynamicPTransf, see the
@@ -1482,6 +1567,9 @@ namespace libsemigroups {
       = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
   class Perm : public Transf<N, Scalar> {
    public:
+    //! \brief Type of the parent class.
+    //!
+    //! Type of the parent class.
     using base_type = PTransf<N, Scalar>;
 
     //! \brief Type of the image values.
@@ -1503,8 +1591,31 @@ namespace libsemigroups {
     }
   };
 
-  //! \copydoc PTransfBase::make(OtherContainer&&)
-  //! \throws LibsemigroupsException if there are repeated values in \p cont.
+  //! \relates Perm
+  //!
+  //! \brief Construct from universal reference container and validate.
+  //!
+  //! Constructs a \ref Perm initialized using the container \p cont as
+  //! follows: the image of the point \c i under the permutation is the value in
+  //! position \c i of the container \p cont.
+  //!
+  //! \tparam N the degree (default: \c 0)
+  //! \tparam Scalar an unsigned integer type (the type of the image values)
+  //! \tparam OtherContainer universal reference for the type of the container
+  //! (default: Container).
+  //!
+  //! \param cont the container.
+  //!
+  //! \returns A \ref Perm instance with degree \c N.
+  //!
+  //! \throw LibsemigroupsException if any of the following hold:
+  //! * the size of \p cont is incompatible with \ref container_type.
+  //! * any value in \p cont exceeds `cont.size()` and is not equal to
+  //!   UNDEFINED.
+  //! * there are repeated values in \p cont.
+  //!
+  //! \complexity
+  //! Linear in the size of the container \p cont.
   template <
       size_t N = 0,
       typename Scalar
@@ -1515,7 +1626,19 @@ namespace libsemigroups {
         std::forward<OtherContainer>(cont));
   }
 
-  //! \copydoc PTransfBase::make()
+  //! \relates Perm
+  //!
+  //! \brief Make an instance of \ref Perm with degree \c 0.
+  //!
+  //! This is equivalent to default constructing a \ref Perm instance and is
+  //! here for consistency of interface only. The ``to_...`` functions
+  //! check their arguments, and the constructed  instance for validity, but in
+  //! this case there's nothing to check.
+  //!
+  //! \tparam N the degree (default: \c 0)
+  //! \tparam Scalar an unsigned integer type (the type of the image values)
+  //!
+  //! \returns A \ref Perm instance with degree \c 0.
   template <
       size_t N = 0,
       typename Scalar
@@ -1524,6 +1647,8 @@ namespace libsemigroups {
     return Perm<N, Scalar>::base_type::template make<Perm<N, Scalar>>();
   }
 
+  //! \relates Perm
+  //!
   //! \copydoc to_perm(OtherContainer&&)
   template <
       size_t N = 0,

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -1393,8 +1393,6 @@ namespace libsemigroups {
   //! value in position \c i of the container \p cont.
   //!
   //! \tparam Return the return type.
-  //! \tparam N the degree (default: \c 0).
-  //! \tparam Scalar an unsigned integer type (the type of the image values).
   //! \tparam OtherContainer universal reference for the type of the container.
   //!
   //! \param cont the container.
@@ -1423,8 +1421,6 @@ namespace libsemigroups {
   //! value in position \c i of the container \p cont.
   //!
   //! \tparam Return the return type.
-  //! \tparam N the degree (default: \c 0).
-  //! \tparam Scalar an unsigned integer type (the type of the image values).
   //!
   //! \param cont the container.
   //!
@@ -1454,8 +1450,6 @@ namespace libsemigroups {
   //! in the range \f$[0, M)\f$.
   //!
   //! \tparam Return the return type.
-  //! \tparam N the degree (default: \c 0).
-  //! \tparam Scalar an unsigned integer type (the type of the image values).
   //!
   //! \param dom the domain
   //! \param ran the range
@@ -1485,8 +1479,6 @@ namespace libsemigroups {
   //! in the range \f$[0, M)\f$.
   //!
   //! \tparam Return the return type.
-  //! \tparam N the degree (default: \c 0).
-  //! \tparam Scalar an unsigned integer type (the type of the image values).
   //!
   //! \param dom the domain
   //! \param ran the range

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -1130,8 +1130,7 @@ namespace libsemigroups {
   //!
   //! \throw LibsemigroupsException if any of the following hold:
   //! * the size of \p cont is incompatible with \ref container_type.
-  //! * any value in \p cont exceeds `cont.size()` and is not equal to
-  //!   UNDEFINED.
+  //! * any value in \p cont exceeds `cont.size()`.
   //!
   //! \complexity
   //! Linear in the size of the container \p cont.

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -240,21 +240,6 @@ namespace libsemigroups {
     PTransfBase(std::initializer_list<Scalar> cont)
         : PTransfBase(cont.begin(), cont.end()) {}
 
-    //! \brief Make an instance of \c Subclass with degree \c 0.
-    //!
-    //! This is equivalent to default constructing a \c Subclass instance and is
-    //! here for consistency of interface only. The ``to_[Subclass]`` functions
-    //! check their arguments, and the constructed \c Subclass instance for
-    //! validity, but in this case there's nothing to check.
-    //!
-    //! \tparam Subclass the type of the return value.
-    //!
-    //! \returns A \c Subclass instance with degree \c 0.
-    template <typename Subclass>
-    [[nodiscard]] static Subclass make() {
-      return Subclass();
-    }
-
     //! \brief Construct from universal reference container and validate.
     //!
     //! Constructs a partial transformation initialized using the
@@ -1078,27 +1063,6 @@ namespace libsemigroups {
 
   //! \relates Transf
   //!
-  //! \brief Make an instance of \ref Transf with degree \c 0.
-  //!
-  //! This is equivalent to default constructing a \ref Transf instance and is
-  //! here for consistency of interface only. The ``to_...`` functions
-  //! check their arguments, and the constructed  instance for validity, but in
-  //! this case there's nothing to check.
-  //!
-  //! \tparam N the degree (default: \c 0)
-  //! \tparam Scalar an unsigned integer type (the type of the image values)
-  //!
-  //! \returns A \ref Transf instance with degree \c 0.
-  template <
-      size_t N = 0,
-      typename Scalar
-      = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
-  [[nodiscard]] Transf<N, Scalar> to_transf() {
-    return Transf<N, Scalar>::base_type::template make<Transf<N, Scalar>>();
-  }
-
-  //! \relates Transf
-  //!
   //! \brief Construct from universal reference container and validate.
   //!
   //! Constructs a \ref Transf initialized using the container \p cont as
@@ -1317,27 +1281,6 @@ namespace libsemigroups {
       return base_type::template one<PPerm>(M);
     }
   };
-
-  //! \relates PPerm
-  //!
-  //! \brief Make an instance of \ref PPerm with degree \c 0.
-  //!
-  //! This is equivalent to default constructing a \ref PPerm instance and is
-  //! here for consistency of interface only. The ``to_...`` functions
-  //! check their arguments, and the constructed  instance for validity, but in
-  //! this case there's nothing to check.
-  //!
-  //! \tparam N the degree (default: \c 0)
-  //! \tparam Scalar an unsigned integer type (the type of the image values)
-  //!
-  //! \returns A \ref PPerm instance with degree \c 0.
-  template <
-      size_t N = 0,
-      typename Scalar
-      = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
-  [[nodiscard]] PPerm<N, Scalar> to_pperm() {
-    return PPerm<N, Scalar>::base_type::template make<PPerm<N, Scalar>>();
-  }
 
   //! \relates PPerm
   //!
@@ -1624,27 +1567,6 @@ namespace libsemigroups {
   [[nodiscard]] Perm<N, Scalar> to_perm(OtherContainer&& cont) {
     return Perm<N, Scalar>::base_type::template make<Perm<N, Scalar>>(
         std::forward<OtherContainer>(cont));
-  }
-
-  //! \relates Perm
-  //!
-  //! \brief Make an instance of \ref Perm with degree \c 0.
-  //!
-  //! This is equivalent to default constructing a \ref Perm instance and is
-  //! here for consistency of interface only. The ``to_...`` functions
-  //! check their arguments, and the constructed  instance for validity, but in
-  //! this case there's nothing to check.
-  //!
-  //! \tparam N the degree (default: \c 0)
-  //! \tparam Scalar an unsigned integer type (the type of the image values)
-  //!
-  //! \returns A \ref Perm instance with degree \c 0.
-  template <
-      size_t N = 0,
-      typename Scalar
-      = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
-  [[nodiscard]] Perm<N, Scalar> to_perm() {
-    return Perm<N, Scalar>::base_type::template make<Perm<N, Scalar>>();
   }
 
   //! \relates Perm

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -243,9 +243,9 @@ namespace libsemigroups {
     //! \brief Make an instance of \c Subclass with degree \c 0.
     //!
     //! This is equivalent to default constructing a \c Subclass instance and is
-    //! here for consistency of interface only. The \c make static member
-    //! functions check their arguments, and the constructed \c Subclass
-    //! instance for validity, but in this case there's nothing to check.
+    //! here for consistency of interface only. The ``to_[Subclass]`` functions
+    //! check their arguments, and the constructed \c Subclass instance for
+    //! validity, but in this case there's nothing to check.
     //!
     //! \tparam Subclass the type of the return value.
     //!
@@ -1016,9 +1016,9 @@ namespace libsemigroups {
       typename Scalar
       = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
   class Transf : public PTransf<N, Scalar> {
+   public:
     using base_type = PTransf<N, Scalar>;
 
-   public:
     //! \brief Type of the image values.
     //!
     //! Also the template parameter \c Scalar.
@@ -1031,28 +1031,6 @@ namespace libsemigroups {
 
     using PTransf<N, Scalar>::PTransf;
     using base_type::degree;
-
-    //! \copydoc PTransfBase::make()
-    //!
-    //! \note \c Subclass is \c Transf !!
-    [[nodiscard]] static Transf make() {
-      return base_type::template make<Transf>();
-    }
-
-    //! \copydoc PTransfBase::make(OtherContainer&&)
-    template <typename OtherContainer>
-    [[nodiscard]] static Transf make(OtherContainer&& cont) {
-      return base_type::template make<Transf>(
-          std::forward<OtherContainer>(cont));
-    }
-
-    //! \copydoc PTransfBase::make(std::initializer_list<OtherScalar>)
-    //! \throws LibsemigroupsException if the value \ref UNDEFINED belongs to \p
-    //! cont.
-    template <typename OtherScalar>
-    [[nodiscard]] static Transf make(std::initializer_list<OtherScalar> cont) {
-      return make<std::initializer_list<OtherScalar>>(std::move(cont));
-    }
 
     //! \brief Multiply two transformations and store the product in \c this.
     //!
@@ -1089,6 +1067,42 @@ namespace libsemigroups {
       return base_type::template one<Transf>(M);
     }
   };
+
+  //! \copydoc PTransfBase::make()
+  //!
+  //! \note \c Subclass is \c Transf !!
+  template <
+      size_t N = 0,
+      typename Scalar
+      = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
+  [[nodiscard]] Transf<N, Scalar> to_transf() {
+    return Transf<N, Scalar>::base_type::template make<Transf<N, Scalar>>();
+  }
+
+  //! \copydoc PTransfBase::make(OtherContainer&&)
+  template <
+      size_t N = 0,
+      typename Scalar
+      = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>,
+      typename OtherContainer>
+  [[nodiscard]] Transf<N, Scalar> to_transf(OtherContainer&& cont) {
+    return Transf<N, Scalar>::base_type::template make<Transf<N, Scalar>>(
+        std::forward<OtherContainer>(cont));
+  }
+
+  //! \copydoc to_transf(OtherContainer&&)
+  //! \throws LibsemigroupsException if the value \ref UNDEFINED belongs to \p
+  //! cont.
+  template <
+      size_t N = 0,
+      typename Scalar
+      = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>,
+      typename OtherScalar>
+  [[nodiscard]] Transf<N, Scalar>
+  to_transf(std::initializer_list<OtherScalar> cont) {
+    return to_transf<N, Scalar, std::initializer_list<OtherScalar>>(
+        std::move(cont));
+  }
 
   namespace detail {
     template <typename T>

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -1190,9 +1190,8 @@ namespace libsemigroups {
       typename Scalar
       = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
   class PPerm : public PTransf<N, Scalar> {
-    using base_type = PTransf<N, Scalar>;
-
    public:
+    using base_type = PTransf<N, Scalar>;
     //! \brief Type of the image values.
     //!
     //! Also the template parameter \c Scalar.
@@ -1247,58 +1246,6 @@ namespace libsemigroups {
         : PPerm(std::vector<point_type>(dom), std::vector<point_type>(img), M) {
     }
 
-    //! \copydoc PTransfBase::make()
-    //!
-    //! \note \c Subclass is \c PPerm !!
-    [[nodiscard]] static PPerm make() {
-      return base_type::template make<PPerm>();
-    }
-
-    //! \copydoc PTransfBase::make(OtherContainer&&)
-    //!
-    //! \note \c Subclass is \c PPerm !!
-    template <typename OtherContainer>
-    [[nodiscard]] static PPerm make(OtherContainer&& cont) {
-      return base_type::template make<PPerm>(
-          std::forward<OtherContainer>(cont));
-    }
-
-    //! \copydoc make(OtherContainer&&)
-    [[nodiscard]] static PPerm make(std::initializer_list<point_type> cont) {
-      return make<std::initializer_list<point_type>>(std::move(cont));
-    }
-
-    //! \brief Construct from domain, range, and degree, and validate
-    //!
-    //! Constructs a partial perm of degree \p M such that `f[dom[i]] =
-    //! ran[i]` for all \c i and which is \ref UNDEFINED on every other value
-    //! in the range \f$[0, M)\f$.
-    //!
-    //! \param dom the domain
-    //! \param ran the range
-    //! \param M the degree
-    //!
-    //! \throws LibsemigroupsException if any of the following fail to hold:
-    //! * the value \p M is not compatible with the template parameter \p N
-    //! * \p dom and \p ran do not have the same size
-    //! * any value in \p dom or \p ran is greater than \p M
-    //! * there are repeated entries in \p dom or \p ran.
-    //!
-    //! \complexity
-    //! Linear in the size of \p dom.
-    template <typename OtherScalar>
-    [[nodiscard]] static PPerm make(std::vector<OtherScalar> const& dom,
-                                    std::vector<OtherScalar> const& ran,
-                                    size_t                          M);
-
-    //! \copydoc make(std::vector<OtherScalar> const&, std::vector<OtherScalar>
-    //! const&, size_t const)
-    [[nodiscard]] static PPerm make(std::initializer_list<Scalar> dom,
-                                    std::initializer_list<Scalar> ran,
-                                    size_t                        M) {
-      return make(std::vector<Scalar>(dom), std::vector<Scalar>(ran), M);
-    }
-
     //! \brief Multiply two partial perms and store the product in \c this.
     //!
     //! Replaces the contents of \c this by the product of \p f and \p g.
@@ -1321,12 +1268,88 @@ namespace libsemigroups {
     [[nodiscard]] static PPerm one(size_t M) {
       return base_type::template one<PPerm>(M);
     }
-
-   private:
-    static void validate_args(std::vector<point_type> const& dom,
-                              std::vector<point_type> const& ran,
-                              size_t                         deg = N);
   };
+
+  //! \copydoc PTransfBase::make()
+  //!
+  //! \note \c Subclass is \c PPerm !!
+  template <
+      size_t N = 0,
+      typename Scalar
+      = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
+  [[nodiscard]] PPerm<N, Scalar> to_pperm() {
+    return PPerm<N, Scalar>::base_type::template make<PPerm<N, Scalar>>();
+  }
+
+  //! \copydoc PTransfBase::make(OtherContainer&&)
+  //!
+  //! \note \c Subclass is \c PPerm !!
+  template <
+      size_t N = 0,
+      typename Scalar
+      = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>,
+      typename OtherContainer>
+  [[nodiscard]] PPerm<N, Scalar> to_pperm(OtherContainer&& cont) {
+    return PPerm<N, Scalar>::base_type::template make<PPerm<N, Scalar>>(
+        std::forward<OtherContainer>(cont));
+  }
+
+  //! \copydoc make(OtherContainer&&)
+  template <
+      size_t N = 0,
+      typename Scalar
+      = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
+  [[nodiscard]] PPerm<N, Scalar>
+  to_pperm(std::initializer_list<typename PPerm<N, Scalar>::point_type> cont) {
+    return to_pperm<
+        N,
+        Scalar,
+        std::initializer_list<typename PPerm<N, Scalar>::point_type>>(
+        std::move(cont));
+  }
+
+  //! \brief Construct from domain, range, and degree, and validate
+  //!
+  //! Constructs a partial perm of degree \p M such that `f[dom[i]] =
+  //! ran[i]` for all \c i and which is \ref UNDEFINED on every other value
+  //! in the range \f$[0, M)\f$.
+  //!
+  //! \param dom the domain
+  //! \param ran the range
+  //! \param M the degree
+  //!
+  //! \throws LibsemigroupsException if any of the following fail to hold:
+  //! * the value \p M is not compatible with the template parameter \p N
+  //! * \p dom and \p ran do not have the same size
+  //! * any value in \p dom or \p ran is greater than \p M
+  //! * there are repeated entries in \p dom or \p ran.
+  //!
+  //! \complexity
+  //! Linear in the size of \p dom.
+  template <
+      size_t N = 0,
+      typename Scalar
+      = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
+  [[nodiscard]] PPerm<N, Scalar>
+  to_pperm(std::vector<typename PPerm<N, Scalar>::point_type> const& dom,
+           std::vector<typename PPerm<N, Scalar>::point_type> const& ran,
+           size_t                                                    M);
+
+  //! \copydoc make(std::vector<OtherScalar> const&, std::vector<OtherScalar>
+  //! const&, size_t const)
+  template <
+      size_t N = 0,
+      typename Scalar
+      = std::conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
+  [[nodiscard]] PPerm<N, Scalar>
+  to_pperm(std::initializer_list<typename PPerm<N, Scalar>::point_type> dom,
+           std::initializer_list<typename PPerm<N, Scalar>::point_type> ran,
+           size_t                                                       M) {
+    return to_pperm<N, Scalar>(
+        std::vector<typename PPerm<N, Scalar>::point_type>(dom),
+        std::vector<typename PPerm<N, Scalar>::point_type>(ran),
+        M);
+  }
 
   namespace detail {
     //! No doc
@@ -1358,6 +1381,14 @@ namespace libsemigroups {
       std::unordered_map<std::decay_t<decltype(*first)>, size_t> seen;
       validate_no_duplicates(first, last, seen);
     }
+
+    template <
+        size_t N        = 0,
+        typename Scalar = std::
+            conditional_t<N == 0, uint32_t, typename SmallestInteger<N>::type>>
+    void validate_args(std::vector<Scalar> const& dom,
+                       std::vector<Scalar> const& ran,
+                       size_t                     deg = N);
   }  // namespace detail
 
   ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/transf.tpp
+++ b/include/libsemigroups/transf.tpp
@@ -172,14 +172,13 @@ namespace libsemigroups {
     detail::validate_no_duplicates(ran.cbegin(), ran.cend(), seen);
   }
 
-  // STATIC
-  template <size_t N, typename Scalar>
-  [[nodiscard]] PPerm<N, Scalar>
-  to_pperm(std::vector<typename PPerm<N, Scalar>::point_type> const& dom,
-           std::vector<typename PPerm<N, Scalar>::point_type> const& ran,
-           size_t const                                              M) {
+  template <typename Return>
+  [[nodiscard]] std::enable_if_t<IsPPerm<Return>, Return>
+  to(std::vector<typename Return::point_type> const& dom,
+     std::vector<typename Return::point_type> const& ran,
+     size_t const                                    M) {
     detail::validate_args(dom, ran, M);
-    PPerm<N, Scalar> result(dom, ran, M);
+    Return result(dom, ran, M);
     validate(result);
     return result;
   }

--- a/include/libsemigroups/transf.tpp
+++ b/include/libsemigroups/transf.tpp
@@ -143,11 +143,10 @@ namespace libsemigroups {
     }
   }
 
-  // STATIC
   template <size_t N, typename Scalar>
-  void PPerm<N, Scalar>::validate_args(std::vector<Scalar> const& dom,
-                                       std::vector<Scalar> const& ran,
-                                       size_t                     deg) {
+  void detail::validate_args(std::vector<Scalar> const& dom,
+                             std::vector<Scalar> const& ran,
+                             size_t                     deg) {
     if (N != 0 && deg != N) {
       // Sanity check that the final argument is compatible with the
       // template param N, if we have a dynamic pperm
@@ -175,13 +174,12 @@ namespace libsemigroups {
 
   // STATIC
   template <size_t N, typename Scalar>
-  template <typename OtherScalar>
   [[nodiscard]] PPerm<N, Scalar>
-  PPerm<N, Scalar>::make(std::vector<OtherScalar> const& dom,
-                         std::vector<OtherScalar> const& ran,
-                         size_t const                    M) {
-    validate_args(dom, ran, M);
-    PPerm result(dom, ran, M);
+  to_pperm(std::vector<typename PPerm<N, Scalar>::point_type> const& dom,
+           std::vector<typename PPerm<N, Scalar>::point_type> const& ran,
+           size_t const                                              M) {
+    detail::validate_args(dom, ran, M);
+    PPerm<N, Scalar> result(dom, ran, M);
     validate(result);
     return result;
   }

--- a/tests/test-action.cpp
+++ b/tests/test-action.cpp
@@ -580,7 +580,7 @@ namespace libsemigroups {
             == PPerm<3>({0, 2}, {0, 2}, 3));
     REQUIRE(o.root_of_scc(PPerm<3>({0, 1}, {0, 1}, 3))
             == PPerm<3>({0, 2}, {0, 2}, 3));
-    REQUIRE_THROWS_AS(o.root_of_scc(to_pperm<3>({0, 3}, {0, 3}, 4)),
+    REQUIRE_THROWS_AS(o.root_of_scc(to<PPerm<3>>({0, 3}, {0, 3}, 4)),
                       LibsemigroupsException);
     REQUIRE(*begin(o) == PPerm<3>({0, 1, 2}, {0, 1, 2}, 3));
   }

--- a/tests/test-action.cpp
+++ b/tests/test-action.cpp
@@ -580,7 +580,7 @@ namespace libsemigroups {
             == PPerm<3>({0, 2}, {0, 2}, 3));
     REQUIRE(o.root_of_scc(PPerm<3>({0, 1}, {0, 1}, 3))
             == PPerm<3>({0, 2}, {0, 2}, 3));
-    REQUIRE_THROWS_AS(o.root_of_scc(PPerm<3>::make({0, 3}, {0, 3}, 4)),
+    REQUIRE_THROWS_AS(o.root_of_scc(to_pperm<3>({0, 3}, {0, 3}, 4)),
                       LibsemigroupsException);
     REQUIRE(*begin(o) == PPerm<3>({0, 1, 2}, {0, 1, 2}, 3));
   }

--- a/tests/test-froidure-pin-transf.cpp
+++ b/tests/test-froidure-pin-transf.cpp
@@ -96,8 +96,9 @@ namespace libsemigroups {
       // For dynamic Transf exception is thrown by FroidurePin because degree
       // is wrong, for static Transf exception is thrown by make, because the
       // container has the wrong size
-      REQUIRE_THROWS_AS(S.add_generator(to<Transf<N>>({1, 7, 2, 6, 0, 0, 1, 2})),
-                        LibsemigroupsException);
+      REQUIRE_THROWS_AS(
+          S.add_generator(to<Transf<N>>({1, 7, 2, 6, 0, 0, 1, 2})),
+          LibsemigroupsException);
     }
 
     void test_idempotent(FroidurePin<Transf<>>& S, Transf<> const& x) {

--- a/tests/test-froidure-pin-transf.cpp
+++ b/tests/test-froidure-pin-transf.cpp
@@ -96,7 +96,7 @@ namespace libsemigroups {
       // For dynamic Transf exception is thrown by FroidurePin because degree
       // is wrong, for static Transf exception is thrown by make, because the
       // container has the wrong size
-      REQUIRE_THROWS_AS(S.add_generator(to_transf<N>({1, 7, 2, 6, 0, 0, 1, 2})),
+      REQUIRE_THROWS_AS(S.add_generator(to<Transf<N>>({1, 7, 2, 6, 0, 0, 1, 2})),
                         LibsemigroupsException);
     }
 

--- a/tests/test-froidure-pin-transf.cpp
+++ b/tests/test-froidure-pin-transf.cpp
@@ -87,15 +87,16 @@ namespace libsemigroups {
       REQUIRE_NOTHROW(to_froidure_pin(gens1));
     }
 
-    template <typename T>
+    template <size_t N = 0>
     void test002() {
-      auto           rg = ReportGuard(REPORT);
+      auto rg = ReportGuard(REPORT);
+      using T = Transf<N>;
       FroidurePin<T> S;
       S.add_generator(T({2, 4, 6, 1, 4, 5, 2, 7, 3}));
       // For dynamic Transf exception is thrown by FroidurePin because degree
       // is wrong, for static Transf exception is thrown by make, because the
       // container has the wrong size
-      REQUIRE_THROWS_AS(S.add_generator(T::make({1, 7, 2, 6, 0, 0, 1, 2})),
+      REQUIRE_THROWS_AS(S.add_generator(to_transf<N>({1, 7, 2, 6, 0, 0, 1, 2})),
                         LibsemigroupsException);
     }
 
@@ -148,8 +149,8 @@ namespace libsemigroups {
                              "exception generators of "
                              "different degrees",
                              "[quick][froidure-pin][transformation][transf]") {
-    test002<Transf<>>();
-    test002<Transf<9>>();
+    test002<>();
+    test002<9>();
   }
 
   LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -490,9 +490,9 @@ namespace libsemigroups {
                           "full_transformation_monoid(3) onesided",
                           "[quick][low-index][no-valgrind]") {
     auto rg = ReportGuard(false);
-    auto S  = to_froidure_pin({Transf<3>::make({1, 2, 0}),
-                               Transf<3>::make({1, 0, 2}),
-                               Transf<3>::make({0, 1, 0})});
+    auto S  = to_froidure_pin({to_transf<3>({1, 2, 0}),
+                               to_transf<3>({1, 0, 2}),
+                               to_transf<3>({0, 1, 0})});
     REQUIRE(S.size() == 27);
     REQUIRE(S.number_of_generators() == 3);
     REQUIRE(S.number_of_rules() == 16);
@@ -1821,9 +1821,9 @@ namespace libsemigroups {
 
     auto rg = ReportGuard(false);
 
-    auto S = to_froidure_pin({Transf<6>::make({0, 0, 2, 1, 4, 1}),
-                              Transf<6>::make({0, 0, 2, 3, 4, 3}),
-                              Transf<6>::make({0, 2, 2, 0, 4, 4})});
+    auto S = to_froidure_pin({to_transf<6>({0, 0, 2, 1, 4, 1}),
+                              to_transf<6>({0, 0, 2, 3, 4, 3}),
+                              to_transf<6>({0, 2, 2, 0, 4, 4})});
 
     REQUIRE(S.size() == 5);
     auto p = to_presentation<word_type>(S);
@@ -3198,11 +3198,11 @@ namespace libsemigroups {
                           "[standard][sims2][low-index]") {
     auto                  rg = ReportGuard(false);
     FroidurePin<PPerm<4>> T;
-    T.add_generator(PPerm<4>::make({1, 2, 3, 0}));
-    T.add_generator(PPerm<4>::make({1, 2, 3}, {1, 2, 3}, 4));
-    T.add_generator(PPerm<4>::make({0, 2, 3}, {0, 2, 3}, 4));
-    T.add_generator(PPerm<4>::make({0, 1, 3}, {0, 1, 3}, 4));
-    T.add_generator(PPerm<4>::make({0, 1, 2}, {0, 1, 2}, 4));
+    T.add_generator(to_pperm<4>({1, 2, 3, 0}));
+    T.add_generator(to_pperm<4>({1, 2, 3}, {1, 2, 3}, 4));
+    T.add_generator(to_pperm<4>({0, 2, 3}, {0, 2, 3}, 4));
+    T.add_generator(to_pperm<4>({0, 1, 3}, {0, 1, 3}, 4));
+    T.add_generator(to_pperm<4>({0, 1, 2}, {0, 1, 2}, 4));
     REQUIRE(T.size() == 61);
 
     auto p = to_presentation<word_type>(T);
@@ -3256,10 +3256,10 @@ namespace libsemigroups {
                           "[quick][sims2][low-index][no-valgrind]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<4>> S;
-    S.add_generator(Transf<4>::make({0, 1, 2, 3}));
-    S.add_generator(Transf<4>::make({0, 0, 2, 3}));
-    S.add_generator(Transf<4>::make({0, 1, 1, 3}));
-    S.add_generator(Transf<4>::make({0, 1, 2, 2}));
+    S.add_generator(to_transf<4>({0, 1, 2, 3}));
+    S.add_generator(to_transf<4>({0, 0, 2, 3}));
+    S.add_generator(to_transf<4>({0, 1, 1, 3}));
+    S.add_generator(to_transf<4>({0, 1, 2, 2}));
     REQUIRE(S.size() == 14);
     auto p = to_presentation<word_type>(S);
 

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -490,9 +490,9 @@ namespace libsemigroups {
                           "full_transformation_monoid(3) onesided",
                           "[quick][low-index][no-valgrind]") {
     auto rg = ReportGuard(false);
-    auto S  = to_froidure_pin({to_transf<3>({1, 2, 0}),
-                               to_transf<3>({1, 0, 2}),
-                               to_transf<3>({0, 1, 0})});
+    auto S  = to_froidure_pin({to<Transf<3>>({1, 2, 0}),
+                               to<Transf<3>>({1, 0, 2}),
+                               to<Transf<3>>({0, 1, 0})});
     REQUIRE(S.size() == 27);
     REQUIRE(S.number_of_generators() == 3);
     REQUIRE(S.number_of_rules() == 16);
@@ -1821,9 +1821,9 @@ namespace libsemigroups {
 
     auto rg = ReportGuard(false);
 
-    auto S = to_froidure_pin({to_transf<6>({0, 0, 2, 1, 4, 1}),
-                              to_transf<6>({0, 0, 2, 3, 4, 3}),
-                              to_transf<6>({0, 2, 2, 0, 4, 4})});
+    auto S = to_froidure_pin({to<Transf<6>>({0, 0, 2, 1, 4, 1}),
+                              to<Transf<6>>({0, 0, 2, 3, 4, 3}),
+                              to<Transf<6>>({0, 2, 2, 0, 4, 4})});
 
     REQUIRE(S.size() == 5);
     auto p = to_presentation<word_type>(S);
@@ -3198,11 +3198,11 @@ namespace libsemigroups {
                           "[standard][sims2][low-index]") {
     auto                  rg = ReportGuard(false);
     FroidurePin<PPerm<4>> T;
-    T.add_generator(to_pperm<4>({1, 2, 3, 0}));
-    T.add_generator(to_pperm<4>({1, 2, 3}, {1, 2, 3}, 4));
-    T.add_generator(to_pperm<4>({0, 2, 3}, {0, 2, 3}, 4));
-    T.add_generator(to_pperm<4>({0, 1, 3}, {0, 1, 3}, 4));
-    T.add_generator(to_pperm<4>({0, 1, 2}, {0, 1, 2}, 4));
+    T.add_generator(to<PPerm<4>>({1, 2, 3, 0}));
+    T.add_generator(to<PPerm<4>>({1, 2, 3}, {1, 2, 3}, 4));
+    T.add_generator(to<PPerm<4>>({0, 2, 3}, {0, 2, 3}, 4));
+    T.add_generator(to<PPerm<4>>({0, 1, 3}, {0, 1, 3}, 4));
+    T.add_generator(to<PPerm<4>>({0, 1, 2}, {0, 1, 2}, 4));
     REQUIRE(T.size() == 61);
 
     auto p = to_presentation<word_type>(T);
@@ -3256,10 +3256,10 @@ namespace libsemigroups {
                           "[quick][sims2][low-index][no-valgrind]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<4>> S;
-    S.add_generator(to_transf<4>({0, 1, 2, 3}));
-    S.add_generator(to_transf<4>({0, 0, 2, 3}));
-    S.add_generator(to_transf<4>({0, 1, 1, 3}));
-    S.add_generator(to_transf<4>({0, 1, 2, 2}));
+    S.add_generator(to<Transf<4>>({0, 1, 2, 3}));
+    S.add_generator(to<Transf<4>>({0, 0, 2, 3}));
+    S.add_generator(to<Transf<4>>({0, 1, 1, 3}));
+    S.add_generator(to<Transf<4>>({0, 1, 2, 2}));
     REQUIRE(S.size() == 14);
     auto p = to_presentation<word_type>(S);
 

--- a/tests/test-transf.cpp
+++ b/tests/test-transf.cpp
@@ -136,7 +136,7 @@ namespace libsemigroups {
                           "exceptions (dynamic)",
                           "[quick][transf]") {
     using point_type = typename Transf<>::point_type;
-    REQUIRE_NOTHROW(to_transf());
+    REQUIRE_NOTHROW(Transf());
     REQUIRE_NOTHROW(to_transf({0}));
     REQUIRE_THROWS_AS(to_transf({1}), LibsemigroupsException);
 
@@ -179,7 +179,7 @@ namespace libsemigroups {
                           "exceptions (dynamic)",
                           "[quick][pperm]") {
     using point_type = typename Transf<>::point_type;
-    REQUIRE_NOTHROW(to_pperm<>());
+    REQUIRE_NOTHROW(PPerm<>());
     REQUIRE_NOTHROW(to_pperm<>({0}));
     REQUIRE_NOTHROW(to_pperm<>({UNDEFINED}));
     REQUIRE_THROWS_AS(to_pperm<>({1}), LibsemigroupsException);
@@ -307,7 +307,7 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(to_perm<5>({1, 5, 0, 3, 2}), LibsemigroupsException);
     REQUIRE_THROWS_AS(to_perm<5>({0, 1, 2, 3, 0}), LibsemigroupsException);
 
-    REQUIRE_NOTHROW(to_perm<5>());
+    REQUIRE_NOTHROW(PPerm<5>());
   }
 
   LIBSEMIGROUPS_TEST_CASE("LeastTransf etc",

--- a/tests/test-transf.cpp
+++ b/tests/test-transf.cpp
@@ -278,36 +278,36 @@ namespace libsemigroups {
                           "008",
                           "exceptions (dynamic)",
                           "[quick][perm]") {
-    REQUIRE_NOTHROW(Perm<>::make({}));
-    REQUIRE_NOTHROW(Perm<>::make({0}));
-    REQUIRE_NOTHROW(Perm<>::make({0, 1}));
-    REQUIRE_NOTHROW(Perm<>::make({1, 0}));
-    REQUIRE_NOTHROW(Perm<>::make({1, 4, 0, 3, 2}));
+    REQUIRE_NOTHROW(to_perm<>({}));
+    REQUIRE_NOTHROW(to_perm<>({0}));
+    REQUIRE_NOTHROW(to_perm<>({0, 1}));
+    REQUIRE_NOTHROW(to_perm<>({1, 0}));
+    REQUIRE_NOTHROW(to_perm<>({1, 4, 0, 3, 2}));
 
-    REQUIRE_THROWS_AS(Perm<>::make({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(Perm<>::make({1, 0, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(Perm<>::make({1, 0, 3, 6, 4}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(Perm<>::make({1, 5, 0, 3, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(Perm<>::make({0, 1, 2, 3, 0}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm<>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm<>({1, 0, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm<>({1, 0, 3, 6, 4}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm<>({1, 5, 0, 3, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm<>({0, 1, 2, 3, 0}), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("Perm",
                           "009",
                           "exceptions (static)",
                           "[quick][perm]") {
-    REQUIRE_NOTHROW(Perm<1>::make({0}));
-    REQUIRE_NOTHROW(Perm<2>::make({0, 1}));
-    REQUIRE_NOTHROW(Perm<2>::make({1, 0}));
-    REQUIRE_NOTHROW(Perm<5>::make({1, 4, 0, 3, 2}));
+    REQUIRE_NOTHROW(to_perm<1>({0}));
+    REQUIRE_NOTHROW(to_perm<2>({0, 1}));
+    REQUIRE_NOTHROW(to_perm<2>({1, 0}));
+    REQUIRE_NOTHROW(to_perm<5>({1, 4, 0, 3, 2}));
 
-    REQUIRE_THROWS_AS(Perm<1>::make({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(Perm<2>::make({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(Perm<3>::make({1, 0, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(Perm<5>::make({1, 0, 3, 6, 4}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(Perm<5>::make({1, 5, 0, 3, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(Perm<5>::make({0, 1, 2, 3, 0}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm<1>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm<2>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm<3>({1, 0, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm<5>({1, 0, 3, 6, 4}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm<5>({1, 5, 0, 3, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm<5>({0, 1, 2, 3, 0}), LibsemigroupsException);
 
-    REQUIRE_NOTHROW(Perm<5>::make());
+    REQUIRE_NOTHROW(to_perm<5>());
   }
 
   LIBSEMIGROUPS_TEST_CASE("LeastTransf etc",

--- a/tests/test-transf.cpp
+++ b/tests/test-transf.cpp
@@ -198,11 +198,11 @@ namespace libsemigroups {
         LibsemigroupsException);
     REQUIRE_THROWS_AS(to_pperm(std::initializer_list<point_type>({1, 2, 3})),
                       LibsemigroupsException);
-    REQUIRE_NOTHROW(to_pperm(std::initializer_list<u_int32_t>({1, 2}),
-                             std::initializer_list<u_int32_t>({0, 3}),
+    REQUIRE_NOTHROW(to_pperm(std::initializer_list<uint32_t>({1, 2}),
+                             std::initializer_list<uint32_t>({0, 3}),
                              5));
-    REQUIRE_NOTHROW(to_pperm<5, u_int32_t>({1, 2}, {0, 3}, 5));
-    REQUIRE_NOTHROW(PPerm<5, u_int32_t>({1, 2}, {0, 3}, 5));
+    REQUIRE_NOTHROW(to_pperm<5, uint32_t>({1, 2}, {0, 3}, 5));
+    REQUIRE_NOTHROW(PPerm<5, uint32_t>({1, 2}, {0, 3}, 5));
     REQUIRE_NOTHROW(PPerm<>({1, 2}, {0, 3}, 5));
     REQUIRE_NOTHROW(to_pperm({1, 2}, {0, 5}, 6));
     REQUIRE_THROWS_AS(to_pperm({1, 2}, {0}, 5), LibsemigroupsException);

--- a/tests/test-transf.cpp
+++ b/tests/test-transf.cpp
@@ -62,7 +62,7 @@ namespace libsemigroups {
       } else {
         REQUIRE_THROWS_AS(x.increase_degree_by(10), LibsemigroupsException);
       }
-      auto t = to_transf({9, 7, 3, 5, 3, 4, 2, 7, 7, 1});
+      auto t = to<Transf<>>({9, 7, 3, 5, 3, 4, 2, 7, 7, 1});
       REQUIRE(t.hash_value() != 0);
       REQUIRE_NOTHROW(t.undef());
     }
@@ -137,18 +137,19 @@ namespace libsemigroups {
                           "[quick][transf]") {
     using point_type = typename Transf<>::point_type;
     REQUIRE_NOTHROW(Transf());
-    REQUIRE_NOTHROW(to_transf({0}));
-    REQUIRE_THROWS_AS(to_transf({1}), LibsemigroupsException);
+    REQUIRE_NOTHROW(to<Transf<>>({0}));
+    REQUIRE_THROWS_AS(to<Transf<>>({1}), LibsemigroupsException);
 
-    REQUIRE_NOTHROW(to_transf({0, 1, 2}));
-    REQUIRE_NOTHROW(to_transf(std::initializer_list<point_type>({0, 1, 2})));
-    REQUIRE_NOTHROW(to_transf({0, 1, 2}));
+    REQUIRE_NOTHROW(to<Transf<>>({0, 1, 2}));
+    REQUIRE_NOTHROW(to<Transf<>>(std::initializer_list<point_type>({0, 1, 2})));
+    REQUIRE_NOTHROW(to<Transf<>>({0, 1, 2}));
 
-    REQUIRE_THROWS_AS(to_transf({1, 2, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_transf(std::initializer_list<point_type>({1, 2, 3})),
-                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Transf<>>({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(
+        to<Transf<>>(std::initializer_list<point_type>({1, 2, 3})),
+        LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to_transf(std::initializer_list<point_type>(
+    REQUIRE_THROWS_AS(to<Transf<>>(std::initializer_list<point_type>(
                           {UNDEFINED, UNDEFINED, UNDEFINED})),
                       LibsemigroupsException);
   }
@@ -157,15 +158,15 @@ namespace libsemigroups {
                           "003",
                           "exceptions (static)",
                           "[quick][transf]") {
-    REQUIRE_NOTHROW(to_transf({0}));
-    REQUIRE_THROWS_AS(to_transf({1}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_transf({1}), LibsemigroupsException);
+    REQUIRE_NOTHROW(to<Transf<>>({0}));
+    REQUIRE_THROWS_AS(to<Transf<>>({1}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Transf<>>({1}), LibsemigroupsException);
 
-    REQUIRE_NOTHROW(to_transf({0, 1, 2}));
+    REQUIRE_NOTHROW(to<Transf<>>({0, 1, 2}));
 
-    REQUIRE_THROWS_AS(to_transf({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Transf<>>({1, 2, 3}), LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to_transf({UNDEFINED, UNDEFINED, UNDEFINED}),
+    REQUIRE_THROWS_AS(to<Transf<>>({UNDEFINED, UNDEFINED, UNDEFINED}),
                       LibsemigroupsException);
   }
 
@@ -180,41 +181,41 @@ namespace libsemigroups {
                           "[quick][pperm]") {
     using point_type = typename Transf<>::point_type;
     REQUIRE_NOTHROW(PPerm<>());
-    REQUIRE_NOTHROW(to_pperm({0}));
-    REQUIRE_NOTHROW(to_pperm({UNDEFINED}));
-    REQUIRE_THROWS_AS(to_pperm({1}), LibsemigroupsException);
+    REQUIRE_NOTHROW(to<PPerm<>>({0}));
+    REQUIRE_NOTHROW(to<PPerm<>>({UNDEFINED}));
+    REQUIRE_THROWS_AS(to<PPerm<>>({1}), LibsemigroupsException);
 
-    REQUIRE_NOTHROW(to_pperm({0, 1, 2}));
-    REQUIRE_NOTHROW(to_pperm(std::initializer_list<point_type>({0, 1, 2})));
-    REQUIRE_NOTHROW(to_pperm({0, UNDEFINED, 2}));
-    REQUIRE_NOTHROW(to_pperm({0, UNDEFINED, 5, UNDEFINED, UNDEFINED, 1}));
+    REQUIRE_NOTHROW(to<PPerm<>>({0, 1, 2}));
+    REQUIRE_NOTHROW(to<PPerm<>>(std::initializer_list<point_type>({0, 1, 2})));
+    REQUIRE_NOTHROW(to<PPerm<>>({0, UNDEFINED, 2}));
+    REQUIRE_NOTHROW(to<PPerm<>>({0, UNDEFINED, 5, UNDEFINED, UNDEFINED, 1}));
 
-    REQUIRE_THROWS_AS(to_pperm({1, 2, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm({UNDEFINED, UNDEFINED, 3}),
+    REQUIRE_THROWS_AS(to<PPerm<>>({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<>>({UNDEFINED, UNDEFINED, 3}),
                       LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm({1, UNDEFINED, 1}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(
-        to_pperm(std::vector<point_type>({3, UNDEFINED, 2, 1, UNDEFINED, 3})),
-        LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm(std::initializer_list<point_type>({1, 2, 3})),
+    REQUIRE_THROWS_AS(to<PPerm<>>({1, UNDEFINED, 1}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<>>(std::vector<point_type>(
+                          {3, UNDEFINED, 2, 1, UNDEFINED, 3})),
                       LibsemigroupsException);
-    REQUIRE_NOTHROW(to_pperm(std::initializer_list<uint32_t>({1, 2}),
-                             std::initializer_list<uint32_t>({0, 3}),
-                             5));
-    REQUIRE_NOTHROW(to_pperm<5, uint32_t>({1, 2}, {0, 3}, 5));
+    REQUIRE_THROWS_AS(to<PPerm<>>(std::initializer_list<point_type>({1, 2, 3})),
+                      LibsemigroupsException);
+    REQUIRE_NOTHROW(to<PPerm<>>(std::initializer_list<uint32_t>({1, 2}),
+                                std::initializer_list<uint32_t>({0, 3}),
+                                5));
+    REQUIRE_NOTHROW(to<PPerm<5, uint32_t>>({1, 2}, {0, 3}, 5));
     REQUIRE_NOTHROW(PPerm<5, uint32_t>({1, 2}, {0, 3}, 5));
     REQUIRE_NOTHROW(PPerm<>({1, 2}, {0, 3}, 5));
-    REQUIRE_NOTHROW(to_pperm({1, 2}, {0, 5}, 6));
-    REQUIRE_THROWS_AS(to_pperm({1, 2}, {0}, 5), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm({1, 2}, {0, 5}, 4), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm({1, 5}, {0, 2}, 4), LibsemigroupsException);
+    REQUIRE_NOTHROW(to<PPerm<>>({1, 2}, {0, 5}, 6));
+    REQUIRE_THROWS_AS(to<PPerm<>>({1, 2}, {0}, 5), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<>>({1, 2}, {0, 5}, 4), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<>>({1, 5}, {0, 2}, 4), LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to_pperm({1, 1}, {0, 2}, 3), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm({1, 0}, {2, 2}, 3), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm({1, 0, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm({1, 0, 3, 6, 4}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm({1, 5, 0, 3, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<>>({1, 1}, {0, 2}, 3), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<>>({1, 0}, {2, 2}, 3), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<>>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<>>({1, 0, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<>>({1, 0, 3, 6, 4}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<>>({1, 5, 0, 3, 2}), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("PPerm",
@@ -222,37 +223,37 @@ namespace libsemigroups {
                           "exceptions (static)",
                           "[quick][pperm]") {
     using point_type = typename PPerm<6>::point_type;
-    REQUIRE_NOTHROW(to_pperm<1>({0}));
-    REQUIRE_NOTHROW(to_pperm<1>({UNDEFINED}));
-    REQUIRE_THROWS_AS(to_pperm<1>({1}), LibsemigroupsException);
+    REQUIRE_NOTHROW(to<PPerm<1>>({0}));
+    REQUIRE_NOTHROW(to<PPerm<1>>({UNDEFINED}));
+    REQUIRE_THROWS_AS(to<PPerm<1>>({1}), LibsemigroupsException);
 
-    REQUIRE_NOTHROW(to_pperm<3>({0, 1, 2}));
-    REQUIRE_NOTHROW(to_pperm<3>({0, 1, 2}));
-    REQUIRE_NOTHROW(to_pperm<3>({0, UNDEFINED, 2}));
-    REQUIRE_NOTHROW(to_pperm<6>({0, UNDEFINED, 5, UNDEFINED, UNDEFINED, 1}));
+    REQUIRE_NOTHROW(to<PPerm<3>>({0, 1, 2}));
+    REQUIRE_NOTHROW(to<PPerm<3>>({0, 1, 2}));
+    REQUIRE_NOTHROW(to<PPerm<3>>({0, UNDEFINED, 2}));
+    REQUIRE_NOTHROW(to<PPerm<6>>({0, UNDEFINED, 5, UNDEFINED, UNDEFINED, 1}));
 
-    REQUIRE_THROWS_AS(to_pperm<3>({1, 2, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<3>({UNDEFINED, UNDEFINED, 3}),
+    REQUIRE_THROWS_AS(to<PPerm<3>>({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<3>>({UNDEFINED, UNDEFINED, 3}),
                       LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<3>({1, UNDEFINED, 1}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<6>({3, UNDEFINED, 2, 1, UNDEFINED, 3}),
+    REQUIRE_THROWS_AS(to<PPerm<3>>({1, UNDEFINED, 1}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<6>>({3, UNDEFINED, 2, 1, UNDEFINED, 3}),
                       LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<3>({1, 2, 3}), LibsemigroupsException);
-    REQUIRE_NOTHROW(to_pperm<5>({1, 2}, {0, 3}, 5));
-    REQUIRE_NOTHROW(to_pperm<6>({1, 2}, {0, 5}, 6));
-    REQUIRE_THROWS_AS(to_pperm<5>({1, 2}, {0}, 5), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<4>({1, 2}, {0, 5}, 4), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<4>({1, 5}, {0, 2}, 4), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<3>>({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_NOTHROW(to<PPerm<5>>({1, 2}, {0, 3}, 5));
+    REQUIRE_NOTHROW(to<PPerm<6>>({1, 2}, {0, 5}, 6));
+    REQUIRE_THROWS_AS(to<PPerm<5>>({1, 2}, {0}, 5), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<4>>({1, 2}, {0, 5}, 4), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<4>>({1, 5}, {0, 2}, 4), LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to_pperm<3>({1, 1}, {0, 2}, 3), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<3>({0, 2}, {1, 1}, 3), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<3>>({1, 1}, {0, 2}, 3), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<3>>({0, 2}, {1, 1}, 3), LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to_pperm<1>({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<2>({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<3>({1, 0, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<5>({1, 0, 3, 6, 4}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<5>({1, 5, 0, 3, 2}), LibsemigroupsException);
-    auto x = to_pperm<5>({0, 2}, {3, 0}, 5);
+    REQUIRE_THROWS_AS(to<PPerm<1>>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<2>>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<3>>({1, 0, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<5>>({1, 0, 3, 6, 4}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<PPerm<5>>({1, 5, 0, 3, 2}), LibsemigroupsException);
+    auto x = to<PPerm<5>>({0, 2}, {3, 0}, 5);
     REQUIRE(image(x) == std::vector<point_type>({0, 3}));
     REQUIRE(domain(x) == std::vector<point_type>({0, 2}));
   }
@@ -278,34 +279,34 @@ namespace libsemigroups {
                           "008",
                           "exceptions (dynamic)",
                           "[quick][perm]") {
-    REQUIRE_NOTHROW(to_perm({}));
-    REQUIRE_NOTHROW(to_perm({0}));
-    REQUIRE_NOTHROW(to_perm({0, 1}));
-    REQUIRE_NOTHROW(to_perm({1, 0}));
-    REQUIRE_NOTHROW(to_perm({1, 4, 0, 3, 2}));
+    REQUIRE_NOTHROW(to<Perm<>>({}));
+    REQUIRE_NOTHROW(to<Perm<>>({0}));
+    REQUIRE_NOTHROW(to<Perm<>>({0, 1}));
+    REQUIRE_NOTHROW(to<Perm<>>({1, 0}));
+    REQUIRE_NOTHROW(to<Perm<>>({1, 4, 0, 3, 2}));
 
-    REQUIRE_THROWS_AS(to_perm({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_perm({1, 0, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_perm({1, 0, 3, 6, 4}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_perm({1, 5, 0, 3, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_perm({0, 1, 2, 3, 0}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Perm<>>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Perm<>>({1, 0, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Perm<>>({1, 0, 3, 6, 4}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Perm<>>({1, 5, 0, 3, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Perm<>>({0, 1, 2, 3, 0}), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("Perm",
                           "009",
                           "exceptions (static)",
                           "[quick][perm]") {
-    REQUIRE_NOTHROW(to_perm<1>({0}));
-    REQUIRE_NOTHROW(to_perm<2>({0, 1}));
-    REQUIRE_NOTHROW(to_perm<2>({1, 0}));
-    REQUIRE_NOTHROW(to_perm<5>({1, 4, 0, 3, 2}));
+    REQUIRE_NOTHROW(to<Perm<1>>({0}));
+    REQUIRE_NOTHROW(to<Perm<2>>({0, 1}));
+    REQUIRE_NOTHROW(to<Perm<2>>({1, 0}));
+    REQUIRE_NOTHROW(to<Perm<5>>({1, 4, 0, 3, 2}));
 
-    REQUIRE_THROWS_AS(to_perm<1>({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_perm<2>({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_perm<3>({1, 0, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_perm<5>({1, 0, 3, 6, 4}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_perm<5>({1, 5, 0, 3, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_perm<5>({0, 1, 2, 3, 0}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Perm<1>>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Perm<2>>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Perm<3>>({1, 0, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Perm<5>>({1, 0, 3, 6, 4}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Perm<5>>({1, 5, 0, 3, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Perm<5>>({0, 1, 2, 3, 0}), LibsemigroupsException);
 
     REQUIRE_NOTHROW(PPerm<5>());
   }

--- a/tests/test-transf.cpp
+++ b/tests/test-transf.cpp
@@ -62,7 +62,7 @@ namespace libsemigroups {
       } else {
         REQUIRE_THROWS_AS(x.increase_degree_by(10), LibsemigroupsException);
       }
-      auto t = Transf<>::make({9, 7, 3, 5, 3, 4, 2, 7, 7, 1});
+      auto t = to_transf({9, 7, 3, 5, 3, 4, 2, 7, 7, 1});
       REQUIRE(t.hash_value() != 0);
       REQUIRE_NOTHROW(t.undef());
     }
@@ -136,21 +136,19 @@ namespace libsemigroups {
                           "exceptions (dynamic)",
                           "[quick][transf]") {
     using point_type = typename Transf<>::point_type;
-    REQUIRE_NOTHROW(Transf<>::make());
-    REQUIRE_NOTHROW(Transf<>::make({0}));
-    REQUIRE_THROWS_AS(Transf<>::make({1}), LibsemigroupsException);
+    REQUIRE_NOTHROW(to_transf());
+    REQUIRE_NOTHROW(to_transf({0}));
+    REQUIRE_THROWS_AS(to_transf({1}), LibsemigroupsException);
 
-    REQUIRE_NOTHROW(Transf<>::make({0, 1, 2}));
-    REQUIRE_NOTHROW(
-        Transf<>::make(std::initializer_list<point_type>({0, 1, 2})));
-    REQUIRE_NOTHROW(Transf<>::make({0, 1, 2}));
+    REQUIRE_NOTHROW(to_transf({0, 1, 2}));
+    REQUIRE_NOTHROW(to_transf(std::initializer_list<point_type>({0, 1, 2})));
+    REQUIRE_NOTHROW(to_transf({0, 1, 2}));
 
-    REQUIRE_THROWS_AS(Transf<>::make({1, 2, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(
-        Transf<>::make(std::initializer_list<point_type>({1, 2, 3})),
-        LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_transf({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_transf(std::initializer_list<point_type>({1, 2, 3})),
+                      LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(Transf<>::make(std::initializer_list<point_type>(
+    REQUIRE_THROWS_AS(to_transf(std::initializer_list<point_type>(
                           {UNDEFINED, UNDEFINED, UNDEFINED})),
                       LibsemigroupsException);
   }
@@ -159,15 +157,15 @@ namespace libsemigroups {
                           "003",
                           "exceptions (static)",
                           "[quick][transf]") {
-    REQUIRE_NOTHROW(Transf<1>::make({0}));
-    REQUIRE_THROWS_AS(Transf<1>::make({1}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(Transf<2>::make({1}), LibsemigroupsException);
+    REQUIRE_NOTHROW(to_transf({0}));
+    REQUIRE_THROWS_AS(to_transf({1}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_transf({1}), LibsemigroupsException);
 
-    REQUIRE_NOTHROW(Transf<3>::make({0, 1, 2}));
+    REQUIRE_NOTHROW(to_transf({0, 1, 2}));
 
-    REQUIRE_THROWS_AS(Transf<3>::make({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_transf({1, 2, 3}), LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(Transf<3>::make({UNDEFINED, UNDEFINED, UNDEFINED}),
+    REQUIRE_THROWS_AS(to_transf({UNDEFINED, UNDEFINED, UNDEFINED}),
                       LibsemigroupsException);
   }
 

--- a/tests/test-transf.cpp
+++ b/tests/test-transf.cpp
@@ -180,41 +180,41 @@ namespace libsemigroups {
                           "[quick][pperm]") {
     using point_type = typename Transf<>::point_type;
     REQUIRE_NOTHROW(PPerm<>());
-    REQUIRE_NOTHROW(to_pperm<>({0}));
-    REQUIRE_NOTHROW(to_pperm<>({UNDEFINED}));
-    REQUIRE_THROWS_AS(to_pperm<>({1}), LibsemigroupsException);
+    REQUIRE_NOTHROW(to_pperm({0}));
+    REQUIRE_NOTHROW(to_pperm({UNDEFINED}));
+    REQUIRE_THROWS_AS(to_pperm({1}), LibsemigroupsException);
 
-    REQUIRE_NOTHROW(to_pperm<>({0, 1, 2}));
-    REQUIRE_NOTHROW(to_pperm<>(std::initializer_list<point_type>({0, 1, 2})));
-    REQUIRE_NOTHROW(to_pperm<>({0, UNDEFINED, 2}));
-    REQUIRE_NOTHROW(to_pperm<>({0, UNDEFINED, 5, UNDEFINED, UNDEFINED, 1}));
+    REQUIRE_NOTHROW(to_pperm({0, 1, 2}));
+    REQUIRE_NOTHROW(to_pperm(std::initializer_list<point_type>({0, 1, 2})));
+    REQUIRE_NOTHROW(to_pperm({0, UNDEFINED, 2}));
+    REQUIRE_NOTHROW(to_pperm({0, UNDEFINED, 5, UNDEFINED, UNDEFINED, 1}));
 
-    REQUIRE_THROWS_AS(to_pperm<>({1, 2, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<>({UNDEFINED, UNDEFINED, 3}),
+    REQUIRE_THROWS_AS(to_pperm({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm({UNDEFINED, UNDEFINED, 3}),
                       LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<>({1, UNDEFINED, 1}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm({1, UNDEFINED, 1}), LibsemigroupsException);
     REQUIRE_THROWS_AS(
-        to_pperm<>(std::vector<point_type>({3, UNDEFINED, 2, 1, UNDEFINED, 3})),
+        to_pperm(std::vector<point_type>({3, UNDEFINED, 2, 1, UNDEFINED, 3})),
         LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<>(std::initializer_list<point_type>({1, 2, 3})),
+    REQUIRE_THROWS_AS(to_pperm(std::initializer_list<point_type>({1, 2, 3})),
                       LibsemigroupsException);
-    REQUIRE_NOTHROW(to_pperm<>(std::initializer_list<u_int32_t>({1, 2}),
-                               std::initializer_list<u_int32_t>({0, 3}),
-                               5));
+    REQUIRE_NOTHROW(to_pperm(std::initializer_list<u_int32_t>({1, 2}),
+                             std::initializer_list<u_int32_t>({0, 3}),
+                             5));
     REQUIRE_NOTHROW(to_pperm<5, u_int32_t>({1, 2}, {0, 3}, 5));
     REQUIRE_NOTHROW(PPerm<5, u_int32_t>({1, 2}, {0, 3}, 5));
     REQUIRE_NOTHROW(PPerm<>({1, 2}, {0, 3}, 5));
-    REQUIRE_NOTHROW(to_pperm<>({1, 2}, {0, 5}, 6));
-    REQUIRE_THROWS_AS(to_pperm<>({1, 2}, {0}, 5), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<>({1, 2}, {0, 5}, 4), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<>({1, 5}, {0, 2}, 4), LibsemigroupsException);
+    REQUIRE_NOTHROW(to_pperm({1, 2}, {0, 5}, 6));
+    REQUIRE_THROWS_AS(to_pperm({1, 2}, {0}, 5), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm({1, 2}, {0, 5}, 4), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm({1, 5}, {0, 2}, 4), LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to_pperm<>({1, 1}, {0, 2}, 3), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<>({1, 0}, {2, 2}, 3), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<>({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<>({1, 0, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<>({1, 0, 3, 6, 4}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pperm<>({1, 5, 0, 3, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm({1, 1}, {0, 2}, 3), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm({1, 0}, {2, 2}, 3), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm({1, 0, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm({1, 0, 3, 6, 4}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm({1, 5, 0, 3, 2}), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("PPerm",
@@ -278,17 +278,17 @@ namespace libsemigroups {
                           "008",
                           "exceptions (dynamic)",
                           "[quick][perm]") {
-    REQUIRE_NOTHROW(to_perm<>({}));
-    REQUIRE_NOTHROW(to_perm<>({0}));
-    REQUIRE_NOTHROW(to_perm<>({0, 1}));
-    REQUIRE_NOTHROW(to_perm<>({1, 0}));
-    REQUIRE_NOTHROW(to_perm<>({1, 4, 0, 3, 2}));
+    REQUIRE_NOTHROW(to_perm({}));
+    REQUIRE_NOTHROW(to_perm({0}));
+    REQUIRE_NOTHROW(to_perm({0, 1}));
+    REQUIRE_NOTHROW(to_perm({1, 0}));
+    REQUIRE_NOTHROW(to_perm({1, 4, 0, 3, 2}));
 
-    REQUIRE_THROWS_AS(to_perm<>({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_perm<>({1, 0, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_perm<>({1, 0, 3, 6, 4}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_perm<>({1, 5, 0, 3, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_perm<>({0, 1, 2, 3, 0}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm({1, 0, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm({1, 0, 3, 6, 4}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm({1, 5, 0, 3, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_perm({0, 1, 2, 3, 0}), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("Perm",

--- a/tests/test-transf.cpp
+++ b/tests/test-transf.cpp
@@ -179,39 +179,42 @@ namespace libsemigroups {
                           "exceptions (dynamic)",
                           "[quick][pperm]") {
     using point_type = typename Transf<>::point_type;
-    REQUIRE_NOTHROW(PPerm<>::make());
-    REQUIRE_NOTHROW(PPerm<>::make({0}));
-    REQUIRE_NOTHROW(PPerm<>::make({UNDEFINED}));
-    REQUIRE_THROWS_AS(PPerm<>::make({1}), LibsemigroupsException);
+    REQUIRE_NOTHROW(to_pperm<>());
+    REQUIRE_NOTHROW(to_pperm<>({0}));
+    REQUIRE_NOTHROW(to_pperm<>({UNDEFINED}));
+    REQUIRE_THROWS_AS(to_pperm<>({1}), LibsemigroupsException);
 
-    REQUIRE_NOTHROW(PPerm<>::make({0, 1, 2}));
-    REQUIRE_NOTHROW(
-        PPerm<>::make(std::initializer_list<point_type>({0, 1, 2})));
-    REQUIRE_NOTHROW(PPerm<>::make({0, UNDEFINED, 2}));
-    REQUIRE_NOTHROW(PPerm<>::make({0, UNDEFINED, 5, UNDEFINED, UNDEFINED, 1}));
+    REQUIRE_NOTHROW(to_pperm<>({0, 1, 2}));
+    REQUIRE_NOTHROW(to_pperm<>(std::initializer_list<point_type>({0, 1, 2})));
+    REQUIRE_NOTHROW(to_pperm<>({0, UNDEFINED, 2}));
+    REQUIRE_NOTHROW(to_pperm<>({0, UNDEFINED, 5, UNDEFINED, UNDEFINED, 1}));
 
-    REQUIRE_THROWS_AS(PPerm<>::make({1, 2, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<>::make({UNDEFINED, UNDEFINED, 3}),
+    REQUIRE_THROWS_AS(to_pperm<>({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<>({UNDEFINED, UNDEFINED, 3}),
                       LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<>::make({1, UNDEFINED, 1}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<>::make(std::vector<point_type>(
-                          {3, UNDEFINED, 2, 1, UNDEFINED, 3})),
-                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<>({1, UNDEFINED, 1}), LibsemigroupsException);
     REQUIRE_THROWS_AS(
-        PPerm<>::make(std::initializer_list<point_type>({1, 2, 3})),
+        to_pperm<>(std::vector<point_type>({3, UNDEFINED, 2, 1, UNDEFINED, 3})),
         LibsemigroupsException);
-    REQUIRE_NOTHROW(PPerm<>::make({1, 2}, {0, 3}, 5));
-    REQUIRE_NOTHROW(PPerm<>::make({1, 2}, {0, 5}, 6));
-    REQUIRE_THROWS_AS(PPerm<>::make({1, 2}, {0}, 5), LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<>::make({1, 2}, {0, 5}, 4), LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<>::make({1, 5}, {0, 2}, 4), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<>(std::initializer_list<point_type>({1, 2, 3})),
+                      LibsemigroupsException);
+    REQUIRE_NOTHROW(to_pperm<>(std::initializer_list<u_int32_t>({1, 2}),
+                               std::initializer_list<u_int32_t>({0, 3}),
+                               5));
+    REQUIRE_NOTHROW(to_pperm<5, u_int32_t>({1, 2}, {0, 3}, 5));
+    REQUIRE_NOTHROW(PPerm<5, u_int32_t>({1, 2}, {0, 3}, 5));
+    REQUIRE_NOTHROW(PPerm<>({1, 2}, {0, 3}, 5));
+    REQUIRE_NOTHROW(to_pperm<>({1, 2}, {0, 5}, 6));
+    REQUIRE_THROWS_AS(to_pperm<>({1, 2}, {0}, 5), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<>({1, 2}, {0, 5}, 4), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<>({1, 5}, {0, 2}, 4), LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(PPerm<>::make({1, 1}, {0, 2}, 3), LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<>::make({1, 0}, {2, 2}, 3), LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<>::make({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<>::make({1, 0, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<>::make({1, 0, 3, 6, 4}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<>::make({1, 5, 0, 3, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<>({1, 1}, {0, 2}, 3), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<>({1, 0}, {2, 2}, 3), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<>({1, 0, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<>({1, 0, 3, 6, 4}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<>({1, 5, 0, 3, 2}), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("PPerm",
@@ -219,42 +222,37 @@ namespace libsemigroups {
                           "exceptions (static)",
                           "[quick][pperm]") {
     using point_type = typename PPerm<6>::point_type;
-    REQUIRE_NOTHROW(PPerm<1>::make({0}));
-    REQUIRE_NOTHROW(PPerm<1>::make({UNDEFINED}));
-    REQUIRE_THROWS_AS(PPerm<1>::make({1}), LibsemigroupsException);
+    REQUIRE_NOTHROW(to_pperm<1>({0}));
+    REQUIRE_NOTHROW(to_pperm<1>({UNDEFINED}));
+    REQUIRE_THROWS_AS(to_pperm<1>({1}), LibsemigroupsException);
 
-    REQUIRE_NOTHROW(PPerm<3>::make({0, 1, 2}));
-    REQUIRE_NOTHROW(PPerm<3>::make({0, 1, 2}));
-    REQUIRE_NOTHROW(PPerm<3>::make({0, UNDEFINED, 2}));
-    REQUIRE_NOTHROW(PPerm<6>::make({0, UNDEFINED, 5, UNDEFINED, UNDEFINED, 1}));
+    REQUIRE_NOTHROW(to_pperm<3>({0, 1, 2}));
+    REQUIRE_NOTHROW(to_pperm<3>({0, 1, 2}));
+    REQUIRE_NOTHROW(to_pperm<3>({0, UNDEFINED, 2}));
+    REQUIRE_NOTHROW(to_pperm<6>({0, UNDEFINED, 5, UNDEFINED, UNDEFINED, 1}));
 
-    REQUIRE_THROWS_AS(PPerm<3>::make({1, 2, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<3>::make({UNDEFINED, UNDEFINED, 3}),
+    REQUIRE_THROWS_AS(to_pperm<3>({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<3>({UNDEFINED, UNDEFINED, 3}),
                       LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<3>::make({1, UNDEFINED, 1}),
+    REQUIRE_THROWS_AS(to_pperm<3>({1, UNDEFINED, 1}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<6>({3, UNDEFINED, 2, 1, UNDEFINED, 3}),
                       LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<6>::make({3, UNDEFINED, 2, 1, UNDEFINED, 3}),
-                      LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<3>::make({1, 2, 3}), LibsemigroupsException);
-    REQUIRE_NOTHROW(PPerm<5>::make({1, 2}, {0, 3}, 5));
-    REQUIRE_NOTHROW(PPerm<6>::make({1, 2}, {0, 5}, 6));
-    REQUIRE_THROWS_AS(PPerm<5>::make({1, 2}, {0}, 5), LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<4>::make({1, 2}, {0, 5}, 4),
-                      LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<4>::make({1, 5}, {0, 2}, 4),
-                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<3>({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_NOTHROW(to_pperm<5>({1, 2}, {0, 3}, 5));
+    REQUIRE_NOTHROW(to_pperm<6>({1, 2}, {0, 5}, 6));
+    REQUIRE_THROWS_AS(to_pperm<5>({1, 2}, {0}, 5), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<4>({1, 2}, {0, 5}, 4), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<4>({1, 5}, {0, 2}, 4), LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(PPerm<3>::make({1, 1}, {0, 2}, 3),
-                      LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<3>::make({0, 2}, {1, 1}, 3),
-                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<3>({1, 1}, {0, 2}, 3), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<3>({0, 2}, {1, 1}, 3), LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(PPerm<1>::make({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<2>::make({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<3>::make({1, 0, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<5>::make({1, 0, 3, 6, 4}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(PPerm<5>::make({1, 5, 0, 3, 2}), LibsemigroupsException);
-    auto x = PPerm<5>::make({0, 2}, {3, 0}, 5);
+    REQUIRE_THROWS_AS(to_pperm<1>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<2>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<3>({1, 0, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<5>({1, 0, 3, 6, 4}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to_pperm<5>({1, 5, 0, 3, 2}), LibsemigroupsException);
+    auto x = to_pperm<5>({0, 2}, {3, 0}, 5);
     REQUIRE(image(x) == std::vector<point_type>({0, 3}));
     REQUIRE(domain(x) == std::vector<point_type>({0, 2}));
   }


### PR DESCRIPTION
This PR replaces the static member function `make` from various `PTransf` classes with a free function template `to<Class>`. This came after discussions with @james-d-mitchell.