### PR TITLE
Fix coverage and downstream CI jobs

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -55,7 +55,7 @@ jobs:
               sudo apt-get --yes update
               sudo apt-get install python3 --yes
               sudo apt-get install python3-pip --yes
-              sudo -H pip3 install -r requirements.txt
+              pip3 install -r requirements.txt
           - name: "Building libsemigroups_pybind11 . . ."
             run: |
               cd libsemigroups_pybind11

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -177,10 +177,10 @@ jobs:
                 export GCOV=/usr/bin/gcov-13
                 etc/test-code-coverage.sh test_all "[quick][exclude:no-valgrind][exclude:no-coverage]"
          - name: "Uploading to Codecov . . ."
-           uses: codecov/codecov-action@v4
+           uses: codecov/codecov-action@v5
            with:
               fail_ci_if_error: true
-              file: coverage.info
+              files: coverage.info
               token: ${{ secrets.CODECOV_TOKEN }}
               verbose: true
          - name: "Cleanup . . ."

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -173,8 +173,8 @@ jobs:
                 sudo apt-get install -y lcov
          - name: "Run quick tests . . ."
            run: |
-                sudo ln -sf /usr/bin/gcov-9 /usr/bin/gcov
-                export GCOV=/usr/bin/gcov-9
+                sudo ln -sf /usr/bin/gcov-13 /usr/bin/gcov
+                export GCOV=/usr/bin/gcov-13
                 etc/test-code-coverage.sh test_all "[quick][exclude:no-valgrind][exclude:no-coverage]"
          - name: "Uploading to Codecov . . ."
            uses: codecov/codecov-action@v4

--- a/etc/test-code-coverage.sh
+++ b/etc/test-code-coverage.sh
@@ -97,8 +97,8 @@ fi
 
 bold "Running lcov and genhtml . . .";
 printf "\033[2m";
-lcov  --directory . --capture --output-file "coverage.info.tmp" --test-name "libsemigroups_1_0_0" --no-checksum --no-external --compat-libtool --gcov-tool "gcov" | grep -v "ignoring data for external file"
-lcov  --directory . --remove "coverage.info.tmp" "/tmp/*" "/Applications/*" --output-file "coverage.info"
+lcov  --ignore-errors mismatch,negative --directory . --capture --output-file "coverage.info.tmp" --test-name "libsemigroups_1_0_0" --no-checksum --no-external --compat-libtool --gcov-tool "gcov" | grep -v "ignoring data for external file"
+lcov  --ignore-errors unused --directory . --remove "coverage.info.tmp" "/tmp/*" "/Applications/*" --output-file "coverage.info"
 LANG=C genhtml  --prefix . --output-directory "coverage" --title "libsemigroups Code Coverage" --legend --show-details "coverage.info.tmp"
 rm -f coverage.info.tmp
 printf "\033[0m";


### PR DESCRIPTION
This PR updates the coverage workflow for use in Ubuntu 24.04, and fixes a bug in the downstream job. 

The coverage update included suppressing some errors produced by `lcov` which are documented below. It's not clear to me whether these errors are caused by us, Catch2, `gcc`, `lcov` or something else, so if anyone could shed some light that would be greatly appreciated. An interesting discussion on a very similar issue can be found at https://github.com/linux-test-project/lcov/issues/341.

For now, suppressing the errors seems to be a suitable temporary solution.

## The errors

```bash
geninfo: ERROR: mismatched end line for _ZN13libsemigroups12_GLOBAL__N_134ns_CATCH2_INTERNAL_TEMPLATE_TEST_131CATCH2_INTERNAL_TEMPLATE_TEST_1IJNS1_8TypeListIJNS_6detail11RewriteTrieEEEENS3_IJNS4_15RewriteFromLeftEEEEEEC2Ev at /home/runner/work/libsemigroups/libsemigroups/tests/test-knuth-bendix-3.cpp:84: 130 -> 84

geninfo: ERROR: Unexpected negative count '-11' for /home/runner/work/libsemigroups/libsemigroups/include/libsemigroups/detail/felsch-graph.tpp:321.
        Perhaps you need to compile with '-fprofile-update=atomic
```