### PR TITLE
Replace some `to_class` functions with `make<Class>`

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -70,13 +70,13 @@ Some more conventions:
 
   * A constructor should be used to construct an object without checking its
     arguments.
-  * A `make` function should be a member of a helper namespace (such as
-    `inverse_presentation` or `blocks`) that is used to construct an object
-    from non-libsemigroups objects such as containers, integers and strings.
-    It should check its arguments.
-  * A `to` function should be a specialisation of a function template that is
-    used to convert from one `libsemigroups` type to another. A typical
-    signature might look something like
+  * A `make` function should be a free function template in the libsemigroups
+    namespace that is used to construct an object from non-libsemigroups
+    objects such as containers, integers and strings. It should check its
+    arguments.
+  * A `to` function should a free function template in the libsemigroups
+    namespace that is used to convert from one `libsemigroups` type to another.
+    A typical signature might look something like
     `to<ToddCoxeter>(Presentation<word_type> p)`. It should check its
     arguments.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -64,10 +64,21 @@ Some more conventions:
   - functions that are (or should be) implemented for all of the public facing
     classes in ``libsemigroups``, such as, for example
     `to_human_readable_repr`
-  - the `to` functions such as `to<Blocks>`, `to<WordGraph>` etc,
-    to avoid the repetition in `blocks::to<Blocks>`, or other functions where
-    the namespace would belong to the function name (like
-    `words::number_of_words`).
+
+* Functions that construct an object must be of one of three types;
+  constructors, `make` functions, or `to` functions:
+
+  * A constructor should be used to construct an object without checking its
+    arguments.
+  * A `make` function should be a member of a helper namespace (such as
+    `inverse_presentation` or `blocks`) that is used to construct an object
+    from non-libsemigroups objects such as containers, integers and strings.
+    It should check its arguments.
+  * A `to` function should be a specialisation of a function template that is
+    used to convert from one `libsemigroups` type to another. A typical
+    signature might look something like
+    `to<ToddCoxeter>(Presentation<word_type> p)`. It should check its
+    arguments.
 
 * The documentation for each function may contain the following section
   indicators in the following order:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -64,8 +64,8 @@ Some more conventions:
   - functions that are (or should be) implemented for all of the public facing
     classes in ``libsemigroups``, such as, for example
     `to_human_readable_repr`
-  - other functions with prefix `to_` such as `to_blocks`, `to_word_graph` etc,
-    to avoid the repetition in `blocks::to_blocks`, or other functions where
+  - the `to` functions such as `to<Blocks>`, `to<WordGraph>` etc,
+    to avoid the repetition in `blocks::to<Blocks>`, or other functions where
     the namespace would belong to the function name (like
     `words::number_of_words`).
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -26,7 +26,7 @@ Object                Convention
 class                 NamedLikeThis
 struct                NamedLikeThis
 function              named\_like\_this
-enum class            namedlikethis 
+enum class            namedlikethis
 enum class member     named_like_this
 stateful type alias   named\_like\_this\_type
 stateless type alias  LikeThis
@@ -43,7 +43,7 @@ Some more conventions:
   functions), then it must have the suffix `_no_checks` if there is any
   possibility that the function will fail. This indicates that anything may
   happen if the function is called on a non-valid object or for non-valid
-  arguments. 
+  arguments.
 
   In the python bindings ``libsemigroups_pybind11`` it should not be possible
   to construct or modify an object so that it is invalid. For example, it
@@ -52,13 +52,13 @@ Some more conventions:
   `Bipartition::rank_no_checks` member function as if it was the
   `Bipartition::rank` function. Hence in the python bindings we bind a
   functions called `Bipartition.rank` to the C++ function
-  `Bipartition::rank_no_checks`. 
+  `Bipartition::rank_no_checks`.
 
 * All class helper functions (i.e. those free functions taking a class as an
   argument, and using public member functions of that class) should be in a
-  helper namespace with the same name as the class (but in lower case). I.e. 
+  helper namespace with the same name as the class (but in lower case). I.e.
   `bipartition::one`, or `ptransf::one`. Exceptions are:
-  
+
   - operators such as `operator*` etc. This is because these are more or less
     difficult to use if they are in a nested namespace.
   - functions that are (or should be) implemented for all of the public facing
@@ -84,19 +84,19 @@ Some more conventions:
 Debugging and valgrinding
 -------------------------
 
-To run `lldb`: 
+To run `lldb`:
 
 .. code-block:: bash
 
-    ./configure --enable-debug && make test_all 
-    libtool --mode=execute lldb test_all 
+    ./configure --enable-debug && make test_all
+    libtool --mode=execute lldb test_all
 
 `test_all` is the name of the check program produced by `make check`. Similarly
 to run valgrind you have to do:
 
 .. code-block:: bash
 
-    ./configure --enable-debug --disable-hpcombi && make test_all 
+    ./configure --enable-debug --disable-hpcombi && make test_all
     libtool --mode=execute valgrind --leak-check=full ./test_all [quick] 2>&1 | tee --append valgrind.txt
 
 Adding new test cases
@@ -105,14 +105,14 @@ Adding new test cases
 Any new tests should be tagged with one of the following:
 
 ========  =======
-Tag       Runtime 
+Tag       Runtime
 --------  -------
 quick     < 200ms
 standard  < 3s
 extreme   > 3s
 ========  =======
 
-They should be declared using 
+They should be declared using
 
 .. code-block:: cpp
 
@@ -120,13 +120,13 @@ They should be declared using
 
 "tags" should include "[FilePrefix]" where "FilePrefix" would be
 "cong-pair" in the file "tests/cong-pair.test.cc", if the file prefix is the
-same as "classname", then it should not be included. Tags are case insensitive. 
+same as "classname", then it should not be included. Tags are case insensitive.
 
 Making a release
 ----------------
 
-A ***bugfix release*** is one of the form `x.y.z -> x.y.z+1`, and                
-a ***non-bugfix release*** is one of the form `x.y.z -> x+1.y.z` or `x.y+1.z`. 
+A ***bugfix release*** is one of the form `x.y.z -> x.y.z+1`, and
+a ***non-bugfix release*** is one of the form `x.y.z -> x+1.y.z` or `x.y+1.z`.
 
 Use the script `etc/release-libsemigroups.py`.
 

--- a/benchmarks/bench-sims1.cpp
+++ b/benchmarks/bench-sims1.cpp
@@ -55,13 +55,13 @@ namespace libsemigroups {
   TEST_CASE("POI(3) from FroidurePin", "[POI3][Sim1][quick][talk]") {
     auto                  rg = ReportGuard(false);
     FroidurePin<PPerm<3>> S;
-    S.add_generator(to<PPerm<3>>({0, 1, 2}, {0, 1, 2}, 3));
-    S.add_generator(to<PPerm<3>>({1, 2}, {0, 1}, 3));
-    S.add_generator(to<PPerm<3>>({0, 1}, {0, 2}, 3));
-    S.add_generator(to<PPerm<3>>({0, 2}, {1, 2}, 3));
-    S.add_generator(to<PPerm<3>>({0, 1}, {1, 2}, 3));
-    S.add_generator(to<PPerm<3>>({0, 2}, {0, 1}, 3));
-    S.add_generator(to<PPerm<3>>({1, 2}, {0, 2}, 3));
+    S.add_generator(make<PPerm<3>>({0, 1, 2}, {0, 1, 2}, 3));
+    S.add_generator(make<PPerm<3>>({1, 2}, {0, 1}, 3));
+    S.add_generator(make<PPerm<3>>({0, 1}, {0, 2}, 3));
+    S.add_generator(make<PPerm<3>>({0, 2}, {1, 2}, 3));
+    S.add_generator(make<PPerm<3>>({0, 1}, {1, 2}, 3));
+    S.add_generator(make<PPerm<3>>({0, 2}, {0, 1}, 3));
+    S.add_generator(make<PPerm<3>>({1, 2}, {0, 2}, 3));
     REQUIRE(S.size() == 20);
 
     auto p = to_presentation<word_type>(S);
@@ -81,15 +81,15 @@ namespace libsemigroups {
   TEST_CASE("POI(4) from FroidurePin", "[POI4][Sim1][standard]") {
     auto                  rg = ReportGuard(false);
     FroidurePin<PPerm<4>> S;
-    S.add_generator(to<PPerm<4>>({0, 1, 2, 3}, {0, 1, 2, 3}, 4));
-    S.add_generator(to<PPerm<4>>({1, 2, 3}, {0, 1, 2}, 4));
-    S.add_generator(to<PPerm<4>>({0, 1, 2}, {0, 1, 3}, 4));
-    S.add_generator(to<PPerm<4>>({0, 1, 3}, {0, 2, 3}, 4));
-    S.add_generator(to<PPerm<4>>({0, 2, 3}, {1, 2, 3}, 4));
-    S.add_generator(to<PPerm<4>>({0, 1, 2}, {1, 2, 3}, 4));
-    S.add_generator(to<PPerm<4>>({0, 1, 3}, {0, 1, 2}, 4));
-    S.add_generator(to<PPerm<4>>({0, 2, 3}, {0, 1, 3}, 4));
-    S.add_generator(to<PPerm<4>>({1, 2, 3}, {0, 2, 3}, 4));
+    S.add_generator(make<PPerm<4>>({0, 1, 2, 3}, {0, 1, 2, 3}, 4));
+    S.add_generator(make<PPerm<4>>({1, 2, 3}, {0, 1, 2}, 4));
+    S.add_generator(make<PPerm<4>>({0, 1, 2}, {0, 1, 3}, 4));
+    S.add_generator(make<PPerm<4>>({0, 1, 3}, {0, 2, 3}, 4));
+    S.add_generator(make<PPerm<4>>({0, 2, 3}, {1, 2, 3}, 4));
+    S.add_generator(make<PPerm<4>>({0, 1, 2}, {1, 2, 3}, 4));
+    S.add_generator(make<PPerm<4>>({0, 1, 3}, {0, 1, 2}, 4));
+    S.add_generator(make<PPerm<4>>({0, 2, 3}, {0, 1, 3}, 4));
+    S.add_generator(make<PPerm<4>>({1, 2, 3}, {0, 2, 3}, 4));
     REQUIRE(S.size() == 70);
 
     auto p = to_presentation<word_type>(S);
@@ -374,9 +374,9 @@ namespace libsemigroups {
             "[full_transf_monoid][length][002]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<4>> S;
-    S.add_generator(to<Transf<4>>({1, 2, 3, 0}));
-    S.add_generator(to<Transf<4>>({1, 0, 2, 3}));
-    S.add_generator(to<Transf<4>>({0, 1, 2, 0}));
+    S.add_generator(make<Transf<4>>({1, 2, 3, 0}));
+    S.add_generator(make<Transf<4>>({1, 0, 2, 3}));
+    S.add_generator(make<Transf<4>>({0, 1, 2, 0}));
     REQUIRE(S.size() == 256);
     auto p = to_presentation<word_type>(S);
     bench_length(p);
@@ -408,26 +408,26 @@ namespace libsemigroups {
     auto rg = ReportGuard(false);
 
     FroidurePin<PPerm<10>> S;
-    S.add_generator(to<PPerm<10>>({1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
-    S.add_generator(to<PPerm<10>>(
+    S.add_generator(make<PPerm<10>>({1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
+    S.add_generator(make<PPerm<10>>(
         {1, 2, 3, 4, 5, 6, 7, 8, 9}, {1, 2, 3, 4, 5, 6, 7, 8, 9}, 10));
-    S.add_generator(to<PPerm<10>>(
+    S.add_generator(make<PPerm<10>>(
         {0, 2, 3, 4, 5, 6, 7, 8, 9}, {0, 2, 3, 4, 5, 6, 7, 8, 9}, 10));
-    S.add_generator(to<PPerm<10>>(
+    S.add_generator(make<PPerm<10>>(
         {0, 1, 3, 4, 5, 6, 7, 8, 9}, {0, 1, 3, 4, 5, 6, 7, 8, 9}, 10));
-    S.add_generator(to<PPerm<10>>(
+    S.add_generator(make<PPerm<10>>(
         {0, 1, 2, 4, 5, 6, 7, 8, 9}, {0, 1, 2, 4, 5, 6, 7, 8, 9}, 10));
-    S.add_generator(to<PPerm<10>>(
+    S.add_generator(make<PPerm<10>>(
         {0, 1, 2, 3, 5, 6, 7, 8, 9}, {0, 1, 2, 3, 5, 6, 7, 8, 9}, 10));
-    S.add_generator(to<PPerm<10>>(
+    S.add_generator(make<PPerm<10>>(
         {0, 1, 2, 3, 4, 6, 7, 8, 9}, {0, 1, 2, 3, 4, 6, 7, 8, 9}, 10));
-    S.add_generator(to<PPerm<10>>(
+    S.add_generator(make<PPerm<10>>(
         {0, 1, 2, 3, 4, 5, 7, 8, 9}, {0, 1, 2, 3, 4, 5, 7, 8, 9}, 10));
-    S.add_generator(to<PPerm<10>>(
+    S.add_generator(make<PPerm<10>>(
         {0, 1, 2, 3, 4, 5, 6, 8, 9}, {0, 1, 2, 3, 4, 5, 6, 8, 9}, 10));
-    S.add_generator(to<PPerm<10>>(
+    S.add_generator(make<PPerm<10>>(
         {0, 1, 2, 3, 4, 5, 6, 7, 9}, {0, 1, 2, 3, 4, 5, 6, 7, 9}, 10));
-    S.add_generator(to<PPerm<10>>(
+    S.add_generator(make<PPerm<10>>(
         {0, 1, 2, 3, 4, 5, 6, 7, 8}, {0, 1, 2, 3, 4, 5, 6, 7, 8}, 10));
 
     size_t n = 10;
@@ -441,8 +441,8 @@ namespace libsemigroups {
     auto rg = ReportGuard(false);
 
     FroidurePin<PPerm<10>> S;
-    S.add_generator(to<PPerm<10>>({1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
-    S.add_generator(to<PPerm<10>>(
+    S.add_generator(make<PPerm<10>>({1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
+    S.add_generator(make<PPerm<10>>(
         {1, 2, 3, 4, 5, 6, 7, 8, 9}, {1, 2, 3, 4, 5, 6, 7, 8, 9}, 10));
 
     size_t n = 10;
@@ -546,7 +546,7 @@ namespace libsemigroups {
   TEST_CASE("Catalan monoid n = 1 - all", "[catalan][n=1]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<1>> S;
-    S.add_generator(to<Transf<1>>({0}));
+    S.add_generator(make<Transf<1>>({0}));
     REQUIRE(S.size() == 1);
     auto p = to_presentation<word_type>(S);
 
@@ -560,8 +560,8 @@ namespace libsemigroups {
   TEST_CASE("Catalan monoid n = 2 - all", "[catalan][n=2]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<2>> S;
-    S.add_generator(to<Transf<2>>({0, 1}));
-    S.add_generator(to<Transf<2>>({0, 0}));
+    S.add_generator(make<Transf<2>>({0, 1}));
+    S.add_generator(make<Transf<2>>({0, 0}));
     REQUIRE(S.size() == 2);
     auto p = to_presentation<word_type>(S);
 
@@ -575,9 +575,9 @@ namespace libsemigroups {
   TEST_CASE("Catalan monoid n = 3 - all", "[catalan][n=3]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<3>> S;
-    S.add_generator(to<Transf<3>>({0, 1, 2}));
-    S.add_generator(to<Transf<3>>({0, 0, 2}));
-    S.add_generator(to<Transf<3>>({0, 1, 1}));
+    S.add_generator(make<Transf<3>>({0, 1, 2}));
+    S.add_generator(make<Transf<3>>({0, 0, 2}));
+    S.add_generator(make<Transf<3>>({0, 1, 1}));
     REQUIRE(S.size() == 5);
     auto p = to_presentation<word_type>(S);
 
@@ -591,10 +591,10 @@ namespace libsemigroups {
   TEST_CASE("Catalan monoid n = 4 - all", "[catalan][n=4]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<4>> S;
-    S.add_generator(to<Transf<4>>({0, 1, 2, 3}));
-    S.add_generator(to<Transf<4>>({0, 0, 2, 3}));
-    S.add_generator(to<Transf<4>>({0, 1, 1, 3}));
-    S.add_generator(to<Transf<4>>({0, 1, 2, 2}));
+    S.add_generator(make<Transf<4>>({0, 1, 2, 3}));
+    S.add_generator(make<Transf<4>>({0, 0, 2, 3}));
+    S.add_generator(make<Transf<4>>({0, 1, 1, 3}));
+    S.add_generator(make<Transf<4>>({0, 1, 2, 2}));
     REQUIRE(S.size() == 14);
     auto p = to_presentation<word_type>(S);
 
@@ -608,11 +608,11 @@ namespace libsemigroups {
   TEST_CASE("Catalan monoid n = 5 - all", "[catalan][n=5]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<5>> S;
-    S.add_generator(to<Transf<5>>({0, 1, 2, 3, 4}));
-    S.add_generator(to<Transf<5>>({0, 0, 2, 3, 4}));
-    S.add_generator(to<Transf<5>>({0, 1, 1, 3, 4}));
-    S.add_generator(to<Transf<5>>({0, 1, 2, 2, 4}));
-    S.add_generator(to<Transf<5>>({0, 1, 2, 3, 3}));
+    S.add_generator(make<Transf<5>>({0, 1, 2, 3, 4}));
+    S.add_generator(make<Transf<5>>({0, 0, 2, 3, 4}));
+    S.add_generator(make<Transf<5>>({0, 1, 1, 3, 4}));
+    S.add_generator(make<Transf<5>>({0, 1, 2, 2, 4}));
+    S.add_generator(make<Transf<5>>({0, 1, 2, 3, 3}));
     REQUIRE(S.size() == 42);
     auto p = to_presentation<word_type>(S);
 
@@ -638,9 +638,9 @@ namespace libsemigroups {
   TEST_CASE("Order endomorphisms n = 2 - all", "[order_endos][n=2]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<2>> S;
-    S.add_generator(to<Transf<2>>({0, 1}));
-    S.add_generator(to<Transf<2>>({0, 0}));
-    S.add_generator(to<Transf<2>>({1, 1}));
+    S.add_generator(make<Transf<2>>({0, 1}));
+    S.add_generator(make<Transf<2>>({0, 0}));
+    S.add_generator(make<Transf<2>>({1, 1}));
     REQUIRE(S.size() == 3);
 
     Sims1 C;

--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -234,6 +234,7 @@
       <publictypes title="" />
       <publicmethods title="" />
       <publicstaticmethods title="" />
+      <related title="" subtitle=""/>
       <!--
       <services title=""/>
       <interfaces title=""/>
@@ -261,7 +262,6 @@
       <privateattributes title=""/>
       <privatestaticattributes title=""/>
       <friends title=""/>
-      <related title="" subtitle=""/>
       <membergroups visible="yes"/>
       -->
     </memberdecl>

--- a/include/libsemigroups/bipart.hpp
+++ b/include/libsemigroups/bipart.hpp
@@ -734,7 +734,8 @@ namespace libsemigroups {
   //! it.
   //!
   //! \tparam Container the type of the parameter \p cont.
-  //! \tparam Return the return type.
+  //! \tparam Return the return type. Must satisfy
+  //! `std::is_same<Return, Blocks>`.
   //!
   //! \param cont container containing a lookup for the blocks.
   //!
@@ -744,7 +745,7 @@ namespace libsemigroups {
   //! \throws LibsemigroupsException if the constructed Blocks object is not
   //! valid.
   template <typename Return, typename Container>
-  [[nodiscard]] enable_if_is_same<Return, Blocks> to(Container const& cont) {
+  [[nodiscard]] enable_if_is_same<Return, Blocks> make(Container const& cont) {
     detail::validate_args<Blocks>(cont);
     Blocks result(cont);
     blocks::validate(result);
@@ -756,7 +757,8 @@ namespace libsemigroups {
   //! \brief Validate the arguments, construct a Blocks object, and validate
   //! it.
   //!
-  //! \tparam Return the return type.
+  //! \tparam Return the return type. Must satisfy
+  //! `std::is_same<Return, Blocks>`.
   //!
   //! \param cont container containing a lookup for the blocks.
   //!
@@ -767,8 +769,8 @@ namespace libsemigroups {
   //! valid.
   template <typename Return>
   [[nodiscard]] enable_if_is_same<Return, Blocks>
-  to(std::initializer_list<std::vector<int32_t>> const& cont) {
-    return to<Blocks, std::initializer_list<std::vector<int32_t>>>(cont);
+  make(std::initializer_list<std::vector<int32_t>> const& cont) {
+    return make<Blocks, std::initializer_list<std::vector<int32_t>>>(cont);
   }
 
   //! \brief Return a human readable representation of a blocks object.
@@ -1466,8 +1468,9 @@ namespace libsemigroups {
   //!
   //! \brief Validate the arguments, construct a bipartition, and validate it.
   //!
-  //! \tparam T the type of the parameter \p cont.
-  //! \tparam Return the return type.
+  //! \tparam Container the type of the parameter \p cont.
+  //! \tparam Return the return type. Must satisfy
+  //! `std::is_same<Return, Bipartition>`.
   //!
   //! \param cont either a vector providing a lookup for the blocks of the
   //! bipartition or a vector of vectors (or initializer list).
@@ -1479,7 +1482,7 @@ namespace libsemigroups {
   //! valid.
   template <typename Return, typename Container>
   [[nodiscard]] enable_if_is_same<Return, Bipartition>
-  to(Container const& cont) {
+  make(Container const& cont) {
     detail::validate_args<Bipartition>(cont);
     Bipartition result(cont);
     bipartition::validate(result);
@@ -1490,20 +1493,20 @@ namespace libsemigroups {
   //!
   //! \brief Validate the arguments, construct a bipartition, and validate it.
   //!
-  //! \copydoc to(Container const&)
+  //! \copydoc make(Container const&)
   template <typename Return>
   [[nodiscard]] enable_if_is_same<Return, Bipartition>
-  to(std::initializer_list<uint32_t> const& cont) {
-    return to<Bipartition, std::initializer_list<uint32_t>>(cont);
+  make(std::initializer_list<uint32_t> const& cont) {
+    return make<Bipartition, std::initializer_list<uint32_t>>(cont);
   }
 
   //! \relates Bipartition
   //!
-  //! \copydoc to(Container const&)
+  //! \copydoc make(Container const&)
   template <typename Return>
   [[nodiscard]] enable_if_is_same<Return, Bipartition>
-  to(std::initializer_list<std::vector<int32_t>> const& cont) {
-    return to<Bipartition, std::initializer_list<std::vector<int32_t>>>(cont);
+  make(std::initializer_list<std::vector<int32_t>> const& cont) {
+    return make<Bipartition, std::initializer_list<std::vector<int32_t>>>(cont);
   }
 
   //! \ingroup bipart_group

--- a/include/libsemigroups/bipart.hpp
+++ b/include/libsemigroups/bipart.hpp
@@ -734,6 +734,7 @@ namespace libsemigroups {
   //! it.
   //!
   //! \tparam Container the type of the parameter \p cont.
+  //! \tparam Return the return type.
   //!
   //! \param cont container containing a lookup for the blocks.
   //!
@@ -752,9 +753,20 @@ namespace libsemigroups {
 
   //! \relates Blocks
   //!
-  //! \copydoc to(Container const&)
-  template <typename Thing>
-  [[nodiscard]] enable_if_is_same<Thing, Blocks>
+  //! \brief Validate the arguments, construct a Blocks object, and validate
+  //! it.
+  //!
+  //! \tparam Return the return type.
+  //!
+  //! \param cont container containing a lookup for the blocks.
+  //!
+  //! \throws LibsemigroupsException if the arguments do not describe a
+  //! signed partition.
+  //!
+  //! \throws LibsemigroupsException if the constructed Blocks object is not
+  //! valid.
+  template <typename Return>
+  [[nodiscard]] enable_if_is_same<Return, Blocks>
   to(std::initializer_list<std::vector<int32_t>> const& cont) {
     return to<Blocks, std::initializer_list<std::vector<int32_t>>>(cont);
   }
@@ -1454,7 +1466,8 @@ namespace libsemigroups {
   //!
   //! \brief Validate the arguments, construct a bipartition, and validate it.
   //!
-  //! \tparam T the type of the parameter \p cont
+  //! \tparam T the type of the parameter \p cont.
+  //! \tparam Return the return type.
   //!
   //! \param cont either a vector providing a lookup for the blocks of the
   //! bipartition or a vector of vectors (or initializer list).
@@ -1477,7 +1490,7 @@ namespace libsemigroups {
   //!
   //! \brief Validate the arguments, construct a bipartition, and validate it.
   //!
-  //! See `to<Bipartition>(Container const&)` for full details.
+  //! \copydoc to(Container const&)
   template <typename Return>
   [[nodiscard]] enable_if_is_same<Return, Bipartition>
   to(std::initializer_list<uint32_t> const& cont) {
@@ -1486,9 +1499,7 @@ namespace libsemigroups {
 
   //! \relates Bipartition
   //!
-  //! \brief Validate the arguments, construct a bipartition, and validate it.
-  //!
-  //! See `to<Bipartition>(Container const&)` for full details.
+  //! \copydoc to(Container const&)
   template <typename Return>
   [[nodiscard]] enable_if_is_same<Return, Bipartition>
   to(std::initializer_list<std::vector<int32_t>> const& cont) {

--- a/include/libsemigroups/bipart.hpp
+++ b/include/libsemigroups/bipart.hpp
@@ -39,6 +39,7 @@
 #include "adapters.hpp"   // for Hash
 #include "debug.hpp"      // for LIBSEMIGROUPS_ASSERT
 #include "exception.hpp"  // for LIBSEMIGROUPS_EXCEPTION
+#include "types.hpp"      // for enable_if_is_same
 
 #include "detail/fmt.hpp"
 
@@ -727,7 +728,7 @@ namespace libsemigroups {
     void throw_if_class_index_out_of_range(size_t index) const;
   };  // class Blocks
 
-  //! \ingroup bipart_group
+  //! \relates Blocks
   //!
   //! \brief Validate the arguments, construct a Blocks object, and validate
   //! it.
@@ -741,20 +742,23 @@ namespace libsemigroups {
   //!
   //! \throws LibsemigroupsException if the constructed Blocks object is not
   //! valid.
-  template <typename Container>
-  [[nodiscard]] Blocks to_blocks(Container const& cont) {
+  template <typename Return, typename Container>
+  [[nodiscard]] enable_if_is_same<Return, Blocks> to(Container const& cont) {
     detail::validate_args<Blocks>(cont);
     Blocks result(cont);
     blocks::validate(result);
     return result;
   }
 
-  //! \copydoc to_blocks(Container const&)
-  [[nodiscard]] Blocks
-  to_blocks(std::initializer_list<std::vector<int32_t>> const& cont);
-
-  //! \ingroup bipart_group
+  //! \relates Blocks
   //!
+  //! \copydoc to(Container const&)
+  template <typename Thing>
+  [[nodiscard]] enable_if_is_same<Thing, Blocks>
+  to(std::initializer_list<std::vector<int32_t>> const& cont) {
+    return to<Blocks, std::initializer_list<std::vector<int32_t>>>(cont);
+  }
+
   //! \brief Return a human readable representation of a blocks object.
   //!
   //! Return a human readable representation (std::string) of a Blocks object.
@@ -1446,6 +1450,8 @@ namespace libsemigroups {
     void init_trans_blocks_lookup() const;
   };  // class Bipartition
 
+  //! \relates Bipartition
+  //!
   //! \brief Validate the arguments, construct a bipartition, and validate it.
   //!
   //! \tparam T the type of the parameter \p cont
@@ -1458,25 +1464,36 @@ namespace libsemigroups {
   //!
   //! \throws LibsemigroupsException if the constructed bipartition is not
   //! valid.
-  template <typename T>
-  [[nodiscard]] static Bipartition to_bipartition(T const& cont) {
+  template <typename Return, typename Container>
+  [[nodiscard]] enable_if_is_same<Return, Bipartition>
+  to(Container const& cont) {
     detail::validate_args<Bipartition>(cont);
     Bipartition result(cont);
     bipartition::validate(result);
     return result;
   }
 
+  //! \relates Bipartition
+  //!
   //! \brief Validate the arguments, construct a bipartition, and validate it.
   //!
-  //! See to_bipartition(T const&) for full details.
-  [[nodiscard]] Bipartition
-  to_bipartition(std::initializer_list<uint32_t> const& cont);
+  //! See `to<Bipartition>(Container const&)` for full details.
+  template <typename Return>
+  [[nodiscard]] enable_if_is_same<Return, Bipartition>
+  to(std::initializer_list<uint32_t> const& cont) {
+    return to<Bipartition, std::initializer_list<uint32_t>>(cont);
+  }
 
+  //! \relates Bipartition
+  //!
   //! \brief Validate the arguments, construct a bipartition, and validate it.
   //!
-  //! See to_bipartition(T const&) for full details.
-  [[nodiscard]] Bipartition
-  to_bipartition(std::initializer_list<std::vector<int32_t>> const& cont);
+  //! See `to<Bipartition>(Container const&)` for full details.
+  template <typename Return>
+  [[nodiscard]] enable_if_is_same<Return, Bipartition>
+  to(std::initializer_list<std::vector<int32_t>> const& cont) {
+    return to<Bipartition, std::initializer_list<std::vector<int32_t>>>(cont);
+  }
 
   //! \ingroup bipart_group
   //!

--- a/include/libsemigroups/forest.hpp
+++ b/include/libsemigroups/forest.hpp
@@ -442,7 +442,7 @@ namespace libsemigroups {
   [[nodiscard]] Forest to_forest(std::initializer_list<size_t> parent,
                                  std::initializer_list<size_t> edge_labels);
 
-  //! \ingroup word_graph_group
+  //! \relates Forest
   //!
   //! \brief Return a human readable representation of a Forest object.
   //!

--- a/include/libsemigroups/forest.hpp
+++ b/include/libsemigroups/forest.hpp
@@ -335,10 +335,10 @@ namespace libsemigroups {
     }
 
     //! \brief Modifies \p w to contain the labels of the edges on the path
-    //! from a root node to \p i.
+    //! to a root node from \p i.
     //!
     //! This function modifies its first argument \p w in-place to contain the
-    //! labels of the edges on the path from a root node to node \p i.
+    //! labels of the edges on the path to a root node from node \p i.
     //!
     //! \param w value to contain the result.
     //! \param i the node.
@@ -347,6 +347,21 @@ namespace libsemigroups {
     // TODO(0) to helper
     void path_to_root_no_checks(word_type& w, node_type i) const;
 
+    //! \brief Store the labels of the edges on the path to a root node from \p
+    //! i.
+    //!
+    //! This function writes labels of the edges on the path to a root node from
+    //! node \p i to the iterator \p d_first.
+    //!
+    //! \tparam Iterator The type of the parameter, and the return type.
+    //!
+    //! \param d_first the output iterator.
+    //! \param i the node.
+    //!
+    //! \returns An \c Iterator pointing one beyond the last letter inserted
+    //! into \p d_first.
+    //!
+    //! \warning No checks are performed on the arguments of this function.
     template <typename Iterator>
     Iterator path_to_root_no_checks(Iterator d_first, node_type i) const {
       auto it = d_first;
@@ -359,10 +374,10 @@ namespace libsemigroups {
     }
 
     //! \brief Returns a word containing the labels of the edges on the path
-    //! from a root node to \p i.
+    //! to a root node from \p i.
     //!
     //! This function returns a word containing the labels of the edges on the
-    //! path from a root node to node \p i.
+    //! path to a root node from node \p i.
     //!
     //! \param i the node.
     //!
@@ -377,10 +392,10 @@ namespace libsemigroups {
     }
 
     //! \brief Modifies \p w to contain the labels of the edges on the path
-    //! from a root node to \p i.
+    //! to a root node from \p i.
     //!
     //! This function modifies its first argument \p w in-place to contain the
-    //! labels of the edges on the path from a root node to node \p i.
+    //! labels of the edges on the path to a root node from node \p i.
     //!
     //! \param w value to contain the result.
     //! \param i the node.
@@ -393,10 +408,10 @@ namespace libsemigroups {
     }
 
     //! \brief Returns a word containing the labels of the edges on the path
-    //! from a root node to \p i.
+    //! to a root node from \p i.
     //!
     //! This function returns a word containing the labels of the edges on the
-    //! path from a root node to node \p i.
+    //! path to a root node from node \p i.
     //!
     //! \param i the node.
     //!

--- a/include/libsemigroups/forest.hpp
+++ b/include/libsemigroups/forest.hpp
@@ -435,7 +435,8 @@ namespace libsemigroups {
   //!
   //! This function constructs a Forest from vector of parents and labels.
   //!
-  //! \tparam Return the return type.
+  //! \tparam Return the return type. Must satisfy
+  //! `std::is_same<Return, Forest>`.
   //!
   //! \param parent the vector of parents of nodes in the Forest.
   //! \param edge_labels the vector of edge labels in the Forest.
@@ -452,7 +453,7 @@ namespace libsemigroups {
   //! for any value of `i`.
   template <typename Return>
   [[nodiscard]] enable_if_is_same<Return, Forest>
-  to(std::vector<size_t> parent, std::vector<size_t> edge_labels) {
+  make(std::vector<size_t> parent, std::vector<size_t> edge_labels) {
     if (parent.size() != edge_labels.size()) {
       LIBSEMIGROUPS_EXCEPTION(
           "expected the 1st and 2nd arguments (parents and edge labels) to "
@@ -487,7 +488,8 @@ namespace libsemigroups {
   //! This function constructs a Forest from initializer lists of parents and
   //! labels.
   //!
-  //! \tparam Return the return type.
+  //! \tparam Return the return type. Must satisfy
+  //! `std::is_same<Return, Forest>`.
   //!
   //! \param parent the initializer list of parents of nodes in the Forest.
   //! \param edge_labels the initializer list of edge labels in the Forest.
@@ -504,9 +506,9 @@ namespace libsemigroups {
   //! for any value of `i`.
   template <typename Return>
   [[nodiscard]] enable_if_is_same<Return, Forest>
-  to(std::initializer_list<size_t> parent,
-     std::initializer_list<size_t> edge_labels) {
-    return to<Forest>(std::vector<size_t>(parent), std::vector(edge_labels));
+  make(std::initializer_list<size_t> parent,
+       std::initializer_list<size_t> edge_labels) {
+    return make<Forest>(std::vector<size_t>(parent), std::vector(edge_labels));
   }
 
   //! \relates Forest

--- a/include/libsemigroups/matrix.hpp
+++ b/include/libsemigroups/matrix.hpp
@@ -7890,8 +7890,7 @@ namespace libsemigroups {
   template <typename Mat,
             typename
             = std::enable_if_t<IsMatrix<Mat> && !IsMatWithSemiring<Mat>>>
-  Mat to_matrix(
-      std::vector<std::vector<typename Mat::scalar_type>> const& rows) {
+  Mat make(std::vector<std::vector<typename Mat::scalar_type>> const& rows) {
     detail::throw_if_any_row_wrong_size(rows);
     Mat m(rows);
     matrix::throw_if_bad_entry(m);
@@ -7926,11 +7925,9 @@ namespace libsemigroups {
   template <typename Mat,
             typename
             = std::enable_if_t<IsMatrix<Mat> && !IsMatWithSemiring<Mat>>>
-  Mat to_matrix(
-      std::initializer_list<std::vector<typename Mat::scalar_type>> const&
-          rows) {
-    return to_matrix<Mat>(
-        std::vector<std::vector<typename Mat::scalar_type>>(rows));
+  Mat make(std::initializer_list<std::vector<typename Mat::scalar_type>> const&
+               rows) {
+    return make<Mat>(std::vector<std::vector<typename Mat::scalar_type>>(rows));
   }
 
   //! \ingroup matrix_group
@@ -7962,7 +7959,7 @@ namespace libsemigroups {
   template <typename Mat,
             typename
             = std::enable_if_t<IsMatrix<Mat> && !IsMatWithSemiring<Mat>>>
-  Mat to_matrix(std::initializer_list<typename Mat::scalar_type> const& row) {
+  Mat make(std::initializer_list<typename Mat::scalar_type> const& row) {
     Mat m(row);
     matrix::throw_if_bad_entry(m);
     return m;
@@ -8005,10 +8002,9 @@ namespace libsemigroups {
             typename = std::enable_if_t<IsMatrix<Mat>>>
   // TODO(1) pass Semiring by reference, this is hard mostly due to the way the
   // tests are written, which is not optimal.
-  Mat to_matrix(
-      Semiring const* semiring,
-      std::initializer_list<
-          std::initializer_list<typename Mat::scalar_type>> const& rows) {
+  Mat make(Semiring const* semiring,
+           std::initializer_list<
+               std::initializer_list<typename Mat::scalar_type>> const& rows) {
     Mat m(semiring, rows);
     matrix::throw_if_bad_entry(m);
     return m;
@@ -8048,9 +8044,8 @@ namespace libsemigroups {
   template <typename Mat,
             typename Semiring,
             typename = std::enable_if_t<IsMatrix<Mat>>>
-  Mat to_matrix(
-      Semiring const*                                            semiring,
-      std::vector<std::vector<typename Mat::scalar_type>> const& rows) {
+  Mat make(Semiring const*                                            semiring,
+           std::vector<std::vector<typename Mat::scalar_type>> const& rows) {
     Mat m(semiring, rows);
     matrix::throw_if_bad_entry(m);
     return m;
@@ -8081,8 +8076,8 @@ namespace libsemigroups {
   template <typename Mat,
             typename Semiring,
             typename = std::enable_if_t<IsMatrix<Mat>>>
-  Mat to_matrix(Semiring const* semiring,
-                std::initializer_list<typename Mat::scalar_type> const& row) {
+  Mat make(Semiring const*                                         semiring,
+           std::initializer_list<typename Mat::scalar_type> const& row) {
     Mat m(semiring, row);
     matrix::throw_if_bad_entry(m);
     return m;
@@ -8117,9 +8112,9 @@ namespace libsemigroups {
   //! number of columns of the matrix.
   template <size_t R, size_t C, typename Scalar>
   ProjMaxPlusMat<R, C, Scalar>
-  to_matrix(std::initializer_list<std::initializer_list<Scalar>> const& rows) {
+  make(std::initializer_list<std::initializer_list<Scalar>> const& rows) {
     return ProjMaxPlusMat<R, C, Scalar>(
-        to_matrix<ProjMaxPlusMat<R, C, Scalar>::underlying_matrix_type>(rows));
+        make<ProjMaxPlusMat<R, C, Scalar>::underlying_matrix_type>(rows));
   }
 
   ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/ranges.hpp
+++ b/include/libsemigroups/ranges.hpp
@@ -83,7 +83,7 @@ namespace libsemigroups {
   //!
   //! \par Example
   //! \code
-  //! auto wg = to<WordGraph<uint8_t>>(4, [[0, 1], [1, 0], [2, 2]]);
+  //! auto wg = make<WordGraph<uint8_t>>(4, [[0, 1], [1, 0], [2, 2]]);
   //! Paths p(wg);
   //! p.source(0).max(10);
   //! p.count();            // returns 1023

--- a/include/libsemigroups/ranges.hpp
+++ b/include/libsemigroups/ranges.hpp
@@ -83,7 +83,7 @@ namespace libsemigroups {
   //!
   //! \par Example
   //! \code
-  //! auto wg = to_word_graph(4, [[0, 1], [1, 0], [2, 2]]);
+  //! auto wg = to<WordGraph<uint8_t>>(4, [[0, 1], [1, 0], [2, 2]]);
   //! Paths p(wg);
   //! p.source(0).max(10);
   //! p.count();            // returns 1023

--- a/include/libsemigroups/sims.hpp
+++ b/include/libsemigroups/sims.hpp
@@ -3015,7 +3015,7 @@ namespace libsemigroups {
   //! \brief For pruning the search tree when looking for congruences arising
   //! from right or two-sided congruences representing faithful actions.
   //!
-  //! Defined in ``sims.hpp``.
+  //! Defined in `sims.hpp`.
   //!
   //! This class provides a pruner for pruning the search tree when looking for
   //! right congruences representing faithful actions. A right congruence

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -1109,7 +1109,7 @@ namespace libsemigroups {
   void validate(Transf<N, Scalar> const& f);
 
   ////////////////////////////////////////////////////////////////////////
-  // to<Transf>
+  // make<Transf>
   ////////////////////////////////////////////////////////////////////////
 
   //! \relates Transf
@@ -1121,7 +1121,7 @@ namespace libsemigroups {
   //! follows: the image of the point \c i under the transformation is the value
   //! in position \c i of the container \p cont.
   //!
-  //! \tparam Return the return type.
+  //! \tparam Return the return type. Must satisfy \ref IsTransf<Return>.
   //! \tparam OtherContainer universal reference for the type of the container.
   //!
   //! \param cont the container.
@@ -1129,14 +1129,14 @@ namespace libsemigroups {
   //! \returns A \ref Transf instance with degree \c N.
   //!
   //! \throw LibsemigroupsException if any of the following hold:
-  //! * the size of \p cont is incompatible with \ref container_type.
+  //! * the size of \p cont is incompatible with \ref Transf::container_type.
   //! * any value in \p cont exceeds `cont.size()`.
   //!
   //! \complexity
   //! Linear in the size of the container \p cont.
   template <typename Return, typename OtherContainer>
   [[nodiscard]] std::enable_if_t<IsTransf<Return>, Return>
-  to(OtherContainer&& cont) {
+  make(OtherContainer&& cont) {
     return Return::template make<Return>(std::forward<OtherContainer>(cont));
   }
 
@@ -1148,7 +1148,7 @@ namespace libsemigroups {
   //! follows: the image of the point \c i under the transformation is the value
   //! in position \c i of the container \p cont.
   //!
-  //! \tparam Return the return type.
+  //! \tparam Return the return type. Must satisfy \ref IsTransf<Return>.
   //! \tparam OtherContainer universal reference for the type of the container.
   //!
   //! \param cont the container.
@@ -1156,7 +1156,7 @@ namespace libsemigroups {
   //! \returns A \ref Transf instance with degree \c N.
   //!
   //! \throw LibsemigroupsException if any of the following hold:
-  //! * the size of \p cont is incompatible with \ref container_type.
+  //! * the size of \p cont is incompatible with \ref Transf::container_type.
   //! * any value in \p cont exceeds `cont.size()` and is not equal to
   //!   UNDEFINED.
   //! * the value \ref UNDEFINED belongs to \p cont.
@@ -1165,8 +1165,8 @@ namespace libsemigroups {
   //! Linear in the size of the container \p cont.
   template <typename Return, typename OtherScalar>
   [[nodiscard]] std::enable_if_t<IsTransf<Return>, Return>
-  to(std::initializer_list<OtherScalar> cont) {
-    return to<Return, std::initializer_list<OtherScalar>>(std::move(cont));
+  make(std::initializer_list<OtherScalar> cont) {
+    return make<Return, std::initializer_list<OtherScalar>>(std::move(cont));
   }
 
   ////////////////////////////////////////////////////////////////////////
@@ -1379,7 +1379,7 @@ namespace libsemigroups {
   }
 
   ////////////////////////////////////////////////////////////////////////
-  // to<PPerm>
+  // make<PPerm>
   ////////////////////////////////////////////////////////////////////////
 
   //! \relates PPerm
@@ -1391,7 +1391,7 @@ namespace libsemigroups {
   //! follows: the image of the point \c i under the partial permutation is the
   //! value in position \c i of the container \p cont.
   //!
-  //! \tparam Return the return type.
+  //! \tparam Return the return type. Must satisfy \ref IsPPerm<Return>.
   //! \tparam OtherContainer universal reference for the type of the container.
   //!
   //! \param cont the container.
@@ -1399,7 +1399,7 @@ namespace libsemigroups {
   //! \returns A \ref PPerm instance with degree \c N.
   //!
   //! \throw LibsemigroupsException if any of the following hold:
-  //! * the size of \p cont is incompatible with \ref container_type.
+  //! * the size of \p cont is incompatible with \ref PPerm::container_type.
   //! * any value in \p cont exceeds `cont.size()` and is not equal to
   //!   UNDEFINED.
   //!
@@ -1407,7 +1407,7 @@ namespace libsemigroups {
   //! Linear in the size of the container \p cont.
   template <typename Return, typename OtherContainer>
   [[nodiscard]] std::enable_if_t<IsPPerm<Return>, Return>
-  to(OtherContainer&& cont) {
+  make(OtherContainer&& cont) {
     return Return::template make<Return>(std::forward<OtherContainer>(cont));
   }
 
@@ -1419,14 +1419,14 @@ namespace libsemigroups {
   //! follows: the image of the point \c i under the partial permutation is the
   //! value in position \c i of the container \p cont.
   //!
-  //! \tparam Return the return type.
+  //! \tparam Return the return type. Must satisfy \ref IsPPerm<Return>.
   //!
   //! \param cont the container.
   //!
   //! \returns A \ref PPerm instance with degree \c N.
   //!
   //! \throw LibsemigroupsException if any of the following hold:
-  //! * the size of \p cont is incompatible with \ref container_type.
+  //! * the size of \p cont is incompatible with \ref PPerm::container_type.
   //! * any value in \p cont exceeds `cont.size()` and is not equal to
   //!   UNDEFINED.
   //!
@@ -1434,8 +1434,8 @@ namespace libsemigroups {
   //! Linear in the size of the container \p cont.
   template <typename Return>
   [[nodiscard]] std::enable_if_t<IsPPerm<Return>, Return>
-  to(std::initializer_list<typename Return::point_type> cont) {
-    return to<Return, std::initializer_list<typename Return::point_type>>(
+  make(std::initializer_list<typename Return::point_type> cont) {
+    return make<Return, std::initializer_list<typename Return::point_type>>(
         std::move(cont));
   }
 
@@ -1448,7 +1448,7 @@ namespace libsemigroups {
   //! ran[i]` for all \c i and which is \ref UNDEFINED on every other value
   //! in the range \f$[0, M)\f$.
   //!
-  //! \tparam Return the return type.
+  //! \tparam Return the return type. Must satisfy \ref IsPPerm<Return>.
   //!
   //! \param dom the domain
   //! \param ran the range
@@ -1464,9 +1464,9 @@ namespace libsemigroups {
   //! Linear in the size of \p dom.
   template <typename Return>
   [[nodiscard]] std::enable_if_t<IsPPerm<Return>, Return>
-  to(std::vector<typename Return::point_type> const& dom,
-     std::vector<typename Return::point_type> const& ran,
-     size_t                                          M);
+  make(std::vector<typename Return::point_type> const& dom,
+       std::vector<typename Return::point_type> const& ran,
+       size_t                                          M);
 
   //! \relates PPerm
   //!
@@ -1477,7 +1477,7 @@ namespace libsemigroups {
   //! ran[i]` for all \c i and which is \ref UNDEFINED on every other value
   //! in the range \f$[0, M)\f$.
   //!
-  //! \tparam Return the return type.
+  //! \tparam Return the return type. Must satisfy \ref IsPPerm<Return>.
   //!
   //! \param dom the domain
   //! \param ran the range
@@ -1493,12 +1493,12 @@ namespace libsemigroups {
   //! Linear in the size of \p dom.
   template <typename Return>
   [[nodiscard]] std::enable_if_t<IsPPerm<Return>, Return>
-  to(std::initializer_list<typename Return::point_type> dom,
-     std::initializer_list<typename Return::point_type> ran,
-     size_t                                             M) {
-    return to<Return>(std::vector<typename Return::point_type>(dom),
-                      std::vector<typename Return::point_type>(ran),
-                      M);
+  make(std::initializer_list<typename Return::point_type> dom,
+       std::initializer_list<typename Return::point_type> ran,
+       size_t                                             M) {
+    return make<Return>(std::vector<typename Return::point_type>(dom),
+                        std::vector<typename Return::point_type>(ran),
+                        M);
   }
 
   ////////////////////////////////////////////////////////////////////////
@@ -1604,7 +1604,7 @@ namespace libsemigroups {
   }
 
   ////////////////////////////////////////////////////////////////////////
-  // to<Perm>
+  // make<Perm>
   ////////////////////////////////////////////////////////////////////////
 
   //! \relates Perm
@@ -1615,7 +1615,7 @@ namespace libsemigroups {
   //! follows: the image of the point \c i under the permutation is the value in
   //! position \c i of the container \p cont.
   //!
-  //! \tparam Return the return type.
+  //! \tparam Return the return type. Must satisfy \ref IsPerm<Return>.
   //! \tparam OtherContainer universal reference for the type of the container.
   //!
   //! \param cont the container.
@@ -1623,7 +1623,7 @@ namespace libsemigroups {
   //! \returns A \ref Perm instance with degree \c N.
   //!
   //! \throw LibsemigroupsException if any of the following hold:
-  //! * the size of \p cont is incompatible with \ref container_type.
+  //! * the size of \p cont is incompatible with \ref Perm::container_type.
   //! * any value in \p cont exceeds `cont.size()` and is not equal to
   //!   UNDEFINED.
   //! * there are repeated values in \p cont.
@@ -1632,7 +1632,7 @@ namespace libsemigroups {
   //! Linear in the size of the container \p cont.
   template <typename Return, typename OtherContainer>
   [[nodiscard]] std::enable_if_t<IsPerm<Return>, Return>
-  to(OtherContainer&& cont) {
+  make(OtherContainer&& cont) {
     return Return::template make<Return>(std::forward<OtherContainer>(cont));
   }
 
@@ -1644,14 +1644,14 @@ namespace libsemigroups {
   //! follows: the image of the point \c i under the permutation is the value in
   //! position \c i of the container \p cont.
   //!
-  //! \tparam Return the return type.
+  //! \tparam Return the return type. Must satisfy \ref IsPerm<Return>.
   //!
   //! \param cont the container.
   //!
   //! \returns A \ref Perm instance with degree \c N.
   //!
   //! \throw LibsemigroupsException if any of the following hold:
-  //! * the size of \p cont is incompatible with \ref container_type.
+  //! * the size of \p cont is incompatible with \ref Perm::container_type.
   //! * any value in \p cont exceeds `cont.size()` and is not equal to
   //!   UNDEFINED.
   //! * there are repeated values in \p cont.
@@ -1660,8 +1660,8 @@ namespace libsemigroups {
   //! Linear in the size of the container \p cont.
   template <typename Return>
   [[nodiscard]] std::enable_if_t<IsPerm<Return>, Return>
-  to(std::initializer_list<typename Return::point_type> cont) {
-    return to<Return, std::initializer_list<typename Return::point_type>>(
+  make(std::initializer_list<typename Return::point_type> cont) {
+    return make<Return, std::initializer_list<typename Return::point_type>>(
         std::move(cont));
   }
 
@@ -2101,8 +2101,8 @@ namespace libsemigroups {
   };
 
   // T = std::vector<S> or StaticVector1<S, N>
-  //! Specialization of the adapter Rho for instances of Transf<N, Scalar> and
-  //! std::vector<S> or detail::StaticVector1<S, N>
+  //! Specialization of the adapter Rho for instances of `Transf<N, Scalar>` and
+  //! `std::vector<S> or detail::StaticVector1<S, N>`
   //!
   //! \sa Rho.
   template <size_t N, typename Scalar, typename T>

--- a/include/libsemigroups/transf.tpp
+++ b/include/libsemigroups/transf.tpp
@@ -174,9 +174,9 @@ namespace libsemigroups {
 
   template <typename Return>
   [[nodiscard]] std::enable_if_t<IsPPerm<Return>, Return>
-  to(std::vector<typename Return::point_type> const& dom,
-     std::vector<typename Return::point_type> const& ran,
-     size_t const                                    M) {
+  make(std::vector<typename Return::point_type> const& dom,
+       std::vector<typename Return::point_type> const& ran,
+       size_t const                                    M) {
     detail::validate_args(dom, ran, M);
     Return result(dom, ran, M);
     validate(result);

--- a/include/libsemigroups/types.hpp
+++ b/include/libsemigroups/types.hpp
@@ -34,12 +34,21 @@ namespace libsemigroups {
   //!
   //! \ingroup misc_group
   //!
-  //! \brief Documentation for types.
+  //! \brief Documentation for types and aliases.
   //!
   //! This file contains functionality for various types used in
   //! `libsemigroups`.
   //!
   //! @{
+
+  //! \brief Alias equal to the second template parameter if both template
+  //! parameters are equal.
+  //!
+  //! Alias equal to the second template parameter if both template
+  //! parameters are equal.
+  template <typename Given, typename Expected>
+  using enable_if_is_same
+      = std::enable_if_t<std::is_same_v<Given, Expected>, Expected>;
 
   //! \brief Enum to indicate true, false or not currently knowable.
   //!

--- a/include/libsemigroups/word-graph.hpp
+++ b/include/libsemigroups/word-graph.hpp
@@ -2044,7 +2044,7 @@ namespace libsemigroups {
     //!
     //! \par Example
     //! \code
-    //! auto wg = to<WordGraph<uint8_t>>(
+    //! auto wg = make<WordGraph<uint8_t>>(
     //!     5, {{0, 0}, {1, 1}, {2}, {3, 3}});
     //! word_graph::is_strictly_cyclic(wg);  // returns false
     //! \endcode
@@ -2692,7 +2692,7 @@ namespace libsemigroups {
   //! out-degree is specified by the length of the first item
   //! in the 2nd parameter.
   //!
-  //! \tparam Return the return type.
+  //! \tparam Return the return type. Must satisfy \ref IsWordGraph<Return>.
   //!
   //! \param num_nodes the number of nodes in the word graph.
   //! \param targets the targets of the word graph.
@@ -2709,22 +2709,22 @@ namespace libsemigroups {
   //! \par Example
   //! \code
   //! // Construct a word graph with 5 nodes and 10 edges (7 specified)
-  //! to<WordGraph<uint8_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
+  //! make<WordGraph<uint8_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
   //! \endcode
   // Passing the 2nd parameter "targets" by value disambiguates it from the
-  // other to<WordGraph>.
+  // other make<WordGraph>.
   template <typename Return>
   [[nodiscard]] std::enable_if_t<IsWordGraph<Return>, Return>
-  to(size_t                                                         num_nodes,
-     std::initializer_list<std::vector<typename Return::node_type>> targets);
+  make(size_t                                                         num_nodes,
+       std::initializer_list<std::vector<typename Return::node_type>> targets);
 
   //! \relates WordGraph
   //!
-  //! \copydoc to
+  //! \copydoc make
   template <typename Return>
   [[nodiscard]] std::enable_if_t<IsWordGraph<Return>, Return>
-  to(size_t                                                      num_nodes,
-     std::vector<std::vector<typename Return::node_type>> const& targets);
+  make(size_t                                                      num_nodes,
+       std::vector<std::vector<typename Return::node_type>> const& targets);
 
   namespace detail {
     template <typename Subclass>

--- a/include/libsemigroups/word-graph.hpp
+++ b/include/libsemigroups/word-graph.hpp
@@ -45,7 +45,7 @@
 #include "forest.hpp"     // for Forest
 #include "order.hpp"      // for Order
 #include "ranges.hpp"     // for ??
-#include "types.hpp"      // for word_type
+#include "types.hpp"      // for word_type, enable_if_is_same
 
 #include "detail/containers.hpp"  // for DynamicArray2
 #include "detail/int-range.hpp"   // for IntRange
@@ -2044,7 +2044,7 @@ namespace libsemigroups {
     //!
     //! \par Example
     //! \code
-    //! auto wg = to_word_graph<uint8_t>(
+    //! auto wg = to<WordGraph<uint8_t>>(
     //!     5, {{0, 0}, {1, 1}, {2}, {3, 3}});
     //! word_graph::is_strictly_cyclic(wg);  // returns false
     //! \endcode
@@ -2639,9 +2639,28 @@ namespace libsemigroups {
 
   }  // namespace word_graph
 
+  namespace detail {
+
+    template <typename T>
+    struct IsWordGraphHelper : std::false_type {};
+
+    template <typename Node>
+    struct IsWordGraphHelper<WordGraph<Node>> : std::true_type {};
+  }  // namespace detail
+
   //////////////////////////////////////////////////////////////////////////
   // WordGraph - non-member functions
   //////////////////////////////////////////////////////////////////////////
+
+  //! \ingroup word_graph_group
+  //! \brief Helper variable template.
+  //!
+  //! The value of this variable is \c true if the template parameter \p T is
+  //! \ref WordGraph for any template parameters.
+  //!
+  //! \tparam T a type.
+  template <typename T>
+  static constexpr bool IsWordGraph = detail::IsWordGraphHelper<T>::value;
 
   //! \ingroup word_graph_group
   //! Output the edges of a wordGraph to a stream.
@@ -2665,7 +2684,7 @@ namespace libsemigroups {
   template <typename Node>
   std::ostream& operator<<(std::ostream& os, WordGraph<Node> const& wg);
 
-  //! \ingroup word_graph_group
+  //! \relates WordGraph
   //!
   //! \brief Constructs a word graph from a number of nodes and targets.
   //!
@@ -2673,7 +2692,7 @@ namespace libsemigroups {
   //! out-degree is specified by the length of the first item
   //! in the 2nd parameter.
   //!
-  //! \tparam Node the type of the nodes of the word graph.
+  //! \tparam Return the return type.
   //!
   //! \param num_nodes the number of nodes in the word graph.
   //! \param targets the targets of the word graph.
@@ -2690,24 +2709,22 @@ namespace libsemigroups {
   //! \par Example
   //! \code
   //! // Construct a word graph with 5 nodes and 10 edges (7 specified)
-  //! to_word_graph<uint8_t>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
+  //! to<WordGraph<uint8_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
   //! \endcode
   // Passing the 2nd parameter "targets" by value disambiguates it from the
-  // other to_word_graph.
-  template <typename Node>
-  [[nodiscard]] WordGraph<Node>
-  to_word_graph(size_t                                   num_nodes,
-                std::initializer_list<std::vector<Node>> targets);
+  // other to<WordGraph>.
+  template <typename Return>
+  [[nodiscard]] std::enable_if_t<IsWordGraph<Return>, Return>
+  to(size_t                                                         num_nodes,
+     std::initializer_list<std::vector<typename Return::node_type>> targets);
 
-  // clang-format off
-  //! \ingroup word_graph_group
+  //! \relates WordGraph
   //!
-  //! \copydoc to_word_graph(size_t, std::initializer_list<std::vector<Node>> const&)  // NOLINT(whitespace/line_length)
-  // clang-format on
-  template <typename Node>
-  [[nodiscard]] WordGraph<Node>
-  to_word_graph(size_t                                num_nodes,
-                std::vector<std::vector<Node>> const& targets);
+  //! \copydoc to
+  template <typename Return>
+  [[nodiscard]] std::enable_if_t<IsWordGraph<Return>, Return>
+  to(size_t                                                      num_nodes,
+     std::vector<std::vector<typename Return::node_type>> const& targets);
 
   namespace detail {
     template <typename Subclass>

--- a/include/libsemigroups/word-graph.tpp
+++ b/include/libsemigroups/word-graph.tpp
@@ -1406,7 +1406,7 @@ namespace libsemigroups {
   std::enable_if_t<IsWordGraph<Return>, Return>
   to(size_t                                                      num_nodes,
      std::vector<std::vector<typename Return::node_type>> const& edges) {
-    WordGraph<Node> result(num_nodes, edges.begin()->size());
+    Return result(num_nodes, edges.begin()->size());
     for (size_t i = 0; i < edges.size(); ++i) {
       for (size_t j = 0; j < (edges.begin() + i)->size(); ++j) {
         auto val = *((edges.begin() + i)->begin() + j);
@@ -1418,10 +1418,12 @@ namespace libsemigroups {
     return result;
   }
 
-  template <typename Return, typename Node>
+  template <typename Return>
   std::enable_if_t<IsWordGraph<Return>, Return>
-  to(size_t num_nodes, std::initializer_list<std::vector<Node>> il) {
-    return to<WordGraph<Node>>(num_nodes, std::vector<std::vector<Node>>(il));
+  to(size_t                                                         num_nodes,
+     std::initializer_list<std::vector<typename Return::node_type>> il) {
+    return to<Return>(num_nodes,
+                      std::vector<std::vector<typename Return::node_type>>(il));
   }
 
   namespace detail {

--- a/include/libsemigroups/word-graph.tpp
+++ b/include/libsemigroups/word-graph.tpp
@@ -1402,9 +1402,10 @@ namespace libsemigroups {
   }
 
   // TODO(1) refactor to use vectors api, not initializer_list
-  template <typename Node>
-  WordGraph<Node> to_word_graph(size_t                                num_nodes,
-                                std::vector<std::vector<Node>> const& edges) {
+  template <typename Return>
+  std::enable_if_t<IsWordGraph<Return>, Return>
+  to(size_t                                                      num_nodes,
+     std::vector<std::vector<typename Return::node_type>> const& edges) {
     WordGraph<Node> result(num_nodes, edges.begin()->size());
     for (size_t i = 0; i < edges.size(); ++i) {
       for (size_t j = 0; j < (edges.begin() + i)->size(); ++j) {
@@ -1417,10 +1418,10 @@ namespace libsemigroups {
     return result;
   }
 
-  template <typename Node>
-  WordGraph<Node> to_word_graph(size_t num_nodes,
-                                std::initializer_list<std::vector<Node>> il) {
-    return to_word_graph<Node>(num_nodes, std::vector<std::vector<Node>>(il));
+  template <typename Return, typename Node>
+  std::enable_if_t<IsWordGraph<Return>, Return>
+  to(size_t num_nodes, std::initializer_list<std::vector<Node>> il) {
+    return to<WordGraph<Node>>(num_nodes, std::vector<std::vector<Node>>(il));
   }
 
   namespace detail {

--- a/include/libsemigroups/word-graph.tpp
+++ b/include/libsemigroups/word-graph.tpp
@@ -1404,8 +1404,8 @@ namespace libsemigroups {
   // TODO(1) refactor to use vectors api, not initializer_list
   template <typename Return>
   std::enable_if_t<IsWordGraph<Return>, Return>
-  to(size_t                                                      num_nodes,
-     std::vector<std::vector<typename Return::node_type>> const& edges) {
+  make(size_t                                                      num_nodes,
+       std::vector<std::vector<typename Return::node_type>> const& edges) {
     Return result(num_nodes, edges.begin()->size());
     for (size_t i = 0; i < edges.size(); ++i) {
       for (size_t j = 0; j < (edges.begin() + i)->size(); ++j) {
@@ -1420,10 +1420,10 @@ namespace libsemigroups {
 
   template <typename Return>
   std::enable_if_t<IsWordGraph<Return>, Return>
-  to(size_t                                                         num_nodes,
-     std::initializer_list<std::vector<typename Return::node_type>> il) {
-    return to<Return>(num_nodes,
-                      std::vector<std::vector<typename Return::node_type>>(il));
+  make(size_t                                                         num_nodes,
+       std::initializer_list<std::vector<typename Return::node_type>> il) {
+    return make<Return>(
+        num_nodes, std::vector<std::vector<typename Return::node_type>>(il));
   }
 
   namespace detail {

--- a/src/bipart.cpp
+++ b/src/bipart.cpp
@@ -178,11 +178,6 @@ namespace libsemigroups {
         x.rank());
   }
 
-  [[nodiscard]] Blocks
-  to_blocks(std::initializer_list<std::vector<int32_t>> const& cont) {
-    return to_blocks<std::initializer_list<std::vector<int32_t>>>(cont);
-  }
-
   ////////////////////////////////////////////////////////////////////////
   // Blocks
   ////////////////////////////////////////////////////////////////////////
@@ -343,19 +338,6 @@ namespace libsemigroups {
     }
 
   }  // namespace bipartition
-
-  [[nodiscard]] Bipartition
-  to_bipartition(std::initializer_list<uint32_t> const& cont) {
-    return to_bipartition<std::initializer_list<uint32_t>>(cont);
-  }
-
-  //! \brief Validate the arguments, construct a bipartition, and validate it.
-  //!
-  //! See to_bipartition(T const&) for full details.
-  [[nodiscard]] Bipartition
-  to_bipartition(std::initializer_list<std::vector<int32_t>> const& cont) {
-    return to_bipartition<std::initializer_list<std::vector<int32_t>>>(cont);
-  }
 
   [[nodiscard]] std::string to_human_readable_repr(Bipartition const& x,
                                                    std::string_view   braces,

--- a/src/forest.cpp
+++ b/src/forest.cpp
@@ -105,39 +105,6 @@ namespace libsemigroups {
     }
   }
 
-  Forest to_forest(std::vector<size_t> parent, std::vector<size_t> edge_label) {
-    if (parent.size() != edge_label.size()) {
-      LIBSEMIGROUPS_EXCEPTION(
-          "expected the 1st and 2nd arguments (parents and edge labels) to "
-          "have equal size equal, found {} != {}",
-          parent.size(),
-          edge_label.size());
-    }
-    size_t const num_nodes = parent.size();
-    Forest       result(num_nodes);
-    for (size_t i = 0; i < num_nodes; ++i) {
-      auto p = *(parent.begin() + i);
-      auto l = *(edge_label.begin() + i);
-      if (p != UNDEFINED && l != UNDEFINED) {
-        result.set_parent_and_label(i, p, l);
-      } else if (!(p == UNDEFINED && l == UNDEFINED)) {
-        LIBSEMIGROUPS_EXCEPTION(
-            "roots not at the same indices in the 1st and 2nd arguments "
-            "(parents and edge labels), expected UNDEFINED at index {} found "
-            "{} and {}",
-            i,
-            p,
-            l);
-      }
-    }
-    return result;
-  }
-
-  Forest to_forest(std::initializer_list<size_t> parent,
-                   std::initializer_list<size_t> edge_labels) {
-    return to_forest(std::vector<size_t>(parent), std::vector(edge_labels));
-  }
-
   std::string to_human_readable_repr(Forest const& f) {
     size_t const num_roots
         = std::count(f.parents().begin(), f.parents().end(), UNDEFINED);

--- a/src/pbr.cpp
+++ b/src/pbr.cpp
@@ -112,15 +112,6 @@ namespace libsemigroups {
       return out;
     }
 
-    std::vector<std::vector<uint32_t>>
-    process_left_right(PBR::vector_type<int32_t> left,
-                       PBR::vector_type<int32_t> right) {
-      throw_if_invalid_left_right(left, right);
-      PBR::vector_type<int32_t> sorted_left(sorted_side(left));
-      PBR::vector_type<int32_t> sorted_right(sorted_side(right));
-      return process_left_right_no_checks(sorted_left, sorted_right);
-    }
-
     void unite_rows(detail::DynamicArray2<bool>& out,
                     detail::DynamicArray2<bool>& tmp,
                     size_t const&                i,
@@ -181,6 +172,15 @@ namespace libsemigroups {
 
   }  // namespace
 
+  std::vector<std::vector<uint32_t>>
+  detail::process_left_right(PBR::vector_type<int32_t> left,
+                             PBR::vector_type<int32_t> right) {
+    throw_if_invalid_left_right(left, right);
+    PBR::vector_type<int32_t> sorted_left(sorted_side(left));
+    PBR::vector_type<int32_t> sorted_right(sorted_side(right));
+    return process_left_right_no_checks(sorted_left, sorted_right);
+  }
+
   PBR operator*(PBR const& x, PBR const& y) {
     PBR xy(x.degree());
     xy.product_inplace_no_checks(x, y);
@@ -234,15 +234,6 @@ namespace libsemigroups {
                                 detail::to_string(u));
       }
     }
-  }
-
-  PBR to_pbr(PBR::initializer_list_type<int32_t> left,
-             PBR::initializer_list_type<int32_t> right) {
-    return PBR(process_left_right(left, right));
-  }
-
-  PBR to_pbr(PBR::vector_type<int32_t> left, PBR::vector_type<int32_t> right) {
-    return PBR(process_left_right(left, right));
   }
 
   [[nodiscard]] std::string to_human_readable_repr(PBR const& x) {

--- a/tests/test-action.cpp
+++ b/tests/test-action.cpp
@@ -580,7 +580,7 @@ namespace libsemigroups {
             == PPerm<3>({0, 2}, {0, 2}, 3));
     REQUIRE(o.root_of_scc(PPerm<3>({0, 1}, {0, 1}, 3))
             == PPerm<3>({0, 2}, {0, 2}, 3));
-    REQUIRE_THROWS_AS(o.root_of_scc(to<PPerm<3>>({0, 3}, {0, 3}, 4)),
+    REQUIRE_THROWS_AS(o.root_of_scc(make<PPerm<3>>({0, 3}, {0, 3}, 4)),
                       LibsemigroupsException);
     REQUIRE(*begin(o) == PPerm<3>({0, 1, 2}, {0, 1, 2}, 3));
   }

--- a/tests/test-bipart.cpp
+++ b/tests/test-bipart.cpp
@@ -51,8 +51,8 @@ namespace libsemigroups {
   }  // namespace
 
   LIBSEMIGROUPS_TEST_CASE("Blocks", "001", "empty blocks", "[quick]") {
-    Blocks b1 = to_blocks({});
-    Blocks b2 = to_blocks({{4, 2}, {-1, -5}, {-3, -6}});
+    Blocks b1 = to<Blocks>({});
+    Blocks b2 = to<Blocks>({{4, 2}, {-1, -5}, {-3, -6}});
     REQUIRE(b2.lookup() == std::vector<bool>({true, false, true}));
     REQUIRE(b1 == b1);
     REQUIRE(!(b1 == b2));
@@ -216,7 +216,7 @@ namespace libsemigroups {
         {0, 1, 2, 1, 0, 2, 1, 0, 2, 2, 0, 0, 2, 0, 3, 4, 4, 1, 3, 0});
     auto y = Bipartition(
         {0, 1, 1, 1, 1, 2, 3, 2, 4, 5, 5, 2, 4, 2, 1, 1, 1, 2, 3, 2});
-    auto z = to_bipartition(
+    auto z = to<Bipartition>(
         {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
     REQUIRE(!(y == z));
 
@@ -367,8 +367,8 @@ namespace libsemigroups {
                           "exceptions",
                           "[quick][bipartition]") {
     REQUIRE_NOTHROW(Bipartition(std::vector<uint32_t>()));
-    REQUIRE_THROWS_AS(to_bipartition({0}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_bipartition({1, 0}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Bipartition>({0}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Bipartition>({1, 0}), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("Bipartition",
@@ -378,30 +378,30 @@ namespace libsemigroups {
     Bipartition xx(
         {0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 0, 0, 1, 2, 3, 3, 0, 4, 1, 1});
 
-    auto x = to_bipartition({{1, 2, 3, 4, 5, 6, 9, -1, -2, -7},
-                             {7, 10, -3, -9, -10},
-                             {8, -4},
-                             {-5, -6},
-                             {-8}});
+    auto x = to<Bipartition>({{1, 2, 3, 4, 5, 6, 9, -1, -2, -7},
+                              {7, 10, -3, -9, -10},
+                              {8, -4},
+                              {-5, -6},
+                              {-8}});
 
-    REQUIRE_THROWS_AS(to_bipartition({{1, 2, 3, 4, 5, 6, 9, 0, -2, -7},
-                                      {7, 10, -3, -9, -10},
-                                      {8, -4},
-                                      {-5, -6},
-                                      {-8}}),
+    REQUIRE_THROWS_AS(to<Bipartition>({{1, 2, 3, 4, 5, 6, 9, 0, -2, -7},
+                                       {7, 10, -3, -9, -10},
+                                       {8, -4},
+                                       {-5, -6},
+                                       {-8}}),
                       LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_bipartition({{1, 2, 3, 4, 5, 6, 9, -2, -7},
-                                      {7, 10, -3, -9, -10},
-                                      {8, -4},
-                                      {-5, -6},
-                                      {-8}}),
+    REQUIRE_THROWS_AS(to<Bipartition>({{1, 2, 3, 4, 5, 6, 9, -2, -7},
+                                       {7, 10, -3, -9, -10},
+                                       {8, -4},
+                                       {-5, -6},
+                                       {-8}}),
                       LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to_bipartition({{1, 2, 3, 4, 5, 6, 9, -2, -7},
-                                      {7, 10, -3, -9, -10},
-                                      {8, -4},
-                                      {-5, 0x40000000},
-                                      {-8}}),
+    REQUIRE_THROWS_AS(to<Bipartition>({{1, 2, 3, 4, 5, 6, 9, -2, -7},
+                                       {7, 10, -3, -9, -10},
+                                       {8, -4},
+                                       {-5, 0x40000000},
+                                       {-8}}),
                       LibsemigroupsException);
     REQUIRE(x == xx);
 
@@ -485,48 +485,48 @@ namespace libsemigroups {
     REQUIRE(xx >= xxx);
 
     // Check for odd degree
-    REQUIRE_THROWS_AS(to_bipartition({0, 1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(to<Bipartition>({0, 1, 2}), LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to_bipartition({{0, 2, 3, 4, 5, 6, 9, -1, -2, -7},
-                                      {7, 10, -3, -9, -10},
-                                      {8, -4},
-                                      {-5, -6},
-                                      {-8}}),
+    REQUIRE_THROWS_AS(to<Bipartition>({{0, 2, 3, 4, 5, 6, 9, -1, -2, -7},
+                                       {7, 10, -3, -9, -10},
+                                       {8, -4},
+                                       {-5, -6},
+                                       {-8}}),
                       LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to_bipartition({{1, 2, 3, 4, 5, 6, 9, 11, -1, -2, -7},
-                                      {7, 10, -3, -9, -10},
-                                      {8, -4},
-                                      {-5, -6},
-                                      {-8}}),
+    REQUIRE_THROWS_AS(to<Bipartition>({{1, 2, 3, 4, 5, 6, 9, 11, -1, -2, -7},
+                                       {7, 10, -3, -9, -10},
+                                       {8, -4},
+                                       {-5, -6},
+                                       {-8}}),
                       LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to_bipartition({{1, 2, 3, 4, 5, 6, 11, -1, -2, -7},
-                                      {7, 10, -3, -9, -10},
-                                      {8, -4},
-                                      {-5, -6},
-                                      {-8}}),
+    REQUIRE_THROWS_AS(to<Bipartition>({{1, 2, 3, 4, 5, 6, 11, -1, -2, -7},
+                                       {7, 10, -3, -9, -10},
+                                       {8, -4},
+                                       {-5, -6},
+                                       {-8}}),
                       LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to_bipartition({{1, 2, 3, 4, 5, 6, -11, -1, -2, -7},
-                                      {7, 10, -3, -9, -10},
-                                      {8, -4},
-                                      {-5, -6},
-                                      {-8}}),
+    REQUIRE_THROWS_AS(to<Bipartition>({{1, 2, 3, 4, 5, 6, -11, -1, -2, -7},
+                                       {7, 10, -3, -9, -10},
+                                       {8, -4},
+                                       {-5, -6},
+                                       {-8}}),
                       LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to_bipartition({{0, 2, 3, 4, 5, 6, 9, -1},
-                                      {7, 10, -3, -9, -10},
-                                      {8, -4},
-                                      {-5, -6},
-                                      {-8}}),
+    REQUIRE_THROWS_AS(to<Bipartition>({{0, 2, 3, 4, 5, 6, 9, -1},
+                                       {7, 10, -3, -9, -10},
+                                       {8, -4},
+                                       {-5, -6},
+                                       {-8}}),
                       LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to_bipartition({{0, 2, 3, 4, 5, 6, 9, -1, -2},
-                                      {7, 10, -3, -9, -10},
-                                      {8, -4},
-                                      {-5, -6},
-                                      {-8}}),
+    REQUIRE_THROWS_AS(to<Bipartition>({{0, 2, 3, 4, 5, 6, 9, -1, -2},
+                                       {7, 10, -3, -9, -10},
+                                       {8, -4},
+                                       {-5, -6},
+                                       {-8}}),
                       LibsemigroupsException);
   }
 

--- a/tests/test-bipart.cpp
+++ b/tests/test-bipart.cpp
@@ -51,8 +51,8 @@ namespace libsemigroups {
   }  // namespace
 
   LIBSEMIGROUPS_TEST_CASE("Blocks", "001", "empty blocks", "[quick]") {
-    Blocks b1 = to<Blocks>({});
-    Blocks b2 = to<Blocks>({{4, 2}, {-1, -5}, {-3, -6}});
+    Blocks b1 = make<Blocks>({});
+    Blocks b2 = make<Blocks>({{4, 2}, {-1, -5}, {-3, -6}});
     REQUIRE(b2.lookup() == std::vector<bool>({true, false, true}));
     REQUIRE(b1 == b1);
     REQUIRE(!(b1 == b2));
@@ -216,7 +216,7 @@ namespace libsemigroups {
         {0, 1, 2, 1, 0, 2, 1, 0, 2, 2, 0, 0, 2, 0, 3, 4, 4, 1, 3, 0});
     auto y = Bipartition(
         {0, 1, 1, 1, 1, 2, 3, 2, 4, 5, 5, 2, 4, 2, 1, 1, 1, 2, 3, 2});
-    auto z = to<Bipartition>(
+    auto z = make<Bipartition>(
         {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
     REQUIRE(!(y == z));
 
@@ -367,8 +367,8 @@ namespace libsemigroups {
                           "exceptions",
                           "[quick][bipartition]") {
     REQUIRE_NOTHROW(Bipartition(std::vector<uint32_t>()));
-    REQUIRE_THROWS_AS(to<Bipartition>({0}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<Bipartition>({1, 0}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Bipartition>({0}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Bipartition>({1, 0}), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("Bipartition",
@@ -378,30 +378,30 @@ namespace libsemigroups {
     Bipartition xx(
         {0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 0, 0, 1, 2, 3, 3, 0, 4, 1, 1});
 
-    auto x = to<Bipartition>({{1, 2, 3, 4, 5, 6, 9, -1, -2, -7},
-                              {7, 10, -3, -9, -10},
-                              {8, -4},
-                              {-5, -6},
-                              {-8}});
+    auto x = make<Bipartition>({{1, 2, 3, 4, 5, 6, 9, -1, -2, -7},
+                                {7, 10, -3, -9, -10},
+                                {8, -4},
+                                {-5, -6},
+                                {-8}});
 
-    REQUIRE_THROWS_AS(to<Bipartition>({{1, 2, 3, 4, 5, 6, 9, 0, -2, -7},
-                                       {7, 10, -3, -9, -10},
-                                       {8, -4},
-                                       {-5, -6},
-                                       {-8}}),
+    REQUIRE_THROWS_AS(make<Bipartition>({{1, 2, 3, 4, 5, 6, 9, 0, -2, -7},
+                                         {7, 10, -3, -9, -10},
+                                         {8, -4},
+                                         {-5, -6},
+                                         {-8}}),
                       LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<Bipartition>({{1, 2, 3, 4, 5, 6, 9, -2, -7},
-                                       {7, 10, -3, -9, -10},
-                                       {8, -4},
-                                       {-5, -6},
-                                       {-8}}),
+    REQUIRE_THROWS_AS(make<Bipartition>({{1, 2, 3, 4, 5, 6, 9, -2, -7},
+                                         {7, 10, -3, -9, -10},
+                                         {8, -4},
+                                         {-5, -6},
+                                         {-8}}),
                       LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to<Bipartition>({{1, 2, 3, 4, 5, 6, 9, -2, -7},
-                                       {7, 10, -3, -9, -10},
-                                       {8, -4},
-                                       {-5, 0x40000000},
-                                       {-8}}),
+    REQUIRE_THROWS_AS(make<Bipartition>({{1, 2, 3, 4, 5, 6, 9, -2, -7},
+                                         {7, 10, -3, -9, -10},
+                                         {8, -4},
+                                         {-5, 0x40000000},
+                                         {-8}}),
                       LibsemigroupsException);
     REQUIRE(x == xx);
 
@@ -485,48 +485,48 @@ namespace libsemigroups {
     REQUIRE(xx >= xxx);
 
     // Check for odd degree
-    REQUIRE_THROWS_AS(to<Bipartition>({0, 1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Bipartition>({0, 1, 2}), LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to<Bipartition>({{0, 2, 3, 4, 5, 6, 9, -1, -2, -7},
-                                       {7, 10, -3, -9, -10},
-                                       {8, -4},
-                                       {-5, -6},
-                                       {-8}}),
+    REQUIRE_THROWS_AS(make<Bipartition>({{0, 2, 3, 4, 5, 6, 9, -1, -2, -7},
+                                         {7, 10, -3, -9, -10},
+                                         {8, -4},
+                                         {-5, -6},
+                                         {-8}}),
                       LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to<Bipartition>({{1, 2, 3, 4, 5, 6, 9, 11, -1, -2, -7},
-                                       {7, 10, -3, -9, -10},
-                                       {8, -4},
-                                       {-5, -6},
-                                       {-8}}),
+    REQUIRE_THROWS_AS(make<Bipartition>({{1, 2, 3, 4, 5, 6, 9, 11, -1, -2, -7},
+                                         {7, 10, -3, -9, -10},
+                                         {8, -4},
+                                         {-5, -6},
+                                         {-8}}),
                       LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to<Bipartition>({{1, 2, 3, 4, 5, 6, 11, -1, -2, -7},
-                                       {7, 10, -3, -9, -10},
-                                       {8, -4},
-                                       {-5, -6},
-                                       {-8}}),
+    REQUIRE_THROWS_AS(make<Bipartition>({{1, 2, 3, 4, 5, 6, 11, -1, -2, -7},
+                                         {7, 10, -3, -9, -10},
+                                         {8, -4},
+                                         {-5, -6},
+                                         {-8}}),
                       LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to<Bipartition>({{1, 2, 3, 4, 5, 6, -11, -1, -2, -7},
-                                       {7, 10, -3, -9, -10},
-                                       {8, -4},
-                                       {-5, -6},
-                                       {-8}}),
+    REQUIRE_THROWS_AS(make<Bipartition>({{1, 2, 3, 4, 5, 6, -11, -1, -2, -7},
+                                         {7, 10, -3, -9, -10},
+                                         {8, -4},
+                                         {-5, -6},
+                                         {-8}}),
                       LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to<Bipartition>({{0, 2, 3, 4, 5, 6, 9, -1},
-                                       {7, 10, -3, -9, -10},
-                                       {8, -4},
-                                       {-5, -6},
-                                       {-8}}),
+    REQUIRE_THROWS_AS(make<Bipartition>({{0, 2, 3, 4, 5, 6, 9, -1},
+                                         {7, 10, -3, -9, -10},
+                                         {8, -4},
+                                         {-5, -6},
+                                         {-8}}),
                       LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to<Bipartition>({{0, 2, 3, 4, 5, 6, 9, -1, -2},
-                                       {7, 10, -3, -9, -10},
-                                       {8, -4},
-                                       {-5, -6},
-                                       {-8}}),
+    REQUIRE_THROWS_AS(make<Bipartition>({{0, 2, 3, 4, 5, 6, 9, -1, -2},
+                                         {7, 10, -3, -9, -10},
+                                         {8, -4},
+                                         {-5, -6},
+                                         {-8}}),
                       LibsemigroupsException);
   }
 

--- a/tests/test-froidure-pin-bipart.cpp
+++ b/tests/test-froidure-pin-bipart.cpp
@@ -40,19 +40,19 @@ namespace libsemigroups {
                           "[quick][froidure-pin][bipartition][bipart]") {
     auto        rg = ReportGuard(REPORT);
     FroidurePin S  = to_froidure_pin(
-        {to_bipartition({{1, 5, 8, -1, -2, -4, -10},
-                          {2, 4, 7, -8},
-                          {3, 6, 9, 10, -3},
-                          {-5, -9},
-                          {-6, -7}}),
-          to_bipartition({{1},
-                          {2, 3, 4, 5, -5, -6, -7},
-                          {6, 8, -2, -4, -8, -10},
-                          {7, -9},
-                          {9, -3},
-                          {10, -1}}),
-          to_bipartition({{1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
-                           -1, -2, -3, -4, -5, -6, -7, -8, -9, -10}})});
+        {to<Bipartition>({{1, 5, 8, -1, -2, -4, -10},
+                           {2, 4, 7, -8},
+                           {3, 6, 9, 10, -3},
+                           {-5, -9},
+                           {-6, -7}}),
+          to<Bipartition>({{1},
+                           {2, 3, 4, 5, -5, -6, -7},
+                           {6, 8, -2, -4, -8, -10},
+                           {7, -9},
+                           {9, -3},
+                           {10, -1}}),
+          to<Bipartition>({{1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+                            -1, -2, -3, -4, -5, -6, -7, -8, -9, -10}})});
 
     S.reserve(10);
 
@@ -65,12 +65,12 @@ namespace libsemigroups {
       pos++;
     }
 
-    auto x = to_bipartition({{1, -2, -10},
-                             {2, 4, 5, 7, -1, -8},
-                             {3, 9, -4},
-                             {6, 10, -3, -5, -9},
-                             {8, -7},
-                             {-6}});
+    auto x = to<Bipartition>({{1, -2, -10},
+                              {2, 4, 5, 7, -1, -8},
+                              {3, 9, -4},
+                              {6, 10, -3, -5, -9},
+                              {8, -7},
+                              {-6}});
     S.add_generator(x);
     REQUIRE(S.number_of_generators() == 4);
     REQUIRE(S.size() == 21);

--- a/tests/test-froidure-pin-bipart.cpp
+++ b/tests/test-froidure-pin-bipart.cpp
@@ -40,19 +40,19 @@ namespace libsemigroups {
                           "[quick][froidure-pin][bipartition][bipart]") {
     auto        rg = ReportGuard(REPORT);
     FroidurePin S  = to_froidure_pin(
-        {to<Bipartition>({{1, 5, 8, -1, -2, -4, -10},
-                           {2, 4, 7, -8},
-                           {3, 6, 9, 10, -3},
-                           {-5, -9},
-                           {-6, -7}}),
-          to<Bipartition>({{1},
-                           {2, 3, 4, 5, -5, -6, -7},
-                           {6, 8, -2, -4, -8, -10},
-                           {7, -9},
-                           {9, -3},
-                           {10, -1}}),
-          to<Bipartition>({{1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
-                            -1, -2, -3, -4, -5, -6, -7, -8, -9, -10}})});
+        {make<Bipartition>({{1, 5, 8, -1, -2, -4, -10},
+                             {2, 4, 7, -8},
+                             {3, 6, 9, 10, -3},
+                             {-5, -9},
+                             {-6, -7}}),
+          make<Bipartition>({{1},
+                             {2, 3, 4, 5, -5, -6, -7},
+                             {6, 8, -2, -4, -8, -10},
+                             {7, -9},
+                             {9, -3},
+                             {10, -1}}),
+          make<Bipartition>({{1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+                              -1, -2, -3, -4, -5, -6, -7, -8, -9, -10}})});
 
     S.reserve(10);
 
@@ -65,12 +65,12 @@ namespace libsemigroups {
       pos++;
     }
 
-    auto x = to<Bipartition>({{1, -2, -10},
-                              {2, 4, 5, 7, -1, -8},
-                              {3, 9, -4},
-                              {6, 10, -3, -5, -9},
-                              {8, -7},
-                              {-6}});
+    auto x = make<Bipartition>({{1, -2, -10},
+                                {2, 4, 5, 7, -1, -8},
+                                {3, 9, -4},
+                                {6, 10, -3, -5, -9},
+                                {8, -7},
+                                {-6}});
     S.add_generator(x);
     REQUIRE(S.number_of_generators() == 4);
     REQUIRE(S.size() == 21);

--- a/tests/test-froidure-pin-intmat.cpp
+++ b/tests/test-froidure-pin-intmat.cpp
@@ -55,7 +55,7 @@ namespace libsemigroups {
     REQUIRE(TestType({{0, 1}, {0, -1}}) * TestType({{0, 1}, {2, 0}})
                 * TestType({{0, 1}, {2, 0}})
             == S.generator(0) * S.generator(1) * S.generator(0));
-    REQUIRE(to_matrix<TestType>({{64, 0}, {-64, 0}})
+    REQUIRE(make<TestType>({{64, 0}, {-64, 0}})
             == S.generator(0) * S.generator(1) * S.generator(0) * S.generator(1)
                    * S.generator(0) * S.generator(1) * S.generator(0)
                    * S.generator(1) * S.generator(0) * S.generator(1)

--- a/tests/test-froidure-pin-matrix.cpp
+++ b/tests/test-froidure-pin-matrix.cpp
@@ -37,8 +37,8 @@ namespace libsemigroups {
                                    MaxPlusMat<>) {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<TestType> S;
-    S.add_generator(to_matrix<TestType>({{0, -4}, {-4, -1}}));
-    S.add_generator(to_matrix<TestType>({{0, -3}, {-3, -1}}));
+    S.add_generator(make<TestType>({{0, -4}, {-4, -1}}));
+    S.add_generator(make<TestType>({{0, -3}, {-3, -1}}));
 
     REQUIRE(S.size() == 26);
     REQUIRE(S.degree() == 2);
@@ -103,7 +103,7 @@ namespace libsemigroups {
                                    MinPlusMat<2>) {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<TestType> S;
-    S.add_generator(to_matrix<TestType>({{1, 0}, {0, POSITIVE_INFINITY}}));
+    S.add_generator(make<TestType>({{1, 0}, {0, POSITIVE_INFINITY}}));
 
     REQUIRE(S.size() == 3);
     REQUIRE(S.degree() == 2);
@@ -137,9 +137,8 @@ namespace libsemigroups {
       sr = new MaxPlusTruncSemiring<>(33);
     }
     FroidurePin<TestType> S;
-    S.add_generator(
-        to_matrix<TestType>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}}));
-    S.add_generator(to_matrix<TestType>(sr, {{0, 0, 0}, {0, 1, 0}, {1, 1, 0}}));
+    S.add_generator(make<TestType>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}}));
+    S.add_generator(make<TestType>(sr, {{0, 0, 0}, {0, 1, 0}, {1, 1, 0}}));
 
     REQUIRE(S.size() == 119);
     REQUIRE(S.degree() == 3);
@@ -151,7 +150,7 @@ namespace libsemigroups {
     REQUIRE(S.position(S.generator(0)) == 0);
     REQUIRE(S.contains(S.generator(0)));
 
-    auto x = to_matrix<TestType>(sr, {{2, 2}, {1, 0}});
+    auto x = make<TestType>(sr, {{2, 2}, {1, 0}});
     REQUIRE(S.position(x) == UNDEFINED);
     delete sr;
   }
@@ -170,10 +169,8 @@ namespace libsemigroups {
       sr = new MinPlusTruncSemiring(11);
     }
     FroidurePin<TestType> S;
-    S.add_generator(
-        to_matrix<TestType>(sr, {{2, 1, 0}, {10, 0, 0}, {1, 2, 1}}));
-    S.add_generator(
-        to_matrix<TestType>(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}}));
+    S.add_generator(make<TestType>(sr, {{2, 1, 0}, {10, 0, 0}, {1, 2, 1}}));
+    S.add_generator(make<TestType>(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}}));
 
     REQUIRE(S.size() == 1039);
     REQUIRE(S.degree() == 3);
@@ -185,7 +182,7 @@ namespace libsemigroups {
     REQUIRE(S.position(S.generator(0)) == 0);
     REQUIRE(S.contains(S.generator(0)));
 
-    auto x = to_matrix<TestType>(sr, {{2, 2, 0}, {1, 0, 0}, {0, 0, 0}});
+    auto x = make<TestType>(sr, {{2, 2, 0}, {1, 0, 0}, {0, 0, 0}});
     REQUIRE(S.position(x) == UNDEFINED);
     REQUIRE(!S.contains(x));
     x.product_inplace_no_checks(S.generator(0), S.generator(0));
@@ -207,10 +204,8 @@ namespace libsemigroups {
       sr = new NTPSemiring<>(11, 3);
     }
     FroidurePin<TestType> S;
-    S.add_generator(
-        to_matrix<TestType>(sr, {{2, 1, 0}, {10, 0, 0}, {1, 2, 1}}));
-    S.add_generator(
-        to_matrix<TestType>(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}}));
+    S.add_generator(make<TestType>(sr, {{2, 1, 0}, {10, 0, 0}, {1, 2, 1}}));
+    S.add_generator(make<TestType>(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}}));
 
     REQUIRE(S.size() == 86);
     REQUIRE(S.degree() == 3);
@@ -222,7 +217,7 @@ namespace libsemigroups {
     REQUIRE(S.position(S.generator(0)) == 0);
     REQUIRE(S.contains(S.generator(0)));
 
-    auto x = to_matrix<TestType>(sr, {{2, 2, 0}, {1, 0, 0}, {0, 0, 0}});
+    auto x = make<TestType>(sr, {{2, 2, 0}, {1, 0, 0}, {0, 0, 0}});
     REQUIRE(S.position(x) == UNDEFINED);
     REQUIRE(!S.contains(x));
     x.product_inplace_no_checks(S.generator(1), S.generator(0));

--- a/tests/test-froidure-pin-transf.cpp
+++ b/tests/test-froidure-pin-transf.cpp
@@ -47,7 +47,7 @@ namespace libsemigroups {
       // is wrong, for static Transf exception is thrown by make, because the
       // container has the wrong size
       REQUIRE_THROWS_AS(
-          S.add_generator(to<Transf<N>>({1, 7, 2, 6, 0, 0, 1, 2})),
+          S.add_generator(make<Transf<N>>({1, 7, 2, 6, 0, 0, 1, 2})),
           LibsemigroupsException);
     }
 
@@ -154,7 +154,7 @@ namespace libsemigroups {
     // For dynamic Transf exception is thrown by FroidurePin because degree
     // is wrong, for static Transf exception is thrown by make, because the
     // container has the wrong size
-    REQUIRE_THROWS_AS(S.add_generator(to<TestType>({1, 7, 2, 6, 0, 0, 1, 2})),
+    REQUIRE_THROWS_AS(S.add_generator(make<TestType>({1, 7, 2, 6, 0, 0, 1, 2})),
                       LibsemigroupsException);
   }
 

--- a/tests/test-gabow.cpp
+++ b/tests/test-gabow.cpp
@@ -27,7 +27,7 @@
 
 #include "libsemigroups/constants.hpp"   // for UNDEFINED, Undefined, Max
 #include "libsemigroups/exception.hpp"   // for LibsemigroupsException
-#include "libsemigroups/forest.hpp"      // for to_forest, Forest, opera...
+#include "libsemigroups/forest.hpp"      // for to<Forest>, Forest, opera...
 #include "libsemigroups/gabow.hpp"       // for Gabow
 #include "libsemigroups/ranges.hpp"      // for equal
 #include "libsemigroups/word-graph.hpp"  // for WordGraph, to_action...
@@ -121,11 +121,11 @@ namespace libsemigroups {
     REQUIRE(scc.number_of_components() == 1);
     {
       auto const& f = scc.spanning_forest();
-      REQUIRE(f == to_forest({2, 2, UNDEFINED}, {0, 1, UNDEFINED}));
+      REQUIRE(f == to<Forest>({2, 2, UNDEFINED}, {0, 1, UNDEFINED}));
     }
     {
       auto const& f = scc.reverse_spanning_forest();
-      REQUIRE(f == to_forest({2, 2, UNDEFINED}, {2, 2, UNDEFINED}));
+      REQUIRE(f == to<Forest>({2, 2, UNDEFINED}, {2, 2, UNDEFINED}));
     }
   }
 
@@ -341,7 +341,7 @@ namespace libsemigroups {
     Gabow scc(wg);
     REQUIRE(scc.number_of_components() == 1);
     REQUIRE(scc.reverse_spanning_forest()
-            == to_forest({4, 2, 0, 4, UNDEFINED}, {2, 0, 1, 0, UNDEFINED}));
+            == to<Forest>({4, 2, 0, 4, UNDEFINED}, {2, 0, 1, 0, UNDEFINED}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("Gabow",

--- a/tests/test-gabow.cpp
+++ b/tests/test-gabow.cpp
@@ -336,7 +336,7 @@ namespace libsemigroups {
                           "012",
                           "reverse_spanning_forest",
                           "[quick][gabow]") {
-    auto wg = to<WordGraph<size_t>>(
+    auto wg = make<WordGraph<size_t>>(
         5, {{0, 1, 4, 3}, {2}, {2, 0, 3, 3}, {4, 1}, {1, 0, 2}});
     Gabow scc(wg);
     REQUIRE(scc.number_of_components() == 1);
@@ -348,7 +348,7 @@ namespace libsemigroups {
                           "013",
                           "to_human_readable_repr",
                           "[quick][gabow]") {
-    auto wg = to<WordGraph<size_t>>(
+    auto wg = make<WordGraph<size_t>>(
         5, {{0, 1, 4, 3}, {2}, {2, 0, 3, 3}, {4, 1}, {1, 0, 2}});
     Gabow scc(wg);
     REQUIRE(to_human_readable_repr(scc)

--- a/tests/test-gabow.cpp
+++ b/tests/test-gabow.cpp
@@ -336,7 +336,7 @@ namespace libsemigroups {
                           "012",
                           "reverse_spanning_forest",
                           "[quick][gabow]") {
-    auto wg = to_word_graph<size_t>(
+    auto wg = to<WordGraph<size_t>>(
         5, {{0, 1, 4, 3}, {2}, {2, 0, 3, 3}, {4, 1}, {1, 0, 2}});
     Gabow scc(wg);
     REQUIRE(scc.number_of_components() == 1);
@@ -348,7 +348,7 @@ namespace libsemigroups {
                           "013",
                           "to_human_readable_repr",
                           "[quick][gabow]") {
-    auto wg = to_word_graph<size_t>(
+    auto wg = to<WordGraph<size_t>>(
         5, {{0, 1, 4, 3}, {2}, {2, 0, 3, 3}, {4, 1}, {1, 0, 2}});
     Gabow scc(wg);
     REQUIRE(to_human_readable_repr(scc)

--- a/tests/test-gabow.cpp
+++ b/tests/test-gabow.cpp
@@ -27,7 +27,7 @@
 
 #include "libsemigroups/constants.hpp"   // for UNDEFINED, Undefined, Max
 #include "libsemigroups/exception.hpp"   // for LibsemigroupsException
-#include "libsemigroups/forest.hpp"      // for to<Forest>, Forest, opera...
+#include "libsemigroups/forest.hpp"      // for make<Forest>, Forest, opera...
 #include "libsemigroups/gabow.hpp"       // for Gabow
 #include "libsemigroups/ranges.hpp"      // for equal
 #include "libsemigroups/word-graph.hpp"  // for WordGraph, to_action...
@@ -121,11 +121,11 @@ namespace libsemigroups {
     REQUIRE(scc.number_of_components() == 1);
     {
       auto const& f = scc.spanning_forest();
-      REQUIRE(f == to<Forest>({2, 2, UNDEFINED}, {0, 1, UNDEFINED}));
+      REQUIRE(f == make<Forest>({2, 2, UNDEFINED}, {0, 1, UNDEFINED}));
     }
     {
       auto const& f = scc.reverse_spanning_forest();
-      REQUIRE(f == to<Forest>({2, 2, UNDEFINED}, {2, 2, UNDEFINED}));
+      REQUIRE(f == make<Forest>({2, 2, UNDEFINED}, {2, 2, UNDEFINED}));
     }
   }
 
@@ -341,7 +341,7 @@ namespace libsemigroups {
     Gabow scc(wg);
     REQUIRE(scc.number_of_components() == 1);
     REQUIRE(scc.reverse_spanning_forest()
-            == to<Forest>({4, 2, 0, 4, UNDEFINED}, {2, 0, 1, 0, UNDEFINED}));
+            == make<Forest>({4, 2, 0, 4, UNDEFINED}, {2, 0, 1, 0, UNDEFINED}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("Gabow",

--- a/tests/test-knuth-bendix-1.cpp
+++ b/tests/test-knuth-bendix-1.cpp
@@ -927,7 +927,7 @@ namespace libsemigroups {
 
     KnuthBendix<TestType> kb1(twosided, p);
 
-    WordGraph test_wg1 = to<WordGraph<size_t>>(
+    WordGraph test_wg1 = make<WordGraph<size_t>>(
         6,
         {{1, 2, 3, 4, 5},
          {},
@@ -944,7 +944,7 @@ namespace libsemigroups {
     presentation::add_rule_no_checks(p, 1_w, 2_w);
     KnuthBendix<TestType> kb2(twosided, p);
 
-    WordGraph test_wg2 = to<WordGraph<size_t>>(
+    WordGraph test_wg2 = make<WordGraph<size_t>>(
         5,
         {{1, 2, UNDEFINED, 3, 4},
          {},
@@ -1165,51 +1165,52 @@ namespace libsemigroups {
     KnuthBendix<TestType> kb1(twosided, p);
     REQUIRE(kb1.gilman_graph().number_of_nodes() == 16);
 
-    WordGraph test_wg1 = to<WordGraph<size_t>>(16,
-                                               {{3,
-                                                 1,
-                                                 UNDEFINED,
-                                                 2,
-                                                 UNDEFINED,
-                                                 UNDEFINED,
-                                                 UNDEFINED,
-                                                 UNDEFINED,
-                                                 UNDEFINED,
-                                                 UNDEFINED,
-                                                 UNDEFINED},
-                                                {6, UNDEFINED, UNDEFINED, 12},
-                                                {7, UNDEFINED},
-                                                {4, 5, UNDEFINED, 9},
-                                                {},
-                                                {8},
-                                                {UNDEFINED, 11},
-                                                {UNDEFINED, 14, UNDEFINED, 15},
-                                                {},
-                                                {10},
-                                                {UNDEFINED, 14},
-                                                {},
-                                                {13},
-                                                {UNDEFINED}});
+    WordGraph test_wg1
+        = make<WordGraph<size_t>>(16,
+                                  {{3,
+                                    1,
+                                    UNDEFINED,
+                                    2,
+                                    UNDEFINED,
+                                    UNDEFINED,
+                                    UNDEFINED,
+                                    UNDEFINED,
+                                    UNDEFINED,
+                                    UNDEFINED,
+                                    UNDEFINED},
+                                   {6, UNDEFINED, UNDEFINED, 12},
+                                   {7, UNDEFINED},
+                                   {4, 5, UNDEFINED, 9},
+                                   {},
+                                   {8},
+                                   {UNDEFINED, 11},
+                                   {UNDEFINED, 14, UNDEFINED, 15},
+                                   {},
+                                   {10},
+                                   {UNDEFINED, 14},
+                                   {},
+                                   {13},
+                                   {UNDEFINED}});
     REQUIRE(equal(knuth_bendix::normal_forms<word_type>(kb1),
                   normal_forms_from_word_graph(kb1, test_wg1)));
 
     presentation::add_rule_no_checks(p, {1}, {3});
     KnuthBendix<TestType> kb2(twosided, p);
 
-    WordGraph test_wg2 = to<WordGraph<size_t>>(4,
-                                               {{2,
-                                                 1,
-                                                 UNDEFINED,
-                                                 UNDEFINED,
-                                                 UNDEFINED,
-                                                 UNDEFINED,
-                                                 UNDEFINED,
-                                                 UNDEFINED,
-                                                 UNDEFINED,
-                                                 UNDEFINED,
-                                                 UNDEFINED},
-                                                {},
-                                                {3}});
+    WordGraph test_wg2 = make<WordGraph<size_t>>(4,
+                                                 {{2,
+                                                   1,
+                                                   UNDEFINED,
+                                                   UNDEFINED,
+                                                   UNDEFINED,
+                                                   UNDEFINED,
+                                                   UNDEFINED,
+                                                   UNDEFINED,
+                                                   UNDEFINED,
+                                                   UNDEFINED,
+                                                   UNDEFINED},
+                                                  {},
+                                                  {3}});
 
     REQUIRE(equal(knuth_bendix::normal_forms<word_type>(kb2),
                   normal_forms_from_word_graph(kb2, test_wg2)));

--- a/tests/test-knuth-bendix-1.cpp
+++ b/tests/test-knuth-bendix-1.cpp
@@ -927,7 +927,7 @@ namespace libsemigroups {
 
     KnuthBendix<TestType> kb1(twosided, p);
 
-    WordGraph test_wg1 = to_word_graph<size_t>(
+    WordGraph test_wg1 = to<WordGraph<size_t>>(
         6,
         {{1, 2, 3, 4, 5},
          {},
@@ -944,7 +944,7 @@ namespace libsemigroups {
     presentation::add_rule_no_checks(p, 1_w, 2_w);
     KnuthBendix<TestType> kb2(twosided, p);
 
-    WordGraph test_wg2 = to_word_graph<size_t>(
+    WordGraph test_wg2 = to<WordGraph<size_t>>(
         5,
         {{1, 2, UNDEFINED, 3, 4},
          {},
@@ -1165,7 +1165,7 @@ namespace libsemigroups {
     KnuthBendix<TestType> kb1(twosided, p);
     REQUIRE(kb1.gilman_graph().number_of_nodes() == 16);
 
-    WordGraph test_wg1 = to_word_graph<size_t>(16,
+    WordGraph test_wg1 = to<WordGraph<size_t>>(16,
                                                {{3,
                                                  1,
                                                  UNDEFINED,
@@ -1196,7 +1196,7 @@ namespace libsemigroups {
     presentation::add_rule_no_checks(p, {1}, {3});
     KnuthBendix<TestType> kb2(twosided, p);
 
-    WordGraph test_wg2 = to_word_graph<size_t>(4,
+    WordGraph test_wg2 = to<WordGraph<size_t>>(4,
                                                {{2,
                                                  1,
                                                  UNDEFINED,

--- a/tests/test-knuth-bendix-2.cpp
+++ b/tests/test-knuth-bendix-2.cpp
@@ -1601,7 +1601,7 @@ namespace libsemigroups {
     // The gilman_graph generated is isomorphic to the word_graph given, but not
     // identical. Since the normal forms are correct (see above) the below check
     // is omitted. REQUIRE(kb.gilman_graph()
-    //         == to_word_graph<size_t>(5, {{1, 3}, {UNDEFINED, 2}, {}, {4}}));
+    //         == to<WordGraph<size_t>>(5, {{1, 3}, {UNDEFINED, 2}, {}, {4}}));
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",

--- a/tests/test-knuth-bendix-2.cpp
+++ b/tests/test-knuth-bendix-2.cpp
@@ -1601,7 +1601,8 @@ namespace libsemigroups {
     // The gilman_graph generated is isomorphic to the word_graph given, but not
     // identical. Since the normal forms are correct (see above) the below check
     // is omitted. REQUIRE(kb.gilman_graph()
-    //         == to<WordGraph<size_t>>(5, {{1, 3}, {UNDEFINED, 2}, {}, {4}}));
+    //         == make<WordGraph<size_t>>(5, {{1, 3}, {UNDEFINED, 2}, {},
+    //         {4}}));
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",

--- a/tests/test-matrix.cpp
+++ b/tests/test-matrix.cpp
@@ -136,7 +136,7 @@ namespace libsemigroups {
                                    BMat<>) {
     auto rg = ReportGuard(REPORT);
     {
-      TestType m = to_matrix<TestType>({{0, 1}, {0, 1}});
+      TestType m = make<TestType>({{0, 1}, {0, 1}});
       REQUIRE_NOTHROW(matrix::throw_if_bad_entry(m));
       REQUIRE(m == TestType({{0, 1}, {0, 1}}));
       REQUIRE(!(m == TestType({{0, 0}, {0, 1}})));
@@ -271,7 +271,7 @@ namespace libsemigroups {
       REQUIRE(m.coords(++it) == std::pair<scalar_type, scalar_type>({1, 1}));
     }
     {
-      REQUIRE_THROWS_AS(to_matrix<TestType>({{0, 0}, {0, 2}}),
+      REQUIRE_THROWS_AS(make<TestType>({{0, 0}, {0, 2}}),
                         LibsemigroupsException);
     }
   }
@@ -340,19 +340,19 @@ namespace libsemigroups {
                                    BMat<3>,
                                    BMat<>) {
     using RowView = typename TestType::RowView;
-    auto x        = to_matrix<TestType>({{1, 0, 0}, {1, 0, 0}, {1, 0, 0}});
+    auto x        = make<TestType>({{1, 0, 0}, {1, 0, 0}, {1, 0, 0}});
     REQUIRE(matrix::row_basis(x).size() == 1);
     REQUIRE(matrix::row_space_size(x) == 1);
-    x = to_matrix<TestType>({{1, 0, 0}, {1, 1, 0}, {1, 1, 1}});
+    x = make<TestType>({{1, 0, 0}, {1, 1, 0}, {1, 1, 1}});
     REQUIRE(matrix::row_basis(x).size() == 3);
     REQUIRE_THROWS_AS(x.row(3), LibsemigroupsException);
     std::vector<RowView> v = {x.row(0), x.row(2)};
     REQUIRE(matrix::row_basis<TestType>(v).size() == 2);
     REQUIRE(matrix::row_space_size(x) == 3);
-    x = to_matrix<TestType>({{1, 0, 0}, {0, 1, 1}, {1, 1, 1}});
+    x = make<TestType>({{1, 0, 0}, {0, 1, 1}, {1, 1, 1}});
     REQUIRE(matrix::row_basis(x).size() == 2);
     REQUIRE(matrix::row_space_size(x) == 3);
-    x = to_matrix<TestType>({{1, 0, 0}, {0, 0, 1}, {0, 1, 0}});
+    x = make<TestType>({{1, 0, 0}, {0, 0, 1}, {0, 1, 0}});
     REQUIRE(matrix::row_space_size(x) == 7);
     std::vector<typename TestType::RowView> views;
     std::vector<typename TestType::RowView> result;
@@ -570,9 +570,9 @@ namespace libsemigroups {
       TestType m1(sr, 2, 2);
       std::fill(m1.begin(), m1.end(), NEGATIVE_INFINITY);
       REQUIRE(m1
-              == to_matrix<TestType>(sr,
-                                     {{NEGATIVE_INFINITY, NEGATIVE_INFINITY},
-                                      {NEGATIVE_INFINITY, NEGATIVE_INFINITY}}));
+              == make<TestType>(sr,
+                                {{NEGATIVE_INFINITY, NEGATIVE_INFINITY},
+                                 {NEGATIVE_INFINITY, NEGATIVE_INFINITY}}));
       TestType m2(sr, 2, 2);
       std::fill(m2.begin(), m2.end(), 4);
       REQUIRE(m1 + m2 == m2);
@@ -626,32 +626,32 @@ namespace libsemigroups {
       sr = new MaxPlusTruncSemiring(5);
     }
 
-    auto m  = to_matrix<TestType>(sr,
-                                 {{2, 2, 0, 1},
-                                   {0, 0, 1, 3},
-                                   {1, NEGATIVE_INFINITY, 0, 0},
-                                   {0, 1, 0, 1}});
+    auto m  = make<TestType>(sr,
+                            {{2, 2, 0, 1},
+                              {0, 0, 1, 3},
+                              {1, NEGATIVE_INFINITY, 0, 0},
+                              {0, 1, 0, 1}});
     auto rg = ReportGuard(REPORT);
     auto r  = matrix::row_basis(m);
     REQUIRE(r.size() == 4);
-    REQUIRE(r[0] == to_matrix<Row>(sr, {0, 0, 1, 3}));
-    REQUIRE(r[1] == to_matrix<Row>(sr, {0, 1, 0, 1}));
-    REQUIRE(r[2] == to_matrix<Row>(sr, {1, NEGATIVE_INFINITY, 0, 0}));
-    REQUIRE(r[3] == to_matrix<Row>(sr, {2, 2, 0, 1}));
+    REQUIRE(r[0] == make<Row>(sr, {0, 0, 1, 3}));
+    REQUIRE(r[1] == make<Row>(sr, {0, 1, 0, 1}));
+    REQUIRE(r[2] == make<Row>(sr, {1, NEGATIVE_INFINITY, 0, 0}));
+    REQUIRE(r[3] == make<Row>(sr, {2, 2, 0, 1}));
     m.transpose();
     REQUIRE(m
-            == to_matrix<TestType>(sr,
-                                   {{2, 0, 1, 0},
-                                    {2, 0, NEGATIVE_INFINITY, 1},
-                                    {0, 1, 0, 0},
-                                    {1, 3, 0, 1}}));
+            == make<TestType>(sr,
+                              {{2, 0, 1, 0},
+                               {2, 0, NEGATIVE_INFINITY, 1},
+                               {0, 1, 0, 0},
+                               {1, 3, 0, 1}}));
     m.transpose();
     REQUIRE(m
-            == to_matrix<TestType>(sr,
-                                   {{2, 2, 0, 1},
-                                    {0, 0, 1, 3},
-                                    {1, NEGATIVE_INFINITY, 0, 0},
-                                    {0, 1, 0, 1}}));
+            == make<TestType>(sr,
+                              {{2, 2, 0, 1},
+                               {0, 0, 1, 3},
+                               {1, NEGATIVE_INFINITY, 0, 0},
+                               {0, 1, 0, 1}}));
 
     std::vector<std::array<scalar_type, 4>> expected;
     expected.push_back({2, 2, 0, 1});
@@ -681,9 +681,8 @@ namespace libsemigroups {
     auto expected = TestType(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
     REQUIRE(x == expected);
 
-    REQUIRE_THROWS_AS(
-        to_matrix<TestType>(sr, {{-100, 0, 0}, {0, 1, 0}, {1, -1, 0}}),
-        LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<TestType>(sr, {{-100, 0, 0}, {0, 1, 0}, {1, -1, 0}}),
+                      LibsemigroupsException);
     auto y = TestType(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}});
     REQUIRE(!(x == y));
 
@@ -736,8 +735,7 @@ namespace libsemigroups {
     }
     auto x = TestType(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
 
-    auto expected
-        = to_matrix<TestType>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
+    auto expected = make<TestType>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
     REQUIRE(x == expected);
 
     auto y = TestType(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}});
@@ -759,7 +757,7 @@ namespace libsemigroups {
     REQUIRE(y == x);
     REQUIRE(Hash<TestType>()(y) != 0);
     REQUIRE_THROWS_AS(
-        to_matrix<TestType>(sr, {{-22, 21, 0}, {10, 0, 0}, {1, 32, 1}}),
+        make<TestType>(sr, {{-22, 21, 0}, {10, 0, 0}, {1, 32, 1}}),
         LibsemigroupsException);
     REQUIRE(x * TestType::one(sr, 3) == x);
     REQUIRE(TestType::one(sr, 3) * x == x);
@@ -788,9 +786,9 @@ namespace libsemigroups {
     TestType m(sr, 3, 3);
     // REQUIRE(matrix::throw_if_bad_entry(m)); // m might not be valid!
     m.product_inplace_no_checks(
-        to_matrix<TestType>(sr, {{1, 1, 0}, {0, 0, 1}, {1, 0, 1}}),
-        to_matrix<TestType>(sr, {{1, 0, 1}, {0, 0, 1}, {1, 1, 0}}));
-    REQUIRE(m == to_matrix<TestType>(sr, {{1, 0, 2}, {1, 1, 0}, {2, 1, 1}}));
+        make<TestType>(sr, {{1, 1, 0}, {0, 0, 1}, {1, 0, 1}}),
+        make<TestType>(sr, {{1, 0, 1}, {0, 0, 1}, {1, 1, 0}}));
+    REQUIRE(m == make<TestType>(sr, {{1, 0, 2}, {1, 1, 0}, {2, 1, 1}}));
     REQUIRE(m.row(0) == Row(sr, {1, 0, 2}));
     REQUIRE(m.row(0).size() == 3);
     auto r = matrix::rows(m);
@@ -818,7 +816,7 @@ namespace libsemigroups {
 
     auto rg = ReportGuard(REPORT);
 
-    TestType m = to_matrix<TestType>(
+    TestType m = make<TestType>(
         sr, {{1, 1, 0, 0}, {2, 0, 2, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}});
     REQUIRE(m.number_of_cols() == 4);
     REQUIRE(m.number_of_rows() == 4);
@@ -832,7 +830,7 @@ namespace libsemigroups {
     REQUIRE(std::vector<scalar_type>(r[1].cbegin(), r[1].cend())
             == std::vector<scalar_type>({2, 0, 2, 0}));
     REQUIRE(m
-            == to_matrix<TestType>(
+            == make<TestType>(
                 sr, {{3, 1, 2, 0}, {2, 0, 2, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}}));
     REQUIRE(r[0][0] == 3);
     REQUIRE(r[0](0) == 3);
@@ -841,27 +839,27 @@ namespace libsemigroups {
     REQUIRE(std::vector<scalar_type>(r[0].cbegin(), r[0].cend())
             == std::vector<scalar_type>({0, 1, 2, 3}));
     REQUIRE(m
-            == to_matrix<TestType>(
+            == make<TestType>(
                 sr, {{0, 1, 2, 3}, {2, 0, 2, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}}));
     r[0] += 9;
     REQUIRE(std::vector<scalar_type>(r[0].cbegin(), r[0].cend())
             == std::vector<scalar_type>({9, 0, 1, 2}));
     REQUIRE(m
-            == to_matrix<TestType>(
+            == make<TestType>(
                 sr, {{9, 0, 1, 2}, {2, 0, 2, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}}));
     r[1] *= 3;
     REQUIRE(m
-            == to_matrix<TestType>(
+            == make<TestType>(
                 sr, {{9, 0, 1, 2}, {6, 0, 6, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}}));
     REQUIRE(std::vector<scalar_type>(r[1].cbegin(), r[1].cend())
             == std::vector<scalar_type>({6, 0, 6, 0}));
     REQUIRE(r[2] < r[1]);
     r[1] = r[2];
     REQUIRE(m
-            == to_matrix<TestType>(
+            == make<TestType>(
                 sr, {{9, 0, 1, 2}, {6, 0, 6, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}}));
     REQUIRE(r[1] == r[2]);
-    REQUIRE(r[1] == to_matrix<Row>(sr, {{1, 2, 3, 9}}));
+    REQUIRE(r[1] == make<Row>(sr, {{1, 2, 3, 9}}));
 
     RowView rv;
     {
@@ -892,23 +890,23 @@ namespace libsemigroups {
     REQUIRE(m.number_of_rows() == 4);
     auto r = matrix::rows(m);
     REQUIRE(r.size() == 4);
-    REQUIRE(r[0] == to_matrix<Row>(sr, {{1, 1, 0, 0}}));
-    REQUIRE(r[1] == to_matrix<Row>(sr, {{2, 0, 2, 0}}));
-    REQUIRE(r[0] != to_matrix<Row>(sr, {{2, 0, 2, 0}}));
-    REQUIRE(r[1] != to_matrix<Row>(sr, {{1, 1, 0, 0}}));
-    REQUIRE(to_matrix<Row>(sr, {{1, 1, 0, 0}}) == r[0]);
-    REQUIRE(to_matrix<Row>(sr, {{2, 0, 2, 0}}) == r[1]);
-    REQUIRE(to_matrix<Row>(sr, {{2, 0, 2, 0}}) != r[0]);
-    REQUIRE(to_matrix<Row>(sr, {{1, 1, 0, 0}}) != r[1]);
-    REQUIRE(to_matrix<Row>(sr, {{1, 1, 0, 0}}) < Row(sr, {{9, 9, 9, 9}}));
-    REQUIRE(r[0] < to_matrix<Row>(sr, {{9, 9, 9, 9}}));
-    REQUIRE(!(to_matrix<Row>(sr, {{9, 9, 9, 9}}) < r[0]));
+    REQUIRE(r[0] == make<Row>(sr, {{1, 1, 0, 0}}));
+    REQUIRE(r[1] == make<Row>(sr, {{2, 0, 2, 0}}));
+    REQUIRE(r[0] != make<Row>(sr, {{2, 0, 2, 0}}));
+    REQUIRE(r[1] != make<Row>(sr, {{1, 1, 0, 0}}));
+    REQUIRE(make<Row>(sr, {{1, 1, 0, 0}}) == r[0]);
+    REQUIRE(make<Row>(sr, {{2, 0, 2, 0}}) == r[1]);
+    REQUIRE(make<Row>(sr, {{2, 0, 2, 0}}) != r[0]);
+    REQUIRE(make<Row>(sr, {{1, 1, 0, 0}}) != r[1]);
+    REQUIRE(make<Row>(sr, {{1, 1, 0, 0}}) < Row(sr, {{9, 9, 9, 9}}));
+    REQUIRE(r[0] < make<Row>(sr, {{9, 9, 9, 9}}));
+    REQUIRE(!(make<Row>(sr, {{9, 9, 9, 9}}) < r[0]));
     Row x(r[3]);
     x *= 3;
-    REQUIRE(x == to_matrix<Row>(sr, {{0, 0, 0, 1}}));
+    REQUIRE(x == make<Row>(sr, {{0, 0, 0, 1}}));
     REQUIRE(x.number_of_rows() == 1);
     REQUIRE(x.number_of_cols() == 4);
-    REQUIRE(r[3] == to_matrix<Row>(sr, {{0, 0, 0, 7}}));
+    REQUIRE(r[3] == make<Row>(sr, {{0, 0, 0, 7}}));
     REQUIRE(r[3] != x);
     REQUIRE(x != r[3]);
     REQUIRE(!(x != x));
@@ -925,18 +923,17 @@ namespace libsemigroups {
     if constexpr (!std::is_same_v<typename TestType::semiring_type, void>) {
       sr = new NTPSemiring<>(33, 2);
     }
-    auto x = to_matrix<TestType>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
-    auto expected
-        = to_matrix<TestType>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
+    auto x        = make<TestType>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
+    auto expected = make<TestType>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
     REQUIRE(x == expected);
     REQUIRE(x.number_of_cols() == 3);
     REQUIRE(x.number_of_rows() == 3);
 
-    auto y = to_matrix<TestType>(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}});
+    auto y = make<TestType>(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}});
     REQUIRE(!(x == y));
 
     y.product_inplace_no_checks(x, x);
-    expected = to_matrix<TestType>(sr, {{34, 34, 0}, {34, 34, 0}, {33, 33, 1}});
+    expected = make<TestType>(sr, {{34, 34, 0}, {34, 34, 0}, {33, 33, 1}});
     REQUIRE(y == expected);
 
     REQUIRE(x < y);
@@ -960,17 +957,15 @@ namespace libsemigroups {
                                    (ProjMaxPlusMat<3, 3>),
                                    ProjMaxPlusMat<3>,
                                    ProjMaxPlusMat<>) {
-    using Row = typename TestType::Row;
-    auto x    = to_matrix<TestType>({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
-    auto expected
-        = to_matrix<TestType>({{-4, 0, -2}, {-3, -2, -2}, {-1, -5, -1}});
+    using Row     = typename TestType::Row;
+    auto x        = make<TestType>({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
+    auto expected = make<TestType>({{-4, 0, -2}, {-3, -2, -2}, {-1, -5, -1}});
     REQUIRE(x == expected);
     REQUIRE(x.scalar_zero() == NEGATIVE_INFINITY);
     REQUIRE(x.scalar_one() == 0);
 
-    auto y = to_matrix<TestType>(
-        {{NEGATIVE_INFINITY, 0, 0}, {0, 1, 0}, {1, -1, 0}});
-    expected = to_matrix<TestType>(
+    auto y = make<TestType>({{NEGATIVE_INFINITY, 0, 0}, {0, 1, 0}, {1, -1, 0}});
+    expected = make<TestType>(
         {{NEGATIVE_INFINITY, -1, -1}, {-1, 0, -1}, {0, -2, -1}});
     REQUIRE(y == expected);
     REQUIRE(!(x == y));
@@ -991,16 +986,15 @@ namespace libsemigroups {
     y.product_inplace_no_checks(x, id);
     REQUIRE(y == x);
 
-    REQUIRE(
-        to_matrix<TestType>({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}}).hash_value()
-        != 0);
+    REQUIRE(make<TestType>({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}}).hash_value()
+            != 0);
 
     y = x;
     REQUIRE(&x != &y);
     REQUIRE(x == y);
     // TODO uncomment or remove
     // REQUIRE(y
-    //         == to_matrix<TestType>(nullptr, {{-2, 2, 0}, {-1, 0, 0}, {1, -3,
+    //         == make<TestType>(nullptr, {{-2, 2, 0}, {-1, 0, 0}, {1, -3,
     //         1}}));
 
     auto yy(y);
@@ -1012,7 +1006,7 @@ namespace libsemigroups {
     std::ostream   os(&buff);
     os << y;  // Also does not do anything visible
 
-    REQUIRE(y.row(0) == to_matrix<Row>({-4, 0, -2}));
+    REQUIRE(y.row(0) == make<Row>({-4, 0, -2}));
     REQUIRE(y.row(1) == Row({-3, -2, -2}));
     REQUIRE(Row(y.row(0)) == y.row(0));
 
@@ -1052,11 +1046,11 @@ namespace libsemigroups {
     NTPSemiring<> const* sr = new NTPSemiring<>(23, 1);
     REQUIRE(sr->scalar_one() == 1);
     REQUIRE(sr->scalar_zero() == 0);
-    auto x = to_matrix<Mat>(sr, std::vector<std::vector<scalar_type>>());
+    auto x = make<Mat>(sr, std::vector<std::vector<scalar_type>>());
     REQUIRE(x.number_of_cols() == x.number_of_rows());
     REQUIRE(x.number_of_cols() == 0);
 
-    REQUIRE_THROWS_AS(to_matrix<Mat>(sr, {{2, 2, 0}, {0, 0, 140}, {1, 3, 1}}),
+    REQUIRE_THROWS_AS(make<Mat>(sr, {{2, 2, 0}, {0, 0, 140}, {1, 3, 1}}),
                       LibsemigroupsException);
     delete sr;
   }
@@ -1069,10 +1063,7 @@ namespace libsemigroups {
       BMat<> y(2, 1);
       REQUIRE_THROWS_AS(matrix::pow(y, 2), LibsemigroupsException);
     }
-    {
-      REQUIRE_THROWS_AS(to_matrix<BMat<>>({{0, 1}, {0}}),
-                        LibsemigroupsException);
-    }
+    { REQUIRE_THROWS_AS(make<BMat<>>({{0, 1}, {0}}), LibsemigroupsException); }
     {
       BMat<> y(2, 2);
       std::fill(y.begin(), y.end(), 0);

--- a/tests/test-paths.cpp
+++ b/tests/test-paths.cpp
@@ -121,7 +121,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Paths", "001", "#1", "[quick]") {
     using namespace rx;
 
-    auto wg = to_word_graph<size_t>(9,
+    auto wg = to<WordGraph<size_t>>(9,
                                     {{1, 2, UNDEFINED},
                                      {},
                                      {3, 4, 6},
@@ -193,7 +193,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Paths", "003", "#2", "[quick]") {
     using namespace rx;
 
-    WordGraph<size_t> wg = to_word_graph<size_t>(
+    WordGraph<size_t> wg = to<WordGraph<size_t>>(
         15, {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}, {13, 14}});
 
     Paths p(wg);
@@ -306,7 +306,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("Paths", "004", "#3", "[quick]") {
     using namespace rx;
-    auto wg = to_word_graph<size_t>(
+    auto wg = to<WordGraph<size_t>>(
         6, {{1, 2}, {3, 4}, {4, 2}, {1, 5}, {5, 4}, {4, 5}});
 
     std::vector<word_type> expected = {01_w,
@@ -478,7 +478,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("Paths", "006", "#5", "[quick][no-valgrind]") {
     using namespace rx;
-    auto wg = to_word_graph<size_t>(
+    auto wg = to<WordGraph<size_t>>(
         6, {{1, 2}, {3, 4}, {4, 2}, {1, 5}, {5, 4}, {4, 5}});
 
     std::vector<word_type> expected = {01_w,
@@ -518,7 +518,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("Paths", "007", "#6", "[quick]") {
     using namespace rx;
-    auto wg = to_word_graph<size_t>(6,
+    auto wg = to<WordGraph<size_t>>(6,
                                     {{1, 2, UNDEFINED},
                                      {2, 0, 3},
                                      {UNDEFINED, UNDEFINED, 3},
@@ -564,7 +564,7 @@ namespace libsemigroups {
                           "008",
                           "path iterators corner cases",
                           "[quick]") {
-    auto wg = to_word_graph<size_t>(6,
+    auto wg = to<WordGraph<size_t>>(6,
                                     {{1, 2, UNDEFINED},
                                      {2, 0, 3},
                                      {UNDEFINED, UNDEFINED, 3},
@@ -603,7 +603,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("Paths", "009", "pstilo corner case", "[quick]") {
     using namespace rx;
-    auto wg = to_word_graph<size_t>(5, {{2, 1}, {}, {3}, {4}, {2}});
+    auto wg = to<WordGraph<size_t>>(5, {{2, 1}, {}, {3}, {4}, {2}});
 
     // Tests the case then there is only a single path, but if we would have
     // used pilo (i.e. not use the reachability check that is in pstilo),
@@ -667,7 +667,7 @@ namespace libsemigroups {
                           "011",
                           "number_of_paths acyclic word graph",
                           "[quick][no-valgrind]") {
-    auto wg = to_word_graph<size_t>(
+    auto wg = to<WordGraph<size_t>>(
         8, {{3, 2, 3}, {7}, {1}, {1, 5}, {6}, {}, {3, 7}});
 
     REQUIRE(word_graph::is_acyclic(wg));
@@ -902,7 +902,7 @@ namespace libsemigroups {
     // auto         wg = WordGraph<size_t>::random(n, 20, 200,
     // std::mt19937());
     // std::cout << word_graph::detail::to_string(wg);
-    auto wg = to_word_graph<size_t>(
+    auto wg = to<WordGraph<size_t>>(
         10,
         {{9, 1, 6, 3, 7, 2, 2, 8, 1, 4, 3, 1, 7, 9, 4, 7, 8, 9, 6, 9},
          {8, 2, 5, 7, 9, 0, 2, 4, 0, 3, 2, 7, 2, 7, 6, 6, 5, 4, 6, 3},
@@ -950,7 +950,7 @@ namespace libsemigroups {
     // REQUIRE(detail::magic_number(6) * 6 == 14.634);
     // auto wg = WordGraph<size_t>::random(6, 3, 15, std::mt19937());
     // std::cout << word_graph::detail::to_string(wg);
-    auto wg = to_word_graph<size_t>(6,
+    auto wg = to<WordGraph<size_t>>(6,
                                     {{0, 3, 4},
                                      {2, 1, 4},
                                      {4, 3, 4},

--- a/tests/test-paths.cpp
+++ b/tests/test-paths.cpp
@@ -121,16 +121,16 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Paths", "001", "#1", "[quick]") {
     using namespace rx;
 
-    auto wg = to<WordGraph<size_t>>(9,
-                                    {{1, 2, UNDEFINED},
-                                     {},
-                                     {3, 4, 6},
-                                     {},
-                                     {UNDEFINED, 5},
-                                     {},
-                                     {UNDEFINED, 7},
-                                     {8},
-                                     {}});
+    auto wg = make<WordGraph<size_t>>(9,
+                                      {{1, 2, UNDEFINED},
+                                       {},
+                                       {3, 4, 6},
+                                       {},
+                                       {UNDEFINED, 5},
+                                       {},
+                                       {UNDEFINED, 7},
+                                       {8},
+                                       {}});
 
     Paths p(wg);
     p.order(Order::shortlex).source(2).min(3).max(4);
@@ -193,7 +193,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Paths", "003", "#2", "[quick]") {
     using namespace rx;
 
-    WordGraph<size_t> wg = to<WordGraph<size_t>>(
+    WordGraph<size_t> wg = make<WordGraph<size_t>>(
         15, {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}, {13, 14}});
 
     Paths p(wg);
@@ -306,7 +306,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("Paths", "004", "#3", "[quick]") {
     using namespace rx;
-    auto wg = to<WordGraph<size_t>>(
+    auto wg = make<WordGraph<size_t>>(
         6, {{1, 2}, {3, 4}, {4, 2}, {1, 5}, {5, 4}, {4, 5}});
 
     std::vector<word_type> expected = {01_w,
@@ -478,7 +478,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("Paths", "006", "#5", "[quick][no-valgrind]") {
     using namespace rx;
-    auto wg = to<WordGraph<size_t>>(
+    auto wg = make<WordGraph<size_t>>(
         6, {{1, 2}, {3, 4}, {4, 2}, {1, 5}, {5, 4}, {4, 5}});
 
     std::vector<word_type> expected = {01_w,
@@ -518,13 +518,13 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("Paths", "007", "#6", "[quick]") {
     using namespace rx;
-    auto wg = to<WordGraph<size_t>>(6,
-                                    {{1, 2, UNDEFINED},
-                                     {2, 0, 3},
-                                     {UNDEFINED, UNDEFINED, 3},
-                                     {4},
-                                     {UNDEFINED, 5},
-                                     {3}});
+    auto wg = make<WordGraph<size_t>>(6,
+                                      {{1, 2, UNDEFINED},
+                                       {2, 0, 3},
+                                       {UNDEFINED, UNDEFINED, 3},
+                                       {4},
+                                       {UNDEFINED, 5},
+                                       {3}});
 
     Paths p(wg);
     p.order(Order::shortlex).source(0).min(0).max(10);
@@ -564,13 +564,13 @@ namespace libsemigroups {
                           "008",
                           "path iterators corner cases",
                           "[quick]") {
-    auto wg = to<WordGraph<size_t>>(6,
-                                    {{1, 2, UNDEFINED},
-                                     {2, 0, 3},
-                                     {UNDEFINED, UNDEFINED, 3},
-                                     {4},
-                                     {UNDEFINED, 5},
-                                     {3}});
+    auto wg = make<WordGraph<size_t>>(6,
+                                      {{1, 2, UNDEFINED},
+                                       {2, 0, 3},
+                                       {UNDEFINED, UNDEFINED, 3},
+                                       {4},
+                                       {UNDEFINED, 5},
+                                       {3}});
 
     REQUIRE_THROWS_AS(cbegin_pstilo(wg, 1, 6), LibsemigroupsException);
     REQUIRE_THROWS_AS(cbegin_pstilo(wg, 6, 1), LibsemigroupsException);
@@ -603,7 +603,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("Paths", "009", "pstilo corner case", "[quick]") {
     using namespace rx;
-    auto wg = to<WordGraph<size_t>>(5, {{2, 1}, {}, {3}, {4}, {2}});
+    auto wg = make<WordGraph<size_t>>(5, {{2, 1}, {}, {3}, {4}, {2}});
 
     // Tests the case then there is only a single path, but if we would have
     // used pilo (i.e. not use the reachability check that is in pstilo),
@@ -667,7 +667,7 @@ namespace libsemigroups {
                           "011",
                           "number_of_paths acyclic word graph",
                           "[quick][no-valgrind]") {
-    auto wg = to<WordGraph<size_t>>(
+    auto wg = make<WordGraph<size_t>>(
         8, {{3, 2, 3}, {7}, {1}, {1, 5}, {6}, {}, {3, 7}});
 
     REQUIRE(word_graph::is_acyclic(wg));
@@ -902,7 +902,7 @@ namespace libsemigroups {
     // auto         wg = WordGraph<size_t>::random(n, 20, 200,
     // std::mt19937());
     // std::cout << word_graph::detail::to_string(wg);
-    auto wg = to<WordGraph<size_t>>(
+    auto wg = make<WordGraph<size_t>>(
         10,
         {{9, 1, 6, 3, 7, 2, 2, 8, 1, 4, 3, 1, 7, 9, 4, 7, 8, 9, 6, 9},
          {8, 2, 5, 7, 9, 0, 2, 4, 0, 3, 2, 7, 2, 7, 6, 6, 5, 4, 6, 3},
@@ -950,13 +950,13 @@ namespace libsemigroups {
     // REQUIRE(detail::magic_number(6) * 6 == 14.634);
     // auto wg = WordGraph<size_t>::random(6, 3, 15, std::mt19937());
     // std::cout << word_graph::detail::to_string(wg);
-    auto wg = to<WordGraph<size_t>>(6,
-                                    {{0, 3, 4},
-                                     {2, 1, 4},
-                                     {4, 3, 4},
-                                     {0, 1, UNDEFINED},
-                                     {UNDEFINED, 3, 3},
-                                     {4, UNDEFINED, 2}});
+    auto wg = make<WordGraph<size_t>>(6,
+                                      {{0, 3, 4},
+                                       {2, 1, 4},
+                                       {4, 3, 4},
+                                       {0, 1, UNDEFINED},
+                                       {UNDEFINED, 3, 3},
+                                       {4, UNDEFINED, 2}});
 
     REQUIRE(wg.number_of_edges() == 15);
 

--- a/tests/test-pbr.cpp
+++ b/tests/test-pbr.cpp
@@ -155,7 +155,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("PBR", "004", "delete/copy", "[quick][pbr]") {
-    PBR x = to_pbr({{1}, {4}, {3}, {1}, {0, 2}, {0, 3, 4, 5}});
+    PBR x = make<PBR>({{1}, {4}, {3}, {1}, {0, 2}, {0, 3, 4, 5}});
     PBR y(x);
     REQUIRE(x == y);
     PBR z({{1}, {4}, {3}, {1}, {0, 2}, {0, 3, 4, 5}});
@@ -173,39 +173,41 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("PBR", "005", "exceptions", "[quick][pbr]") {
-    REQUIRE_THROWS_AS(to_pbr({{1}, {4}, {3}, {10}, {0, 2}, {0, 3, 4, 5}}),
+    REQUIRE_THROWS_AS(make<PBR>({{1}, {4}, {3}, {10}, {0, 2}, {0, 3, 4, 5}}),
                       LibsemigroupsException);
-    REQUIRE_THROWS_AS(to_pbr({{4}, {3}, {0}, {0, 2}, {0, 3, 4, 5}}),
+    REQUIRE_THROWS_AS(make<PBR>({{4}, {3}, {0}, {0, 2}, {0, 3, 4, 5}}),
                       LibsemigroupsException);
 
     REQUIRE_NOTHROW(PBR({{-3, -1}, {-3, -2, -1, 1, 2, 3}, {-3, -2, -1, 1, 3}},
                         {{-3, -1, 1, 2, 3}, {-3, 1, 3}, {-3, -2, -1, 2, 3}}));
     REQUIRE_NOTHROW(
-        to_pbr({{-3, -1}, {-3, -2, -1, 1, 2, 3}, {-3, -2, -1, 1, 3}},
-               {{-3, -1, 1, 2, 3}, {-3, 1, 3}, {-3, -2, -1, 2, 3}}));
+        make<PBR>({{-3, -1}, {-3, -2, -1, 1, 2, 3}, {-3, -2, -1, 1, 3}},
+                  {{-3, -1, 1, 2, 3}, {-3, 1, 3}, {-3, -2, -1, 2, 3}}));
 
     REQUIRE_NOTHROW(PBR({{}, {}}));
 
     REQUIRE_THROWS_AS(
-        to_pbr({{-4, -1}, {-3, -2, -1, 1, 2, 3}, {-3, -2, -1, 1, 3}},
-               {{-3, -1, 1, 2, 3}, {-3, 1, 3}, {-3, -2, -1, 2, 3}}),
+        make<PBR>({{-4, -1}, {-3, -2, -1, 1, 2, 3}, {-3, -2, -1, 1, 3}},
+                  {{-3, -1, 1, 2, 3}, {-3, 1, 3}, {-3, -2, -1, 2, 3}}),
         LibsemigroupsException);
 
     REQUIRE_THROWS_AS(
-        to_pbr({{-4, -1}, {-3, -2, -1, 1, 2, 3}, {-3, -2, -1, 1, 3}},
-               {{-3, -1, 1, 2, 3}, {-3, 1, 3}, {-3, -2, -1, 2, 3}}),
+        make<PBR>({{-4, -1}, {-3, -2, -1, 1, 2, 3}, {-3, -2, -1, 1, 3}},
+                  {{-3, -1, 1, 2, 3}, {-3, 1, 3}, {-3, -2, -1, 2, 3}}),
         LibsemigroupsException);
 
     REQUIRE_THROWS_AS(
-        to_pbr({{-4, -1}, {-3, -2, -1, 1, 2, 3}, {-3, -2, -1, 1, 3}},
-               {{-3, -1, 1, 2, 3}, {-3, 1, 3}, {-3, -2, -1, 2, 3}, {-1, -2}}),
+        make<PBR>(
+            {{-4, -1}, {-3, -2, -1, 1, 2, 3}, {-3, -2, -1, 1, 3}},
+            {{-3, -1, 1, 2, 3}, {-3, 1, 3}, {-3, -2, -1, 2, 3}, {-1, -2}}),
         LibsemigroupsException);
     REQUIRE_THROWS_AS(
-        to_pbr({{-3, -1, 1, 2, 3}, {-3, 1, 3}, {-3, -2, -1, 2, 3}},
-               {{-4, -1}, {-3, -2, -1, 1, 2, 3}, {-3, -2, -1, 1, 3}}),
+        make<PBR>({{-3, -1, 1, 2, 3}, {-3, 1, 3}, {-3, -2, -1, 2, 3}},
+                  {{-4, -1}, {-3, -2, -1, 1, 2, 3}, {-3, -2, -1, 1, 3}}),
         LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to_pbr({{}, {2}, {1}, {3, 0}}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PBR>({{}, {2}, {1}, {3, 0}}),
+                      LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("PBR", "006", "product exceptions", "[quick][pbr]") {
@@ -286,13 +288,13 @@ namespace libsemigroups {
     REQUIRE_NOTHROW(IncreaseDegree<PBR>()(x, 0));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("PBR", "011", "to_pbr", "[quick][pbr]") {
+  LIBSEMIGROUPS_TEST_CASE("PBR", "011", "make<PBR>", "[quick][pbr]") {
     PBR x({{-1, 1}, {2}}, {{-2, 1}, {-1, 2}});
     pbr::throw_if_invalid(x);
-    REQUIRE(to_pbr({}) == PBR({}));
-    REQUIRE(to_pbr({{1, 2}, {0, 3}, {2, 3}, {1}})
+    REQUIRE(make<PBR>({}) == PBR({}));
+    REQUIRE(make<PBR>({{1, 2}, {0, 3}, {2, 3}, {1}})
             == PBR({{1, 2}, {0, 3}, {2, 3}, {1}}));
-    REQUIRE(to_pbr({{-1, 1}, {2}}, {{-2, 1}, {-1, 2}})
+    REQUIRE(make<PBR>({{-1, 1}, {2}}, {{-2, 1}, {-1, 2}})
             == PBR({{-1, 1}, {2}}, {{-2, 1}, {-1, 2}}));
   }
 }  // namespace libsemigroups

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -114,7 +114,7 @@ namespace libsemigroups {
       REQUIRE(T.included_pairs() == e);
 
       // auto it = std::find_if(T.cbegin(n), T.cend(n), foo);
-      // REQUIRE(*it == to_word_graph<uint32_t>(1, {{0, 0}}));
+      // REQUIRE(*it == to<WordGraph<uint32_t>>(1, {{0, 0}}));
       REQUIRE(std::all_of(T.cbegin(n), T.cend(n), foo));
       REQUIRE(static_cast<uint64_t>(std::count_if(S.cbegin(n), S.cend(n), foo))
               == T.number_of_congruences(n));
@@ -278,22 +278,22 @@ namespace libsemigroups {
       REQUIRE(S.number_of_congruences(1) == 1);
 
       auto it = S.cbegin(1);
-      REQUIRE(*it == to_word_graph<node_type>(1, {{0, 0}}));
+      REQUIRE(*it == to<WordGraph<node_type>>(1, {{0, 0}}));
 
       it = S.cbegin(5);
-      REQUIRE(*(it++) == to_word_graph<node_type>(5, {{0, 0}}));
-      REQUIRE(*(it++) == to_word_graph<node_type>(5, {{1, 0}, {1, 1}}));
-      REQUIRE(*(it++) == to_word_graph<node_type>(5, {{1, 1}, {1, 1}}));
-      REQUIRE(*(it++) == to_word_graph<node_type>(5, {{1, 2}, {1, 1}, {1, 2}}));
-      REQUIRE(*(it++) == to_word_graph<node_type>(5, {{1, 2}, {1, 1}, {2, 2}}));
+      REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{0, 0}}));
+      REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 0}, {1, 1}}));
+      REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 1}, {1, 1}}));
+      REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {1, 2}}));
+      REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {2, 2}}));
       REQUIRE(*(it++)
-              == to_word_graph<node_type>(5, {{1, 2}, {1, 1}, {3, 2}, {3, 3}}));
+              == to<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {3, 2}, {3, 3}}));
       REQUIRE(*(it++) == WordGraph<node_type>(0, 2));
       REQUIRE(*(it++) == WordGraph<node_type>(0, 2));
       REQUIRE(*(it++) == WordGraph<node_type>(0, 2));
 
       it = S.cbegin(3);
-      REQUIRE(*it == to_word_graph<node_type>(3, {{0, 0}}));
+      REQUIRE(*it == to<WordGraph<node_type>>(3, {{0, 0}}));
       // Note that Catch's REQUIRE macro is not thread safe, see:
       // https://github.com/catchorg/Catch2/issues/99
       // as such we cannot call any function (like
@@ -364,9 +364,9 @@ namespace libsemigroups {
     REQUIRE(S.number_of_congruences(10) == 176);
 
     auto it = S.cbegin(2);
-    REQUIRE(*(it++) == to_word_graph<node_type>(2, {{0, 0, 0}}));
-    REQUIRE(*(it++) == to_word_graph<node_type>(2, {{1, 0, 1}, {1, 1, 1}}));
-    REQUIRE(*(it++) == to_word_graph<node_type>(2, {{1, 1, 1}, {1, 1, 1}}));
+    REQUIRE(*(it++) == to<WordGraph<node_type>>(2, {{0, 0, 0}}));
+    REQUIRE(*(it++) == to<WordGraph<node_type>>(2, {{1, 0, 1}, {1, 1, 1}}));
+    REQUIRE(*(it++) == to<WordGraph<node_type>>(2, {{1, 1, 1}, {1, 1, 1}}));
     REQUIRE(*(it++) == WordGraph<node_type>(0, 3));
     REQUIRE(*(it++) == WordGraph<node_type>(0, 3));
     // sims::dot_poset("example-001", S.cbegin(4), S.cend(4));
@@ -1099,7 +1099,7 @@ namespace libsemigroups {
     // REQUIRE(word_graph::is_strictly_cyclic(d));
     // REQUIRE(
     //     d
-    //     == to_word_graph<uint32_t>(
+    //     == to<WordGraph<uint32_t>>(
     //         22, {{0, 0, 1, 0, 2, 3, 2},        {1, 4, 0, 5, 6, 3, 7},
     //              {2, 2, 2, 2, 2, 2, 2},        {3, 8, 3, 9, 6, 3, 7},
     //              {4, 1, 4, 10, 6, 2, 11},      {5, 10, 5, 1, 12, 2, 7},
@@ -1756,7 +1756,7 @@ namespace libsemigroups {
     // whichever one is found first, in multiple threads
     // REQUIRE(
     //     d
-    //     == to_word_graph<node_type>(
+    //     == to<WordGraph<node_type>>(
     //         22,
     //         {{0, 1, 0, 2, 0},      {1, 3, 3, 4, 5},      {2, 6, 6, 2, 0},
     //          {3, 0, 1, 2, 5},      {4, 4, 4, 4, 4},      {5, 5, 5, 7, 5},
@@ -1946,25 +1946,25 @@ namespace libsemigroups {
 
     REQUIRE(
         *it++
-        == to_word_graph<node_type>(5, {{1, 1, 1, 1}, {1, 1, 1, 1}}));  // Good
+        == to<WordGraph<node_type>>(5, {{1, 1, 1, 1}, {1, 1, 1, 1}}));  // Good
     REQUIRE(*it++
-            == to_word_graph<node_type>(
+            == to<WordGraph<node_type>>(
                 5, {{1, 1, 1, 2}, {1, 1, 1, 2}, {1, 1, 1, 2}}));  // Good
     REQUIRE(*it++
-            == to_word_graph<node_type>(
+            == to<WordGraph<node_type>>(
                 5, {{1, 2, 1, 1}, {1, 1, 1, 1}, {2, 2, 2, 2}}));  // Good
     REQUIRE(
         *it++
-        == to_word_graph<node_type>(
+        == to<WordGraph<node_type>>(
             5,
             {{1, 2, 1, 1}, {1, 1, 1, 1}, {2, 2, 2, 3}, {2, 2, 2, 3}}));  // Good
     REQUIRE(
         *it++
-        == to_word_graph<node_type>(
+        == to<WordGraph<node_type>>(
             5,
             {{1, 2, 1, 3}, {1, 1, 1, 3}, {2, 2, 2, 2}, {1, 1, 1, 3}}));  // Good
     REQUIRE(*it++
-            == to_word_graph<node_type>(5,
+            == to<WordGraph<node_type>>(5,
                                         {{1, 2, 1, 3},
                                          {1, 1, 1, 3},
                                          {2, 2, 2, 4},
@@ -1974,24 +1974,24 @@ namespace libsemigroups {
 
     it = T.cbegin(5);
 
-    REQUIRE(*it++ == to_word_graph<node_type>(5, {{0, 0, 0, 0}}));
-    REQUIRE(*it++ == to_word_graph<node_type>(5, {{0, 0, 0, 1}, {0, 0, 0, 1}}));
-    REQUIRE(*it++ == to_word_graph<node_type>(5, {{1, 1, 1, 0}, {1, 1, 1, 0}}));
-    REQUIRE(*it++ == to_word_graph<node_type>(5, {{1, 1, 1, 1}, {1, 1, 1, 1}}));
+    REQUIRE(*it++ == to<WordGraph<node_type>>(5, {{0, 0, 0, 0}}));
+    REQUIRE(*it++ == to<WordGraph<node_type>>(5, {{0, 0, 0, 1}, {0, 0, 0, 1}}));
+    REQUIRE(*it++ == to<WordGraph<node_type>>(5, {{1, 1, 1, 0}, {1, 1, 1, 0}}));
+    REQUIRE(*it++ == to<WordGraph<node_type>>(5, {{1, 1, 1, 1}, {1, 1, 1, 1}}));
     REQUIRE(*it++
-            == to_word_graph<node_type>(
+            == to<WordGraph<node_type>>(
                 5, {{1, 1, 1, 2}, {1, 1, 1, 2}, {1, 1, 1, 2}}));
     REQUIRE(*it++
-            == to_word_graph<node_type>(
+            == to<WordGraph<node_type>>(
                 5, {{1, 2, 1, 1}, {1, 1, 1, 1}, {2, 2, 2, 2}}));
     REQUIRE(*it++
-            == to_word_graph<node_type>(
+            == to<WordGraph<node_type>>(
                 5, {{1, 2, 1, 1}, {1, 1, 1, 1}, {2, 2, 2, 3}, {2, 2, 2, 3}}));
     REQUIRE(*it++
-            == to_word_graph<node_type>(
+            == to<WordGraph<node_type>>(
                 5, {{1, 2, 1, 3}, {1, 1, 1, 3}, {2, 2, 2, 2}, {1, 1, 1, 3}}));
     REQUIRE(*it++
-            == to_word_graph<node_type>(5,
+            == to<WordGraph<node_type>>(5,
                                         {{1, 2, 1, 3},
                                          {1, 1, 1, 3},
                                          {2, 2, 2, 4},
@@ -2056,7 +2056,7 @@ namespace libsemigroups {
     REQUIRE(word_graph::is_strictly_cyclic(d));
     REQUIRE(d.number_of_nodes() == 4);
     REQUIRE(d
-            == to_word_graph<uint32_t>(
+            == to<WordGraph<uint32_t>>(
                 4, {{2, 2, 3}, {0, 1, 2}, {2, 2, 2}, {3, 3, 3}}));
     auto T = to_froidure_pin<Transf<4>>(d);
     REQUIRE(T.generator(0) == Transf<4>({2, 0, 2, 3}));
@@ -2064,7 +2064,7 @@ namespace libsemigroups {
     REQUIRE(T.generator(2) == Transf<4>({3, 2, 2, 3}));
     REQUIRE(T.size() == 5);
 
-    auto dd = to_word_graph<uint8_t>(5,
+    auto dd = to<WordGraph<uint8_t>>(5,
                                      {{0, 0, 0, 0, 0},
                                       {0, 0, 0, 0, 2},
                                       {2, 2, 2, 2, 2},
@@ -2103,7 +2103,7 @@ namespace libsemigroups {
           REQUIRE(W.generator(2) == Transf<0, node_type>({4, 3, 2, 3, 4}));
           REQUIRE(
               result
-              == to_word_graph<uint32_t>(
+              == to<WordGraph<uint32_t>>(
                   5, {{3, 3, 4}, {0, 1, 3}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}));
           non_strictly_cyclic_count++;
         }
@@ -3819,13 +3819,13 @@ namespace libsemigroups {
     Sims2 s(p);
     REQUIRE(s.number_of_congruences(4) == 4);  // Verified with GAP
     auto it = s.cbegin(4);
-    REQUIRE(*(it++) == to_word_graph<node_type>(4, {{0, 0}}));          // ok
-    REQUIRE(*(it++) == to_word_graph<node_type>(4, {{0, 1}, {1, 1}}));  // ok
+    REQUIRE(*(it++) == to<WordGraph<node_type>>(4, {{0, 0}}));          // ok
+    REQUIRE(*(it++) == to<WordGraph<node_type>>(4, {{0, 1}, {1, 1}}));  // ok
     REQUIRE(*(it++)
-            == to_word_graph<node_type>(4, {{1, 2}, {0, 2}, {2, 2}}));  // ok
+            == to<WordGraph<node_type>>(4, {{1, 2}, {0, 2}, {2, 2}}));  // ok
 
     REQUIRE(*(it++)
-            == to_word_graph<node_type>(
+            == to<WordGraph<node_type>>(
                 4, {{1, 2}, {0, 2}, {3, 2}, {2, 2}}));  // ok
     REQUIRE(it == s.cend(4));
 
@@ -3882,13 +3882,13 @@ namespace libsemigroups {
     REQUIRE(s.number_of_congruences(4) == 6);  // Verified with GAP
     auto it = s.cbegin(5);
     // Verified in 000
-    REQUIRE(*(it++) == to_word_graph<node_type>(5, {{0, 0}}));
-    REQUIRE(*(it++) == to_word_graph<node_type>(5, {{1, 0}, {1, 1}}));
-    REQUIRE(*(it++) == to_word_graph<node_type>(5, {{1, 1}, {1, 1}}));
-    REQUIRE(*(it++) == to_word_graph<node_type>(5, {{1, 2}, {1, 1}, {1, 2}}));
-    REQUIRE(*(it++) == to_word_graph<node_type>(5, {{1, 2}, {1, 1}, {2, 2}}));
+    REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{0, 0}}));
+    REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 0}, {1, 1}}));
+    REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 1}, {1, 1}}));
+    REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {1, 2}}));
+    REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {2, 2}}));
     REQUIRE(*(it++)
-            == to_word_graph<node_type>(5, {{1, 2}, {1, 1}, {3, 2}, {3, 3}}));
+            == to<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {3, 2}, {3, 3}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
@@ -3917,14 +3917,14 @@ namespace libsemigroups {
 
     auto it = s.cbegin(27);
 
-    REQUIRE(*(it++) == to_word_graph<node_type>(27, {{0, 0, 0}}));  // ok
+    REQUIRE(*(it++) == to<WordGraph<node_type>>(27, {{0, 0, 0}}));  // ok
     REQUIRE(*(it++)
-            == to_word_graph<node_type>(27, {{0, 0, 1}, {1, 1, 1}}));  // ok
+            == to<WordGraph<node_type>>(27, {{0, 0, 1}, {1, 1, 1}}));  // ok
     REQUIRE(*(it++)
-            == to_word_graph<node_type>(
+            == to<WordGraph<node_type>>(
                 27, {{0, 1, 2}, {1, 0, 2}, {2, 2, 2}}));  // ok
     REQUIRE(*(it++)
-            == to_word_graph<node_type>(27,
+            == to<WordGraph<node_type>>(27,
                                         {{1, 2, 3},
                                          {4, 5, 3},
                                          {6, 0, 3},
@@ -3933,7 +3933,7 @@ namespace libsemigroups {
                                          {2, 1, 3},
                                          {5, 4, 3}}));  // ok
     REQUIRE(*(it++)
-            == to_word_graph<node_type>(27,
+            == to<WordGraph<node_type>>(27,
                                         {{1, 2, 3},
                                          {4, 5, 6},
                                          {7, 0, 6},
@@ -3951,7 +3951,7 @@ namespace libsemigroups {
                                          {14, 14, 14},
                                          {9, 12, 14}}));  // ok
     REQUIRE(*(it++)
-            == to_word_graph<node_type>(
+            == to<WordGraph<node_type>>(
                 27, {{1, 2, 3},    {4, 5, 6},    {7, 0, 6},    {8, 9, 3},
                      {0, 7, 10},   {2, 1, 10},   {11, 12, 6},  {5, 4, 3},
                      {13, 14, 9},  {15, 3, 9},   {16, 17, 10}, {18, 19, 12},
@@ -3960,7 +3960,7 @@ namespace libsemigroups {
                      {19, 18, 6},  {21, 21, 21}, {10, 24, 21}, {17, 16, 21},
                      {23, 22, 10}}));  // ok
     REQUIRE(*(it++)
-            == to_word_graph<node_type>(
+            == to<WordGraph<node_type>>(
                 27, {{1, 2, 3},    {4, 5, 6},    {7, 0, 6},    {8, 9, 3},
                      {0, 7, 10},   {2, 1, 10},   {11, 12, 6},  {5, 4, 3},
                      {13, 14, 9},  {15, 3, 9},   {16, 17, 10}, {18, 19, 12},
@@ -4196,8 +4196,8 @@ namespace libsemigroups {
     REQUIRE(s.number_of_congruences(2) == 2);
 
     auto it = s.cbegin(2);
-    REQUIRE(*(it++) == to_word_graph<uint32_t>(2, {{0, 0}}));
-    REQUIRE(*(it++) == to_word_graph<uint32_t>(2, {{1, 1}, {1, 1}}));
+    REQUIRE(*(it++) == to<WordGraph<uint32_t>>(2, {{0, 0}}));
+    REQUIRE(*(it++) == to<WordGraph<uint32_t>>(2, {{1, 1}, {1, 1}}));
 
     REQUIRE(s.number_of_congruences(3) == 4);
     REQUIRE(s.number_of_congruences(4) == 9);
@@ -4310,7 +4310,7 @@ namespace libsemigroups {
     // });
 
     // REQUIRE(wg_found.number_of_active_nodes() == 0);
-    // auto wg_expected = to_word_graph<uint32_t>(6,
+    // auto wg_expected = to<WordGraph<uint32_t>>(6,
     //                                            {{1, 0, 0, 2, 0, 0},
     //                                             {1, 0, 3, 1, 1, 1},
     //                                             {2, 2, 2, 2, 0, 2},
@@ -4438,40 +4438,40 @@ namespace libsemigroups {
     word_graph_type wg;
 
     // Wrong alphabet size
-    wg = to_word_graph<node_type>(3, {{1, 1, 1}, {2, 2, 2}, {2, 2, 2}});
+    wg = to<WordGraph<node_type>>(3, {{1, 1, 1}, {2, 2, 2}, {2, 2, 2}});
     wg.number_of_active_nodes(3);
     REQUIRE(!sims::is_right_congruence(p, wg));
 
     // Incomplete
-    wg = to_word_graph<node_type>(2, {{1, 1}, {1, UNDEFINED}});
+    wg = to<WordGraph<node_type>>(2, {{1, 1}, {1, UNDEFINED}});
     wg.number_of_active_nodes(2);
     REQUIRE(!sims::is_right_congruence(p, wg));
 
     // Incompatible
-    wg = to_word_graph<node_type>(2, {{1, 1}, {1, 0}});
+    wg = to<WordGraph<node_type>>(2, {{1, 1}, {1, 0}});
     wg.number_of_active_nodes(2);
     REQUIRE(!sims::is_right_congruence(p, wg));
     REQUIRE_THROWS_AS(sims::throw_if_not_right_congruence(p, wg),
                       LibsemigroupsException);
 
     // Works
-    wg = to_word_graph<node_type>(4, {{1, 2}, {2, 2}, {3, 3}, {3, 3}});
+    wg = to<WordGraph<node_type>>(4, {{1, 2}, {2, 2}, {3, 3}, {3, 3}});
     wg.number_of_active_nodes(4);
     REQUIRE(sims::is_right_congruence(p, wg));
 
     // Non maximal
-    wg = to_word_graph<node_type>(2, {{1, 1}, {1, 0}});
+    wg = to<WordGraph<node_type>>(2, {{1, 1}, {1, 0}});
     wg.number_of_active_nodes(2);
     REQUIRE(!sims::is_maximal_right_congruence(p, wg));
-    wg = to_word_graph<node_type>(4, {{1, 2}, {2, 2}, {3, 3}, {3, 3}});
+    wg = to<WordGraph<node_type>>(4, {{1, 2}, {2, 2}, {3, 3}, {3, 3}});
     wg.number_of_active_nodes(4);
     REQUIRE(!sims::is_maximal_right_congruence(p, wg));
-    wg = to_word_graph<node_type>(1, {{0, 0}});
+    wg = to<WordGraph<node_type>>(1, {{0, 0}});
     wg.number_of_active_nodes(1);
     REQUIRE(!sims::is_maximal_right_congruence(p, wg));
 
     // Is maximal
-    wg = to_word_graph<node_type>(2, {{1, 1}, {1, 1}});
+    wg = to<WordGraph<node_type>>(2, {{1, 1}, {1, 1}});
     wg.number_of_active_nodes(2);
     REQUIRE(sims::is_maximal_right_congruence(p, wg));
   }
@@ -4489,31 +4489,31 @@ namespace libsemigroups {
     word_graph_type wg;
 
     // Wrong alphabet size
-    wg = to_word_graph<node_type>(3, {{1, 1, 1}, {2, 2, 2}, {2, 2, 2}});
+    wg = to<WordGraph<node_type>>(3, {{1, 1, 1}, {2, 2, 2}, {2, 2, 2}});
     wg.number_of_active_nodes(3);
     REQUIRE(!sims::is_two_sided_congruence(p, wg));
 
     // Incomplete
-    wg = to_word_graph<node_type>(2, {{1, 1}, {1, UNDEFINED}});
+    wg = to<WordGraph<node_type>>(2, {{1, 1}, {1, UNDEFINED}});
     wg.number_of_active_nodes(2);
     REQUIRE(!sims::is_two_sided_congruence(p, wg));
 
     // Incompatible
-    wg = to_word_graph<node_type>(2, {{1, 1}, {1, 0}});
+    wg = to<WordGraph<node_type>>(2, {{1, 1}, {1, 0}});
     wg.number_of_active_nodes(2);
     REQUIRE(!sims::is_two_sided_congruence(p, wg));
     REQUIRE_THROWS_AS(sims::throw_if_not_two_sided_congruence(p, wg),
                       LibsemigroupsException);
 
     // Not compatible with X_Gamma
-    wg = to_word_graph<node_type>(4, {{1, 2}, {2, 2}, {3, 3}, {3, 3}});
+    wg = to<WordGraph<node_type>>(4, {{1, 2}, {2, 2}, {3, 3}, {3, 3}});
     wg.number_of_active_nodes(4);
     REQUIRE(!sims::is_two_sided_congruence(p, wg));
     REQUIRE_THROWS_AS(sims::throw_if_not_two_sided_congruence(p, wg),
                       LibsemigroupsException);
 
     // Works
-    wg = to_word_graph<node_type>(2, {{1, 1}, {1, 1}});
+    wg = to<WordGraph<node_type>>(2, {{1, 1}, {1, 1}});
     wg.number_of_active_nodes(2);
     REQUIRE(sims::is_two_sided_congruence(p, wg));
   }

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -546,9 +546,9 @@ namespace libsemigroups {
                           "full_transformation_monoid(3) onesided",
                           "[quick][low-index][no-valgrind]") {
     auto rg = ReportGuard(false);
-    auto S  = to_froidure_pin({to<Transf<3>>({1, 2, 0}),
-                               to<Transf<3>>({1, 0, 2}),
-                               to<Transf<3>>({0, 1, 0})});
+    auto S  = to_froidure_pin({make<Transf<3>>({1, 2, 0}),
+                               make<Transf<3>>({1, 0, 2}),
+                               make<Transf<3>>({0, 1, 0})});
     REQUIRE(S.size() == 27);
     REQUIRE(S.number_of_generators() == 3);
     REQUIRE(S.number_of_rules() == 16);
@@ -2052,9 +2052,9 @@ namespace libsemigroups {
 
     auto rg = ReportGuard(false);
 
-    auto S = to_froidure_pin({to<Transf<6>>({0, 0, 2, 1, 4, 1}),
-                              to<Transf<6>>({0, 0, 2, 3, 4, 3}),
-                              to<Transf<6>>({0, 2, 2, 0, 4, 4})});
+    auto S = to_froidure_pin({make<Transf<6>>({0, 0, 2, 1, 4, 1}),
+                              make<Transf<6>>({0, 0, 2, 3, 4, 3}),
+                              make<Transf<6>>({0, 2, 2, 0, 4, 4})});
 
     REQUIRE(S.size() == 5);
     auto p = to_presentation<word_type>(S);
@@ -3568,11 +3568,11 @@ namespace libsemigroups {
                           "[standard][sims2][low-index]") {
     auto                  rg = ReportGuard(false);
     FroidurePin<PPerm<4>> T;
-    T.add_generator(to<PPerm<4>>({1, 2, 3, 0}));
-    T.add_generator(to<PPerm<4>>({1, 2, 3}, {1, 2, 3}, 4));
-    T.add_generator(to<PPerm<4>>({0, 2, 3}, {0, 2, 3}, 4));
-    T.add_generator(to<PPerm<4>>({0, 1, 3}, {0, 1, 3}, 4));
-    T.add_generator(to<PPerm<4>>({0, 1, 2}, {0, 1, 2}, 4));
+    T.add_generator(make<PPerm<4>>({1, 2, 3, 0}));
+    T.add_generator(make<PPerm<4>>({1, 2, 3}, {1, 2, 3}, 4));
+    T.add_generator(make<PPerm<4>>({0, 2, 3}, {0, 2, 3}, 4));
+    T.add_generator(make<PPerm<4>>({0, 1, 3}, {0, 1, 3}, 4));
+    T.add_generator(make<PPerm<4>>({0, 1, 2}, {0, 1, 2}, 4));
     REQUIRE(T.size() == 61);
 
     auto p = to_presentation<word_type>(T);
@@ -3626,10 +3626,10 @@ namespace libsemigroups {
                           "[quick][sims2][low-index][no-valgrind]") {
     auto                   rg = ReportGuard(false);
     FroidurePin<Transf<4>> S;
-    S.add_generator(to<Transf<4>>({0, 1, 2, 3}));
-    S.add_generator(to<Transf<4>>({0, 0, 2, 3}));
-    S.add_generator(to<Transf<4>>({0, 1, 1, 3}));
-    S.add_generator(to<Transf<4>>({0, 1, 2, 2}));
+    S.add_generator(make<Transf<4>>({0, 1, 2, 3}));
+    S.add_generator(make<Transf<4>>({0, 0, 2, 3}));
+    S.add_generator(make<Transf<4>>({0, 1, 1, 3}));
+    S.add_generator(make<Transf<4>>({0, 1, 2, 2}));
     REQUIRE(S.size() == 14);
     auto p = to_presentation<word_type>(S);
 

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -4891,25 +4891,25 @@ namespace libsemigroups {
 
     auto it = S.cbegin(9);
     REQUIRE(*(it++)
-            == to_word_graph<node_type>(
+            == make<WordGraph<node_type>>(
                 9, {{1, 2}, {1, 3}, {4, 5}, {4, 4}, {3, 1}, {3, 0}}));
     REQUIRE(*(it++)
-            == to_word_graph<node_type>(
+            == make<WordGraph<node_type>>(
                 9, {{1, 2}, {3, 3}, {4, 5}, {1, 4}, {4, 1}, {3, 0}}));
     REQUIRE(*(it++)
-            == to_word_graph<node_type>(
+            == make<WordGraph<node_type>>(
                 9, {{1, 2}, {3, 4}, {3, 5}, {1, 1}, {4, 3}, {4, 0}}));
     REQUIRE(*(it++)
-            == to_word_graph<node_type>(9,
-                                        {{1, 2},
-                                         {3, 4},
-                                         {5, 6},
-                                         {1, 7},
-                                         {8, 5},
-                                         {7, 1},
-                                         {4, 0},
-                                         {5, 8},
-                                         {4, 3}}));
+            == make<WordGraph<node_type>>(9,
+                                          {{1, 2},
+                                           {3, 4},
+                                           {5, 6},
+                                           {1, 7},
+                                           {8, 5},
+                                           {7, 1},
+                                           {4, 0},
+                                           {5, 8},
+                                           {4, 3}}));
     REQUIRE(*(it++) == WordGraph<node_type>(0, 2));
     REQUIRE(*(it++) == WordGraph<node_type>(0, 2));
     REQUIRE(*(it++) == WordGraph<node_type>(0, 2));

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -114,7 +114,7 @@ namespace libsemigroups {
       REQUIRE(T.included_pairs() == e);
 
       // auto it = std::find_if(T.cbegin(n), T.cend(n), foo);
-      // REQUIRE(*it == to<WordGraph<uint32_t>>(1, {{0, 0}}));
+      // REQUIRE(*it == make<WordGraph<uint32_t>>(1, {{0, 0}}));
       REQUIRE(std::all_of(T.cbegin(n), T.cend(n), foo));
       REQUIRE(static_cast<uint64_t>(std::count_if(S.cbegin(n), S.cend(n), foo))
               == T.number_of_congruences(n));
@@ -278,22 +278,25 @@ namespace libsemigroups {
       REQUIRE(S.number_of_congruences(1) == 1);
 
       auto it = S.cbegin(1);
-      REQUIRE(*it == to<WordGraph<node_type>>(1, {{0, 0}}));
+      REQUIRE(*it == make<WordGraph<node_type>>(1, {{0, 0}}));
 
       it = S.cbegin(5);
-      REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{0, 0}}));
-      REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 0}, {1, 1}}));
-      REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 1}, {1, 1}}));
-      REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {1, 2}}));
-      REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {2, 2}}));
+      REQUIRE(*(it++) == make<WordGraph<node_type>>(5, {{0, 0}}));
+      REQUIRE(*(it++) == make<WordGraph<node_type>>(5, {{1, 0}, {1, 1}}));
+      REQUIRE(*(it++) == make<WordGraph<node_type>>(5, {{1, 1}, {1, 1}}));
       REQUIRE(*(it++)
-              == to<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {3, 2}, {3, 3}}));
+              == make<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {1, 2}}));
+      REQUIRE(*(it++)
+              == make<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {2, 2}}));
+      REQUIRE(
+          *(it++)
+          == make<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {3, 2}, {3, 3}}));
       REQUIRE(*(it++) == WordGraph<node_type>(0, 2));
       REQUIRE(*(it++) == WordGraph<node_type>(0, 2));
       REQUIRE(*(it++) == WordGraph<node_type>(0, 2));
 
       it = S.cbegin(3);
-      REQUIRE(*it == to<WordGraph<node_type>>(3, {{0, 0}}));
+      REQUIRE(*it == make<WordGraph<node_type>>(3, {{0, 0}}));
       // Note that Catch's REQUIRE macro is not thread safe, see:
       // https://github.com/catchorg/Catch2/issues/99
       // as such we cannot call any function (like
@@ -364,9 +367,9 @@ namespace libsemigroups {
     REQUIRE(S.number_of_congruences(10) == 176);
 
     auto it = S.cbegin(2);
-    REQUIRE(*(it++) == to<WordGraph<node_type>>(2, {{0, 0, 0}}));
-    REQUIRE(*(it++) == to<WordGraph<node_type>>(2, {{1, 0, 1}, {1, 1, 1}}));
-    REQUIRE(*(it++) == to<WordGraph<node_type>>(2, {{1, 1, 1}, {1, 1, 1}}));
+    REQUIRE(*(it++) == make<WordGraph<node_type>>(2, {{0, 0, 0}}));
+    REQUIRE(*(it++) == make<WordGraph<node_type>>(2, {{1, 0, 1}, {1, 1, 1}}));
+    REQUIRE(*(it++) == make<WordGraph<node_type>>(2, {{1, 1, 1}, {1, 1, 1}}));
     REQUIRE(*(it++) == WordGraph<node_type>(0, 3));
     REQUIRE(*(it++) == WordGraph<node_type>(0, 3));
     // sims::dot_poset("example-001", S.cbegin(4), S.cend(4));
@@ -1099,7 +1102,7 @@ namespace libsemigroups {
     // REQUIRE(word_graph::is_strictly_cyclic(d));
     // REQUIRE(
     //     d
-    //     == to<WordGraph<uint32_t>>(
+    //     == make<WordGraph<uint32_t>>(
     //         22, {{0, 0, 1, 0, 2, 3, 2},        {1, 4, 0, 5, 6, 3, 7},
     //              {2, 2, 2, 2, 2, 2, 2},        {3, 8, 3, 9, 6, 3, 7},
     //              {4, 1, 4, 10, 6, 2, 11},      {5, 10, 5, 1, 12, 2, 7},
@@ -1756,7 +1759,7 @@ namespace libsemigroups {
     // whichever one is found first, in multiple threads
     // REQUIRE(
     //     d
-    //     == to<WordGraph<node_type>>(
+    //     == make<WordGraph<node_type>>(
     //         22,
     //         {{0, 1, 0, 2, 0},      {1, 3, 3, 4, 5},      {2, 6, 6, 2, 0},
     //          {3, 0, 1, 2, 5},      {4, 4, 4, 4, 4},      {5, 5, 5, 7, 5},
@@ -1944,59 +1947,62 @@ namespace libsemigroups {
 
     auto it = S.cbegin(4);
 
-    REQUIRE(
-        *it++
-        == to<WordGraph<node_type>>(5, {{1, 1, 1, 1}, {1, 1, 1, 1}}));  // Good
     REQUIRE(*it++
-            == to<WordGraph<node_type>>(
+            == make<WordGraph<node_type>>(
+                5, {{1, 1, 1, 1}, {1, 1, 1, 1}}));  // Good
+    REQUIRE(*it++
+            == make<WordGraph<node_type>>(
                 5, {{1, 1, 1, 2}, {1, 1, 1, 2}, {1, 1, 1, 2}}));  // Good
     REQUIRE(*it++
-            == to<WordGraph<node_type>>(
+            == make<WordGraph<node_type>>(
                 5, {{1, 2, 1, 1}, {1, 1, 1, 1}, {2, 2, 2, 2}}));  // Good
     REQUIRE(
         *it++
-        == to<WordGraph<node_type>>(
+        == make<WordGraph<node_type>>(
             5,
             {{1, 2, 1, 1}, {1, 1, 1, 1}, {2, 2, 2, 3}, {2, 2, 2, 3}}));  // Good
     REQUIRE(
         *it++
-        == to<WordGraph<node_type>>(
+        == make<WordGraph<node_type>>(
             5,
             {{1, 2, 1, 3}, {1, 1, 1, 3}, {2, 2, 2, 2}, {1, 1, 1, 3}}));  // Good
     REQUIRE(*it++
-            == to<WordGraph<node_type>>(5,
-                                        {{1, 2, 1, 3},
-                                         {1, 1, 1, 3},
-                                         {2, 2, 2, 4},
-                                         {1, 1, 1, 3},
-                                         {2, 2, 2, 4}}));  // Good
+            == make<WordGraph<node_type>>(5,
+                                          {{1, 2, 1, 3},
+                                           {1, 1, 1, 3},
+                                           {2, 2, 2, 4},
+                                           {1, 1, 1, 3},
+                                           {2, 2, 2, 4}}));  // Good
     REQUIRE(it->number_of_nodes() == 0);
 
     it = T.cbegin(5);
 
-    REQUIRE(*it++ == to<WordGraph<node_type>>(5, {{0, 0, 0, 0}}));
-    REQUIRE(*it++ == to<WordGraph<node_type>>(5, {{0, 0, 0, 1}, {0, 0, 0, 1}}));
-    REQUIRE(*it++ == to<WordGraph<node_type>>(5, {{1, 1, 1, 0}, {1, 1, 1, 0}}));
-    REQUIRE(*it++ == to<WordGraph<node_type>>(5, {{1, 1, 1, 1}, {1, 1, 1, 1}}));
+    REQUIRE(*it++ == make<WordGraph<node_type>>(5, {{0, 0, 0, 0}}));
     REQUIRE(*it++
-            == to<WordGraph<node_type>>(
+            == make<WordGraph<node_type>>(5, {{0, 0, 0, 1}, {0, 0, 0, 1}}));
+    REQUIRE(*it++
+            == make<WordGraph<node_type>>(5, {{1, 1, 1, 0}, {1, 1, 1, 0}}));
+    REQUIRE(*it++
+            == make<WordGraph<node_type>>(5, {{1, 1, 1, 1}, {1, 1, 1, 1}}));
+    REQUIRE(*it++
+            == make<WordGraph<node_type>>(
                 5, {{1, 1, 1, 2}, {1, 1, 1, 2}, {1, 1, 1, 2}}));
     REQUIRE(*it++
-            == to<WordGraph<node_type>>(
+            == make<WordGraph<node_type>>(
                 5, {{1, 2, 1, 1}, {1, 1, 1, 1}, {2, 2, 2, 2}}));
     REQUIRE(*it++
-            == to<WordGraph<node_type>>(
+            == make<WordGraph<node_type>>(
                 5, {{1, 2, 1, 1}, {1, 1, 1, 1}, {2, 2, 2, 3}, {2, 2, 2, 3}}));
     REQUIRE(*it++
-            == to<WordGraph<node_type>>(
+            == make<WordGraph<node_type>>(
                 5, {{1, 2, 1, 3}, {1, 1, 1, 3}, {2, 2, 2, 2}, {1, 1, 1, 3}}));
     REQUIRE(*it++
-            == to<WordGraph<node_type>>(5,
-                                        {{1, 2, 1, 3},
-                                         {1, 1, 1, 3},
-                                         {2, 2, 2, 4},
-                                         {1, 1, 1, 3},
-                                         {2, 2, 2, 4}}));
+            == make<WordGraph<node_type>>(5,
+                                          {{1, 2, 1, 3},
+                                           {1, 1, 1, 3},
+                                           {2, 2, 2, 4},
+                                           {1, 1, 1, 3},
+                                           {2, 2, 2, 4}}));
     REQUIRE(it->number_of_nodes() == 0);
   }
 
@@ -2056,7 +2062,7 @@ namespace libsemigroups {
     REQUIRE(word_graph::is_strictly_cyclic(d));
     REQUIRE(d.number_of_nodes() == 4);
     REQUIRE(d
-            == to<WordGraph<uint32_t>>(
+            == make<WordGraph<uint32_t>>(
                 4, {{2, 2, 3}, {0, 1, 2}, {2, 2, 2}, {3, 3, 3}}));
     auto T = to_froidure_pin<Transf<4>>(d);
     REQUIRE(T.generator(0) == Transf<4>({2, 0, 2, 3}));
@@ -2064,12 +2070,12 @@ namespace libsemigroups {
     REQUIRE(T.generator(2) == Transf<4>({3, 2, 2, 3}));
     REQUIRE(T.size() == 5);
 
-    auto dd = to<WordGraph<uint8_t>>(5,
-                                     {{0, 0, 0, 0, 0},
-                                      {0, 0, 0, 0, 2},
-                                      {2, 2, 2, 2, 2},
-                                      {0, 1, 2, 3, 0},
-                                      {4, 4, 4, 4, 4}});
+    auto dd = make<WordGraph<uint8_t>>(5,
+                                       {{0, 0, 0, 0, 0},
+                                        {0, 0, 0, 0, 2},
+                                        {2, 2, 2, 2, 2},
+                                        {0, 1, 2, 3, 0},
+                                        {4, 4, 4, 4, 4}});
 
     REQUIRE(!word_graph::is_strictly_cyclic(dd));
     REQUIRE(dd.number_of_nodes() == 5);
@@ -2103,7 +2109,7 @@ namespace libsemigroups {
           REQUIRE(W.generator(2) == Transf<0, node_type>({4, 3, 2, 3, 4}));
           REQUIRE(
               result
-              == to<WordGraph<uint32_t>>(
+              == make<WordGraph<uint32_t>>(
                   5, {{3, 3, 4}, {0, 1, 3}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}));
           non_strictly_cyclic_count++;
         }
@@ -3819,13 +3825,13 @@ namespace libsemigroups {
     Sims2 s(p);
     REQUIRE(s.number_of_congruences(4) == 4);  // Verified with GAP
     auto it = s.cbegin(4);
-    REQUIRE(*(it++) == to<WordGraph<node_type>>(4, {{0, 0}}));          // ok
-    REQUIRE(*(it++) == to<WordGraph<node_type>>(4, {{0, 1}, {1, 1}}));  // ok
+    REQUIRE(*(it++) == make<WordGraph<node_type>>(4, {{0, 0}}));          // ok
+    REQUIRE(*(it++) == make<WordGraph<node_type>>(4, {{0, 1}, {1, 1}}));  // ok
     REQUIRE(*(it++)
-            == to<WordGraph<node_type>>(4, {{1, 2}, {0, 2}, {2, 2}}));  // ok
+            == make<WordGraph<node_type>>(4, {{1, 2}, {0, 2}, {2, 2}}));  // ok
 
     REQUIRE(*(it++)
-            == to<WordGraph<node_type>>(
+            == make<WordGraph<node_type>>(
                 4, {{1, 2}, {0, 2}, {3, 2}, {2, 2}}));  // ok
     REQUIRE(it == s.cend(4));
 
@@ -3882,13 +3888,13 @@ namespace libsemigroups {
     REQUIRE(s.number_of_congruences(4) == 6);  // Verified with GAP
     auto it = s.cbegin(5);
     // Verified in 000
-    REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{0, 0}}));
-    REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 0}, {1, 1}}));
-    REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 1}, {1, 1}}));
-    REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {1, 2}}));
-    REQUIRE(*(it++) == to<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {2, 2}}));
+    REQUIRE(*(it++) == make<WordGraph<node_type>>(5, {{0, 0}}));
+    REQUIRE(*(it++) == make<WordGraph<node_type>>(5, {{1, 0}, {1, 1}}));
+    REQUIRE(*(it++) == make<WordGraph<node_type>>(5, {{1, 1}, {1, 1}}));
+    REQUIRE(*(it++) == make<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {1, 2}}));
+    REQUIRE(*(it++) == make<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {2, 2}}));
     REQUIRE(*(it++)
-            == to<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {3, 2}, {3, 3}}));
+            == make<WordGraph<node_type>>(5, {{1, 2}, {1, 1}, {3, 2}, {3, 3}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
@@ -3917,41 +3923,41 @@ namespace libsemigroups {
 
     auto it = s.cbegin(27);
 
-    REQUIRE(*(it++) == to<WordGraph<node_type>>(27, {{0, 0, 0}}));  // ok
+    REQUIRE(*(it++) == make<WordGraph<node_type>>(27, {{0, 0, 0}}));  // ok
     REQUIRE(*(it++)
-            == to<WordGraph<node_type>>(27, {{0, 0, 1}, {1, 1, 1}}));  // ok
+            == make<WordGraph<node_type>>(27, {{0, 0, 1}, {1, 1, 1}}));  // ok
     REQUIRE(*(it++)
-            == to<WordGraph<node_type>>(
+            == make<WordGraph<node_type>>(
                 27, {{0, 1, 2}, {1, 0, 2}, {2, 2, 2}}));  // ok
     REQUIRE(*(it++)
-            == to<WordGraph<node_type>>(27,
-                                        {{1, 2, 3},
-                                         {4, 5, 3},
-                                         {6, 0, 3},
-                                         {3, 3, 3},
-                                         {0, 6, 3},
-                                         {2, 1, 3},
-                                         {5, 4, 3}}));  // ok
+            == make<WordGraph<node_type>>(27,
+                                          {{1, 2, 3},
+                                           {4, 5, 3},
+                                           {6, 0, 3},
+                                           {3, 3, 3},
+                                           {0, 6, 3},
+                                           {2, 1, 3},
+                                           {5, 4, 3}}));  // ok
     REQUIRE(*(it++)
-            == to<WordGraph<node_type>>(27,
-                                        {{1, 2, 3},
-                                         {4, 5, 6},
-                                         {7, 0, 6},
-                                         {8, 3, 3},
-                                         {0, 7, 9},
-                                         {2, 1, 9},
-                                         {10, 6, 6},
-                                         {5, 4, 3},
-                                         {11, 11, 3},
-                                         {12, 9, 9},
-                                         {13, 13, 6},
-                                         {3, 8, 14},
-                                         {15, 15, 9},
-                                         {6, 10, 14},
-                                         {14, 14, 14},
-                                         {9, 12, 14}}));  // ok
+            == make<WordGraph<node_type>>(27,
+                                          {{1, 2, 3},
+                                           {4, 5, 6},
+                                           {7, 0, 6},
+                                           {8, 3, 3},
+                                           {0, 7, 9},
+                                           {2, 1, 9},
+                                           {10, 6, 6},
+                                           {5, 4, 3},
+                                           {11, 11, 3},
+                                           {12, 9, 9},
+                                           {13, 13, 6},
+                                           {3, 8, 14},
+                                           {15, 15, 9},
+                                           {6, 10, 14},
+                                           {14, 14, 14},
+                                           {9, 12, 14}}));  // ok
     REQUIRE(*(it++)
-            == to<WordGraph<node_type>>(
+            == make<WordGraph<node_type>>(
                 27, {{1, 2, 3},    {4, 5, 6},    {7, 0, 6},    {8, 9, 3},
                      {0, 7, 10},   {2, 1, 10},   {11, 12, 6},  {5, 4, 3},
                      {13, 14, 9},  {15, 3, 9},   {16, 17, 10}, {18, 19, 12},
@@ -3960,7 +3966,7 @@ namespace libsemigroups {
                      {19, 18, 6},  {21, 21, 21}, {10, 24, 21}, {17, 16, 21},
                      {23, 22, 10}}));  // ok
     REQUIRE(*(it++)
-            == to<WordGraph<node_type>>(
+            == make<WordGraph<node_type>>(
                 27, {{1, 2, 3},    {4, 5, 6},    {7, 0, 6},    {8, 9, 3},
                      {0, 7, 10},   {2, 1, 10},   {11, 12, 6},  {5, 4, 3},
                      {13, 14, 9},  {15, 3, 9},   {16, 17, 10}, {18, 19, 12},
@@ -4196,8 +4202,8 @@ namespace libsemigroups {
     REQUIRE(s.number_of_congruences(2) == 2);
 
     auto it = s.cbegin(2);
-    REQUIRE(*(it++) == to<WordGraph<uint32_t>>(2, {{0, 0}}));
-    REQUIRE(*(it++) == to<WordGraph<uint32_t>>(2, {{1, 1}, {1, 1}}));
+    REQUIRE(*(it++) == make<WordGraph<uint32_t>>(2, {{0, 0}}));
+    REQUIRE(*(it++) == make<WordGraph<uint32_t>>(2, {{1, 1}, {1, 1}}));
 
     REQUIRE(s.number_of_congruences(3) == 4);
     REQUIRE(s.number_of_congruences(4) == 9);
@@ -4310,7 +4316,7 @@ namespace libsemigroups {
     // });
 
     // REQUIRE(wg_found.number_of_active_nodes() == 0);
-    // auto wg_expected = to<WordGraph<uint32_t>>(6,
+    // auto wg_expected = make<WordGraph<uint32_t>>(6,
     //                                            {{1, 0, 0, 2, 0, 0},
     //                                             {1, 0, 3, 1, 1, 1},
     //                                             {2, 2, 2, 2, 0, 2},
@@ -4438,40 +4444,40 @@ namespace libsemigroups {
     word_graph_type wg;
 
     // Wrong alphabet size
-    wg = to<WordGraph<node_type>>(3, {{1, 1, 1}, {2, 2, 2}, {2, 2, 2}});
+    wg = make<WordGraph<node_type>>(3, {{1, 1, 1}, {2, 2, 2}, {2, 2, 2}});
     wg.number_of_active_nodes(3);
     REQUIRE(!sims::is_right_congruence(p, wg));
 
     // Incomplete
-    wg = to<WordGraph<node_type>>(2, {{1, 1}, {1, UNDEFINED}});
+    wg = make<WordGraph<node_type>>(2, {{1, 1}, {1, UNDEFINED}});
     wg.number_of_active_nodes(2);
     REQUIRE(!sims::is_right_congruence(p, wg));
 
     // Incompatible
-    wg = to<WordGraph<node_type>>(2, {{1, 1}, {1, 0}});
+    wg = make<WordGraph<node_type>>(2, {{1, 1}, {1, 0}});
     wg.number_of_active_nodes(2);
     REQUIRE(!sims::is_right_congruence(p, wg));
     REQUIRE_THROWS_AS(sims::throw_if_not_right_congruence(p, wg),
                       LibsemigroupsException);
 
     // Works
-    wg = to<WordGraph<node_type>>(4, {{1, 2}, {2, 2}, {3, 3}, {3, 3}});
+    wg = make<WordGraph<node_type>>(4, {{1, 2}, {2, 2}, {3, 3}, {3, 3}});
     wg.number_of_active_nodes(4);
     REQUIRE(sims::is_right_congruence(p, wg));
 
     // Non maximal
-    wg = to<WordGraph<node_type>>(2, {{1, 1}, {1, 0}});
+    wg = make<WordGraph<node_type>>(2, {{1, 1}, {1, 0}});
     wg.number_of_active_nodes(2);
     REQUIRE(!sims::is_maximal_right_congruence(p, wg));
-    wg = to<WordGraph<node_type>>(4, {{1, 2}, {2, 2}, {3, 3}, {3, 3}});
+    wg = make<WordGraph<node_type>>(4, {{1, 2}, {2, 2}, {3, 3}, {3, 3}});
     wg.number_of_active_nodes(4);
     REQUIRE(!sims::is_maximal_right_congruence(p, wg));
-    wg = to<WordGraph<node_type>>(1, {{0, 0}});
+    wg = make<WordGraph<node_type>>(1, {{0, 0}});
     wg.number_of_active_nodes(1);
     REQUIRE(!sims::is_maximal_right_congruence(p, wg));
 
     // Is maximal
-    wg = to<WordGraph<node_type>>(2, {{1, 1}, {1, 1}});
+    wg = make<WordGraph<node_type>>(2, {{1, 1}, {1, 1}});
     wg.number_of_active_nodes(2);
     REQUIRE(sims::is_maximal_right_congruence(p, wg));
   }
@@ -4489,31 +4495,31 @@ namespace libsemigroups {
     word_graph_type wg;
 
     // Wrong alphabet size
-    wg = to<WordGraph<node_type>>(3, {{1, 1, 1}, {2, 2, 2}, {2, 2, 2}});
+    wg = make<WordGraph<node_type>>(3, {{1, 1, 1}, {2, 2, 2}, {2, 2, 2}});
     wg.number_of_active_nodes(3);
     REQUIRE(!sims::is_two_sided_congruence(p, wg));
 
     // Incomplete
-    wg = to<WordGraph<node_type>>(2, {{1, 1}, {1, UNDEFINED}});
+    wg = make<WordGraph<node_type>>(2, {{1, 1}, {1, UNDEFINED}});
     wg.number_of_active_nodes(2);
     REQUIRE(!sims::is_two_sided_congruence(p, wg));
 
     // Incompatible
-    wg = to<WordGraph<node_type>>(2, {{1, 1}, {1, 0}});
+    wg = make<WordGraph<node_type>>(2, {{1, 1}, {1, 0}});
     wg.number_of_active_nodes(2);
     REQUIRE(!sims::is_two_sided_congruence(p, wg));
     REQUIRE_THROWS_AS(sims::throw_if_not_two_sided_congruence(p, wg),
                       LibsemigroupsException);
 
     // Not compatible with X_Gamma
-    wg = to<WordGraph<node_type>>(4, {{1, 2}, {2, 2}, {3, 3}, {3, 3}});
+    wg = make<WordGraph<node_type>>(4, {{1, 2}, {2, 2}, {3, 3}, {3, 3}});
     wg.number_of_active_nodes(4);
     REQUIRE(!sims::is_two_sided_congruence(p, wg));
     REQUIRE_THROWS_AS(sims::throw_if_not_two_sided_congruence(p, wg),
                       LibsemigroupsException);
 
     // Works
-    wg = to<WordGraph<node_type>>(2, {{1, 1}, {1, 1}});
+    wg = make<WordGraph<node_type>>(2, {{1, 1}, {1, 1}});
     wg.number_of_active_nodes(2);
     REQUIRE(sims::is_two_sided_congruence(p, wg));
   }

--- a/tests/test-stephen.cpp
+++ b/tests/test-stephen.cpp
@@ -59,8 +59,9 @@ namespace libsemigroups {
     void check_000(Stephen<PresentationType>& s) {
       s.set_word({0}).run();
       REQUIRE(s.word_graph().number_of_nodes() == 2);
-      REQUIRE(s.word_graph()
-              == to<WordGraph<uint32_t>>(2, {{1, UNDEFINED}, {UNDEFINED, 1}}));
+      REQUIRE(
+          s.word_graph()
+          == make<WordGraph<uint32_t>>(2, {{1, UNDEFINED}, {UNDEFINED, 1}}));
       REQUIRE(stephen::number_of_words_accepted(s) == POSITIVE_INFINITY);
       {
         REQUIRE((stephen::words_accepted(s) | rx::take(10) | rx::to_vector())
@@ -161,14 +162,14 @@ namespace libsemigroups {
     s.set_word(1101_w).run();
     REQUIRE(s.word_graph().number_of_nodes() == 7);
     REQUIRE(s.word_graph()
-            == to<WordGraph<uint32_t>>(7,
-                                       {{UNDEFINED, 1},
-                                        {UNDEFINED, 2},
-                                        {3, 1},
-                                        {4, 5},
-                                        {3, 6},
-                                        {6, 3},
-                                        {5, 4}}));
+            == make<WordGraph<uint32_t>>(7,
+                                         {{UNDEFINED, 1},
+                                          {UNDEFINED, 2},
+                                          {3, 1},
+                                          {4, 5},
+                                          {3, 6},
+                                          {6, 3},
+                                          {5, 4}}));
     REQUIRE(stephen::number_of_words_accepted(s) == POSITIVE_INFINITY);
 
     word_type w = 1101_w;
@@ -223,7 +224,7 @@ namespace libsemigroups {
     s.set_word(00_w).run();
     REQUIRE(s.word_graph().number_of_nodes() == 5);
     REQUIRE(s.word_graph()
-            == to<WordGraph<uint32_t>>(
+            == make<WordGraph<uint32_t>>(
                 5, {{1, UNDEFINED}, {2, 3}, {1, 4}, {4, 1}, {3, 2}}));
 
     p.rules.clear();
@@ -232,7 +233,7 @@ namespace libsemigroups {
     s.init(p).set_word(00_w).run();
     REQUIRE(s.word_graph().number_of_nodes() == 3);
     REQUIRE(s.word_graph()
-            == to<WordGraph<uint32_t>>(
+            == make<WordGraph<uint32_t>>(
                 3, {{1, UNDEFINED}, {2, UNDEFINED}, {1, UNDEFINED}}));
   }
 
@@ -251,7 +252,7 @@ namespace libsemigroups {
     REQUIRE(s.word_graph().number_of_nodes() == 120);
     REQUIRE(
         s.word_graph()
-        == to<WordGraph<uint32_t>>(
+        == make<WordGraph<uint32_t>>(
             120,
             {{1, 2, 3, 4, UNDEFINED},        {0, 5, 6, 7, UNDEFINED},
              {8, 0, 9, 10, UNDEFINED},       {11, 12, 0, 13, UNDEFINED},
@@ -358,7 +359,7 @@ namespace libsemigroups {
     S.set_word("abcef"_w).run();
     REQUIRE("abcef"_w == 01245_w);
     REQUIRE(S.word_graph()
-            == to<WordGraph<uint32_t>>(
+            == make<WordGraph<uint32_t>>(
                 11,
                 {{1,
                   UNDEFINED,
@@ -1073,12 +1074,13 @@ namespace libsemigroups {
     REQUIRE(S.word_graph().number_of_nodes() == 4);
     REQUIRE(S.word_graph().number_of_edges() == 8);
 
-    REQUIRE(S.word_graph()
-            == to<WordGraph<uint32_t>>(4,
-                                       {{1, 2, UNDEFINED, UNDEFINED},
-                                        {UNDEFINED, 1, 0, 1},
-                                        {UNDEFINED, 3, UNDEFINED, 0},
-                                        {UNDEFINED, UNDEFINED, UNDEFINED, 2}}));
+    REQUIRE(
+        S.word_graph()
+        == make<WordGraph<uint32_t>>(4,
+                                     {{1, 2, UNDEFINED, UNDEFINED},
+                                      {UNDEFINED, 1, 0, 1},
+                                      {UNDEFINED, 3, UNDEFINED, 0},
+                                      {UNDEFINED, UNDEFINED, UNDEFINED, 2}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
@@ -1119,7 +1121,7 @@ namespace libsemigroups {
     S.run();
     REQUIRE(S.word_graph().number_of_nodes() == 7);
     REQUIRE(S.word_graph()
-            == to<WordGraph<uint32_t>>(
+            == make<WordGraph<uint32_t>>(
                 7,
                 {{1, UNDEFINED, 2, UNDEFINED, 3, UNDEFINED},
                  {UNDEFINED, UNDEFINED, UNDEFINED, 0, 4, UNDEFINED},
@@ -1180,7 +1182,7 @@ namespace libsemigroups {
     S.run();
     REQUIRE(S.word_graph().number_of_nodes() == 7);
     REQUIRE(S.word_graph()
-            == to<WordGraph<uint32_t>>(
+            == make<WordGraph<uint32_t>>(
                 7,
                 {{1, UNDEFINED, 2, UNDEFINED, 3, UNDEFINED},
                  {UNDEFINED, UNDEFINED, UNDEFINED, 0, 4, UNDEFINED},

--- a/tests/test-stephen.cpp
+++ b/tests/test-stephen.cpp
@@ -60,7 +60,7 @@ namespace libsemigroups {
       s.set_word({0}).run();
       REQUIRE(s.word_graph().number_of_nodes() == 2);
       REQUIRE(s.word_graph()
-              == to_word_graph<uint32_t>(2, {{1, UNDEFINED}, {UNDEFINED, 1}}));
+              == to<WordGraph<uint32_t>>(2, {{1, UNDEFINED}, {UNDEFINED, 1}}));
       REQUIRE(stephen::number_of_words_accepted(s) == POSITIVE_INFINITY);
       {
         REQUIRE((stephen::words_accepted(s) | rx::take(10) | rx::to_vector())
@@ -161,7 +161,7 @@ namespace libsemigroups {
     s.set_word(1101_w).run();
     REQUIRE(s.word_graph().number_of_nodes() == 7);
     REQUIRE(s.word_graph()
-            == to_word_graph<uint32_t>(7,
+            == to<WordGraph<uint32_t>>(7,
                                        {{UNDEFINED, 1},
                                         {UNDEFINED, 2},
                                         {3, 1},
@@ -223,7 +223,7 @@ namespace libsemigroups {
     s.set_word(00_w).run();
     REQUIRE(s.word_graph().number_of_nodes() == 5);
     REQUIRE(s.word_graph()
-            == to_word_graph<uint32_t>(
+            == to<WordGraph<uint32_t>>(
                 5, {{1, UNDEFINED}, {2, 3}, {1, 4}, {4, 1}, {3, 2}}));
 
     p.rules.clear();
@@ -232,7 +232,7 @@ namespace libsemigroups {
     s.init(p).set_word(00_w).run();
     REQUIRE(s.word_graph().number_of_nodes() == 3);
     REQUIRE(s.word_graph()
-            == to_word_graph<uint32_t>(
+            == to<WordGraph<uint32_t>>(
                 3, {{1, UNDEFINED}, {2, UNDEFINED}, {1, UNDEFINED}}));
   }
 
@@ -251,7 +251,7 @@ namespace libsemigroups {
     REQUIRE(s.word_graph().number_of_nodes() == 120);
     REQUIRE(
         s.word_graph()
-        == to_word_graph<uint32_t>(
+        == to<WordGraph<uint32_t>>(
             120,
             {{1, 2, 3, 4, UNDEFINED},        {0, 5, 6, 7, UNDEFINED},
              {8, 0, 9, 10, UNDEFINED},       {11, 12, 0, 13, UNDEFINED},
@@ -358,7 +358,7 @@ namespace libsemigroups {
     S.set_word("abcef"_w).run();
     REQUIRE("abcef"_w == 01245_w);
     REQUIRE(S.word_graph()
-            == to_word_graph<uint32_t>(
+            == to<WordGraph<uint32_t>>(
                 11,
                 {{1,
                   UNDEFINED,
@@ -1074,7 +1074,7 @@ namespace libsemigroups {
     REQUIRE(S.word_graph().number_of_edges() == 8);
 
     REQUIRE(S.word_graph()
-            == to_word_graph<uint32_t>(4,
+            == to<WordGraph<uint32_t>>(4,
                                        {{1, 2, UNDEFINED, UNDEFINED},
                                         {UNDEFINED, 1, 0, 1},
                                         {UNDEFINED, 3, UNDEFINED, 0},
@@ -1119,7 +1119,7 @@ namespace libsemigroups {
     S.run();
     REQUIRE(S.word_graph().number_of_nodes() == 7);
     REQUIRE(S.word_graph()
-            == to_word_graph<uint32_t>(
+            == to<WordGraph<uint32_t>>(
                 7,
                 {{1, UNDEFINED, 2, UNDEFINED, 3, UNDEFINED},
                  {UNDEFINED, UNDEFINED, UNDEFINED, 0, 4, UNDEFINED},
@@ -1180,7 +1180,7 @@ namespace libsemigroups {
     S.run();
     REQUIRE(S.word_graph().number_of_nodes() == 7);
     REQUIRE(S.word_graph()
-            == to_word_graph<uint32_t>(
+            == to<WordGraph<uint32_t>>(
                 7,
                 {{1, UNDEFINED, 2, UNDEFINED, 3, UNDEFINED},
                  {UNDEFINED, UNDEFINED, UNDEFINED, 0, 4, UNDEFINED},

--- a/tests/test-to-froidure-pin.cpp
+++ b/tests/test-to-froidure-pin.cpp
@@ -40,7 +40,7 @@ namespace libsemigroups {
                           "from WordGraph",
                           "[quick][to_froidure_pin]") {
     auto rg = ReportGuard(false);
-    auto ad = to<WordGraph<uint8_t>>(
+    auto ad = make<WordGraph<uint8_t>>(
         5,
         {{1, 3, 4, 1}, {0, 0, 1, 1}, {2, 1, 2, 2}, {3, 2, 3, 3}, {4, 4, 4, 4}});
     auto T = to_froidure_pin<Transf<5>>(ad);
@@ -58,7 +58,7 @@ namespace libsemigroups {
                           "from WordGraph (exceptions)",
                           "[quick][make]") {
     auto rg = ReportGuard(false);
-    auto ad = to<WordGraph<uint8_t>>(
+    auto ad = make<WordGraph<uint8_t>>(
         5,
         {{1, 3, 4, 1}, {0, 0, 1, 1}, {2, 1, 2, 2}, {3, 2, 3, 3}, {4, 4, 4, 4}});
     REQUIRE_THROWS_AS((to_froidure_pin<Transf<0, uint8_t>>(ad, 10, 0)),

--- a/tests/test-to-froidure-pin.cpp
+++ b/tests/test-to-froidure-pin.cpp
@@ -40,7 +40,7 @@ namespace libsemigroups {
                           "from WordGraph",
                           "[quick][to_froidure_pin]") {
     auto rg = ReportGuard(false);
-    auto ad = to_word_graph<uint8_t>(
+    auto ad = to<WordGraph<uint8_t>>(
         5,
         {{1, 3, 4, 1}, {0, 0, 1, 1}, {2, 1, 2, 2}, {3, 2, 3, 3}, {4, 4, 4, 4}});
     auto T = to_froidure_pin<Transf<5>>(ad);
@@ -58,7 +58,7 @@ namespace libsemigroups {
                           "from WordGraph (exceptions)",
                           "[quick][make]") {
     auto rg = ReportGuard(false);
-    auto ad = to_word_graph<uint8_t>(
+    auto ad = to<WordGraph<uint8_t>>(
         5,
         {{1, 3, 4, 1}, {0, 0, 1, 1}, {2, 1, 2, 2}, {3, 2, 3, 3}, {4, 4, 4, 4}});
     REQUIRE_THROWS_AS((to_froidure_pin<Transf<0, uint8_t>>(ad, 10, 0)),

--- a/tests/test-transf.cpp
+++ b/tests/test-transf.cpp
@@ -83,7 +83,7 @@ namespace libsemigroups {
     } else {
       REQUIRE_THROWS_AS(x.increase_degree_by(10), LibsemigroupsException);
     }
-    auto t = to<Transf<>>({9, 7, 3, 5, 3, 4, 2, 7, 7, 1});
+    auto t = make<Transf<>>({9, 7, 3, 5, 3, 4, 2, 7, 7, 1});
     REQUIRE(t.hash_value() != 0);
     REQUIRE_NOTHROW(t.undef());
   }
@@ -94,19 +94,20 @@ namespace libsemigroups {
                           "[quick][transf]") {
     using point_type = typename Transf<>::point_type;
     REQUIRE_NOTHROW(Transf());
-    REQUIRE_NOTHROW(to<Transf<>>({0}));
-    REQUIRE_THROWS_AS(to<Transf<>>({1}), LibsemigroupsException);
+    REQUIRE_NOTHROW(make<Transf<>>({0}));
+    REQUIRE_THROWS_AS(make<Transf<>>({1}), LibsemigroupsException);
 
-    REQUIRE_NOTHROW(to<Transf<>>({0, 1, 2}));
-    REQUIRE_NOTHROW(to<Transf<>>(std::initializer_list<point_type>({0, 1, 2})));
-    REQUIRE_NOTHROW(to<Transf<>>({0, 1, 2}));
+    REQUIRE_NOTHROW(make<Transf<>>({0, 1, 2}));
+    REQUIRE_NOTHROW(
+        make<Transf<>>(std::initializer_list<point_type>({0, 1, 2})));
+    REQUIRE_NOTHROW(make<Transf<>>({0, 1, 2}));
 
-    REQUIRE_THROWS_AS(to<Transf<>>({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Transf<>>({1, 2, 3}), LibsemigroupsException);
     REQUIRE_THROWS_AS(
-        to<Transf<>>(std::initializer_list<point_type>({1, 2, 3})),
+        make<Transf<>>(std::initializer_list<point_type>({1, 2, 3})),
         LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to<Transf<>>(std::initializer_list<point_type>(
+    REQUIRE_THROWS_AS(make<Transf<>>(std::initializer_list<point_type>(
                           {UNDEFINED, UNDEFINED, UNDEFINED})),
                       LibsemigroupsException);
   }
@@ -115,15 +116,15 @@ namespace libsemigroups {
                           "003",
                           "exceptions (static)",
                           "[quick][transf]") {
-    REQUIRE_NOTHROW(to<Transf<>>({0}));
-    REQUIRE_THROWS_AS(to<Transf<>>({1}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<Transf<>>({1}), LibsemigroupsException);
+    REQUIRE_NOTHROW(make<Transf<>>({0}));
+    REQUIRE_THROWS_AS(make<Transf<>>({1}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Transf<>>({1}), LibsemigroupsException);
 
-    REQUIRE_NOTHROW(to<Transf<>>({0, 1, 2}));
+    REQUIRE_NOTHROW(make<Transf<>>({0, 1, 2}));
 
-    REQUIRE_THROWS_AS(to<Transf<>>({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Transf<>>({1, 2, 3}), LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to<Transf<>>({UNDEFINED, UNDEFINED, UNDEFINED}),
+    REQUIRE_THROWS_AS(make<Transf<>>({UNDEFINED, UNDEFINED, UNDEFINED}),
                       LibsemigroupsException);
   }
 
@@ -180,41 +181,43 @@ namespace libsemigroups {
                           "[quick][pperm]") {
     using point_type = typename Transf<>::point_type;
     REQUIRE_NOTHROW(PPerm<>());
-    REQUIRE_NOTHROW(to<PPerm<>>({0}));
-    REQUIRE_NOTHROW(to<PPerm<>>({UNDEFINED}));
-    REQUIRE_THROWS_AS(to<PPerm<>>({1}), LibsemigroupsException);
+    REQUIRE_NOTHROW(make<PPerm<>>({0}));
+    REQUIRE_NOTHROW(make<PPerm<>>({UNDEFINED}));
+    REQUIRE_THROWS_AS(make<PPerm<>>({1}), LibsemigroupsException);
 
-    REQUIRE_NOTHROW(to<PPerm<>>({0, 1, 2}));
-    REQUIRE_NOTHROW(to<PPerm<>>(std::initializer_list<point_type>({0, 1, 2})));
-    REQUIRE_NOTHROW(to<PPerm<>>({0, UNDEFINED, 2}));
-    REQUIRE_NOTHROW(to<PPerm<>>({0, UNDEFINED, 5, UNDEFINED, UNDEFINED, 1}));
+    REQUIRE_NOTHROW(make<PPerm<>>({0, 1, 2}));
+    REQUIRE_NOTHROW(
+        make<PPerm<>>(std::initializer_list<point_type>({0, 1, 2})));
+    REQUIRE_NOTHROW(make<PPerm<>>({0, UNDEFINED, 2}));
+    REQUIRE_NOTHROW(make<PPerm<>>({0, UNDEFINED, 5, UNDEFINED, UNDEFINED, 1}));
 
-    REQUIRE_THROWS_AS(to<PPerm<>>({1, 2, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<>>({UNDEFINED, UNDEFINED, 3}),
+    REQUIRE_THROWS_AS(make<PPerm<>>({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<>>({UNDEFINED, UNDEFINED, 3}),
                       LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<>>({1, UNDEFINED, 1}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<>>(std::vector<point_type>(
+    REQUIRE_THROWS_AS(make<PPerm<>>({1, UNDEFINED, 1}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<>>(std::vector<point_type>(
                           {3, UNDEFINED, 2, 1, UNDEFINED, 3})),
                       LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<>>(std::initializer_list<point_type>({1, 2, 3})),
-                      LibsemigroupsException);
-    REQUIRE_NOTHROW(to<PPerm<>>(std::initializer_list<uint32_t>({1, 2}),
-                                std::initializer_list<uint32_t>({0, 3}),
-                                5));
-    REQUIRE_NOTHROW(to<PPerm<5, uint32_t>>({1, 2}, {0, 3}, 5));
+    REQUIRE_THROWS_AS(
+        make<PPerm<>>(std::initializer_list<point_type>({1, 2, 3})),
+        LibsemigroupsException);
+    REQUIRE_NOTHROW(make<PPerm<>>(std::initializer_list<uint32_t>({1, 2}),
+                                  std::initializer_list<uint32_t>({0, 3}),
+                                  5));
+    REQUIRE_NOTHROW(make<PPerm<5, uint32_t>>({1, 2}, {0, 3}, 5));
     REQUIRE_NOTHROW(PPerm<5, uint32_t>({1, 2}, {0, 3}, 5));
     REQUIRE_NOTHROW(PPerm<>({1, 2}, {0, 3}, 5));
-    REQUIRE_NOTHROW(to<PPerm<>>({1, 2}, {0, 5}, 6));
-    REQUIRE_THROWS_AS(to<PPerm<>>({1, 2}, {0}, 5), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<>>({1, 2}, {0, 5}, 4), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<>>({1, 5}, {0, 2}, 4), LibsemigroupsException);
+    REQUIRE_NOTHROW(make<PPerm<>>({1, 2}, {0, 5}, 6));
+    REQUIRE_THROWS_AS(make<PPerm<>>({1, 2}, {0}, 5), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<>>({1, 2}, {0, 5}, 4), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<>>({1, 5}, {0, 2}, 4), LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to<PPerm<>>({1, 1}, {0, 2}, 3), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<>>({1, 0}, {2, 2}, 3), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<>>({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<>>({1, 0, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<>>({1, 0, 3, 6, 4}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<>>({1, 5, 0, 3, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<>>({1, 1}, {0, 2}, 3), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<>>({1, 0}, {2, 2}, 3), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<>>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<>>({1, 0, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<>>({1, 0, 3, 6, 4}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<>>({1, 5, 0, 3, 2}), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("PPerm",
@@ -222,37 +225,42 @@ namespace libsemigroups {
                           "exceptions (static)",
                           "[quick][pperm]") {
     using point_type = typename PPerm<6>::point_type;
-    REQUIRE_NOTHROW(to<PPerm<1>>({0}));
-    REQUIRE_NOTHROW(to<PPerm<1>>({UNDEFINED}));
-    REQUIRE_THROWS_AS(to<PPerm<1>>({1}), LibsemigroupsException);
+    REQUIRE_NOTHROW(make<PPerm<1>>({0}));
+    REQUIRE_NOTHROW(make<PPerm<1>>({UNDEFINED}));
+    REQUIRE_THROWS_AS(make<PPerm<1>>({1}), LibsemigroupsException);
 
-    REQUIRE_NOTHROW(to<PPerm<3>>({0, 1, 2}));
-    REQUIRE_NOTHROW(to<PPerm<3>>({0, 1, 2}));
-    REQUIRE_NOTHROW(to<PPerm<3>>({0, UNDEFINED, 2}));
-    REQUIRE_NOTHROW(to<PPerm<6>>({0, UNDEFINED, 5, UNDEFINED, UNDEFINED, 1}));
+    REQUIRE_NOTHROW(make<PPerm<3>>({0, 1, 2}));
+    REQUIRE_NOTHROW(make<PPerm<3>>({0, 1, 2}));
+    REQUIRE_NOTHROW(make<PPerm<3>>({0, UNDEFINED, 2}));
+    REQUIRE_NOTHROW(make<PPerm<6>>({0, UNDEFINED, 5, UNDEFINED, UNDEFINED, 1}));
 
-    REQUIRE_THROWS_AS(to<PPerm<3>>({1, 2, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<3>>({UNDEFINED, UNDEFINED, 3}),
+    REQUIRE_THROWS_AS(make<PPerm<3>>({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<3>>({UNDEFINED, UNDEFINED, 3}),
                       LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<3>>({1, UNDEFINED, 1}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<6>>({3, UNDEFINED, 2, 1, UNDEFINED, 3}),
+    REQUIRE_THROWS_AS(make<PPerm<3>>({1, UNDEFINED, 1}),
                       LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<3>>({1, 2, 3}), LibsemigroupsException);
-    REQUIRE_NOTHROW(to<PPerm<5>>({1, 2}, {0, 3}, 5));
-    REQUIRE_NOTHROW(to<PPerm<6>>({1, 2}, {0, 5}, 6));
-    REQUIRE_THROWS_AS(to<PPerm<5>>({1, 2}, {0}, 5), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<4>>({1, 2}, {0, 5}, 4), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<4>>({1, 5}, {0, 2}, 4), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<6>>({3, UNDEFINED, 2, 1, UNDEFINED, 3}),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<3>>({1, 2, 3}), LibsemigroupsException);
+    REQUIRE_NOTHROW(make<PPerm<5>>({1, 2}, {0, 3}, 5));
+    REQUIRE_NOTHROW(make<PPerm<6>>({1, 2}, {0, 5}, 6));
+    REQUIRE_THROWS_AS(make<PPerm<5>>({1, 2}, {0}, 5), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<4>>({1, 2}, {0, 5}, 4),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<4>>({1, 5}, {0, 2}, 4),
+                      LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to<PPerm<3>>({1, 1}, {0, 2}, 3), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<3>>({0, 2}, {1, 1}, 3), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<3>>({1, 1}, {0, 2}, 3),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<3>>({0, 2}, {1, 1}, 3),
+                      LibsemigroupsException);
 
-    REQUIRE_THROWS_AS(to<PPerm<1>>({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<2>>({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<3>>({1, 0, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<5>>({1, 0, 3, 6, 4}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<PPerm<5>>({1, 5, 0, 3, 2}), LibsemigroupsException);
-    auto x = to<PPerm<5>>({0, 2}, {3, 0}, 5);
+    REQUIRE_THROWS_AS(make<PPerm<1>>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<2>>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<3>>({1, 0, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<5>>({1, 0, 3, 6, 4}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<PPerm<5>>({1, 5, 0, 3, 2}), LibsemigroupsException);
+    auto x = make<PPerm<5>>({0, 2}, {3, 0}, 5);
     REQUIRE(image(x) == std::vector<point_type>({0, 3}));
     REQUIRE(domain(x) == std::vector<point_type>({0, 2}));
   }
@@ -278,34 +286,34 @@ namespace libsemigroups {
                           "008",
                           "exceptions (dynamic)",
                           "[quick][perm]") {
-    REQUIRE_NOTHROW(to<Perm<>>({}));
-    REQUIRE_NOTHROW(to<Perm<>>({0}));
-    REQUIRE_NOTHROW(to<Perm<>>({0, 1}));
-    REQUIRE_NOTHROW(to<Perm<>>({1, 0}));
-    REQUIRE_NOTHROW(to<Perm<>>({1, 4, 0, 3, 2}));
+    REQUIRE_NOTHROW(make<Perm<>>({}));
+    REQUIRE_NOTHROW(make<Perm<>>({0}));
+    REQUIRE_NOTHROW(make<Perm<>>({0, 1}));
+    REQUIRE_NOTHROW(make<Perm<>>({1, 0}));
+    REQUIRE_NOTHROW(make<Perm<>>({1, 4, 0, 3, 2}));
 
-    REQUIRE_THROWS_AS(to<Perm<>>({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<Perm<>>({1, 0, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<Perm<>>({1, 0, 3, 6, 4}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<Perm<>>({1, 5, 0, 3, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<Perm<>>({0, 1, 2, 3, 0}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Perm<>>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Perm<>>({1, 0, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Perm<>>({1, 0, 3, 6, 4}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Perm<>>({1, 5, 0, 3, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Perm<>>({0, 1, 2, 3, 0}), LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("Perm",
                           "009",
                           "exceptions (static)",
                           "[quick][perm]") {
-    REQUIRE_NOTHROW(to<Perm<1>>({0}));
-    REQUIRE_NOTHROW(to<Perm<2>>({0, 1}));
-    REQUIRE_NOTHROW(to<Perm<2>>({1, 0}));
-    REQUIRE_NOTHROW(to<Perm<5>>({1, 4, 0, 3, 2}));
+    REQUIRE_NOTHROW(make<Perm<1>>({0}));
+    REQUIRE_NOTHROW(make<Perm<2>>({0, 1}));
+    REQUIRE_NOTHROW(make<Perm<2>>({1, 0}));
+    REQUIRE_NOTHROW(make<Perm<5>>({1, 4, 0, 3, 2}));
 
-    REQUIRE_THROWS_AS(to<Perm<1>>({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<Perm<2>>({1, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<Perm<3>>({1, 0, 3}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<Perm<5>>({1, 0, 3, 6, 4}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<Perm<5>>({1, 5, 0, 3, 2}), LibsemigroupsException);
-    REQUIRE_THROWS_AS(to<Perm<5>>({0, 1, 2, 3, 0}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Perm<1>>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Perm<2>>({1, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Perm<3>>({1, 0, 3}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Perm<5>>({1, 0, 3, 6, 4}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Perm<5>>({1, 5, 0, 3, 2}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(make<Perm<5>>({0, 1, 2, 3, 0}), LibsemigroupsException);
 
     REQUIRE_NOTHROW(PPerm<5>());
   }

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -278,7 +278,9 @@ namespace libsemigroups {
     wg.target(2, 0, 0);
 
     wg.induced_subgraph_no_checks(0, 2);
-    REQUIRE(wg == to_word_graph<size_t>(2, {{1, UNDEFINED}, {0}}));
+    static_assert(!IsWordGraph<size_t>);
+    static_assert(IsWordGraph<WordGraph<size_t>>);
+    REQUIRE(wg == to<WordGraph<size_t>>(2, {{1, UNDEFINED}, {0}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
@@ -293,7 +295,7 @@ namespace libsemigroups {
     wg.target(2, 0, 0);
 
     wg.remove_target_no_checks(0, 0);  // remove edge from 0 labelled 0
-    REQUIRE(wg == to_word_graph<size_t>(3, {{UNDEFINED, UNDEFINED}, {0}, {0}}));
+    REQUIRE(wg == to<WordGraph<size_t>>(3, {{UNDEFINED, UNDEFINED}, {0}, {0}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
@@ -309,7 +311,7 @@ namespace libsemigroups {
 
     // swap edge from 0 labelled 0 with edge from 1 labelled 0
     wg.swap_targets_no_checks(0, 1, 0);
-    REQUIRE(wg == to_word_graph<size_t>(3, {{0, UNDEFINED}, {1}, {2}}));
+    REQUIRE(wg == to<WordGraph<size_t>>(3, {{0, UNDEFINED}, {1}, {2}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph", "016", "operator<<", "[quick]") {
@@ -599,12 +601,12 @@ namespace libsemigroups {
             == "{6, {{1}, {2}, {3}, {4}, {5}, {18446744073709551615}}}");
   }
 
-  LIBSEMIGROUPS_TEST_CASE("WordGraph", "033", "to_word_graph", "[quick]") {
-    auto wg = to_word_graph<uint8_t>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
+  LIBSEMIGROUPS_TEST_CASE("WordGraph", "033", "to<WordGraph>", "[quick]") {
+    auto wg = to<WordGraph<uint8_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
     REQUIRE(detail::to_string(wg)
             == "{5, {{0, 0}, {1, 1}, {2, 255}, {3, 3}, {255, 255}}}");
     REQUIRE_THROWS_AS(
-        to_word_graph<uint8_t>(5, {{0, 0}, {1, 1, 1}, {2}, {3, 3}}),
+        to<WordGraph<uint8_t>>(5, {{0, 0}, {1, 1, 1}, {2}, {3, 3}}),
         LibsemigroupsException);
     wg = WordGraph<uint8_t>(5, 2);
     REQUIRE(
@@ -613,7 +615,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph", "034", "is_connected", "[quick]") {
-    auto wg = to_word_graph<size_t>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
+    auto wg = to<WordGraph<size_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
     REQUIRE(!word_graph::is_connected(wg));
     wg = path(1'000);
     REQUIRE(word_graph::is_connected(wg));
@@ -632,7 +634,7 @@ namespace libsemigroups {
                           "035",
                           "is_strictly_cyclic",
                           "[quick][no-valgrind]") {
-    auto wg = to_word_graph<size_t>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
+    auto wg = to<WordGraph<size_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
     REQUIRE(!word_graph::is_strictly_cyclic(wg));
     wg = path(1'000);
     REQUIRE(word_graph::is_strictly_cyclic(wg));
@@ -650,7 +652,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph", "046", "Joiner x 1", "[quick]") {
     WordGraph<size_t> x(
-        to_word_graph<size_t>(3, {{0, 1, 2}, {0, 1, 2}, {0, 1, 2}}));
+        to<WordGraph<size_t>>(3, {{0, 1, 2}, {0, 1, 2}, {0, 1, 2}}));
     WordGraph<size_t> y = x;
 
     Joiner join;
@@ -674,17 +676,17 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph", "050", "Joiner x 2", "[quick]") {
     WordGraph<size_t> x(
-        to_word_graph<size_t>(3, {{1, 1, 1}, {2, 2, 2}, {2, 2, 2}}));
+        to<WordGraph<size_t>>(3, {{1, 1, 1}, {2, 2, 2}, {2, 2, 2}}));
 
     WordGraph<size_t> y(
-        to_word_graph<size_t>(3, {{1, 1, 2}, {1, 1, 2}, {1, 1, 2}}));
+        to<WordGraph<size_t>>(3, {{1, 1, 2}, {1, 1, 2}, {1, 1, 2}}));
 
     WordGraph<size_t> xy;
 
     Joiner join;
     xy = join(x, y);
     REQUIRE(x != y);
-    REQUIRE(xy == to_word_graph<size_t>(2, {{1, 1, 1}, {1, 1, 1}}));
+    REQUIRE(xy == to<WordGraph<size_t>>(2, {{1, 1, 1}, {1, 1, 1}}));
     REQUIRE(join.is_subrelation(x, xy));
     REQUIRE(join.is_subrelation(y, xy));
   }
@@ -693,44 +695,44 @@ namespace libsemigroups {
     // These word graphs were taken from the lattice of
     // 2-sided congruences of the free semigroup with 2
     // generators.
-    WordGraph<size_t> x(to_word_graph<size_t>(3, {{1, 2}, {1, 1}, {2, 2}}));
-    WordGraph<size_t> y(to_word_graph<size_t>(3, {{1, 2}, {1, 1}, {1, 1}}));
+    WordGraph<size_t> x(to<WordGraph<size_t>>(3, {{1, 2}, {1, 1}, {2, 2}}));
+    WordGraph<size_t> y(to<WordGraph<size_t>>(3, {{1, 2}, {1, 1}, {1, 1}}));
 
     WordGraph<size_t> xy;
 
     Meeter meet;
     meet(xy, x, y);
 
-    REQUIRE(xy == to_word_graph<size_t>(4, {{1, 2}, {1, 1}, {3, 3}, {3, 3}}));
+    REQUIRE(xy == to<WordGraph<size_t>>(4, {{1, 2}, {1, 1}, {3, 3}, {3, 3}}));
 
-    y = to_word_graph<size_t>(3, {{1, 2}, {2, 2}, {2, 2}});
+    y = to<WordGraph<size_t>>(3, {{1, 2}, {2, 2}, {2, 2}});
 
     meet(xy, x, y);
-    REQUIRE(xy == to_word_graph<size_t>(4, {{1, 2}, {3, 3}, {2, 2}, {3, 3}}));
+    REQUIRE(xy == to<WordGraph<size_t>>(4, {{1, 2}, {3, 3}, {2, 2}, {3, 3}}));
 
     word_graph::standardize(xy);
-    REQUIRE(xy == to_word_graph<size_t>(4, {{1, 2}, {3, 3}, {2, 2}, {3, 3}}));
+    REQUIRE(xy == to<WordGraph<size_t>>(4, {{1, 2}, {3, 3}, {2, 2}, {3, 3}}));
 
     x = xy;
     meet(xy, x, y);
-    REQUIRE(xy == to_word_graph<size_t>(4, {{1, 2}, {3, 3}, {2, 2}, {3, 3}}));
+    REQUIRE(xy == to<WordGraph<size_t>>(4, {{1, 2}, {3, 3}, {2, 2}, {3, 3}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph", "037", "Meeter x 2", "[quick]") {
-    auto x = to_word_graph<size_t>(5, {{1, 0}, {1, 2}, {1, 2}});
-    auto y = to_word_graph<size_t>(5, {{0, 1}, {0, 1}});
+    auto x = to<WordGraph<size_t>>(5, {{1, 0}, {1, 2}, {1, 2}});
+    auto y = to<WordGraph<size_t>>(5, {{0, 1}, {0, 1}});
     REQUIRE(word_graph::number_of_nodes_reachable_from(x, 0) == 3);
     REQUIRE(word_graph::number_of_nodes_reachable_from(y, 0) == 2);
 
     Meeter meet;
     auto   xy = meet(x, y);
-    REQUIRE(xy == to_word_graph<size_t>(4, {{1, 2}, {1, 3}, {1, 2}, {1, 3}}));
+    REQUIRE(xy == to<WordGraph<size_t>>(4, {{1, 2}, {1, 3}, {1, 2}, {1, 3}}));
     word_graph::standardize(xy);
-    REQUIRE(xy == to_word_graph<size_t>(4, {{1, 2}, {1, 3}, {1, 2}, {1, 3}}));
+    REQUIRE(xy == to<WordGraph<size_t>>(4, {{1, 2}, {1, 3}, {1, 2}, {1, 3}}));
 
     Joiner join;
     join(xy, x, y);
-    REQUIRE(xy == to_word_graph<size_t>(1, {{0, 0}}));
+    REQUIRE(xy == to<WordGraph<size_t>>(1, {{0, 0}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph", "038", "Joiner incomplete", "[quick]") {
@@ -738,7 +740,7 @@ namespace libsemigroups {
     word_graph::add_cycle(wg, 5);
     wg.remove_target(0, 0);
     Joiner join;
-    REQUIRE(join(wg, wg) == to_word_graph<uint32_t>(1, {{UNDEFINED}}));
+    REQUIRE(join(wg, wg) == to<WordGraph<uint32_t>>(1, {{UNDEFINED}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph", "039", "Meeter incomplete", "[quick]") {
@@ -746,7 +748,7 @@ namespace libsemigroups {
     word_graph::add_cycle(wg, 5);
     wg.remove_target(0, 0);
     Meeter meet;
-    REQUIRE(meet(wg, wg) == to_word_graph<uint32_t>(1, {{UNDEFINED}}));
+    REQUIRE(meet(wg, wg) == to<WordGraph<uint32_t>>(1, {{UNDEFINED}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
@@ -757,8 +759,9 @@ namespace libsemigroups {
     word_graph::add_cycle(wg, 5);
     wg.remove_target(0, 0);
     REQUIRE(to_input_string(wg) == "5, {{4294967295}, {2}, {3}, {4}, {0}}");
-    REQUIRE(to_input_string(wg, "to_word_graph(", "[]", ")")
-            == "to_word_graph(5, [[4294967295], [2], [3], [4], [0]])");
+    REQUIRE(
+        to_input_string(wg, "to<WordGraph<uint32_t>>(", "[]", ")")
+        == "to<WordGraph<uint32_t>>(5, [[4294967295], [2], [3], [4], [0]])");
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -280,7 +280,7 @@ namespace libsemigroups {
     wg.induced_subgraph_no_checks(0, 2);
     static_assert(!IsWordGraph<size_t>);
     static_assert(IsWordGraph<WordGraph<size_t>>);
-    REQUIRE(wg == to<WordGraph<size_t>>(2, {{1, UNDEFINED}, {0}}));
+    REQUIRE(wg == make<WordGraph<size_t>>(2, {{1, UNDEFINED}, {0}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
@@ -295,7 +295,8 @@ namespace libsemigroups {
     wg.target(2, 0, 0);
 
     wg.remove_target_no_checks(0, 0);  // remove edge from 0 labelled 0
-    REQUIRE(wg == to<WordGraph<size_t>>(3, {{UNDEFINED, UNDEFINED}, {0}, {0}}));
+    REQUIRE(wg
+            == make<WordGraph<size_t>>(3, {{UNDEFINED, UNDEFINED}, {0}, {0}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
@@ -311,7 +312,7 @@ namespace libsemigroups {
 
     // swap edge from 0 labelled 0 with edge from 1 labelled 0
     wg.swap_targets_no_checks(0, 1, 0);
-    REQUIRE(wg == to<WordGraph<size_t>>(3, {{0, UNDEFINED}, {1}, {2}}));
+    REQUIRE(wg == make<WordGraph<size_t>>(3, {{0, UNDEFINED}, {1}, {2}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph", "016", "operator<<", "[quick]") {
@@ -601,12 +602,12 @@ namespace libsemigroups {
             == "{6, {{1}, {2}, {3}, {4}, {5}, {18446744073709551615}}}");
   }
 
-  LIBSEMIGROUPS_TEST_CASE("WordGraph", "033", "to<WordGraph>", "[quick]") {
-    auto wg = to<WordGraph<uint8_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
+  LIBSEMIGROUPS_TEST_CASE("WordGraph", "033", "make<WordGraph>", "[quick]") {
+    auto wg = make<WordGraph<uint8_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
     REQUIRE(detail::to_string(wg)
             == "{5, {{0, 0}, {1, 1}, {2, 255}, {3, 3}, {255, 255}}}");
     REQUIRE_THROWS_AS(
-        to<WordGraph<uint8_t>>(5, {{0, 0}, {1, 1, 1}, {2}, {3, 3}}),
+        make<WordGraph<uint8_t>>(5, {{0, 0}, {1, 1, 1}, {2}, {3, 3}}),
         LibsemigroupsException);
     wg = WordGraph<uint8_t>(5, 2);
     REQUIRE(
@@ -615,7 +616,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph", "034", "is_connected", "[quick]") {
-    auto wg = to<WordGraph<size_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
+    auto wg = make<WordGraph<size_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
     REQUIRE(!word_graph::is_connected(wg));
     wg = path(1'000);
     REQUIRE(word_graph::is_connected(wg));
@@ -634,7 +635,7 @@ namespace libsemigroups {
                           "035",
                           "is_strictly_cyclic",
                           "[quick][no-valgrind]") {
-    auto wg = to<WordGraph<size_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
+    auto wg = make<WordGraph<size_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
     REQUIRE(!word_graph::is_strictly_cyclic(wg));
     wg = path(1'000);
     REQUIRE(word_graph::is_strictly_cyclic(wg));
@@ -652,7 +653,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph", "046", "Joiner x 1", "[quick]") {
     WordGraph<size_t> x(
-        to<WordGraph<size_t>>(3, {{0, 1, 2}, {0, 1, 2}, {0, 1, 2}}));
+        make<WordGraph<size_t>>(3, {{0, 1, 2}, {0, 1, 2}, {0, 1, 2}}));
     WordGraph<size_t> y = x;
 
     Joiner join;
@@ -676,17 +677,17 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph", "050", "Joiner x 2", "[quick]") {
     WordGraph<size_t> x(
-        to<WordGraph<size_t>>(3, {{1, 1, 1}, {2, 2, 2}, {2, 2, 2}}));
+        make<WordGraph<size_t>>(3, {{1, 1, 1}, {2, 2, 2}, {2, 2, 2}}));
 
     WordGraph<size_t> y(
-        to<WordGraph<size_t>>(3, {{1, 1, 2}, {1, 1, 2}, {1, 1, 2}}));
+        make<WordGraph<size_t>>(3, {{1, 1, 2}, {1, 1, 2}, {1, 1, 2}}));
 
     WordGraph<size_t> xy;
 
     Joiner join;
     xy = join(x, y);
     REQUIRE(x != y);
-    REQUIRE(xy == to<WordGraph<size_t>>(2, {{1, 1, 1}, {1, 1, 1}}));
+    REQUIRE(xy == make<WordGraph<size_t>>(2, {{1, 1, 1}, {1, 1, 1}}));
     REQUIRE(join.is_subrelation(x, xy));
     REQUIRE(join.is_subrelation(y, xy));
   }
@@ -695,44 +696,44 @@ namespace libsemigroups {
     // These word graphs were taken from the lattice of
     // 2-sided congruences of the free semigroup with 2
     // generators.
-    WordGraph<size_t> x(to<WordGraph<size_t>>(3, {{1, 2}, {1, 1}, {2, 2}}));
-    WordGraph<size_t> y(to<WordGraph<size_t>>(3, {{1, 2}, {1, 1}, {1, 1}}));
+    WordGraph<size_t> x(make<WordGraph<size_t>>(3, {{1, 2}, {1, 1}, {2, 2}}));
+    WordGraph<size_t> y(make<WordGraph<size_t>>(3, {{1, 2}, {1, 1}, {1, 1}}));
 
     WordGraph<size_t> xy;
 
     Meeter meet;
     meet(xy, x, y);
 
-    REQUIRE(xy == to<WordGraph<size_t>>(4, {{1, 2}, {1, 1}, {3, 3}, {3, 3}}));
+    REQUIRE(xy == make<WordGraph<size_t>>(4, {{1, 2}, {1, 1}, {3, 3}, {3, 3}}));
 
-    y = to<WordGraph<size_t>>(3, {{1, 2}, {2, 2}, {2, 2}});
+    y = make<WordGraph<size_t>>(3, {{1, 2}, {2, 2}, {2, 2}});
 
     meet(xy, x, y);
-    REQUIRE(xy == to<WordGraph<size_t>>(4, {{1, 2}, {3, 3}, {2, 2}, {3, 3}}));
+    REQUIRE(xy == make<WordGraph<size_t>>(4, {{1, 2}, {3, 3}, {2, 2}, {3, 3}}));
 
     word_graph::standardize(xy);
-    REQUIRE(xy == to<WordGraph<size_t>>(4, {{1, 2}, {3, 3}, {2, 2}, {3, 3}}));
+    REQUIRE(xy == make<WordGraph<size_t>>(4, {{1, 2}, {3, 3}, {2, 2}, {3, 3}}));
 
     x = xy;
     meet(xy, x, y);
-    REQUIRE(xy == to<WordGraph<size_t>>(4, {{1, 2}, {3, 3}, {2, 2}, {3, 3}}));
+    REQUIRE(xy == make<WordGraph<size_t>>(4, {{1, 2}, {3, 3}, {2, 2}, {3, 3}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph", "037", "Meeter x 2", "[quick]") {
-    auto x = to<WordGraph<size_t>>(5, {{1, 0}, {1, 2}, {1, 2}});
-    auto y = to<WordGraph<size_t>>(5, {{0, 1}, {0, 1}});
+    auto x = make<WordGraph<size_t>>(5, {{1, 0}, {1, 2}, {1, 2}});
+    auto y = make<WordGraph<size_t>>(5, {{0, 1}, {0, 1}});
     REQUIRE(word_graph::number_of_nodes_reachable_from(x, 0) == 3);
     REQUIRE(word_graph::number_of_nodes_reachable_from(y, 0) == 2);
 
     Meeter meet;
     auto   xy = meet(x, y);
-    REQUIRE(xy == to<WordGraph<size_t>>(4, {{1, 2}, {1, 3}, {1, 2}, {1, 3}}));
+    REQUIRE(xy == make<WordGraph<size_t>>(4, {{1, 2}, {1, 3}, {1, 2}, {1, 3}}));
     word_graph::standardize(xy);
-    REQUIRE(xy == to<WordGraph<size_t>>(4, {{1, 2}, {1, 3}, {1, 2}, {1, 3}}));
+    REQUIRE(xy == make<WordGraph<size_t>>(4, {{1, 2}, {1, 3}, {1, 2}, {1, 3}}));
 
     Joiner join;
     join(xy, x, y);
-    REQUIRE(xy == to<WordGraph<size_t>>(1, {{0, 0}}));
+    REQUIRE(xy == make<WordGraph<size_t>>(1, {{0, 0}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph", "038", "Joiner incomplete", "[quick]") {
@@ -740,7 +741,7 @@ namespace libsemigroups {
     word_graph::add_cycle(wg, 5);
     wg.remove_target(0, 0);
     Joiner join;
-    REQUIRE(join(wg, wg) == to<WordGraph<uint32_t>>(1, {{UNDEFINED}}));
+    REQUIRE(join(wg, wg) == make<WordGraph<uint32_t>>(1, {{UNDEFINED}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph", "039", "Meeter incomplete", "[quick]") {
@@ -748,7 +749,7 @@ namespace libsemigroups {
     word_graph::add_cycle(wg, 5);
     wg.remove_target(0, 0);
     Meeter meet;
-    REQUIRE(meet(wg, wg) == to<WordGraph<uint32_t>>(1, {{UNDEFINED}}));
+    REQUIRE(meet(wg, wg) == make<WordGraph<uint32_t>>(1, {{UNDEFINED}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
@@ -760,8 +761,8 @@ namespace libsemigroups {
     wg.remove_target(0, 0);
     REQUIRE(to_input_string(wg) == "5, {{4294967295}, {2}, {3}, {4}, {0}}");
     REQUIRE(
-        to_input_string(wg, "to<WordGraph<uint32_t>>(", "[]", ")")
-        == "to<WordGraph<uint32_t>>(5, [[4294967295], [2], [3], [4], [0]])");
+        to_input_string(wg, "make<WordGraph<uint32_t>>(", "[]", ")")
+        == "make<WordGraph<uint32_t>>(5, [[4294967295], [2], [3], [4], [0]])");
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",


### PR DESCRIPTION
This PR builds on #629 by converting several `to_class` functions to  `make<Class>` functions. Specifically, the functions in question are:

- [x] `to_bipartition`
- [x] `to_blocks`
- [x] `to_forest`
- [x] `to_matrix`
- [x] `to_pbr`
- [x] `to_perm`
- [x] `to_pperm`
- [x] `to_transf`
- [x] `to_word_graph`

If I have missed any, please let me know!