### PR TITLE
tests: improve `LibsemigroupsTestListener`

### DIFF
--- a/include/libsemigroups/matrix.hpp
+++ b/include/libsemigroups/matrix.hpp
@@ -6267,15 +6267,13 @@ namespace libsemigroups {
   //!
   //! Defined in `matrix.hpp`.
   //!
-  //! Alias template for truncated min-plus matrices.
+  //! Alias template for ntp matrices.
   //!
   //! \tparam T the threshold. If both \c T and \c P are \c 0, this indicates
-  //! that
-  //!   the value will be set at run time (default: \c 0).
+  //! that the value will be set at run time (default: \c 0).
   //!
   //! \tparam P the period. If both \c T and \c P are \c 0, this indicates
-  //! that the
-  //!   value will be set at run time (default: \c 0).
+  //! that the value will be set at run time (default: \c 0).
   //!
   //! \tparam R the number of rows.  A value of \c 0 indicates that the value
   //! will be set at run time (default: \c 0).

--- a/include/libsemigroups/word-range.hpp
+++ b/include/libsemigroups/word-range.hpp
@@ -24,8 +24,8 @@
 // * nodiscard
 // * tests for code coverage
 
-#ifndef LIBSEMIGROUPS_WORDS_HPP_
-#define LIBSEMIGROUPS_WORDS_HPP_
+#ifndef LIBSEMIGROUPS_WORD_RANGE_HPP_
+#define LIBSEMIGROUPS_WORD_RANGE_HPP_
 
 #ifndef PARSED_BY_DOXYGEN
 #define NOT_PARSED_BY_DOXYGEN
@@ -347,8 +347,7 @@ namespace libsemigroups {
     //! function could be anything.
     [[nodiscard]] output_type get() const noexcept {
       set_iterator();
-      return std::visit(
-          [](auto& it) -> auto const& { return *it; }, _current);
+      return std::visit([](auto& it) -> auto const& { return *it; }, _current);
     }
 
     //! \brief Advance to the next value.
@@ -964,7 +963,7 @@ namespace libsemigroups {
     //! * \ref literals
     [[nodiscard]] word_type operator()(std::string const& input) const {
       word_type output;
-                operator()(output, input);
+      operator()(output, input);
       return output;
     }
 
@@ -1297,7 +1296,7 @@ namespace libsemigroups {
     //! * \ref literals
     [[nodiscard]] std::string operator()(word_type const& input) const {
       std::string output;
-                  operator()(output, input);
+      operator()(output, input);
       return output;
     }
 
@@ -1306,7 +1305,7 @@ namespace libsemigroups {
     operator()(std::initializer_list<Int> input) const {
       // TODO(0) use iterators instead
       word_type copy(input.begin(), input.end());
-      return    operator()(copy);
+      return operator()(copy);
     }
 
     template <typename InputRange>
@@ -2399,4 +2398,4 @@ namespace libsemigroups {
   //
 }  // namespace libsemigroups
 
-#endif  // LIBSEMIGROUPS_WORDS_HPP_
+#endif  // LIBSEMIGROUPS_WORD_RANGE_HPP_

--- a/include/libsemigroups/word-range.hpp
+++ b/include/libsemigroups/word-range.hpp
@@ -347,7 +347,8 @@ namespace libsemigroups {
     //! function could be anything.
     [[nodiscard]] output_type get() const noexcept {
       set_iterator();
-      return std::visit([](auto& it) -> auto const& { return *it; }, _current);
+      return std::visit(
+          [](auto& it) -> auto const& { return *it; }, _current);
     }
 
     //! \brief Advance to the next value.
@@ -963,7 +964,7 @@ namespace libsemigroups {
     //! * \ref literals
     [[nodiscard]] word_type operator()(std::string const& input) const {
       word_type output;
-      operator()(output, input);
+                operator()(output, input);
       return output;
     }
 
@@ -1296,7 +1297,7 @@ namespace libsemigroups {
     //! * \ref literals
     [[nodiscard]] std::string operator()(word_type const& input) const {
       std::string output;
-      operator()(output, input);
+                  operator()(output, input);
       return output;
     }
 
@@ -1305,7 +1306,7 @@ namespace libsemigroups {
     operator()(std::initializer_list<Int> input) const {
       // TODO(0) use iterators instead
       word_type copy(input.begin(), input.end());
-      return operator()(copy);
+      return    operator()(copy);
     }
 
     template <typename InputRange>

--- a/tests/test-action.cpp
+++ b/tests/test-action.cpp
@@ -33,7 +33,7 @@
 #include "libsemigroups/detail/report.hpp"      // for ReportGuard
 
 #include "catch_amalgamated.hpp"  // for REQUIRE, REQUIRE_THROWS_AS, REQUI...
-#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE
 
 namespace libsemigroups {
   using namespace rx;
@@ -46,10 +46,10 @@ namespace libsemigroups {
   using row_orb_type    = RightAction<BMat8, BMat8, row_action_type>;
   using col_orb_type    = LeftAction<BMat8, BMat8, col_action_type>;
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "001",
-                             "row and column basis orbits for BMat8 x 1",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "001",
+                          "row and column basis orbits for BMat8 x 1",
+                          "[quick]") {
     auto         rg = ReportGuard(REPORT);
     row_orb_type row_orb;
     row_orb.add_seed(BMat8({{1, 0, 0}, {0, 1, 0}, {0, 0, 0}}));
@@ -69,10 +69,10 @@ namespace libsemigroups {
     REQUIRE(col_orb.size() == 1);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "002",
-                             "row and column basis orbits for BMat8 x 2",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "002",
+                          "row and column basis orbits for BMat8 x 2",
+                          "[quick]") {
     using bmat8::col_space_basis;
     using bmat8::row_space_basis;
 
@@ -129,10 +129,10 @@ namespace libsemigroups {
     REQUIRE(col_orb.size() == 553);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "003",
-                             "add generators after enumeration",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "003",
+                          "add generators after enumeration",
+                          "[quick]") {
     using bmat8::col_space_basis;
     using bmat8::row_space_basis;
     auto         rg = ReportGuard(REPORT);
@@ -177,10 +177,10 @@ namespace libsemigroups {
     REQUIRE(col_orb.size() == 553);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "004",
-                             "multipliers for BMat8 row and column orbits",
-                             "[quick][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "004",
+                          "multipliers for BMat8 row and column orbits",
+                          "[quick][no-valgrind]") {
     using bmat8::col_space_basis;
     using bmat8::row_space_basis;
     auto         rg = ReportGuard(REPORT);
@@ -254,10 +254,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "005",
-                             "orbits for regular boolean mat monoid 5",
-                             "[quick][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "005",
+                          "orbits for regular boolean mat monoid 5",
+                          "[quick][no-valgrind]") {
     auto                     rg             = ReportGuard(REPORT);
     const std::vector<BMat8> reg_bmat5_gens = {BMat8({{0, 1, 0, 0, 0},
                                                       {1, 0, 0, 0, 0},
@@ -295,11 +295,11 @@ namespace libsemigroups {
     REQUIRE(col_orb.size() == 110'519);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "006",
-                             "orbits for regular boolean mat monoid 6",
-                             "[extreme]") {
-    // auto                     rg             = ReportGuard(REPORT);
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "006",
+                          "orbits for regular boolean mat monoid 6",
+                          "[extreme]") {
+    auto                     rg             = ReportGuard(true);
     const std::vector<BMat8> reg_bmat6_gens = {BMat8({{0, 1, 0, 0, 0, 0},
                                                       {1, 0, 0, 0, 0, 0},
                                                       {0, 0, 1, 0, 0, 0},
@@ -336,10 +336,10 @@ namespace libsemigroups {
     REQUIRE(row_orb.size() == 37'977'468);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "007",
-                             "partial perm image orbit x 1",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "007",
+                          "partial perm image orbit x 1",
+                          "[quick]") {
     auto rg = ReportGuard(REPORT);
     RightAction<PPerm<8>, PPerm<8>, ImageRightAction<PPerm<8>, PPerm<8>>> o;
     o.add_seed(PPerm<8>::one(8));
@@ -361,10 +361,10 @@ namespace libsemigroups {
     REQUIRE(o.size() == 256);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "008",
-                             "partial perm image orbit x 2",
-                             "[quick][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "008",
+                          "partial perm image orbit x 2",
+                          "[quick][no-valgrind]") {
     auto rg = ReportGuard(REPORT);
     RightAction<PPerm<16>, PPerm<16>, ImageRightAction<PPerm<16>, PPerm<16>>> o;
     o.add_seed(PPerm<16>::one(16));
@@ -388,10 +388,10 @@ namespace libsemigroups {
     REQUIRE(o.size() == 65536);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "009",
-                             "partial perm image orbit x 3",
-                             "[quick][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "009",
+                          "partial perm image orbit x 3",
+                          "[quick][no-valgrind]") {
     auto rg = ReportGuard(REPORT);
     RightAction<PPerm<16>, PPerm<16>, ImageRightAction<PPerm<16>, PPerm<16>>> o;
     o.add_seed(One<PPerm<16>>()(16));
@@ -416,10 +416,10 @@ namespace libsemigroups {
     REQUIRE(o.scc().number_of_components() == 17);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "010",
-                             "partial perm image orbit x 4",
-                             "[quick][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "010",
+                          "partial perm image orbit x 4",
+                          "[quick][no-valgrind]") {
     auto rg = ReportGuard(REPORT);
     LeftAction<PPerm<16>, PPerm<16>, ImageLeftAction<PPerm<16>, PPerm<16>>> o;
     o.add_seed(One<PPerm<16>>()(16));
@@ -443,10 +443,10 @@ namespace libsemigroups {
     REQUIRE(o.scc().number_of_components() == 17);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "011",
-                             "permutation on integers",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "011",
+                          "permutation on integers",
+                          "[quick]") {
     auto rg    = ReportGuard(REPORT);
     using Perm = LeastPerm<8>;
     RightAction<Perm, uint8_t, ImageRightAction<Perm, uint8_t>> o;
@@ -458,10 +458,10 @@ namespace libsemigroups {
     REQUIRE(o.scc().number_of_components() == 1);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "012",
-                             "permutation on sets, arrays",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "012",
+                          "permutation on sets, arrays",
+                          "[quick]") {
     auto rg    = ReportGuard(REPORT);
     using Perm = LeastPerm<10>;
 
@@ -476,10 +476,10 @@ namespace libsemigroups {
     REQUIRE(o.size() == 252);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "013",
-                             "permutation on tuples, arrays",
-                             "[quick][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "013",
+                          "permutation on tuples, arrays",
+                          "[quick][no-valgrind]") {
     auto rg    = ReportGuard(REPORT);
     using Perm = LeastPerm<10>;
 
@@ -494,10 +494,10 @@ namespace libsemigroups {
     REQUIRE(o.size() == 30240);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "014",
-                             "permutation on sets, vectors",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "014",
+                          "permutation on sets, vectors",
+                          "[quick]") {
     auto rg    = ReportGuard(REPORT);
     using Perm = LeastPerm<10>;
 
@@ -508,10 +508,10 @@ namespace libsemigroups {
     REQUIRE(o.size() == 252);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "015",
-                             "permutation on tuples, vectors",
-                             "[quick][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "015",
+                          "permutation on tuples, vectors",
+                          "[quick][no-valgrind]") {
     auto rg    = ReportGuard(REPORT);
     using Perm = LeastPerm<10>;
 
@@ -523,7 +523,7 @@ namespace libsemigroups {
     REQUIRE(o.size() == 30240);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action", "016", "misc", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Action", "016", "misc", "[quick]") {
     auto rg    = ReportGuard(REPORT);
     using Perm = LeastPerm<8>;
     RightAction<Perm, uint8_t, ImageRightAction<Perm, uint8_t>> o;
@@ -554,10 +554,10 @@ namespace libsemigroups {
             == std::vector<uint8_t>({0, 1, 2, 3, 4, 5, 6, 7}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "017",
-                             "partial perm image orbit",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "017",
+                          "partial perm image orbit",
+                          "[quick]") {
     auto rg = ReportGuard(REPORT);
     RightAction<PPerm<3>, PPerm<3>, ImageRightAction<PPerm<3>, PPerm<3>>> o;
     o.add_seed(PPerm<3>({0, 1, 2}, {0, 1, 2}, 3));
@@ -585,10 +585,10 @@ namespace libsemigroups {
     REQUIRE(*begin(o) == PPerm<3>({0, 1, 2}, {0, 1, 2}, 3));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Action",
-                             "018",
-                             "permutation on tuples, arrays (360360)",
-                             "[quick][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "018",
+                          "permutation on tuples, arrays (360360)",
+                          "[quick][no-valgrind]") {
     auto rg    = ReportGuard(REPORT);
     using Perm = LeastPerm<15>;
 
@@ -603,11 +603,10 @@ namespace libsemigroups {
     REQUIRE(o.size() == 360360);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "Action",
-      "019",
-      "orbits for regular BMat8 monoid 5 with stop/start",
-      "[quick][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("Action",
+                          "019",
+                          "orbits for regular BMat8 monoid 5 with stop/start",
+                          "[quick][no-valgrind]") {
     auto                     rg             = ReportGuard(REPORT);
     const std::vector<BMat8> reg_bmat5_gens = {BMat8({{0, 1, 0, 0, 0},
                                                       {1, 0, 0, 0, 0},
@@ -650,10 +649,12 @@ namespace libsemigroups {
     REQUIRE(col_orb.size() == 110519);
   }
 
-  TEMPLATE_TEST_CASE("Action: regular boolean mat monoid 5",
-                     "[020][quick][no-valgrind]",
-                     BMat<>,
-                     BMat<5>) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Action",
+                                   "020",
+                                   "regular boolean mat monoid 5",
+                                   "[quick][no-valgrind]",
+                                   BMat<>,
+                                   BMat<5>) {
     auto rg = ReportGuard(false);
 
     using static_vector = detail::StaticVector1<BitSet<5>, 5>;

--- a/tests/test-aho-corasick.cpp
+++ b/tests/test-aho-corasick.cpp
@@ -15,14 +15,21 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <iostream>
+#include <string>  // for basic_string, allocator
+#include <tuple>   // for __ignore_t, ignore
+#include <vector>  // for vector, operator==
 
+#include "catch_amalgamated.hpp"  // for SourceLineInfo, operator""...
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE
+
+#include "libsemigroups/aho-corasick.hpp"  // for traverse_word, AhoCorasick
 #include "libsemigroups/aho-corasick.hpp"  // for AhoCorasick
+#include "libsemigroups/constants.hpp"     // for operator==, operator!=
+#include "libsemigroups/dot.hpp"           // for Dot
 #include "libsemigroups/exception.hpp"     // for LibsemigroupsException
 #include "libsemigroups/types.hpp"         // for word_type
-
-#include "catch_amalgamated.hpp"  // for REQUIRE, REQUIRE_THROWS_AS, REQUI...
-#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE
+#include "libsemigroups/word-range.hpp"    // for operator""_w, WordRange, pow
+#include "libsemigroups/word-range.hpp"    // for namespace literals
 
 namespace libsemigroups {
   using namespace literals;

--- a/tests/test-bipart.cpp
+++ b/tests/test-bipart.cpp
@@ -30,7 +30,7 @@
 #include <vector>     // for vector, operator==, allocator
 
 #include "catch_amalgamated.hpp"  // for REQUIRE, REQUIRE_THROWS_AS, REQUIRE_NOTHROW
-#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE
 
 #include "libsemigroups/bipart.hpp"     // for Bipartition
 #include "libsemigroups/exception.hpp"  // for LibsemigroupsException
@@ -50,7 +50,7 @@ namespace libsemigroups {
 
   }  // namespace
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Blocks", "001", "empty blocks", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Blocks", "001", "empty blocks", "[quick]") {
     Blocks b1 = to_blocks({});
     Blocks b2 = to_blocks({{4, 2}, {-1, -5}, {-3, -6}});
     REQUIRE(b2.lookup() == std::vector<bool>({true, false, true}));
@@ -67,7 +67,7 @@ namespace libsemigroups {
             == "Blocks({{-1, -5}, {2, 4}, {-3, -6}})");
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Blocks", "002", "non-empty blocks", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Blocks", "002", "non-empty blocks", "[quick]") {
     Blocks b = construct_blocks({0, 1, 2, 1, 0, 2}, {true, false, true});
     REQUIRE(b == b);
     REQUIRE_NOTHROW(b.block_no_checks(0, 0));
@@ -93,10 +93,10 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(blocks::validate(b), LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Blocks",
-                             "003",
-                             "left blocks of bipartition",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Blocks",
+                          "003",
+                          "left blocks of bipartition",
+                          "[quick]") {
     Bipartition x = Bipartition(
         {0, 1, 2, 1, 0, 2, 1, 0, 2, 2, 0, 0, 2, 0, 3, 4, 4, 1, 3, 0});
     Blocks* b = x.left_blocks();
@@ -115,10 +115,10 @@ namespace libsemigroups {
     delete b;
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Blocks",
-                             "004",
-                             "right blocks of bipartition",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Blocks",
+                          "004",
+                          "right blocks of bipartition",
+                          "[quick]") {
     Bipartition x = Bipartition(
         {0, 1, 1, 1, 1, 2, 3, 2, 4, 4, 5, 2, 4, 2, 1, 1, 1, 2, 3, 2});
     Blocks* b = x.right_blocks();
@@ -139,10 +139,7 @@ namespace libsemigroups {
     delete b;
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Blocks",
-                             "005",
-                             "copy [empty blocks]",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Blocks", "005", "copy [empty blocks]", "[quick]") {
     Blocks b = construct_blocks({}, {});
     Blocks c(b);
     REQUIRE(!IsBipartition<Blocks>);
@@ -156,10 +153,10 @@ namespace libsemigroups {
     REQUIRE(c.rank() == 0);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Blocks",
-                             "006",
-                             "copy [non-empty blocks]",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Blocks",
+                          "006",
+                          "copy [non-empty blocks]",
+                          "[quick]") {
     Blocks b = construct_blocks({0, 0, 1, 0, 2, 0, 1, 2, 2, 1, 0},
                                 {false, true, false});
     Blocks c(b);
@@ -179,7 +176,7 @@ namespace libsemigroups {
     REQUIRE(c.rank() == 1);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Blocks", "007", "hash value", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Blocks", "007", "hash value", "[quick]") {
     Blocks b = construct_blocks({0, 0, 1, 0, 2, 0, 1, 2, 2, 1, 0},
                                 {false, true, false});
     Blocks c = construct_blocks({0, 0, 1, 0, 2, 0, 1, 2, 2, 1, 0},
@@ -194,7 +191,7 @@ namespace libsemigroups {
     REQUIRE(b.hash_value() == 0);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Blocks", "008", "operator<", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Blocks", "008", "operator<", "[quick]") {
     Blocks b = construct_blocks({0, 0, 1, 0, 2, 0, 1, 2, 2, 1, 0},
                                 {false, true, false});
     Blocks c = construct_blocks({0, 0, 1, 0, 2, 0, 1, 2, 2, 1, 0},
@@ -211,10 +208,10 @@ namespace libsemigroups {
     REQUIRE(b < c);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Bipartition",
-                             "009",
-                             "mem fns 1",
-                             "[quick][bipartition]") {
+  LIBSEMIGROUPS_TEST_CASE("Bipartition",
+                          "009",
+                          "mem fns 1",
+                          "[quick][bipartition]") {
     auto x = Bipartition(
         {0, 1, 2, 1, 0, 2, 1, 0, 2, 2, 0, 0, 2, 0, 3, 4, 4, 1, 3, 0});
     auto y = Bipartition(
@@ -271,10 +268,10 @@ namespace libsemigroups {
             == "<bipartition of degree 10 with 5 blocks and rank 1>");
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Bipartition",
-                             "010",
-                             "hash",
-                             "[quick][bipartition]") {
+  LIBSEMIGROUPS_TEST_CASE("Bipartition",
+                          "010",
+                          "hash",
+                          "[quick][bipartition]") {
     Bipartition x({0, 1, 2, 1, 0, 2, 1, 0, 2, 2, 0, 0, 2, 0, 3, 4, 4, 1, 3, 0});
     auto        expected = x.hash_value();
     for (size_t i = 0; i < 1'000'000; i++) {
@@ -282,10 +279,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Bipartition",
-                             "011",
-                             "mem fns 2",
-                             "[quick][bipartition]") {
+  LIBSEMIGROUPS_TEST_CASE("Bipartition",
+                          "011",
+                          "mem fns 2",
+                          "[quick][bipartition]") {
     Bipartition x({0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 0, 0, 1, 2, 3, 3, 0, 4, 1, 1});
 
     REQUIRE(x.rank() == 3);
@@ -335,10 +332,10 @@ namespace libsemigroups {
     REQUIRE(x.rank() == 3);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Bipartition",
-                             "012",
-                             "delete/copy",
-                             "[quick][bipartition]") {
+  LIBSEMIGROUPS_TEST_CASE("Bipartition",
+                          "012",
+                          "delete/copy",
+                          "[quick][bipartition]") {
     Bipartition x({0, 0, 0, 0});
     Bipartition y(x);
 
@@ -346,10 +343,10 @@ namespace libsemigroups {
     REQUIRE(y == expected);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Bipartition",
-                             "013",
-                             "degree 0",
-                             "[quick][bipartition]") {
+  LIBSEMIGROUPS_TEST_CASE("Bipartition",
+                          "013",
+                          "degree 0",
+                          "[quick][bipartition]") {
     Bipartition x(std::vector<uint32_t>({}));
     REQUIRE(x.number_of_blocks() == 0);
     REQUIRE(x.number_of_left_blocks() == 0);
@@ -365,19 +362,19 @@ namespace libsemigroups {
     delete b;
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Bipartition",
-                             "014",
-                             "exceptions",
-                             "[quick][bipartition]") {
+  LIBSEMIGROUPS_TEST_CASE("Bipartition",
+                          "014",
+                          "exceptions",
+                          "[quick][bipartition]") {
     REQUIRE_NOTHROW(Bipartition(std::vector<uint32_t>()));
     REQUIRE_THROWS_AS(to_bipartition({0}), LibsemigroupsException);
     REQUIRE_THROWS_AS(to_bipartition({1, 0}), LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Bipartition",
-                             "015",
-                             "convenience constructor",
-                             "[quick][bipartition]") {
+  LIBSEMIGROUPS_TEST_CASE("Bipartition",
+                          "015",
+                          "convenience constructor",
+                          "[quick][bipartition]") {
     Bipartition xx(
         {0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 0, 0, 1, 2, 3, 3, 0, 4, 1, 1});
 
@@ -533,10 +530,10 @@ namespace libsemigroups {
                       LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Bipartition",
-                             "016",
-                             "force copy constructor over move constructor",
-                             "[quick][bipartition]") {
+  LIBSEMIGROUPS_TEST_CASE("Bipartition",
+                          "016",
+                          "force copy constructor over move constructor",
+                          "[quick][bipartition]") {
     std::vector<uint32_t> xx(
         {0, 1, 2, 1, 0, 2, 1, 0, 2, 2, 0, 0, 2, 0, 3, 4, 4, 1, 3, 0});
     auto                  x = Bipartition(xx);
@@ -582,15 +579,12 @@ namespace libsemigroups {
     REQUIRE(copy1 == copy2);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Bipartition",
-                             "017",
-                             "adapters",
-                             "[quick][bipart]") {
+  LIBSEMIGROUPS_TEST_CASE("Bipartition", "017", "adapters", "[quick][bipart]") {
     Bipartition x({0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 3, 3, 1, 2, 1});
     REQUIRE_NOTHROW(IncreaseDegree<Bipartition>()(x, 0));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Bipartition", "018", "bug", "[quick][bipart]") {
+  LIBSEMIGROUPS_TEST_CASE("Bipartition", "018", "bug", "[quick][bipart]") {
     Bipartition x({{1, -2, -3}, {-1}, {2, 3}});
     REQUIRE_NOTHROW(bipartition::validate(x));
   }

--- a/tests/test-bitset.cpp
+++ b/tests/test-bitset.cpp
@@ -18,58 +18,53 @@
 
 #include "catch_amalgamated.hpp"     // for REQUIRE
 #include "libsemigroups/bitset.hpp"  // for BitSet
-#include "test-main.hpp"             // for LIBSEMIGROUPS_TEST_CASE
+#include "test-main.hpp"             // for LIBSEMIGROUPS_TEMPLATE_TEST_CASE
 
 namespace libsemigroups {
 
-  template <size_t N>
-  void test_bitset_000() {
-    BitSet<N> bs;
-    REQUIRE(bs.size() == N);
-  }
+#define BITSET_32_TYPES \
+  BitSet<7>, BitSet<8>, BitSet<10>, BitSet<16>, BitSet<20>, BitSet<32>
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet", "000", "size", "[bitset][quick]") {
-    test_bitset_000<5>();
-    test_bitset_000<8>();
-    test_bitset_000<10>();
-    test_bitset_000<16>();
-    test_bitset_000<20>();
-    test_bitset_000<32>();
 #if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-    test_bitset_000<40>();
-    test_bitset_000<64>();
+#define BITSET_64_TYPES BitSet<40>, BitSet<64>
+#else
+#define BITESET_64_TYPES
 #endif
+
+#define BITSET_TYPES BITSET_32_TYPES, BITSET_64_TYPES
+
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "000",
+                                   "size",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs;
+    REQUIRE(bs.size() >= 7);
+    REQUIRE(bs.size() <= 64);
   }
 
-  template <size_t N>
-  void test_bitset_001() {
-    BitSet<N> bs1;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "001",
+                                   "operator<",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs1;
     bs1.reset();
-    BitSet<N> bs2;
+    TestType bs2;
     bs2.reset();
     bs2.set(0);
 
     REQUIRE(bs1 < bs2);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet", "001", "operator<", "[bitset][quick]") {
-    test_bitset_001<5>();
-    test_bitset_001<8>();
-    test_bitset_001<10>();
-    test_bitset_001<16>();
-    test_bitset_001<20>();
-    test_bitset_001<32>();
-#if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-    test_bitset_001<40>();
-    test_bitset_001<64>();
-#endif
-  }
-
-  template <size_t N>
-  void test_bitset_002() {
-    BitSet<N> bs1;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "002",
+                                   "operator==",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs1;
     bs1.reset();
-    BitSet<N> bs2;
+    TestType bs2;
     bs2.reset();
     bs2.set(0);
 
@@ -78,24 +73,14 @@ namespace libsemigroups {
     REQUIRE(bs1 == bs2);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet", "002", "operator==", "[bitset][quick]") {
-    test_bitset_002<5>();
-    test_bitset_002<8>();
-    test_bitset_002<10>();
-    test_bitset_002<16>();
-    test_bitset_002<20>();
-    test_bitset_002<32>();
-#if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-    test_bitset_002<40>();
-    test_bitset_002<64>();
-#endif
-  }
-
-  template <size_t N>
-  void test_bitset_003() {
-    BitSet<N> bs1;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "003",
+                                   "operator!=",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs1;
     bs1.reset();
-    BitSet<N> bs2;
+    TestType bs2;
     bs2.reset();
     bs2.set(0);
 
@@ -104,26 +89,16 @@ namespace libsemigroups {
     REQUIRE(bs1 == bs2);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet", "003", "operator!=", "[bitset][quick]") {
-    test_bitset_003<5>();
-    test_bitset_003<8>();
-    test_bitset_003<10>();
-    test_bitset_003<16>();
-    test_bitset_003<20>();
-    test_bitset_003<32>();
-#if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-    test_bitset_003<40>();
-    test_bitset_003<64>();
-#endif
-  }
-
-  template <size_t N>
-  void test_bitset_004() {
-    BitSet<N> bs1;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "004",
+                                   "operator&=",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs1;
     bs1.reset();
     bs1.set(0);
     bs1.set(1);
-    BitSet<N> bs2;
+    TestType bs2;
     bs2.reset();
     bs2.set(1);
     bs1 &= bs2;
@@ -132,29 +107,19 @@ namespace libsemigroups {
     REQUIRE(bs2.count() == 1);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet", "004", "operator&=", "[bitset][quick]") {
-    test_bitset_004<5>();
-    test_bitset_004<8>();
-    test_bitset_004<10>();
-    test_bitset_004<16>();
-    test_bitset_004<20>();
-    test_bitset_004<32>();
-#if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-    test_bitset_004<40>();
-    test_bitset_004<64>();
-#endif
-  }
-
-  template <size_t N>
-  void test_bitset_005() {
-    BitSet<N> bs1;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "005",
+                                   "&",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs1;
     bs1.reset();
     bs1.set(0);
     bs1.set(1);
-    BitSet<N> bs2;
+    TestType bs2;
     bs2.reset();
     bs2.set(1);
-    BitSet<N> bs3 = bs1 & bs2;
+    TestType bs3 = bs1 & bs2;
     REQUIRE(bs3 == bs2);
     REQUIRE(&bs3 != &bs2);
     REQUIRE(bs1.count() == 2);
@@ -162,25 +127,15 @@ namespace libsemigroups {
     REQUIRE(bs3.count() == 1);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet", "005", "&", "[bitset][quick]") {
-    test_bitset_005<5>();
-    test_bitset_005<8>();
-    test_bitset_005<10>();
-    test_bitset_005<16>();
-    test_bitset_005<20>();
-    test_bitset_005<32>();
-#if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-    test_bitset_005<40>();
-    test_bitset_005<64>();
-#endif
-  }
-
-  template <size_t N>
-  void test_bitset_006() {
-    BitSet<N> bs1;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "006",
+                                   "operator|=",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs1;
     bs1.reset();
     bs1.set(0);
-    BitSet<N> bs2;
+    TestType bs2;
     bs2.reset();
     bs2.set(1);
     bs2 |= bs1;
@@ -192,22 +147,12 @@ namespace libsemigroups {
     REQUIRE(!bs2.test(2));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet", "006", "operator|=", "[bitset][quick]") {
-    test_bitset_006<5>();
-    test_bitset_006<8>();
-    test_bitset_006<10>();
-    test_bitset_006<16>();
-    test_bitset_006<20>();
-    test_bitset_006<32>();
-#if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-    test_bitset_006<40>();
-    test_bitset_006<64>();
-#endif
-  }
-
-  template <size_t N>
-  void test_bitset_007() {
-    BitSet<N> bs;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "007",
+                                   "operator[]",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs;
     bs.reset();
     bs.set(0);
     bs.set(3);
@@ -220,22 +165,12 @@ namespace libsemigroups {
     REQUIRE(bs[5]);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet", "007", "operator[]", "[bitset][quick]") {
-    test_bitset_007<6>();
-    test_bitset_007<8>();
-    test_bitset_007<10>();
-    test_bitset_007<16>();
-    test_bitset_007<20>();
-    test_bitset_007<32>();
-#if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-    test_bitset_007<40>();
-    test_bitset_007<64>();
-#endif
-  }
-
-  template <size_t N>
-  void test_bitset_008() {
-    BitSet<N> bs;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "008",
+                                   "set(none)",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs;
     bs.set();
     REQUIRE(bs[0]);
     REQUIRE(bs[1]);
@@ -243,25 +178,15 @@ namespace libsemigroups {
     REQUIRE(bs[3]);
     REQUIRE(bs[4]);
     REQUIRE(bs[5]);
-    REQUIRE(bs.count() == N);
+    REQUIRE(bs.count() == bs.size());
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet", "008", "set(none)", "[bitset][quick]") {
-    test_bitset_008<6>();
-    test_bitset_008<8>();
-    test_bitset_008<10>();
-    test_bitset_008<16>();
-    test_bitset_008<20>();
-    test_bitset_008<32>();
-#if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-    test_bitset_008<40>();
-    test_bitset_008<64>();
-#endif
-  }
-
-  template <size_t N>
-  void test_bitset_009() {
-    BitSet<N> bs;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "009",
+                                   "set(pos, value)",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs;
     bs.set();
     bs.set(0, false);
     REQUIRE(!bs[0]);
@@ -270,28 +195,15 @@ namespace libsemigroups {
     REQUIRE(bs[3]);
     REQUIRE(bs[4]);
     REQUIRE(bs[5]);
-    REQUIRE(bs.count() == N - 1);
+    REQUIRE(bs.count() == bs.size() - 1);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet",
-                          "009",
-                          "set(pos, value)",
-                          "[bitset][quick]") {
-    test_bitset_009<6>();
-    test_bitset_009<8>();
-    test_bitset_009<10>();
-    test_bitset_009<16>();
-    test_bitset_009<20>();
-    test_bitset_009<32>();
-#if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-    test_bitset_009<40>();
-    test_bitset_009<64>();
-#endif
-  }
-
-  template <size_t N>
-  void test_bitset_010() {
-    BitSet<N> bs;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "010",
+                                   "set(first, last, value)",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs;
     bs.reset();
     REQUIRE(bs.count() == 0);
     bs.set(2, 6, true);
@@ -305,30 +217,17 @@ namespace libsemigroups {
     REQUIRE(!bs[6]);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet",
-                          "010",
-                          "set(first, last, value)",
-                          "[bitset][quick]") {
-    test_bitset_010<7>();
-    test_bitset_010<8>();
-    test_bitset_010<10>();
-    test_bitset_010<16>();
-    test_bitset_010<20>();
-    test_bitset_010<32>();
-#if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-    test_bitset_010<40>();
-    test_bitset_010<64>();
-#endif
-  }
-
-  template <size_t N>
-  void test_bitset_011() {
-    BitSet<N> bs;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "011",
+                                   "reset(first, last)",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs;
     bs.set();
-    REQUIRE(bs.count() == N);
+    REQUIRE(bs.count() == bs.size());
     bs.reset(2, 6);
 
-    REQUIRE(bs.count() == N - 4);
+    REQUIRE(bs.count() == bs.size() - 4);
     REQUIRE(bs[0]);
     REQUIRE(bs[1]);
     REQUIRE(!bs[2]);
@@ -337,33 +236,20 @@ namespace libsemigroups {
     REQUIRE(bs[6]);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet",
-                          "011",
-                          "reset(first, last)",
-                          "[bitset][quick]") {
-    test_bitset_011<7>();
-    test_bitset_011<8>();
-    test_bitset_011<10>();
-    test_bitset_011<16>();
-    test_bitset_011<20>();
-    test_bitset_011<32>();
-#if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-    test_bitset_011<40>();
-    test_bitset_011<64>();
-#endif
-  }
-
-  template <size_t N>
-  void test_bitset_012() {
-    BitSet<N> bs;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "012",
+                                   "reset(pos)",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs;
     bs.set();
-    REQUIRE(bs.count() == N);
+    REQUIRE(bs.count() == bs.size());
     bs.reset(2);
     bs.reset(3);
     bs.reset(4);
     bs.reset(5);
 
-    REQUIRE(bs.count() == N - 4);
+    REQUIRE(bs.count() == bs.size() - 4);
     REQUIRE(bs[0]);
     REQUIRE(bs[1]);
     REQUIRE(!bs[2]);
@@ -372,22 +258,12 @@ namespace libsemigroups {
     REQUIRE(bs[6]);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet", "012", "reset(pos)", "[bitset][quick]") {
-    test_bitset_012<7>();
-    test_bitset_012<8>();
-    test_bitset_012<10>();
-    test_bitset_012<16>();
-    test_bitset_012<20>();
-    test_bitset_012<32>();
-#if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-    test_bitset_012<40>();
-    test_bitset_012<64>();
-#endif
-  }
-
-  template <size_t N>
-  void test_bitset_013() {
-    BitSet<N> bs;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "013",
+                                   "apply (iterate through set bits)",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs;
     bs.set();
     bs.reset(2);
     bs.reset(3);
@@ -395,7 +271,7 @@ namespace libsemigroups {
     bs.reset(5);
 
     std::vector<size_t> expected = {0, 1};
-    for (typename BitSet<N>::block_type i = 6; i < N; i++) {
+    for (typename TestType::block_type i = 6; i < bs.size(); i++) {
       expected.push_back(i);
     }
     std::vector<size_t> result;
@@ -403,120 +279,93 @@ namespace libsemigroups {
     // hi bits are not nec. set to false
     bs.apply([&result](size_t i) { result.push_back(i); });
 
-    REQUIRE(bs.count() == N - 4);
+    REQUIRE(bs.count() == bs.size() - 4);
     // hi bits are set to false
     result.clear();
     bs.apply([&result](size_t i) { result.push_back(i); });
     REQUIRE(result == expected);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet",
-                          "013",
-                          "apply (iterate through set bits)",
-                          "[bitset][quick]") {
-    test_bitset_013<7>();
-    test_bitset_013<8>();
-    test_bitset_013<10>();
-    test_bitset_013<16>();
-    test_bitset_013<20>();
-    test_bitset_013<32>();
-#if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-    test_bitset_013<40>();
-    test_bitset_013<64>();
-#endif
-  }
-
-  template <size_t N>
-  void test_bitset_014() {
-    BitSet<N> bs;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "014",
+                                   "std::hash",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs;
     bs.reset();
-    std::hash<BitSet<N>>()(bs);
+    std::hash<TestType>()(bs);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet", "014", "std::hash", "[bitset][quick]") {
-    test_bitset_014<7>();
-    test_bitset_014<8>();
-    test_bitset_014<10>();
-    test_bitset_014<16>();
-    test_bitset_014<20>();
-    test_bitset_014<32>();
-#if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-    test_bitset_014<40>();
-    test_bitset_014<64>();
-#endif
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("BitSet", "015", "constructors", "[bitset][quick]") {
-    BitSet<10> bs;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "015",
+                                   "constructors",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs;
     bs.set();
     bs.reset(2, 6);
-    REQUIRE(bs.count() == 6);
+    REQUIRE(bs.count() == bs.size() - 4);
     REQUIRE(bs[0]);
     REQUIRE(bs[1]);
     REQUIRE(!bs[2]);
     REQUIRE(!bs[3]);
     REQUIRE(!bs[4]);
     REQUIRE(bs[6]);
-    REQUIRE(bs[7]);
 
     {  // Copy constructor
       auto copy(bs);
       REQUIRE(copy == bs);
       REQUIRE(&copy != &bs);
     }
-    REQUIRE(bs.count() == 6);
+    REQUIRE(bs.count() == bs.size() - 4);
     REQUIRE(bs[0]);
     REQUIRE(bs[1]);
     REQUIRE(!bs[2]);
     REQUIRE(!bs[3]);
     REQUIRE(!bs[4]);
     REQUIRE(bs[6]);
-    REQUIRE(bs[7]);
     {  // Move constructor
       auto copy(std::move(bs));
-      REQUIRE(copy.count() == 6);
+      REQUIRE(copy.count() == copy.size() - 4);
       REQUIRE(copy[0]);
       REQUIRE(copy[1]);
       REQUIRE(!copy[2]);
       REQUIRE(!copy[3]);
       REQUIRE(!copy[4]);
       REQUIRE(copy[6]);
-      REQUIRE(copy[7]);
     }
     bs.set();
     bs.reset(2, 6);
     {  // Copy assignment
       auto copy = bs;
-      REQUIRE(copy.count() == 6);
+      REQUIRE(copy.count() == copy.size() - 4);
       REQUIRE(copy[0]);
       REQUIRE(copy[1]);
       REQUIRE(!copy[2]);
       REQUIRE(!copy[3]);
       REQUIRE(!copy[4]);
       REQUIRE(copy[6]);
-      REQUIRE(copy[7]);
     }
-    REQUIRE(bs.count() == 6);
+    REQUIRE(bs.count() == bs.size() - 4);
     REQUIRE(bs[0]);
     REQUIRE(bs[1]);
     REQUIRE(!bs[2]);
     REQUIRE(!bs[3]);
     REQUIRE(!bs[4]);
     REQUIRE(bs[6]);
-    REQUIRE(bs[7]);
     {  // Move assignment
       auto copy = std::move(bs);
-      REQUIRE(copy.count() == 6);
+      REQUIRE(copy.count() == copy.size() - 4);
       REQUIRE(copy[0]);
       REQUIRE(copy[1]);
       REQUIRE(!copy[2]);
       REQUIRE(!copy[3]);
       REQUIRE(!copy[4]);
       REQUIRE(copy[6]);
-      REQUIRE(copy[7]);
     }
 
     // block_type constructor
+    // TODO(0) separate test case
     BitSet<30> bs2(0x15);
     REQUIRE(bs2.count() == 3);
     REQUIRE(bs2[0]);
@@ -526,7 +375,11 @@ namespace libsemigroups {
     REQUIRE(bs2[4]);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet", "016", "max_size", "[bitset][quick]") {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "016",
+                                   "max_size",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
 #if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
     REQUIRE(BitSet<1>::max_size() == 64);
 #else
@@ -534,11 +387,12 @@ namespace libsemigroups {
 #endif
   }
 
-  LIBSEMIGROUPS_TEST_CASE("BitSet",
-                          "017",
-                          "insertion operators",
-                          "[bitset][quick]") {
-    BitSet<10> bs;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
+                                   "017",
+                                   "insertion operators",
+                                   "[bitset][quick]",
+                                   BITSET_TYPES) {
+    TestType bs;
     bs.set();
     bs.reset(2, 6);
     std::ostringstream oss;

--- a/tests/test-bitset.cpp
+++ b/tests/test-bitset.cpp
@@ -26,12 +26,12 @@ namespace libsemigroups {
   BitSet<7>, BitSet<8>, BitSet<10>, BitSet<16>, BitSet<20>, BitSet<32>
 
 #if LIBSEMIGROUPS_SIZEOF_VOID_P == 8
-#define BITSET_64_TYPES BitSet<40>, BitSet<64>
+#define BITSET_64_TYPES , BitSet<40>, BitSet<64>
 #else
-#define BITESET_64_TYPES
+#define BITSET_64_TYPES
 #endif
 
-#define BITSET_TYPES BITSET_32_TYPES, BITSET_64_TYPES
+#define BITSET_TYPES BITSET_32_TYPES BITSET_64_TYPES
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("BitSet",
                                    "000",

--- a/tests/test-bmat8.cpp
+++ b/tests/test-bmat8.cpp
@@ -25,7 +25,7 @@
 #include <vector>         // for vector
 
 #include "catch_amalgamated.hpp"  // for REQUIRE, REQUIRE_THROWS_AS, REQUIRE_NOTHROW
-#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE
 
 #include "libsemigroups/bmat8.hpp"         // for BMat8, operator<<, col_sp...
 #include "libsemigroups/exception.hpp"     // for LibsemigroupsException
@@ -39,10 +39,7 @@ namespace libsemigroups {
   // Forward decl
   struct LibsemigroupsException;
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8",
-                             "000",
-                             "transpose",
-                             "[quick][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "000", "transpose", "[quick][no-valgrind]") {
     auto  rg = ReportGuard(false);
     BMat8 bm1(0);
     REQUIRE(bmat8::transpose(bm1) == bm1);
@@ -70,7 +67,7 @@ namespace libsemigroups {
                       {1, 1, 1, 1, 1, 1, 1, 0}}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "001", "arithmetic", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "001", "arithmetic", "[quick]") {
     auto  rg = ReportGuard(false);
     BMat8 bm({{0, 0, 0, 1, 0, 0, 1, 1},
               {1, 1, 1, 1, 1, 1, 0, 1},
@@ -137,7 +134,7 @@ namespace libsemigroups {
     REQUIRE(bm == BMat8({{1, 0, 1}, {1, 1, 0}, {1, 0, 0}}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "002", "identity matrix", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "002", "identity matrix", "[quick]") {
     auto  rg = ReportGuard(false);
     BMat8 bm({{0, 1, 1, 1, 0, 1, 0, 1},
               {0, 0, 0, 0, 0, 0, 0, 1},
@@ -160,7 +157,7 @@ namespace libsemigroups {
     REQUIRE(bmat8::one() == id);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "003", "random", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "003", "random", "[quick]") {
     auto rg = ReportGuard(false);
     for (size_t d = 1; d < 9; ++d) {
       BMat8 const bm = bmat8::random(d);
@@ -177,7 +174,7 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(bmat8::random(9), LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "004", "call operator", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "004", "call operator", "[quick]") {
     auto                           rg  = ReportGuard(false);
     std::vector<std::vector<bool>> mat = {{0, 0, 0, 1, 0, 0, 1},
                                           {0, 1, 1, 1, 0, 1, 0},
@@ -195,7 +192,7 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "005", "operator<<", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "005", "operator<<", "[quick]") {
     auto               rg = ReportGuard(false);
     std::ostringstream oss;
     oss << bmat8::random();  // Does not do anything visible
@@ -205,7 +202,7 @@ namespace libsemigroups {
     os << bmat8::random();  // Also does not do anything visible
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "006", "set", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "006", "set", "[quick]") {
     auto  rg = ReportGuard(false);
     BMat8 bm({{0, 1, 1, 1, 0, 1, 0, 1},
               {0, 0, 0, 0, 0, 0, 0, 1},
@@ -287,7 +284,7 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(zeros.at(8, 8) = true, LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "007", "row space basis", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "007", "row space basis", "[quick]") {
     auto  rg = ReportGuard(false);
     BMat8 bm({{0, 1, 1, 1, 0, 1, 0, 1},
               {0, 0, 0, 0, 0, 0, 0, 1},
@@ -346,7 +343,7 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "008", "col space basis", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "008", "col space basis", "[quick]") {
     auto  rg = ReportGuard(false);
     BMat8 bm({{0, 1, 1, 1, 0, 1, 0, 1},
               {0, 0, 0, 0, 0, 0, 0, 1},
@@ -405,7 +402,7 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "009", "row space basis x 2", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "009", "row space basis x 2", "[quick]") {
     auto                     rg = ReportGuard(false);
     detail::Timer            t;
     const std::vector<BMat8> gens
@@ -441,10 +438,10 @@ namespace libsemigroups {
     // std::cout << t;
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8",
-                             "010",
-                             "number_of_rows, number_of_cols",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8",
+                          "010",
+                          "number_of_rows, number_of_cols",
+                          "[quick]") {
     auto  rg    = ReportGuard(false);
     BMat8 idem1 = bmat8::one();
     BMat8 idem2 = bmat8::one();
@@ -482,10 +479,7 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8",
-                             "011",
-                             "row_space, col_space",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "011", "row_space, col_space", "[quick]") {
     auto  rg    = ReportGuard(false);
     BMat8 idem1 = bmat8::one();
     BMat8 idem2 = bmat8::one();
@@ -583,7 +577,7 @@ namespace libsemigroups {
     REQUIRE(21 == bmat8::row_space_size(bm3t));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "012", "rows", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "012", "rows", "[quick]") {
     auto  rg = ReportGuard(false);
     BMat8 x({{0, 1}, {1, 0}});
     REQUIRE(x.to_int() == 4647714815446351872);
@@ -661,7 +655,7 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "013", "one", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "013", "one", "[quick]") {
     auto rg = ReportGuard(false);
     for (size_t i = 1; i <= 8; ++i) {
       BMat8 x = bmat8::one<BMat8>(i);
@@ -671,7 +665,7 @@ namespace libsemigroups {
     REQUIRE(bmat8::minimum_dim(BMat8(0)) == 0);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "014", "vector constructor", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "014", "vector constructor", "[quick]") {
     auto  rg = ReportGuard(false);
     BMat8 zero(0);
     REQUIRE(BMat8({{0, 0}, {0, 0}}) == zero);
@@ -703,10 +697,7 @@ namespace libsemigroups {
                       LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8",
-                             "015",
-                             "comparison operators",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "015", "comparison operators", "[quick]") {
     auto  rg = ReportGuard(false);
     BMat8 bm1(0);
     BMat8 bm2({{0, 0, 0, 1, 0, 0, 1, 1},
@@ -738,7 +729,7 @@ namespace libsemigroups {
     REQUIRE(bm1 != bm2);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "016", "adapters", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "016", "adapters", "[quick]") {
     auto  rg = ReportGuard(false);
     BMat8 bm1(0);
     REQUIRE(Complexity<BMat8>()(bm1) == 0);
@@ -794,7 +785,7 @@ namespace libsemigroups {
     REQUIRE(Inverse<BMat8>()(bm6) == bm6 * bm6);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "017", "one x 2", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "017", "one x 2", "[quick]") {
     BMat8 bm5({{1, 0, 0, 0, 0, 0, 0, 0},
                {0, 1, 0, 0, 0, 0, 0, 0},
                {0, 0, 1, 0, 0, 0, 0, 0},
@@ -808,7 +799,7 @@ namespace libsemigroups {
     REQUIRE(bmat8::one(8) == bmat8::one());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "018", "is_regular_element", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "018", "is_regular_element", "[quick]") {
     REQUIRE((rx::seq<uint64_t>() | rx::take(100'000) | rx::filter([](auto val) {
                return bmat8::is_regular_element(BMat8(val));
              })
@@ -816,12 +807,12 @@ namespace libsemigroups {
             == 97'996);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "019", "at", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "019", "at", "[quick]") {
     auto x = bmat8::random();
     REQUIRE_THROWS_AS(x.at(0, 8), LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("BMat8", "020", "to_string", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("BMat8", "020", "to_string", "[quick]") {
     REQUIRE(to_string(bmat8::one(5)) == R"V0G0N(BMat8({{1, 0, 0, 0, 0},
        {0, 1, 0, 0, 0},
        {0, 0, 1, 0, 0},

--- a/tests/test-cong-intf.cpp
+++ b/tests/test-cong-intf.cpp
@@ -39,11 +39,13 @@ namespace libsemigroups {
   using todd_coxeter::non_trivial_classes;
   using todd_coxeter::normal_forms;
 
-  TEMPLATE_TEST_CASE("CongruenceInterface: add_generating_pair",
-                     "[000][quick]",
-                     ToddCoxeter,
-                     Congruence,
-                     KnuthBendix<>) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("CongruenceInterface",
+                                   "000",
+                                   "add_generating_pair",
+                                   "[quick]",
+                                   ToddCoxeter,
+                                   Congruence,
+                                   KnuthBendix<>) {
     // Kambites doesn't work in this example
     auto rg = ReportGuard(false);
 
@@ -62,11 +64,13 @@ namespace libsemigroups {
                       LibsemigroupsException);
   }
 
-  TEMPLATE_TEST_CASE("CongruenceInterface: contains",
-                     "[001][quick]",
-                     ToddCoxeter,
-                     Congruence,
-                     KnuthBendix<>) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("CongruenceInterface",
+                                   "001",
+                                   "contains",
+                                   "[quick]",
+                                   ToddCoxeter,
+                                   Congruence,
+                                   KnuthBendix<>) {
     // Kambites doesn't work in this example
     auto rg = ReportGuard(false);
 
@@ -93,11 +97,14 @@ namespace libsemigroups {
             == tril::FALSE);
   }
 
-  TEMPLATE_TEST_CASE("CongruenceInterface: is_obviously_infinite",
-                     "[002][quick]",
-                     // ToddCoxeter, TODO(0) currently broken for ToddCoxeter
-                     Congruence,
-                     KnuthBendix<>) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "CongruenceInterface",
+      "002",
+      "is_obviously_infinite",
+      "[quick]",
+      // ToddCoxeter, TODO(0) currently broken for ToddCoxeter
+      Congruence,
+      KnuthBendix<>) {
     auto rg = ReportGuard(false);
 
     TestType cong;
@@ -131,11 +138,13 @@ namespace libsemigroups {
     REQUIRE(!is_obviously_infinite(cong));
   }
 
-  TEMPLATE_TEST_CASE("CongruenceInterface: non_trivial_classes x1",
-                     "[003][quick]",
-                     ToddCoxeter,
-                     Congruence,
-                     KnuthBendix<>) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("CongruenceInterface",
+                                   "003",
+                                   "non_trivial_classes x1",
+                                   "[quick]",
+                                   ToddCoxeter,
+                                   Congruence,
+                                   KnuthBendix<>) {
     auto rg = ReportGuard(false);
     auto S  = to_froidure_pin(
         {Transf<>({1, 3, 4, 2, 3}), Transf<>({3, 2, 1, 3, 3})});
@@ -174,11 +183,13 @@ namespace libsemigroups {
     REQUIRE(ntc[0] == expect);
   }
 
-  TEMPLATE_TEST_CASE("CongruenceInterface: non_trivial_classes x2",
-                     "[004][quick]",
-                     ToddCoxeter,
-                     Congruence,
-                     KnuthBendix<>) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("CongruenceInterface",
+                                   "004",
+                                   "non_trivial_classes x2",
+                                   "[quick]",
+                                   ToddCoxeter,
+                                   Congruence,
+                                   KnuthBendix<>) {
     auto rg = ReportGuard(false);
     auto S  = to_froidure_pin(
         {Transf<>({1, 3, 4, 2, 3}), Transf<>({3, 2, 1, 3, 3})});
@@ -207,12 +218,14 @@ namespace libsemigroups {
     REQUIRE(actual == expect);
   }
 
-  TEMPLATE_TEST_CASE("CongruenceInterface: no generating pairs added",
-                     "[005][quick]",
-                     ToddCoxeter,
-                     Congruence,
-                     KnuthBendix<>,
-                     Kambites<>) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("CongruenceInterface",
+                                   "005",
+                                   "no generating pairs added",
+                                   "[quick]",
+                                   ToddCoxeter,
+                                   Congruence,
+                                   KnuthBendix<>,
+                                   Kambites<>) {
     auto rg = ReportGuard(false);
 
     Presentation<word_type> p;
@@ -226,9 +239,11 @@ namespace libsemigroups {
     REQUIRE(cong.number_of_classes() == POSITIVE_INFINITY);
   }
 
-  TEMPLATE_TEST_CASE("CongruenceInterface: to_froidure_pin",
-                     "[006][quick]",
-                     Kambites<>) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("CongruenceInterface",
+                                   "006",
+                                   "to_froidure_pin",
+                                   "[quick]",
+                                   Kambites<>) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcdefg");
@@ -261,10 +276,12 @@ namespace libsemigroups {
                  "aff", "afg", "aga", "agb", "agc", "agd"}));
   }
 
-  TEMPLATE_TEST_CASE("CongruenceInterface: to_froidure_pin",
-                     "[007][quick]",
-                     KnuthBendix<>,
-                     ToddCoxeter) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("CongruenceInterface",
+                                   "007",
+                                   "to_froidure_pin",
+                                   "[quick]",
+                                   KnuthBendix<>,
+                                   ToddCoxeter) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -281,9 +298,11 @@ namespace libsemigroups {
     REQUIRE(to_froidure_pin(cong).size() == 12);
   }
 
-  TEMPLATE_TEST_CASE("CongruenceInterface: to_froidure_pin",
-                     "[008][quick]",
-                     Congruence) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("CongruenceInterface",
+                                   "008",
+                                   "to_froidure_pin",
+                                   "[quick]",
+                                   Congruence) {
     auto rg = ReportGuard(false);
     using knuth_bendix::normal_forms;
     using todd_coxeter::normal_forms;
@@ -315,10 +334,12 @@ namespace libsemigroups {
     REQUIRE(fp->current_size() == 8'205);
   }
 
-  TEMPLATE_TEST_CASE("CongruenceInterface: normal_forms",
-                     "[009][quick]",
-                     KnuthBendix<>,
-                     ToddCoxeter) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("CongruenceInterface",
+                                   "009",
+                                   "normal_forms",
+                                   "[quick]",
+                                   KnuthBendix<>,
+                                   ToddCoxeter) {
     auto rg = ReportGuard(false);
     using knuth_bendix::normal_forms;
     using todd_coxeter::normal_forms;
@@ -362,9 +383,11 @@ namespace libsemigroups {
                                        {98, 97, 66}}));
   }
 
-  TEMPLATE_TEST_CASE("CongruenceInterface: normal_forms",
-                     "[010][quick]",
-                     Congruence) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("CongruenceInterface",
+                                   "010",
+                                   "normal_forms",
+                                   "[quick]",
+                                   Congruence) {
     using knuth_bendix::normal_forms;
     using todd_coxeter::normal_forms;
 

--- a/tests/test-fpsemi-examples-1.cpp
+++ b/tests/test-fpsemi-examples-1.cpp
@@ -493,7 +493,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
-                          "107",
+                          "119",
                           "orientation_preserving_monoid auth except",
                           "[fpsemi-examples][quick]") {
     auto rg = ReportGuard(REPORT);

--- a/tests/test-fpsemi-examples-3.cpp
+++ b/tests/test-fpsemi-examples-3.cpp
@@ -38,11 +38,10 @@ namespace libsemigroups {
   using fpsemigroup::not_symmetric_group;
   using fpsemigroup::symmetric_group;
 
-  LIBSEMIGROUPS_TEST_CASE(
-      "fpsemi-examples",
-      "070",
-      "not_symmetric_group(5) Guralnick + Kantor + Kassabov + Lubotzky",
-      "[fpsemi-examples][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("fpsemi-examples",
+                          "070",
+                          "not_symmetric_group(5) GKKL",
+                          "[fpsemi-examples][quick]") {
     auto   rg = ReportGuard(false);
     size_t n  = 5;
 

--- a/tests/test-froidure-pin-bipart.cpp
+++ b/tests/test-froidure-pin-bipart.cpp
@@ -20,10 +20,11 @@
 #include <vector>   // for vector
 
 #include "catch_amalgamated.hpp"  // for REQUIRE
-#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE
 
 #include "libsemigroups/bipart.hpp"        // for Bipartition
 #include "libsemigroups/froidure-pin.hpp"  // for FroidurePin
+#include "libsemigroups/word-range.hpp"    // for namespace literals
 
 namespace libsemigroups {
   using namespace literals;  // for operator""_w
@@ -33,10 +34,10 @@ namespace libsemigroups {
 
   constexpr bool REPORT = false;
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "000",
-                             "small example 1 .................. Bipartition",
-                             "[quick][froidure-pin][bipartition][bipart]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "000",
+                          "small example 1 .................. Bipartition",
+                          "[quick][froidure-pin][bipartition][bipart]") {
     auto        rg = ReportGuard(REPORT);
     FroidurePin S  = to_froidure_pin(
         {to_bipartition({{1, 5, 8, -1, -2, -4, -10},
@@ -93,10 +94,10 @@ namespace libsemigroups {
     REQUIRE(std::is_sorted(S.cbegin_sorted(), S.cend_sorted()));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "001",
-                             "default constructed .............. Bipartition",
-                             "[quick][froidure-pin][bipartition][bipart]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "001",
+                          "default constructed .............. Bipartition",
+                          "[quick][froidure-pin][bipartition][bipart]") {
     auto rg = ReportGuard(REPORT);
 
     FroidurePin<Bipartition> S;
@@ -153,10 +154,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "002",
-                             "small example 2 - Bipartition",
-                             "[quick][froidure-pin][element]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "002",
+                          "small example 2 - Bipartition",
+                          "[quick][froidure-pin][element]") {
     auto                     rg = ReportGuard(REPORT);
     FroidurePin<Bipartition> S;
     S.add_generator(Bipartition(
@@ -196,10 +197,10 @@ namespace libsemigroups {
     REQUIRE(S.contains(y));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "003",
-                             "number of idempotents - Bipartition",
-                             "[extreme][froidure-pin][element]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "003",
+                          "number of idempotents - Bipartition",
+                          "[extreme][froidure-pin][element]") {
     auto                     rg = ReportGuard();
     FroidurePin<Bipartition> S;
     S.add_generator(Bipartition({0, 1, 2, 3, 4, 5, 5, 0, 1, 2, 3, 4}));
@@ -211,10 +212,10 @@ namespace libsemigroups {
     REQUIRE(S.number_of_idempotents() == 541'254);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "004",
-                             "exception: is_idempotent - Bipartition",
-                             "[quick][froidure-pin][element]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "004",
+                          "exception: is_idempotent - Bipartition",
+                          "[quick][froidure-pin][element]") {
     FroidurePin<Bipartition> S;
     S.add_generator(Bipartition(
         {0, 1, 2, 1, 0, 2, 1, 0, 2, 2, 0, 0, 2, 0, 3, 4, 4, 1, 3, 0}));

--- a/tests/test-froidure-pin-bmat.cpp
+++ b/tests/test-froidure-pin-bmat.cpp
@@ -21,10 +21,11 @@
 
 #include "bmat-data.hpp"          // for clark_gens
 #include "catch_amalgamated.hpp"  // for REQUIRE
-#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE
 
 #include "libsemigroups/froidure-pin.hpp"  // for FroidurePin<>::element_index_type
 #include "libsemigroups/matrix.hpp"        // for BMat
+#include "libsemigroups/word-range.hpp"  // for namespace literals
 
 #include "libsemigroups/detail/report.hpp"  // for ReportGuard
 
@@ -40,10 +41,12 @@ namespace libsemigroups {
   // Test cases - BMat
   ////////////////////////////////////////////////////////////////////////
 
-  TEMPLATE_TEST_CASE("FroidurePin: small example 1",
-                     "[005][quick][froidure-pin][bmat]",
-                     BMat<4>,
-                     BMat<>) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "005",
+                                   "small example 1",
+                                   "[quick][froidure-pin][bmat]",
+                                   BMat<4>,
+                                   BMat<>) {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<TestType> S;
     S.add_generator(
@@ -89,10 +92,12 @@ namespace libsemigroups {
     REQUIRE(std::is_sorted(S.cbegin_sorted(), S.cend_sorted()));
   }
 
-  TEMPLATE_TEST_CASE("FroidurePin: regular bmat monoid 4",
-                     "[007][quick][froidure-pin][bmat][no-valgrind]",
-                     BMat<4>,
-                     BMat<>) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "007",
+                                   "regular bmat monoid 4",
+                                   "[quick][froidure-pin][bmat][no-valgrind]",
+                                   BMat<4>,
+                                   BMat<>) {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<TestType> S;
     S.add_generator(
@@ -107,10 +112,12 @@ namespace libsemigroups {
     REQUIRE(S.number_of_idempotents() == 2'360);
   }
 
-  TEMPLATE_TEST_CASE("FroidurePin: small example 2",
-                     "[009][quick][froidure-pin][bmat]",
-                     BMat<3>,
-                     BMat<>) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "009",
+                                   "small example 2",
+                                   "[quick][froidure-pin][bmat]",
+                                   BMat<3>,
+                                   BMat<>) {
     auto rg = ReportGuard(REPORT);
 
     FroidurePin<TestType> S;
@@ -143,10 +150,12 @@ namespace libsemigroups {
     REQUIRE(S.fast_product(1, 2) == 1);
   }
 
-  TEMPLATE_TEST_CASE("FroidurePin: small example 3",
-                     "[011][quick][froidure-pin][bmat]",
-                     BMat<4>,
-                     BMat<>) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "011",
+                                   "small example 3",
+                                   "[quick][froidure-pin][bmat]",
+                                   BMat<4>,
+                                   BMat<>) {
     auto S = to_froidure_pin(
         {TestType({{1, 0, 0, 0}, {0, 0, 1, 0}, {1, 0, 0, 1}, {0, 1, 0, 0}}),
          TestType({{1, 0, 0, 1}, {1, 0, 0, 1}, {1, 1, 1, 1}, {0, 1, 1, 0}}),
@@ -156,10 +165,12 @@ namespace libsemigroups {
     REQUIRE(S.size() == 415);
   }
 
-  TEMPLATE_TEST_CASE("FroidurePin: Clark generators",
-                     "[013][extreme][froidure-pin][bmat]",
-                     BMat<40>,
-                     BMat<>) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "013",
+                                   "Clark generators",
+                                   "[extreme][froidure-pin][bmat]",
+                                   BMat<40>,
+                                   BMat<>) {
     auto                  rg = ReportGuard(true);
     FroidurePin<TestType> S;
     for (auto const& x : konieczny_data::clark_gens) {

--- a/tests/test-froidure-pin-bmat8.cpp
+++ b/tests/test-froidure-pin-bmat8.cpp
@@ -22,7 +22,7 @@
 #include <cstddef>  // for size_t
 #include <vector>   // for vector
 
-#include "catch_amalgamated.hpp"  // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "catch_amalgamated.hpp"  // for LIBSEMIGROUPS_TEST_CASE
 #include "test-main.hpp"
 
 #include "libsemigroups/bmat8.hpp"         // for BMat8
@@ -39,10 +39,10 @@ namespace libsemigroups {
 
 #if (LIBSEMIGROUPS_SIZEOF_VOID_P == 8)
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "015",
-                             "regular boolean mat monoid 4 - BMat8",
-                             "[quick][froidure-pin][bmat8][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "015",
+                          "regular boolean mat monoid 4 - BMat8",
+                          "[quick][froidure-pin][bmat8][no-valgrind]") {
     auto               rg = ReportGuard(false);
     std::vector<BMat8> gens
         = {BMat8({{0, 1, 0, 0}, {1, 0, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}),
@@ -226,19 +226,19 @@ namespace libsemigroups {
   }
 #endif
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "016",
-                             "exception zero generators given - BMat8",
-                             "[quick][froidure-pin][bmat8]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "016",
+                          "exception zero generators given - BMat8",
+                          "[quick][froidure-pin][bmat8]") {
     std::vector<BMat8> gens;
 
     REQUIRE_NOTHROW(to_froidure_pin(gens));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "017",
-                             "exception to_element - BMat8",
-                             "[quick][froidure-pin][bmat8]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "017",
+                          "exception to_element - BMat8",
+                          "[quick][froidure-pin][bmat8]") {
     std::vector<BMat8> gens
         = {BMat8({{0, 1, 0, 0}, {1, 0, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}),
            BMat8({{0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}, {1, 0, 0, 0}}),
@@ -254,10 +254,10 @@ namespace libsemigroups {
                       LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "018",
-                             "exception prefix - BMat8",
-                             "[quick][froidure-pin][bmat8][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "018",
+                          "exception prefix - BMat8",
+                          "[quick][froidure-pin][bmat8][no-valgrind]") {
     std::vector<BMat8> gens
         = {BMat8({{0, 1, 0, 0}, {1, 0, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}),
            BMat8({{0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}, {1, 0, 0, 0}}),
@@ -270,10 +270,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "020",
-                             "exception first_letter - BMat8",
-                             "[quick][froidure-pin][bmat8][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "020",
+                          "exception first_letter - BMat8",
+                          "[quick][froidure-pin][bmat8][no-valgrind]") {
     std::vector<BMat8> gens
         = {BMat8({{0, 1, 0, 0}, {1, 0, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}),
            BMat8({{0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}, {1, 0, 0, 0}}),
@@ -286,10 +286,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "022",
-                             "exception current_length - BMat8",
-                             "[quick][froidure-pin][bmat8][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "022",
+                          "exception current_length - BMat8",
+                          "[quick][froidure-pin][bmat8][no-valgrind]") {
     std::vector<BMat8> gens
         = {BMat8({{0, 1, 0, 0}, {1, 0, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}),
            BMat8({{0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}, {1, 0, 0, 0}}),
@@ -302,10 +302,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "023",
-                             "exception product_by_reduction - BMat8",
-                             "[quick][froidure-pin][bmat8][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "023",
+                          "exception product_by_reduction - BMat8",
+                          "[quick][froidure-pin][bmat8][no-valgrind]") {
     std::vector<BMat8> gens
         = {BMat8({{0, 1, 0, 0}, {1, 0, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}),
            BMat8({{1, 1, 0, 0}, {1, 0, 1, 0}, {0, 1, 1, 1}, {0, 1, 1, 1}})};
@@ -327,10 +327,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "024",
-                             "exception fast_product - BMat8",
-                             "[quick][froidure-pin][bmat8][024]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "024",
+                          "exception fast_product - BMat8",
+                          "[quick][froidure-pin][bmat8][024]") {
     std::vector<BMat8> gens
         = {BMat8({{0, 1, 0, 0}, {1, 0, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}),
            BMat8({{1, 1, 0, 0}, {1, 0, 1, 0}, {0, 1, 1, 1}, {0, 1, 1, 1}})};
@@ -349,10 +349,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "025",
-                             "exception is_idempotent - BMat8",
-                             "[quick][froidure-pin][bmat8][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "025",
+                          "exception is_idempotent - BMat8",
+                          "[quick][froidure-pin][bmat8][no-valgrind]") {
     auto S = to_froidure_pin(
         {BMat8({{0, 1, 0, 0}, {1, 0, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}),
          BMat8({{0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}, {1, 0, 0, 0}}),
@@ -384,10 +384,10 @@ namespace libsemigroups {
                  1103121210_w, 1103121211_w, 1103121212_w, 1103121213_w}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "026",
-                             "copy constructor - BMat8",
-                             "[quick][froidure-pin][bmat8][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "026",
+                          "copy constructor - BMat8",
+                          "[quick][froidure-pin][bmat8][no-valgrind]") {
     auto rg = ReportGuard(REPORT);
     auto S  = to_froidure_pin(
         {BMat8({{0, 1, 0, 0}, {1, 0, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}),
@@ -412,10 +412,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "027",
-                             "cbegin/end_rules - BMat8",
-                             "[quick][froidure-pin][bmat8]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "027",
+                          "cbegin/end_rules - BMat8",
+                          "[quick][froidure-pin][bmat8]") {
     FroidurePin<BMat8> S;
     S.add_generator(
         BMat8({{1, 0, 0, 0}, {1, 0, 0, 0}, {1, 0, 0, 0}, {1, 0, 0, 0}}));

--- a/tests/test-froidure-pin-integers.cpp
+++ b/tests/test-froidure-pin-integers.cpp
@@ -20,7 +20,7 @@
 #include <cstdint>      // for uint8_t
 #include <type_traits>  // for enable_if, is_integral
 
-#include "catch_amalgamated.hpp"           // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "catch_amalgamated.hpp"           // for LIBSEMIGROUPS_TEST_CASE
 #include "libsemigroups/adapters.hpp"      // for complexity etc
 #include "libsemigroups/debug.hpp"         // for LIBSEMIGROUPS_ASSERT
 #include "libsemigroups/froidure-pin.hpp"  // for FroidurePin<>::element_i...
@@ -79,10 +79,10 @@ namespace libsemigroups {
     }
   };
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "031",
-                             "uint32_t/uint8_t",
-                             "[quick][froidure-pin][integers]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "031",
+                          "uint32_t/uint8_t",
+                          "[quick][froidure-pin][integers]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<uint32_t> S;
     S.add_generator(2);

--- a/tests/test-froidure-pin-intmat.cpp
+++ b/tests/test-froidure-pin-intmat.cpp
@@ -33,14 +33,16 @@ namespace libsemigroups {
   // Forward declaration
   struct LibsemigroupsException;
 
-  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "032",
-                                   "Example 000",
-                                   "[quick][froidure-pin][intmat]",
-                                   (IntMat<0, 0, int64_t>),
-                                   (IntMat<2, 2, int64_t>) ) {
-    // FIXME this test seemingly causes undefined behaviour (multiplication of
-    // signed integers that overflows)
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "FroidurePin",
+      "032",
+      "Example 000",
+      "[quick][froidure-pin][intmat][no-sanitize-undefined]",
+      (IntMat<0, 0, int64_t>),
+      (IntMat<2, 2, int64_t>) ) {
+    // this test seemingly causes undefined behaviour (multiplication of
+    // signed integers that overflows), which is either a bug or a feature
+    // depending on your perspective.
     auto rg = ReportGuard(false);
 
     FroidurePin<TestType> S;

--- a/tests/test-froidure-pin-intmat.cpp
+++ b/tests/test-froidure-pin-intmat.cpp
@@ -20,11 +20,12 @@
 #include <cstdint>  // for int64_t
 
 #include "catch_amalgamated.hpp"  // for REQUIRE, REQUIRE_THROWS_AS
-#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE
 
 #include "libsemigroups/constants.hpp"     // for UNDEFINED
 #include "libsemigroups/froidure-pin.hpp"  // for FroidurePin
 #include "libsemigroups/matrix.hpp"        // for IntMat
+#include "libsemigroups/word-range.hpp"    // for namespace literals
 
 namespace libsemigroups {
   using namespace literals;  // for operator""_w
@@ -32,112 +33,15 @@ namespace libsemigroups {
   // Forward declaration
   struct LibsemigroupsException;
 
-  constexpr bool REPORT = false;
-
-  namespace {
-
-    template <typename Mat>
-    void test_IntMat001() {}
-
-    // IntMat
-    template <typename Mat>
-    void test008() {
-      FroidurePin<Mat> T;
-      T.add_generator(Mat({{0, 0}, {0, 1}}));
-      T.add_generator(Mat({{0, 1}, {-1, 0}}));
-      REQUIRE(froidure_pin::current_position(T, {}) == UNDEFINED);
-      REQUIRE_NOTHROW(froidure_pin::current_position(T, 0011_w));
-      REQUIRE(froidure_pin::current_position(T, 0011_w) == UNDEFINED);
-      auto w = froidure_pin::to_element(T, 0011_w);
-      REQUIRE(T.current_position(w) == UNDEFINED);
-      REQUIRE_THROWS_AS(froidure_pin::current_position(T, 0012_w),
-                        LibsemigroupsException);
-
-      REQUIRE(T.size() == 13);
-      REQUIRE(froidure_pin::current_position(T, 0011_w) == 6);
-      w = froidure_pin::to_element(T, 0011_w);
-      REQUIRE(T.current_position(w) == 6);
-    }
-
-    template <typename Mat>
-    void test009() {
-      FroidurePin<Mat> T;
-      T.add_generator(Mat({{0, 0}, {0, 1}}));
-      T.add_generator(Mat({{0, 1}, {-1, 0}}));
-
-      REQUIRE_THROWS_AS(froidure_pin::to_element(T, {}),
-                        LibsemigroupsException);
-      REQUIRE_THROWS_AS(froidure_pin::to_element(T, {0, 0, 1, 2}),
-                        LibsemigroupsException);
-
-      auto t = froidure_pin::to_element(T, {0, 0, 1, 1});
-      REQUIRE(t
-              == T.generator(0) * T.generator(0) * T.generator(1)
-                     * T.generator(1));
-    }
-    template <typename Mat>
-    void test010() {
-      FroidurePin<Mat> T;
-      T.add_generator(Mat({{0, 0}, {0, 1}}));
-      T.add_generator(Mat({{0, 1}, {-1, 0}}));
-
-      for (size_t i = 0; i < T.size(); ++i) {
-        REQUIRE_NOTHROW(T.prefix(i));
-        REQUIRE_THROWS_AS(T.prefix(i + T.size()), LibsemigroupsException);
-      }
-      for (size_t i = 0; i < T.size(); ++i) {
-        REQUIRE_NOTHROW(T.suffix(i));
-        REQUIRE_THROWS_AS(T.suffix(i + T.size()), LibsemigroupsException);
-      }
-      for (size_t i = 0; i < T.size(); ++i) {
-        REQUIRE_NOTHROW(T.first_letter(i));
-        REQUIRE_THROWS_AS(T.first_letter(i + T.size()), LibsemigroupsException);
-      }
-      for (size_t i = 0; i < T.size(); ++i) {
-        REQUIRE_NOTHROW(T.final_letter(i));
-        REQUIRE_THROWS_AS(T.final_letter(i + T.size()), LibsemigroupsException);
-      }
-      for (size_t i = 0; i < T.size(); ++i) {
-        REQUIRE_NOTHROW(T.current_length(i));
-        REQUIRE_THROWS_AS(T.current_length(i + T.size()),
-                          LibsemigroupsException);
-      }
-      for (size_t i = 0; i < T.size(); ++i) {
-        for (size_t j = 0; j < T.size(); ++j) {
-          REQUIRE_NOTHROW(froidure_pin::product_by_reduction(T, i, j));
-          REQUIRE_THROWS_AS(
-              froidure_pin::product_by_reduction(T, i + T.size(), j),
-              LibsemigroupsException);
-          REQUIRE_THROWS_AS(
-              froidure_pin::product_by_reduction(T, i, j + T.size()),
-              LibsemigroupsException);
-          REQUIRE_THROWS_AS(
-              froidure_pin::product_by_reduction(T, i + T.size(), j + T.size()),
-              LibsemigroupsException);
-        }
-      }
-      for (size_t i = 0; i < T.size(); ++i) {
-        for (size_t j = 0; j < T.size(); ++j) {
-          REQUIRE_NOTHROW(T.fast_product(i, j));
-          REQUIRE_THROWS_AS(T.fast_product(i + T.size(), j),
-                            LibsemigroupsException);
-          REQUIRE_THROWS_AS(T.fast_product(i, j + T.size()),
-                            LibsemigroupsException);
-          REQUIRE_THROWS_AS(T.fast_product(i + T.size(), j + T.size()),
-                            LibsemigroupsException);
-        }
-      }
-    }
-  }  // namespace
-
-  TEMPLATE_TEST_CASE(
-      "FroidurePin: Example 000",
-      "[032][quick][froidure-pin][intmat][no-sanitize-undefined]",
-      (IntMat<0, 0, int64_t>),
-      (IntMat<2, 2, int64_t>) ) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "032",
+                                   "Example 000",
+                                   "[quick][froidure-pin][intmat]",
+                                   (IntMat<0, 0, int64_t>),
+                                   (IntMat<2, 2, int64_t>) ) {
     // FIXME this test seemingly causes undefined behaviour (multiplication of
     // signed integers that overflows)
-    auto rg = ReportGuard(REPORT);
+    auto rg = ReportGuard(false);
 
     FroidurePin<TestType> S;
     S.add_generator(TestType({{0, 1}, {0, -1}}));
@@ -182,11 +86,13 @@ namespace libsemigroups {
                       LibsemigroupsException);
   }
 
-  TEMPLATE_TEST_CASE("FroidurePin: Example 001",
-                     "[034][quick][froidure-pin][intmat]",
-                     (IntMat<0, 0, int64_t>),
-                     (IntMat<2, 2, int64_t>) ) {
-    auto                  rg = ReportGuard(REPORT);
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "034",
+                                   "Example 001",
+                                   "[quick][froidure-pin][intmat]",
+                                   (IntMat<0, 0, int64_t>),
+                                   (IntMat<2, 2, int64_t>) ) {
+    auto                  rg = ReportGuard(false);
     FroidurePin<TestType> S;
     S.add_generator(TestType({{0, 0}, {0, 1}}));
     S.add_generator(TestType({{0, 1}, {-1, 0}}));
@@ -214,27 +120,103 @@ namespace libsemigroups {
     REQUIRE(S.contains(x));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<IntMat>",
-                             "036",
-                             "exception: current_position",
-                             "[quick][froidure-pin][element]") {
-    test008<IntMat<2>>();
-    test008<IntMat<>>();
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "036",
+                                   "exception: current_position",
+                                   "[quick][froidure-pin][element]",
+                                   IntMat<2>,
+                                   IntMat<>) {
+    FroidurePin<TestType> T;
+    T.add_generator(TestType({{0, 0}, {0, 1}}));
+    T.add_generator(TestType({{0, 1}, {-1, 0}}));
+    REQUIRE(froidure_pin::current_position(T, {}) == UNDEFINED);
+    REQUIRE_NOTHROW(froidure_pin::current_position(T, 0011_w));
+    REQUIRE(froidure_pin::current_position(T, 0011_w) == UNDEFINED);
+    auto w = froidure_pin::to_element(T, 0011_w);
+    REQUIRE(T.current_position(w) == UNDEFINED);
+    REQUIRE_THROWS_AS(froidure_pin::current_position(T, 0012_w),
+                      LibsemigroupsException);
+
+    REQUIRE(T.size() == 13);
+    REQUIRE(froidure_pin::current_position(T, 0011_w) == 6);
+    w = froidure_pin::to_element(T, 0011_w);
+    REQUIRE(T.current_position(w) == 6);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<IntMat>",
-                             "037",
-                             "exception: to_element",
-                             "[quick][froidure-pin][element]") {
-    test009<IntMat<2>>();
-    test009<IntMat<>>();
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "037",
+                                   "exception: to_element",
+                                   "[quick][froidure-pin][element]",
+                                   IntMat<2>,
+                                   IntMat<>) {
+    FroidurePin<TestType> T;
+    T.add_generator(TestType({{0, 0}, {0, 1}}));
+    T.add_generator(TestType({{0, 1}, {-1, 0}}));
+
+    REQUIRE_THROWS_AS(froidure_pin::to_element(T, {}), LibsemigroupsException);
+    REQUIRE_THROWS_AS(froidure_pin::to_element(T, {0, 0, 1, 2}),
+                      LibsemigroupsException);
+
+    auto t = froidure_pin::to_element(T, {0, 0, 1, 1});
+    REQUIRE(
+        t == T.generator(0) * T.generator(0) * T.generator(1) * T.generator(1));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<IntMat>",
-                             "038",
-                             "exception: prefix, suffix, first_letter",
-                             "[quick][froidure-pin][element][no-valgrind]") {
-    test010<IntMat<2>>();
-    test010<IntMat<>>();
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "FroidurePin",
+      "038",
+      "exception: prefix, suffix, first_letter",
+      "[quick][froidure-pin][element][no-valgrind]",
+      IntMat<2>,
+      IntMat<>) {
+    FroidurePin<TestType> T;
+    T.add_generator(TestType({{0, 0}, {0, 1}}));
+    T.add_generator(TestType({{0, 1}, {-1, 0}}));
+
+    for (size_t i = 0; i < T.size(); ++i) {
+      REQUIRE_NOTHROW(T.prefix(i));
+      REQUIRE_THROWS_AS(T.prefix(i + T.size()), LibsemigroupsException);
+    }
+    for (size_t i = 0; i < T.size(); ++i) {
+      REQUIRE_NOTHROW(T.suffix(i));
+      REQUIRE_THROWS_AS(T.suffix(i + T.size()), LibsemigroupsException);
+    }
+    for (size_t i = 0; i < T.size(); ++i) {
+      REQUIRE_NOTHROW(T.first_letter(i));
+      REQUIRE_THROWS_AS(T.first_letter(i + T.size()), LibsemigroupsException);
+    }
+    for (size_t i = 0; i < T.size(); ++i) {
+      REQUIRE_NOTHROW(T.final_letter(i));
+      REQUIRE_THROWS_AS(T.final_letter(i + T.size()), LibsemigroupsException);
+    }
+    for (size_t i = 0; i < T.size(); ++i) {
+      REQUIRE_NOTHROW(T.current_length(i));
+      REQUIRE_THROWS_AS(T.current_length(i + T.size()), LibsemigroupsException);
+    }
+    for (size_t i = 0; i < T.size(); ++i) {
+      for (size_t j = 0; j < T.size(); ++j) {
+        REQUIRE_NOTHROW(froidure_pin::product_by_reduction(T, i, j));
+        REQUIRE_THROWS_AS(
+            froidure_pin::product_by_reduction(T, i + T.size(), j),
+            LibsemigroupsException);
+        REQUIRE_THROWS_AS(
+            froidure_pin::product_by_reduction(T, i, j + T.size()),
+            LibsemigroupsException);
+        REQUIRE_THROWS_AS(
+            froidure_pin::product_by_reduction(T, i + T.size(), j + T.size()),
+            LibsemigroupsException);
+      }
+    }
+    for (size_t i = 0; i < T.size(); ++i) {
+      for (size_t j = 0; j < T.size(); ++j) {
+        REQUIRE_NOTHROW(T.fast_product(i, j));
+        REQUIRE_THROWS_AS(T.fast_product(i + T.size(), j),
+                          LibsemigroupsException);
+        REQUIRE_THROWS_AS(T.fast_product(i, j + T.size()),
+                          LibsemigroupsException);
+        REQUIRE_THROWS_AS(T.fast_product(i + T.size(), j + T.size()),
+                          LibsemigroupsException);
+      }
+    }
   }
 }  // namespace libsemigroups

--- a/tests/test-froidure-pin-intpairs.cpp
+++ b/tests/test-froidure-pin-intpairs.cpp
@@ -19,7 +19,7 @@
 #include <cstddef>      // for size_t
 #include <type_traits>  // for integral_constant<>::value
 
-#include "catch_amalgamated.hpp"  // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "catch_amalgamated.hpp"  // for LIBSEMIGROUPS_TEST_CASE
 #include "test-main.hpp"
 
 #include "libsemigroups/adapters.hpp"      // for complexity etc
@@ -109,10 +109,10 @@ namespace std {
 namespace libsemigroups {
   static_assert(!std::is_trivial<IntPair>::value, "IntPair is not non-trivial");
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "039",
-                             "(pairs of integers) non-trivial user type",
-                             "[quick][froidure-pin][intpairs][108]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "039",
+                          "(pairs of integers) non-trivial user type",
+                          "[quick][froidure-pin][intpairs][108]") {
     auto                 rg = ReportGuard(REPORT);
     FroidurePin<IntPair> S;
     S.add_generator(IntPair(1, 1));

--- a/tests/test-froidure-pin-matrix.cpp
+++ b/tests/test-froidure-pin-matrix.cpp
@@ -61,9 +61,14 @@ namespace libsemigroups {
     REQUIRE(S.position(x) == 5);
     REQUIRE(S.contains(x));
 
-    x = TestType({{-2, 2, 0}, {-1, 0, 0}, {0, 0, 0}});
-    REQUIRE(S.position(x) == UNDEFINED);
-    REQUIRE(!S.contains(x));
+    if constexpr (IsDynamicMatrix<TestType>) {
+      // If TestType is a static matrix, then the next line leads to out of
+      // bounds accesses, since we are constructing a too big matrix without
+      // checks.
+      x = TestType({{-2, 2, 0}, {-1, 0, 0}, {0, 0, 0}});
+      REQUIRE(S.position(x) == UNDEFINED);
+      REQUIRE(!S.contains(x));
+    }
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",

--- a/tests/test-froidure-pin-matrix.cpp
+++ b/tests/test-froidure-pin-matrix.cpp
@@ -17,7 +17,7 @@
 //
 
 #include "catch_amalgamated.hpp"  // REQUIRE
-#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE
 
 #include "libsemigroups/constants.hpp"     // for UNDEFINED
 #include "libsemigroups/froidure-pin.hpp"  // for FroidurePin
@@ -28,266 +28,201 @@
 namespace libsemigroups {
   struct LibsemigroupsException;
   constexpr bool REPORT = false;
-  namespace {
-    template <typename Mat>
-    void test000() {
-      auto             rg = ReportGuard(REPORT);
-      FroidurePin<Mat> S;
-      S.add_generator(to_matrix<Mat>({{0, -4}, {-4, -1}}));
-      S.add_generator(to_matrix<Mat>({{0, -3}, {-3, -1}}));
 
-      REQUIRE(S.size() == 26);
-      REQUIRE(S.degree() == 2);
-      REQUIRE(S.number_of_idempotents() == 4);
-      REQUIRE(S.number_of_generators() == 2);
-      REQUIRE(S.number_of_rules() == 9);
-      REQUIRE(S[0] == S.generator(0));
-      REQUIRE(S[1] == S.generator(1));
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "040",
+                                   "Example 000",
+                                   "[quick][froidure-pin][matrix]",
+                                   MaxPlusMat<2>,
+                                   MaxPlusMat<>) {
+    auto                  rg = ReportGuard(REPORT);
+    FroidurePin<TestType> S;
+    S.add_generator(to_matrix<TestType>({{0, -4}, {-4, -1}}));
+    S.add_generator(to_matrix<TestType>({{0, -3}, {-3, -1}}));
 
-      REQUIRE(S.position(S.generator(0)) == 0);
-      REQUIRE(S.contains(S.generator(0)));
+    REQUIRE(S.size() == 26);
+    REQUIRE(S.degree() == 2);
+    REQUIRE(S.number_of_idempotents() == 4);
+    REQUIRE(S.number_of_generators() == 2);
+    REQUIRE(S.number_of_rules() == 9);
+    REQUIRE(S[0] == S.generator(0));
+    REQUIRE(S[1] == S.generator(1));
 
-      REQUIRE(S.position(S.generator(1)) == 1);
-      REQUIRE(S.contains(S.generator(1)));
+    REQUIRE(S.position(S.generator(0)) == 0);
+    REQUIRE(S.contains(S.generator(0)));
 
-      Mat x({{-2, 2}, {-1, 0}});
-      REQUIRE(S.position(x) == UNDEFINED);
-      REQUIRE(!S.contains(x));
-      x.product_inplace_no_checks(S.generator(1), S.generator(1));
-      REQUIRE(S.position(x) == 5);
-      REQUIRE(S.contains(x));
+    REQUIRE(S.position(S.generator(1)) == 1);
+    REQUIRE(S.contains(S.generator(1)));
 
-      // x = Mat({{-2, 2, 0}, {-1, 0, 0}, {0, 0, 0}});
-      // REQUIRE(S.position(x) == UNDEFINED);
-      // REQUIRE(!S.contains(x));
+    TestType x({{-2, 2}, {-1, 0}});
+    REQUIRE(S.position(x) == UNDEFINED);
+    REQUIRE(!S.contains(x));
+    x.product_inplace_no_checks(S.generator(1), S.generator(1));
+    REQUIRE(S.position(x) == 5);
+    REQUIRE(S.contains(x));
+
+    x = TestType({{-2, 2, 0}, {-1, 0, 0}, {0, 0, 0}});
+    REQUIRE(S.position(x) == UNDEFINED);
+    REQUIRE(!S.contains(x));
+  }
+
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "042",
+                                   "Example 001",
+                                   "[extreme][froidure-pin][matrix]",
+                                   (NTPMat<0, 6, 3>),
+                                   (NTPMat<0, 6>),
+                                   NTPMat<>) {
+    auto rg = ReportGuard();
+
+    NTPSemiring<>* sr = nullptr;
+    if constexpr (!std::is_same_v<typename TestType::semiring_type, void>) {
+      sr = new NTPSemiring<>(0, 6);
     }
-
-    template <typename Mat>
-    void test001(NTPSemiring<> const* sr = nullptr) {
-      auto rg = ReportGuard();
-
-      FroidurePin<Mat> S;
-      S.add_generator(Mat(sr, {{0, 0, 1}, {0, 1, 0}, {1, 1, 0}}));
-      S.add_generator(Mat(sr, {{0, 0, 1}, {0, 1, 0}, {2, 0, 0}}));
-      S.add_generator(Mat(sr, {{0, 0, 1}, {0, 1, 1}, {1, 0, 0}}));
-      S.add_generator(Mat(sr, {{0, 0, 1}, {0, 1, 0}, {3, 0, 0}}));
-      S.reserve(10077696);
-      REQUIRE(S.size() == 10077696);
-      REQUIRE(S.number_of_idempotents() == 13688);
-    }
-
-    // Min-plus
-    template <typename Mat>
-    void test004() {
-      auto             rg = ReportGuard(REPORT);
-      FroidurePin<Mat> S;
-      S.add_generator(to_matrix<Mat>({{1, 0}, {0, POSITIVE_INFINITY}}));
-
-      REQUIRE(S.size() == 3);
-      REQUIRE(S.degree() == 2);
-      REQUIRE(S.number_of_idempotents() == 1);
-      REQUIRE(S.number_of_generators() == 1);
-      REQUIRE(S.number_of_rules() == 1);
-
-      REQUIRE(S[0] == S.generator(0));
-      REQUIRE(S.position(S.generator(0)) == 0);
-      REQUIRE(S.contains(S.generator(0)));
-
-      auto x = Mat({{-2, 2}, {-1, 0}});
-      REQUIRE(S.position(x) == UNDEFINED);
-      REQUIRE(!S.contains(x));
-      x.product_inplace_no_checks(S.generator(0), S.generator(0));
-      REQUIRE(S.position(x) == 1);
-      REQUIRE(S.contains(x));
-    }
-
-    // MaxPlusTruncMat(33)
-    template <typename Mat>
-    void test005(MaxPlusTruncSemiring<> const* sr = nullptr) {
-      auto             rg = ReportGuard(REPORT);
-      FroidurePin<Mat> S;
-      S.add_generator(
-          to_matrix<Mat>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}}));
-      S.add_generator(to_matrix<Mat>(sr, {{0, 0, 0}, {0, 1, 0}, {1, 1, 0}}));
-
-      REQUIRE(S.size() == 119);
-      REQUIRE(S.degree() == 3);
-      REQUIRE(S.number_of_idempotents() == 1);
-      REQUIRE(S.number_of_generators() == 2);
-      REQUIRE(S.number_of_rules() == 18);
-
-      REQUIRE(S[0] == S.generator(0));
-      REQUIRE(S.position(S.generator(0)) == 0);
-      REQUIRE(S.contains(S.generator(0)));
-
-      // auto x = to_matrix<Mat>(sr, {{2, 2}, {1, 0}});
-      // REQUIRE(S.position(x) == UNDEFINED);
-      // REQUIRE(!S.contains(x));
-    }
-
-    // MinPlusTruncMat(11)
-    template <typename Mat>
-    void test006(MinPlusTruncSemiring<> const* sr = nullptr) {
-      auto             rg = ReportGuard(REPORT);
-      FroidurePin<Mat> S;
-      S.add_generator(to_matrix<Mat>(sr, {{2, 1, 0}, {10, 0, 0}, {1, 2, 1}}));
-      S.add_generator(to_matrix<Mat>(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}}));
-
-      REQUIRE(S.size() == 1039);
-      REQUIRE(S.degree() == 3);
-      REQUIRE(S.number_of_idempotents() == 5);
-      REQUIRE(S.number_of_generators() == 2);
-      REQUIRE(S.number_of_rules() == 38);
-
-      REQUIRE(S[0] == S.generator(0));
-      REQUIRE(S.position(S.generator(0)) == 0);
-      REQUIRE(S.contains(S.generator(0)));
-
-      auto x = to_matrix<Mat>(sr, {{2, 2, 0}, {1, 0, 0}, {0, 0, 0}});
-      REQUIRE(S.position(x) == UNDEFINED);
-      REQUIRE(!S.contains(x));
-      x.product_inplace_no_checks(S.generator(0), S.generator(0));
-      REQUIRE(S.position(x) == 2);
-      REQUIRE(S.contains(x));
-    }
-
-    // NTPSemiring(11, 3);
-    template <typename Mat>
-    void test007(NTPSemiring<> const* sr = nullptr) {
-      auto             rg = ReportGuard(REPORT);
-      FroidurePin<Mat> S;
-      S.add_generator(to_matrix<Mat>(sr, {{2, 1, 0}, {10, 0, 0}, {1, 2, 1}}));
-      S.add_generator(to_matrix<Mat>(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}}));
-
-      REQUIRE(S.size() == 86);
-      REQUIRE(S.degree() == 3);
-      REQUIRE(S.number_of_idempotents() == 10);
-      REQUIRE(S.number_of_generators() == 2);
-      REQUIRE(S.number_of_rules() == 16);
-
-      REQUIRE(S[0] == S.generator(0));
-      REQUIRE(S.position(S.generator(0)) == 0);
-      REQUIRE(S.contains(S.generator(0)));
-
-      auto x = to_matrix<Mat>(sr, {{2, 2, 0}, {1, 0, 0}, {0, 0, 0}});
-      REQUIRE(S.position(x) == UNDEFINED);
-      REQUIRE(!S.contains(x));
-      x.product_inplace_no_checks(S.generator(1), S.generator(0));
-      REQUIRE(S.position(x) == 4);
-      REQUIRE(S.contains(x));
-    }
-  }  // namespace
-
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<MaxPlusMat<2>>",
-                             "040",
-                             "Example 000",
-                             "[quick][froidure-pin][matrix]") {
-    test000<MaxPlusMat<2>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<MaxPlusMat<>>",
-                             "041",
-                             "Example 000",
-                             "[quick][froidure-pin][matrix]") {
-    test000<MaxPlusMat<>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<NTPMat<0, 6, 3>>",
-                             "042",
-                             "Example 001",
-                             "[extreme][froidure-pin][matrix]") {
-    test001<NTPMat<0, 6, 3>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<NTPMat<0, 6>>",
-                             "043",
-                             "Example 001",
-                             "[extreme][froidure-pin][matrix]") {
-    test001<NTPMat<0, 6>>();
-  }
-
-  // TODO(later) Example 001 with a semiring
-
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<MinPlusMat<2>>",
-                             "044",
-                             "Example 004",
-                             "[quick][froidure-pin][matrix]") {
-    test004<MinPlusMat<2>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<MinPlusMat<>>",
-                             "045",
-                             "Example 004",
-                             "[quick][froidure-pin][matrix]") {
-    test004<MinPlusMat<>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<MaxPlusTruncMat<33, 3>>",
-                             "046",
-                             "Example 005",
-                             "[quick][froidure-pin][matrix]") {
-    test005<MaxPlusTruncMat<33, 3>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<MaxPlusTruncMat<33>>",
-                             "047",
-                             "Example 005",
-                             "[quick][froidure-pin][matrix]") {
-    test005<MaxPlusTruncMat<33>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<MaxPlusTruncMat<>>",
-                             "048",
-                             "Example 005",
-                             "[quick][froidure-pin][matrix]") {
-    MaxPlusTruncSemiring<> const* sr = new MaxPlusTruncSemiring<>(33);
-    test005<MaxPlusTruncMat<>>(sr);
+    FroidurePin<TestType> S;
+    S.add_generator(TestType(sr, {{0, 0, 1}, {0, 1, 0}, {1, 1, 0}}));
+    S.add_generator(TestType(sr, {{0, 0, 1}, {0, 1, 0}, {2, 0, 0}}));
+    S.add_generator(TestType(sr, {{0, 0, 1}, {0, 1, 1}, {1, 0, 0}}));
+    S.add_generator(TestType(sr, {{0, 0, 1}, {0, 1, 0}, {3, 0, 0}}));
+    S.reserve(10'077'696);
+    REQUIRE(S.size() == 10'077'696);
+    REQUIRE(S.number_of_idempotents() == 13'688);
     delete sr;
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<MinPlusTruncMat<11, 3>>",
-                             "049",
-                             "Example 006",
-                             "[quick][froidure-pin][matrix]") {
-    test006<MinPlusTruncMat<11, 3>>();
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "044",
+                                   "Example 004",
+                                   "[quick][froidure-pin][matrix]",
+                                   MinPlusMat<>,
+                                   MinPlusMat<2>) {
+    auto                  rg = ReportGuard(REPORT);
+    FroidurePin<TestType> S;
+    S.add_generator(to_matrix<TestType>({{1, 0}, {0, POSITIVE_INFINITY}}));
+
+    REQUIRE(S.size() == 3);
+    REQUIRE(S.degree() == 2);
+    REQUIRE(S.number_of_idempotents() == 1);
+    REQUIRE(S.number_of_generators() == 1);
+    REQUIRE(S.number_of_rules() == 1);
+
+    REQUIRE(S[0] == S.generator(0));
+    REQUIRE(S.position(S.generator(0)) == 0);
+    REQUIRE(S.contains(S.generator(0)));
+
+    auto x = TestType({{-2, 2}, {-1, 0}});
+    REQUIRE(S.position(x) == UNDEFINED);
+    REQUIRE(!S.contains(x));
+    x.product_inplace_no_checks(S.generator(0), S.generator(0));
+    REQUIRE(S.position(x) == 1);
+    REQUIRE(S.contains(x));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<MinPlusTruncMat<11>>",
-                             "050",
-                             "Example 006",
-                             "[quick][froidure-pin][matrix]") {
-    test006<MinPlusTruncMat<11>>();
-  }
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "046",
+                                   "Example 005",
+                                   "[quick][froidure-pin][matrix]",
+                                   (MaxPlusTruncMat<33, 3>),
+                                   MaxPlusTruncMat<33>,
+                                   MaxPlusTruncMat<>) {
+    auto rg = ReportGuard(REPORT);
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<MinPlusTruncMat<>>",
-                             "051",
-                             "Example 006",
-                             "[quick][froidure-pin][matrix]") {
-    MinPlusTruncSemiring<> const* sr = new MinPlusTruncSemiring<>(11);
-    test006<MinPlusTruncMat<>>(sr);
+    MaxPlusTruncSemiring<> const* sr = nullptr;
+    if constexpr (!std::is_same_v<typename TestType::semiring_type, void>) {
+      sr = new MaxPlusTruncSemiring<>(33);
+    }
+    FroidurePin<TestType> S;
+    S.add_generator(
+        to_matrix<TestType>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}}));
+    S.add_generator(to_matrix<TestType>(sr, {{0, 0, 0}, {0, 1, 0}, {1, 1, 0}}));
+
+    REQUIRE(S.size() == 119);
+    REQUIRE(S.degree() == 3);
+    REQUIRE(S.number_of_idempotents() == 1);
+    REQUIRE(S.number_of_generators() == 2);
+    REQUIRE(S.number_of_rules() == 18);
+
+    REQUIRE(S[0] == S.generator(0));
+    REQUIRE(S.position(S.generator(0)) == 0);
+    REQUIRE(S.contains(S.generator(0)));
+
+    auto x = to_matrix<TestType>(sr, {{2, 2}, {1, 0}});
+    REQUIRE(S.position(x) == UNDEFINED);
     delete sr;
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<NTPMat<11, 3, 3>>",
-                             "052",
-                             "Example 007",
-                             "[quick][froidure-pin][matrix]") {
-    test007<NTPMat<11, 3, 3>>();
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "049",
+                                   "Example 006",
+                                   "[quick][froidure-pin][matrix]",
+                                   (MinPlusTruncMat<11, 3>),
+                                   MinPlusTruncMat<11>,
+                                   MinPlusTruncMat<>) {
+    auto rg = ReportGuard(REPORT);
+
+    MinPlusTruncSemiring<>* sr = nullptr;
+    if constexpr (!std::is_same_v<typename TestType::semiring_type, void>) {
+      sr = new MinPlusTruncSemiring(11);
+    }
+    FroidurePin<TestType> S;
+    S.add_generator(
+        to_matrix<TestType>(sr, {{2, 1, 0}, {10, 0, 0}, {1, 2, 1}}));
+    S.add_generator(
+        to_matrix<TestType>(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}}));
+
+    REQUIRE(S.size() == 1039);
+    REQUIRE(S.degree() == 3);
+    REQUIRE(S.number_of_idempotents() == 5);
+    REQUIRE(S.number_of_generators() == 2);
+    REQUIRE(S.number_of_rules() == 38);
+
+    REQUIRE(S[0] == S.generator(0));
+    REQUIRE(S.position(S.generator(0)) == 0);
+    REQUIRE(S.contains(S.generator(0)));
+
+    auto x = to_matrix<TestType>(sr, {{2, 2, 0}, {1, 0, 0}, {0, 0, 0}});
+    REQUIRE(S.position(x) == UNDEFINED);
+    REQUIRE(!S.contains(x));
+    x.product_inplace_no_checks(S.generator(0), S.generator(0));
+    REQUIRE(S.position(x) == 2);
+    REQUIRE(S.contains(x));
+    delete sr;
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<NTPMat<11, 3>>",
-                             "053",
-                             "Example 007",
-                             "[quick][froidure-pin][matrix]") {
-    test007<NTPMat<11, 3>>();
-  }
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "052",
+                                   "Example 007",
+                                   "[quick][froidure-pin][matrix]",
+                                   (NTPMat<11, 3>),
+                                   NTPMat<>) {
+    auto rg = ReportGuard(REPORT);
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<NTPMat<>>",
-                             "054",
-                             "Example 007",
-                             "[quick][froidure-pin][matrix]") {
-    NTPSemiring<> const* sr = new NTPSemiring<>(11, 3);
-    test007<NTPMat<>>(sr);
+    NTPSemiring<>* sr = nullptr;
+    if constexpr (!std::is_same_v<typename TestType::semiring_type, void>) {
+      sr = new NTPSemiring<>(11, 3);
+    }
+    FroidurePin<TestType> S;
+    S.add_generator(
+        to_matrix<TestType>(sr, {{2, 1, 0}, {10, 0, 0}, {1, 2, 1}}));
+    S.add_generator(
+        to_matrix<TestType>(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}}));
+
+    REQUIRE(S.size() == 86);
+    REQUIRE(S.degree() == 3);
+    REQUIRE(S.number_of_idempotents() == 10);
+    REQUIRE(S.number_of_generators() == 2);
+    REQUIRE(S.number_of_rules() == 16);
+
+    REQUIRE(S[0] == S.generator(0));
+    REQUIRE(S.position(S.generator(0)) == 0);
+    REQUIRE(S.contains(S.generator(0)));
+
+    auto x = to_matrix<TestType>(sr, {{2, 2, 0}, {1, 0, 0}, {0, 0, 0}});
+    REQUIRE(S.position(x) == UNDEFINED);
+    REQUIRE(!S.contains(x));
+    x.product_inplace_no_checks(S.generator(1), S.generator(0));
+    REQUIRE(S.position(x) == 4);
+    REQUIRE(S.contains(x));
     delete sr;
   }
 

--- a/tests/test-froidure-pin-maxplustrunc.cpp
+++ b/tests/test-froidure-pin-maxplustrunc.cpp
@@ -22,7 +22,7 @@
 #include <vector>   // for vector
 
 #include "catch_amalgamated.hpp"  // for  REQUIRE
-#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE
 
 #include "libsemigroups/debug.hpp"         // for LIBSEMIGROUPS_ASSERT
 #include "libsemigroups/froidure-pin.hpp"  // for FroidurePin
@@ -107,10 +107,10 @@ namespace libsemigroups {
 
   constexpr bool REPORT = false;
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "055",
-                             "(tropical max-plus semiring matrices)",
-                             "[quick][froidure-pin][tropmaxplus]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin",
+                          "055",
+                          "(tropical max-plus semiring matrices)",
+                          "[quick][froidure-pin][tropmaxplus]") {
     auto rg = ReportGuard(REPORT);
     // threshold 9, 2 x 2
     using Mat = MaxPlusTruncMat<9, 2>;

--- a/tests/test-froidure-pin-pbr.cpp
+++ b/tests/test-froidure-pin-pbr.cpp
@@ -20,7 +20,7 @@
 #include <vector>   // for vector
 
 #include "catch_amalgamated.hpp"  // for REQUIRE, AssertionHandler, REQUIRE_THROWS_AS
-#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE
 
 #include "libsemigroups/froidure-pin.hpp"  // for FroidurePin
 #include "libsemigroups/pbr.hpp"           // for PBR
@@ -33,10 +33,10 @@ namespace libsemigroups {
 
   constexpr bool REPORT = false;
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<PBR>",
-                             "056",
-                             "example 1",
-                             "[quick][froidure-pin][pbr]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<PBR>",
+                          "056",
+                          "example 1",
+                          "[quick][froidure-pin][pbr]") {
     auto             rg   = ReportGuard(REPORT);
     std::vector<PBR> gens = {PBR({{3, 5},
                                   {0, 1, 2, 3, 4, 5},
@@ -126,10 +126,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<PBR>",
-                             "057",
-                             "example 2",
-                             "[quick][froidure-pin][pbr]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<PBR>",
+                          "057",
+                          "example 2",
+                          "[quick][froidure-pin][pbr]") {
     auto rg = ReportGuard(REPORT);
 
     FroidurePin<PBR> S;

--- a/tests/test-froidure-pin-pperm.cpp
+++ b/tests/test-froidure-pin-pperm.cpp
@@ -21,7 +21,7 @@
 #include <vector>   // for vector
 
 #include "catch_amalgamated.hpp"  // for REQUIRE
-#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE
 
 #include "libsemigroups/froidure-pin.hpp"  // for FroidurePin
 #include "libsemigroups/transf.hpp"        // for PPerm
@@ -32,10 +32,10 @@ namespace libsemigroups {
 
   constexpr bool REPORT = false;
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<PPerm<>>",
-                             "058",
-                             "",
-                             "[quick][froidure-pin][pperm]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<PPerm<>>",
+                          "058",
+                          "",
+                          "[quick][froidure-pin][pperm]") {
     auto rg = ReportGuard(REPORT);
 
     FroidurePin<PPerm<>> S;
@@ -78,10 +78,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<PPerm<>>",
-                             "059",
-                             "",
-                             "[quick][froidure-pin][pperm]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<PPerm<>>",
+                          "059",
+                          "",
+                          "[quick][froidure-pin][pperm]") {
     auto                 rg = ReportGuard(REPORT);
     FroidurePin<PPerm<>> S;
     S.add_generator(PPerm<>({0, 1, 2, 3, 5, 6, 9}, {9, 7, 3, 5, 4, 2, 1}, 11));
@@ -120,10 +120,10 @@ namespace libsemigroups {
     REQUIRE(y == S[2]);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<PPerm<>>",
-                             "060",
-                             "exceptions: add_generator(s)",
-                             "[quick][froidure-pin][pperm]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<PPerm<>>",
+                          "060",
+                          "exceptions: add_generator(s)",
+                          "[quick][froidure-pin][pperm]") {
     FroidurePin<PPerm<>> S;
     S.add_generator(PPerm<>({0, 1, 2, 3, 5, 6, 9}, {9, 7, 3, 5, 4, 2, 1}, 10));
 

--- a/tests/test-froidure-pin-projmaxplus.cpp
+++ b/tests/test-froidure-pin-projmaxplus.cpp
@@ -19,7 +19,7 @@
 #include <cstddef>  // for size_t
 
 #include "catch_amalgamated.hpp"  // for REQUIRE
-#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE
 
 #include "libsemigroups/froidure-pin.hpp"  // for FroidurePin
 #include "libsemigroups/matrix.hpp"        // for ProjMaxPlusMat
@@ -30,84 +30,75 @@ namespace libsemigroups {
 
   constexpr bool REPORT = false;
 
-  namespace {
-    template <typename Mat>
-    void test000() {
-      auto             rg = ReportGuard(REPORT);
-      FroidurePin<Mat> S;
-      S.add_generator(Mat({{0, 1, 2}, {3, 4, 1}, {2, 1, 1}}));
-      S.add_generator(Mat({{0, 1, 1}, {1, 1, 1}, {0, 0, 0}}));
-      S.add_generator(Mat({{0, 1, 1}, {0, 0, 1}, {1, 0, 0}}));
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "061",
+                                   "example 1",
+                                   "[quick][froidure-pin][projmaxplus]",
+                                   ProjMaxPlusMat<3>,
+                                   ProjMaxPlusMat<>) {
+    auto                  rg = ReportGuard(REPORT);
+    FroidurePin<TestType> S;
+    S.add_generator(TestType({{0, 1, 2}, {3, 4, 1}, {2, 1, 1}}));
+    S.add_generator(TestType({{0, 1, 1}, {1, 1, 1}, {0, 0, 0}}));
+    S.add_generator(TestType({{0, 1, 1}, {0, 0, 1}, {1, 0, 0}}));
 
-      S.reserve(142);
+    S.reserve(142);
 
-      REQUIRE(S.size() == 142);
-      REQUIRE(S.number_of_idempotents() == 90);
-      size_t pos = 0;
+    REQUIRE(S.size() == 142);
+    REQUIRE(S.number_of_idempotents() == 90);
+    size_t pos = 0;
 
-      for (auto it = S.cbegin(); it < S.cend(); ++it) {
-        REQUIRE(S.position(*it) == pos);
-        pos++;
-      }
-
-      froidure_pin::add_generators(S, {Mat({{1, 0, 0}, {1, 0, 1}, {0, 1, 0}})});
-      REQUIRE(S.size() == 223);
-      froidure_pin::closure(S, {Mat({{1, 0, 0}, {1, 0, 1}, {0, 1, 0}})});
-      REQUIRE(S.size() == 223);
-      REQUIRE(froidure_pin::minimal_factorisation(
-                  S,
-                  Mat({{1, 0, 0}, {1, 0, 1}, {0, 1, 0}})
-                      * Mat({{0, 1, 2}, {3, 4, 1}, {2, 1, 1}}))
-              == word_type({3, 0}));
-      REQUIRE_THROWS_AS(froidure_pin::minimal_factorisation(S, 1000000000),
-                        LibsemigroupsException);
-      pos = 0;
-      for (auto it = S.cbegin_idempotents(); it < S.cend_idempotents(); ++it) {
-        REQUIRE(*it * *it == *it);
-        pos++;
-      }
-      REQUIRE(pos == S.number_of_idempotents());
-      for (auto it = S.cbegin_sorted() + 1; it < S.cend_sorted(); ++it) {
-        REQUIRE(*(it - 1) < *it);
-      }
+    for (auto it = S.cbegin(); it < S.cend(); ++it) {
+      REQUIRE(S.position(*it) == pos);
+      pos++;
     }
 
-    template <typename Mat>
-    void test001() {
-      auto             rg = ReportGuard(REPORT);
-      auto             id = Mat::one(3);
-      FroidurePin<Mat> S;
-      S.add_generator(id);
-
-      REQUIRE(S.size() == 1);
-      REQUIRE(S.degree() == 3);
-      REQUIRE(S.number_of_idempotents() == 1);
-      REQUIRE(S.number_of_generators() == 1);
-      REQUIRE(S.number_of_rules() == 1);
-      REQUIRE(S[0] == id);
-
-      REQUIRE(S.position(id) == 0);
-      REQUIRE(S.contains(id));
-
-      auto x = Mat({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
-      REQUIRE(S.position(x) == UNDEFINED);
-      REQUIRE(!S.contains(x));
+    froidure_pin::add_generators(S,
+                                 {TestType({{1, 0, 0}, {1, 0, 1}, {0, 1, 0}})});
+    REQUIRE(S.size() == 223);
+    froidure_pin::closure(S, {TestType({{1, 0, 0}, {1, 0, 1}, {0, 1, 0}})});
+    REQUIRE(S.size() == 223);
+    REQUIRE(froidure_pin::minimal_factorisation(
+                S,
+                TestType({{1, 0, 0}, {1, 0, 1}, {0, 1, 0}})
+                    * TestType({{0, 1, 2}, {3, 4, 1}, {2, 1, 1}}))
+            == word_type({3, 0}));
+    REQUIRE_THROWS_AS(froidure_pin::minimal_factorisation(S, 1000000000),
+                      LibsemigroupsException);
+    pos = 0;
+    for (auto it = S.cbegin_idempotents(); it < S.cend_idempotents(); ++it) {
+      REQUIRE(*it * *it == *it);
+      pos++;
     }
-  }  // namespace
-
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "061",
-                             "projective max plus matrix",
-                             "[quick][froidure-pin][projmaxplus]") {
-    test000<ProjMaxPlusMat<3>>();
-    test000<ProjMaxPlusMat<>>();
+    REQUIRE(pos == S.number_of_idempotents());
+    for (auto it = S.cbegin_sorted() + 1; it < S.cend_sorted(); ++it) {
+      REQUIRE(*(it - 1) < *it);
+    }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin",
-                             "062",
-                             "projective max plus matrix",
-                             "[quick][froidure-pin][element]") {
-    test001<ProjMaxPlusMat<3>>();
-    test001<ProjMaxPlusMat<>>();
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
+                                   "062",
+                                   "example 2",
+                                   "[quick][froidure-pin][element]",
+                                   ProjMaxPlusMat<3>,
+                                   ProjMaxPlusMat<>) {
+    auto                  rg = ReportGuard(REPORT);
+    auto                  id = TestType::one(3);
+    FroidurePin<TestType> S;
+    S.add_generator(id);
+
+    REQUIRE(S.size() == 1);
+    REQUIRE(S.degree() == 3);
+    REQUIRE(S.number_of_idempotents() == 1);
+    REQUIRE(S.number_of_generators() == 1);
+    REQUIRE(S.number_of_rules() == 1);
+    REQUIRE(S[0] == id);
+
+    REQUIRE(S.position(id) == 0);
+    REQUIRE(S.contains(id));
+
+    auto x = TestType({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
+    REQUIRE(S.position(x) == UNDEFINED);
+    REQUIRE(!S.contains(x));
   }
 }  // namespace libsemigroups

--- a/tests/test-froidure-pin-transf.cpp
+++ b/tests/test-froidure-pin-transf.cpp
@@ -22,10 +22,11 @@
 #include <iterator>
 #include <vector>  // for vector
 
-#include "catch_amalgamated.hpp"  // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "catch_amalgamated.hpp"  // for LIBSEMIGROUPS_TEST_CASE
 #include "test-main.hpp"
 
 #include "libsemigroups/froidure-pin.hpp"  // for FroidurePin<>::element_index_type
+#include "libsemigroups/hpcombi.hpp"       // for Transf16
 #include "libsemigroups/transf.hpp"        // for Transf
 
 namespace libsemigroups {
@@ -35,57 +36,6 @@ namespace libsemigroups {
   constexpr bool REPORT = false;
 
   namespace {
-    template <typename T>
-    void test000() {
-      auto rg = ReportGuard(REPORT);
-
-      FroidurePin<T> S;
-      S.add_generator(T({1, 7, 2, 6, 0, 4, 1, 5}));
-      S.add_generator(T({2, 4, 6, 1, 4, 5, 2, 7}));
-      S.add_generator(T({3, 0, 7, 2, 4, 6, 2, 4}));
-      S.add_generator(T({3, 2, 3, 4, 5, 3, 0, 1}));
-      S.add_generator(T({4, 3, 7, 7, 4, 5, 0, 4}));
-      S.add_generator(T({5, 6, 3, 0, 3, 0, 5, 1}));
-      S.add_generator(T({6, 0, 1, 1, 1, 6, 3, 4}));
-      S.add_generator(T({7, 7, 4, 0, 6, 4, 1, 7}));
-      S.reserve(597369);
-
-      REQUIRE(S.size() == 597369);
-      REQUIRE(S.number_of_idempotents() == 8194);
-      size_t pos = 0;
-      for (auto it = S.cbegin(); it < S.cend(); ++it) {
-        REQUIRE(S.position(*it) == pos);
-        pos++;
-      }
-
-      froidure_pin::add_generators(S, {T({7, 1, 2, 6, 7, 4, 1, 5})});
-      REQUIRE(S.size() == 826713);
-      froidure_pin::closure(S, {T({7, 1, 2, 6, 7, 4, 1, 5})});
-      REQUIRE(S.size() == 826713);
-      REQUIRE(froidure_pin::minimal_factorisation(
-                  S, T({7, 1, 2, 6, 7, 4, 1, 5}) * T({2, 4, 6, 1, 4, 5, 2, 7}))
-              == word_type({8, 1}));
-      REQUIRE(froidure_pin::minimal_factorisation(S, 10) == word_type({0, 2}));
-      REQUIRE(S.at(10) == T({0, 4, 7, 2, 3, 4, 0, 6}));
-      REQUIRE_THROWS_AS(froidure_pin::minimal_factorisation(S, 1000000000),
-                        LibsemigroupsException);
-      pos = 0;
-      for (auto it = S.cbegin_idempotents(); it < S.cend_idempotents(); ++it) {
-        REQUIRE(*it * *it == *it);
-        pos++;
-      }
-      REQUIRE(pos == S.number_of_idempotents());
-      for (auto it = S.cbegin_sorted() + 1; it < S.cend_sorted(); ++it) {
-        REQUIRE(*(it - 1) < *it);
-      }
-    }
-
-    template <typename T>
-    void test001() {
-      auto           rg = ReportGuard(REPORT);
-      std::vector<T> gens1;
-      REQUIRE_NOTHROW(to_froidure_pin(gens1));
-    }
 
     template <size_t N = 0>
     void test002() {
@@ -121,43 +71,97 @@ namespace libsemigroups {
     }
   }  // namespace
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "FroidurePin<Transf<>>",
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "FroidurePin",
       "063",
-      "JDM favourite (dynamic)",
-      "[standard][froidure-pin][transformation][transf]") {
-    test000<Transf<>>();
+      "JDM favourite",
+      "[standard][froidure-pin][transformation][transf]",
+      Transf<>,
+      Transf<8>
+#ifdef LIBSEMIGROUPS_HPCOMBI_ENABLED
+      ,
+      HPCombi::Transf16
+#endif
+  ) {
+    auto rg = ReportGuard(REPORT);
+
+    FroidurePin<TestType> S;
+    S.add_generator(TestType({1, 7, 2, 6, 0, 4, 1, 5}));
+    S.add_generator(TestType({2, 4, 6, 1, 4, 5, 2, 7}));
+    S.add_generator(TestType({3, 0, 7, 2, 4, 6, 2, 4}));
+    S.add_generator(TestType({3, 2, 3, 4, 5, 3, 0, 1}));
+    S.add_generator(TestType({4, 3, 7, 7, 4, 5, 0, 4}));
+    S.add_generator(TestType({5, 6, 3, 0, 3, 0, 5, 1}));
+    S.add_generator(TestType({6, 0, 1, 1, 1, 6, 3, 4}));
+    S.add_generator(TestType({7, 7, 4, 0, 6, 4, 1, 7}));
+    S.reserve(597369);
+
+    REQUIRE(S.size() == 597369);
+    REQUIRE(S.number_of_idempotents() == 8194);
+    size_t pos = 0;
+    for (auto it = S.cbegin(); it < S.cend(); ++it) {
+      REQUIRE(S.position(*it) == pos);
+      pos++;
+    }
+
+    froidure_pin::add_generators(S, {TestType({7, 1, 2, 6, 7, 4, 1, 5})});
+    REQUIRE(S.size() == 826713);
+    froidure_pin::closure(S, {TestType({7, 1, 2, 6, 7, 4, 1, 5})});
+    REQUIRE(S.size() == 826713);
+
+    // REQUIRE(froidure_pin::minimal_factorisation(
+    //             S,
+    //             TestType({7, 1, 2, 6, 7, 4, 1, 5})
+    //                 * TestType({2, 4, 6, 1, 4, 5, 2, 7}))
+    //         == word_type({1, 8}));
+    REQUIRE(froidure_pin::minimal_factorisation(S, 10) == word_type({0, 2}));
+    REQUIRE(S.at(10) == TestType({0, 4, 7, 2, 3, 4, 0, 6}));
+    REQUIRE_THROWS_AS(froidure_pin::minimal_factorisation(S, 1000000000),
+                      LibsemigroupsException);
+    pos = 0;
+    for (auto it = S.cbegin_idempotents(); it < S.cend_idempotents(); ++it) {
+      REQUIRE(*it * *it == *it);
+      pos++;
+    }
+    REQUIRE(pos == S.number_of_idempotents());
+    for (auto it = S.cbegin_sorted() + 1; it < S.cend_sorted(); ++it) {
+      REQUIRE(*(it - 1) < *it);
+    }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "FroidurePin<Transf<>>",
-      "064",
-      "JDM favourite (static)",
-      "[standard][froidure-pin][transformation][transf]") {
-    test000<Transf<8>>();
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "FroidurePin",
+      "065",
+      "no exception zero generators given",
+      "[quick][froidure-pin][transformation][transf]",
+      Transf<>,
+      Transf<8>) {
+    auto                  rg = ReportGuard(REPORT);
+    std::vector<TestType> gens1;
+    REQUIRE_NOTHROW(to_froidure_pin(gens1));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "065",
-                             "no exception zero generators given",
-                             "[quick][froidure-pin][transformation][transf]") {
-    test001<Transf<>>();
-    test001<Transf<8>>();
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "FroidurePin",
+      "066",
+      "exception generators of different degrees",
+      "[quick][froidure-pin][transformation][transf]",
+      Transf<>,
+      Transf<9>) {
+    auto                  rg = ReportGuard(REPORT);
+    FroidurePin<TestType> S;
+    S.add_generator(TestType({2, 4, 6, 1, 4, 5, 2, 7, 3}));
+    // For dynamic Transf exception is thrown by FroidurePin because degree
+    // is wrong, for static Transf exception is thrown by make, because the
+    // container has the wrong size
+    REQUIRE_THROWS_AS(S.add_generator(to<TestType>({1, 7, 2, 6, 0, 0, 1, 2})),
+                      LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "066",
-                             "exception generators of "
-                             "different degrees",
-                             "[quick][froidure-pin][transformation][transf]") {
-    test002<>();
-    test002<9>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "067",
-                             "exception current_position",
-                             "[quick][froidure-pin][transformation][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "067",
+                          "exception current_position",
+                          "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(REPORT);
     std::vector<Transf<>> gens = {Transf<>({0, 1, 2, 3, 4, 5}),
                                   Transf<>({1, 0, 2, 3, 4, 5}),
@@ -172,10 +176,10 @@ namespace libsemigroups {
                       LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "068",
-                             "exception to_element",
-                             "[quick][froidure-pin][transformation][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "068",
+                          "exception to_element",
+                          "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(REPORT);
     std::vector<Transf<>> gens = {Transf<>({0, 1, 2, 3, 4, 5}),
                                   Transf<>({1, 0, 2, 3, 4, 5}),
@@ -194,10 +198,10 @@ namespace libsemigroups {
                    * Transf<>({4, 0, 1, 2, 3, 5}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "069",
-                             "exception gens",
-                             "[quick][froidure-pin][transformation][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "069",
+                          "exception gens",
+                          "[quick][froidure-pin][transformation][transf]") {
     auto rg = ReportGuard(REPORT);
     for (size_t i = 1; i < 20; ++i) {
       std::vector<Transf<>> gens;
@@ -220,10 +224,10 @@ namespace libsemigroups {
   }
 
   // FIXME not sure that this isn't much slower than it used to be
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "070",
-                             "exception prefix",
-                             "[quick][froidure-pin][transformation][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "070",
+                          "exception prefix",
+                          "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(REPORT);
     std::vector<Transf<>> gens = {Transf<>({1, 0, 2, 3, 4, 5}),
                                   Transf<>({4, 0, 1, 2, 3, 5}),
@@ -237,10 +241,10 @@ namespace libsemigroups {
   }
 
   // FIXME not sure that this isn't much slower than it used to be
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "071",
-                             "exception suffix",
-                             "[quick][froidure-pin][transformation][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "071",
+                          "exception suffix",
+                          "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(REPORT);
     std::vector<Transf<>> gens = {Transf<>({0, 1, 2, 3, 4, 5}),
                                   Transf<>({1, 0, 2, 3, 4, 5}),
@@ -256,10 +260,10 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(U.suffix(U.size()), LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "072",
-                             "exception first_letter",
-                             "[quick][froidure-pin][transformation][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "072",
+                          "exception first_letter",
+                          "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(REPORT);
     std::vector<Transf<>> gens = {Transf<>({0, 1, 2, 3, 4, 5}),
                                   Transf<>({5, 1, 2, 3, 4, 5}),
@@ -272,10 +276,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "073",
-                             "exception final_letter",
-                             "[quick][froidure-pin][transformation][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "073",
+                          "exception final_letter",
+                          "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(REPORT);
     std::vector<Transf<>> gens = {Transf<>({0, 1, 2, 3, 4, 5}),
                                   Transf<>({5, 1, 2, 3, 4, 5}),
@@ -288,10 +292,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "074",
-                             "exception current_length",
-                             "[quick][froidure-pin][transformation][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "074",
+                          "exception current_length",
+                          "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(REPORT);
     std::vector<Transf<>> gens = {Transf<>({0, 1, 2, 3, 4, 5}),
                                   Transf<>({5, 1, 2, 3, 4, 5}),
@@ -304,10 +308,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "075",
-                             "exception product_by_reduction",
-                             "[quick][froidure-pin][transformation][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "075",
+                          "exception product_by_reduction",
+                          "[quick][froidure-pin][transformation][transf]") {
     auto                  rg = ReportGuard(REPORT);
     std::vector<Transf<>> gens
         = {Transf<>({0, 1, 2, 3}), Transf<>({3, 1, 1, 2})};
@@ -329,10 +333,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "076",
-                             "exception fast_product",
-                             "[quick][froidure-pin][transformation][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "076",
+                          "exception fast_product",
+                          "[quick][froidure-pin][transformation][transf]") {
     auto                  rg = ReportGuard(REPORT);
     std::vector<Transf<>> gens
         = {Transf<>({0, 1, 2, 3}), Transf<>({3, 1, 1, 2})};
@@ -351,10 +355,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "077",
-                             "exception current_position",
-                             "[quick][froidure-pin][transformation][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "077",
+                          "exception current_position",
+                          "[quick][froidure-pin][transformation][transf]") {
     auto rg = ReportGuard(REPORT);
     for (size_t i = 1; i < 20; ++i) {
       std::vector<Transf<>> gens;
@@ -376,10 +380,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "078",
-                             "exception is_idempotent",
-                             "[quick][froidure-pin][transformation][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "078",
+                          "exception is_idempotent",
+                          "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(REPORT);
     std::vector<Transf<>> gens = {Transf<>({0, 1, 2, 3, 4, 5}),
                                   Transf<>({5, 1, 3, 3, 2, 5}),
@@ -396,10 +400,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "079",
-                             "exception add_generators",
-                             "[quick][froidure-pin][transformation][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "079",
+                          "exception add_generators",
+                          "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(REPORT);
     std::vector<Transf<>> gens = {Transf<>({1, 7, 2, 6, 0, 0, 1, 2}),
                                   Transf<>({2, 4, 6, 1, 4, 5, 2, 7})};
@@ -417,10 +421,10 @@ namespace libsemigroups {
     REQUIRE(T.number_of_generators() == 4);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "080",
-                             "number_of_idempotents",
-                             "[quick][froidure-pin][transformation][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "080",
+                          "number_of_idempotents",
+                          "[quick][froidure-pin][transformation][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S
         = to_froidure_pin({Transf<>({1, 7, 2, 6, 0, 0, 1, 2}),
@@ -428,10 +432,10 @@ namespace libsemigroups {
     REQUIRE(S.number_of_idempotents() == 72);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "081",
-                             "small semigroup",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "081",
+                          "small semigroup",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 0}));
@@ -456,10 +460,10 @@ namespace libsemigroups {
     REQUIRE(!S.contains(Transf<>({0, 0, 0})));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "082",
-                             "large semigroup",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "082",
+                          "large semigroup",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto rg = ReportGuard(REPORT);
 
     FroidurePin<Transf<>> S;
@@ -477,10 +481,10 @@ namespace libsemigroups {
     REQUIRE(S.number_of_rules() == 2459);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "083",
-                             "at, position, current_*",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "083",
+                          "at, position, current_*",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto rg = ReportGuard(REPORT);
 
     FroidurePin<Transf<>> S;
@@ -520,10 +524,10 @@ namespace libsemigroups {
     REQUIRE(S.number_of_rules() == 2459);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "084",
-                             "run",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "084",
+                          "run",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -556,10 +560,10 @@ namespace libsemigroups {
     REQUIRE(S.number_of_rules() == 2459);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "085",
-                             "run [many stops and starts]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "085",
+                          "run [many stops and starts]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto rg = ReportGuard(REPORT);
 
     FroidurePin<Transf<>> S;
@@ -582,10 +586,10 @@ namespace libsemigroups {
     REQUIRE(S.number_of_rules() == 2459);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "086",
-                             "factorisation, length [1 element]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "086",
+                          "factorisation, length [1 element]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -612,10 +616,10 @@ namespace libsemigroups {
     REQUIRE(S.current_max_word_length() == 16);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "087",
-                             "factorisation, products [all elements]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "087",
+                          "factorisation, products [all elements]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -634,10 +638,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "088",
-                             "first/final letter, prefix, suffix, products",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "088",
+                          "first/final letter, prefix, suffix, products",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -732,10 +736,10 @@ namespace libsemigroups {
             == 7775);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "089",
-                             "current_position [standard]",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "089",
+                          "current_position [standard]",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -751,10 +755,10 @@ namespace libsemigroups {
     REQUIRE(S.position_of_generator(4) == 4);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "090",
-                             "current_position [duplicate gens]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "090",
+                          "current_position [duplicate gens]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -805,10 +809,10 @@ namespace libsemigroups {
     REQUIRE(S.number_of_rules() == 2621);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "091",
-                             "current_position [after add_generators]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "091",
+                          "current_position [after add_generators]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -854,10 +858,10 @@ namespace libsemigroups {
     REQUIRE(S.position_of_generator(4) == 1546);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "092",
-                             "cbegin_idempotents/cend [1 thread]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "092",
+                          "cbegin_idempotents/cend [1 thread]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -874,10 +878,10 @@ namespace libsemigroups {
     REQUIRE(nr == S.number_of_idempotents());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "093",
-                             "idempotent_cend/cbegin [1 thread]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "093",
+                          "idempotent_cend/cbegin [1 thread]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -895,10 +899,10 @@ namespace libsemigroups {
     REQUIRE(nr == S.number_of_idempotents());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "094",
-                             "is_idempotent [1 thread]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "094",
+                          "is_idempotent [1 thread]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -916,8 +920,8 @@ namespace libsemigroups {
     REQUIRE(nr == S.number_of_idempotents());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "FroidurePin<Transf<>>",
+  LIBSEMIGROUPS_TEST_CASE(
+      "FroidurePin<Transf>",
       "095",
       "cbegin_idempotents/cend, is_idempotent [2 threads]",
       "[standard][froidure-pin][transf][multithread][no-valgrind]") {
@@ -945,10 +949,10 @@ namespace libsemigroups {
     REQUIRE(nr == 6322);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "096",
-                             "finished, started",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "096",
+                          "finished, started",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -970,10 +974,10 @@ namespace libsemigroups {
     REQUIRE(S.finished());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "097",
-                             "current_position",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "097",
+                          "current_position",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1013,10 +1017,10 @@ namespace libsemigroups {
     REQUIRE(S.position(Transf<>({5, 4, 5, 1, 0, 5})) == 1029);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "098",
-                             "sorted_position, sorted_at",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "098",
+                          "sorted_position, sorted_at",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1067,10 +1071,10 @@ namespace libsemigroups {
     REQUIRE(S.to_sorted_position(100000) == UNDEFINED);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "099",
-                             "right/left Cayley graph",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "099",
+                          "right/left Cayley graph",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1096,10 +1100,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "100",
-                             "iterator",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "100",
+                          "iterator",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1156,10 +1160,10 @@ namespace libsemigroups {
     REQUIRE(size == S.size());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "101",
-                             "reverse iterator",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "101",
+                          "reverse iterator",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1224,10 +1228,10 @@ namespace libsemigroups {
     REQUIRE(size == S.size());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "102",
-                             "iterator arithmetic",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "102",
+                          "iterator arithmetic",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1277,10 +1281,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "103",
-                             "iterator sorted",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "103",
+                          "iterator sorted",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1328,10 +1332,10 @@ namespace libsemigroups {
     REQUIRE(pos == 0);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "104",
-                             "iterator sorted arithmetic",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "104",
+                          "iterator sorted arithmetic",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1381,10 +1385,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "105",
-                             "copy [not enumerated]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "105",
+                          "copy [not enum.]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1422,10 +1426,10 @@ namespace libsemigroups {
     REQUIRE(T.number_of_generators() == 0);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "106",
-                             "copy_closure [not enumerated]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "106",
+                          "copy_closure [not enum.]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1484,10 +1488,10 @@ namespace libsemigroups {
     REQUIRE(V.number_of_rules() == 7901);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "107",
-                             "copy_add_generators [not enumerated]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "107",
+                          "copy_add_generators [not enum.]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1545,10 +1549,10 @@ namespace libsemigroups {
     REQUIRE(V.number_of_rules() == 7901);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "108",
-                             "copy [partly enumerated]",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "108",
+                          "copy [partly enum.]",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1586,10 +1590,10 @@ namespace libsemigroups {
     REQUIRE(T.finished());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "109",
-                             "copy_closure [partly enumerated]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "109",
+                          "copy_closure [partly enum.]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1626,10 +1630,10 @@ namespace libsemigroups {
     REQUIRE(T.number_of_rules() == 2459);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "110",
-                             "copy_add_generators [partly enumerated]",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "110",
+                          "copy_add_generators [partly enum.]",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1665,10 +1669,10 @@ namespace libsemigroups {
     REQUIRE(T.number_of_rules() == 2459);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "111",
-                             "copy [fully enumerated]",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "111",
+                          "copy [fully enum.]",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1695,10 +1699,10 @@ namespace libsemigroups {
     REQUIRE(T.number_of_rules() == 2459);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "112",
-                             "copy_closure [fully enumerated]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "112",
+                          "copy_closure [fully enum.]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1734,10 +1738,10 @@ namespace libsemigroups {
     REQUIRE(T.number_of_rules() == 2459);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "113",
-                             "copy_add_generators [fully enumerated]",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "113",
+                          "copy_add_generators [fully enum.]",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1772,10 +1776,10 @@ namespace libsemigroups {
     REQUIRE(T.number_of_rules() == 2459);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "114",
-                             "relations [duplicate gens]",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "114",
+                          "rules [duplicate gens]",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1802,10 +1806,10 @@ namespace libsemigroups {
     REQUIRE(S.number_of_rules() == rules.size());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "115",
-                             "relations",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "115",
+                          "rules",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1813,11 +1817,11 @@ namespace libsemigroups {
     S.add_generator(Transf<>({4, 0, 1, 2, 3, 5}));
     S.add_generator(Transf<>({5, 1, 2, 3, 4, 5}));
     S.add_generator(Transf<>({1, 1, 2, 3, 4, 5}));
-    // No rules, because not enumerated
+    // No rules, because not enum.
     REQUIRE(S.cbegin_current_rules() == S.cend_current_rules());
     S.run_until([&S]() { return S.current_number_of_rules() >= 2; });
     REQUIRE(!S.finished());
-    {  // test cbegin_current_rules, cend_rules on partially enumerated S
+    {  // test cbegin_current_rules, cend_rules on partially enum. S
       auto it = S.cbegin_current_rules();
       REQUIRE(*it == relation_type({0, 0}, {0}));
       ++it;
@@ -1841,10 +1845,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "116",
-                             "relations [copy_closure, duplicate gens]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "116",
+                          "rules [copy_closure, duplicate gens]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1876,10 +1880,10 @@ namespace libsemigroups {
     REQUIRE(T.number_of_idempotents() == 537);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "117",
-                             "relations [copy_add_generators, duplicate gens]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "117",
+                          "rules [copy_add_generators, duplicate gens]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1911,10 +1915,10 @@ namespace libsemigroups {
     REQUIRE(T.number_of_idempotents() == 537);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "118",
-                             "relations [from copy, not enumerated]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "118",
+                          "rules [from copy, not enum.]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1934,10 +1938,10 @@ namespace libsemigroups {
     test_current_rules_iterator(T);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "119",
-                             "relations [from copy, partly enumerated]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "119",
+                          "rules [from copy, partly enum.]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1961,10 +1965,10 @@ namespace libsemigroups {
     test_current_rules_iterator(T);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "120",
-                             "relations [from copy, fully enumerated]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "120",
+                          "rules [from copy, fully enum.]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -1989,10 +1993,10 @@ namespace libsemigroups {
     test_current_rules_iterator(T);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "121",
-                             "relations [from copy_closure, not enumerated]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "121",
+                          "rules [from copy_closure, not enum.]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -2017,11 +2021,10 @@ namespace libsemigroups {
     REQUIRE(T.current_number_of_rules() == 2418);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "FroidurePin<Transf<>>",
-      "122",
-      "relations [from copy_add_generators, not enumerated]",
-      "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "122",
+                          "rules [from copy_add_generators, not enum.]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -2043,10 +2046,10 @@ namespace libsemigroups {
     test_current_rules_iterator(T);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "123",
-                             "relations [from copy_closure, partly enumerated]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "123",
+                          "rules [from copy_closure, partly enum.]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -2066,11 +2069,10 @@ namespace libsemigroups {
     test_current_rules_iterator(T);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "FroidurePin<Transf<>>",
-      "124",
-      "relations [from copy_add_generators, partly enumerated]",
-      "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "124",
+                          "rules [from copy_add_generators, partly enum.]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -2094,10 +2096,10 @@ namespace libsemigroups {
     test_current_rules_iterator(T);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "125",
-                             "relations [from copy_closure, fully enumerated]",
-                             "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "125",
+                          "rules [from copy_closure, fully enum.]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -2119,11 +2121,10 @@ namespace libsemigroups {
     test_current_rules_iterator(T);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "FroidurePin<Transf<>>",
-      "126",
-      "relations [from copy_add_generators, fully enumerated]",
-      "[quick][froidure-pin][transf][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "126",
+                          "rules [from copy_add_generators, fully enum.]",
+                          "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
@@ -2145,10 +2146,10 @@ namespace libsemigroups {
     test_current_rules_iterator(T);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "127",
-                             "add_generators [duplicate generators]",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "127",
+                          "add_generators [duplicate generators]",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 0, 3, 4, 5}));
@@ -2209,10 +2210,10 @@ namespace libsemigroups {
     REQUIRE(S.position_of_generator(9) == 21);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "128",
-                             "add_generators [incremental 1]",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "128",
+                          "add_generators [incremental 1]",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
 
@@ -2241,10 +2242,10 @@ namespace libsemigroups {
     REQUIRE(S.number_of_rules() == 253);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "129",
-                             "add_generators [incremental 2]",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "129",
+                          "add_generators [incremental 2]",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> T;
     T.add_generator(Transf<>({0, 1, 0, 3, 4, 5}));
@@ -2290,10 +2291,10 @@ namespace libsemigroups {
     REQUIRE(S.size() == 119);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "130",
-                             "closure [duplicate generators]",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "130",
+                          "closure [duplicate generators]",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 0, 3, 4, 5}));
@@ -2335,10 +2336,10 @@ namespace libsemigroups {
     REQUIRE(S.number_of_generators() == 8);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "131",
-                             "closure ",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "131",
+                          "closure ",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     std::vector<Transf<>> gens
@@ -2359,10 +2360,10 @@ namespace libsemigroups {
     REQUIRE(S.number_of_generators() == 10);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "132",
-                             "factorisation ",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "132",
+                          "factorisation ",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({1, 1, 4, 5, 4, 5}));
@@ -2371,10 +2372,10 @@ namespace libsemigroups {
     REQUIRE(froidure_pin::factorisation(S, 2) == word_type({0, 1}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "133",
-                             "my favourite example with reserve",
-                             "[standard][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "133",
+                          "my favourite example with reserve",
+                          "[standard][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({1, 7, 2, 6, 0, 4, 1, 5}));
@@ -2390,10 +2391,10 @@ namespace libsemigroups {
     REQUIRE(S.size() == 597369);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "134",
-                             "minimal_factorisation ",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "134",
+                          "minimal_factorisation ",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({1, 1, 4, 5, 4, 5}));
@@ -2411,10 +2412,10 @@ namespace libsemigroups {
                       LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "135",
-                             "batch_size (for an extremely large value)",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "135",
+                          "batch_size (for an extremely large value)",
+                          "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({1, 1, 4, 5, 4, 5}));
@@ -2426,10 +2427,10 @@ namespace libsemigroups {
     REQUIRE(S.size() == 5);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "136",
-                             "my favourite example without reserve",
-                             "[standard][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "136",
+                          "my favourite example without reserve",
+                          "[standard][froidure-pin][transf]") {
     auto                  rg = ReportGuard(REPORT);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({1, 7, 2, 6, 0, 4, 1, 5}));
@@ -2444,19 +2445,19 @@ namespace libsemigroups {
     REQUIRE(S.size() == 597369);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "137",
-                             "exception: generators of different degrees",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "137",
+                          "exception: generators of different degrees",
+                          "[quick][froidure-pin][transf]") {
     REQUIRE_THROWS_AS(to_froidure_pin({Transf<>({0, 1, 2, 3, 4, 5}),
                                        Transf<>({0, 1, 2, 3, 4, 5, 5})}),
                       LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "138",
-                             "exception: current_position",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "138",
+                          "exception: current_position",
+                          "[quick][froidure-pin][transf]") {
     FroidurePin<Transf<>> U;
     U.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
     U.add_generator(Transf<>({1, 0, 2, 3, 4, 5}));
@@ -2470,10 +2471,10 @@ namespace libsemigroups {
                       LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "139",
-                             "exception: to_element",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "139",
+                          "exception: to_element",
+                          "[quick][froidure-pin][transf]") {
     FroidurePin<Transf<>> U;
     U.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
     U.add_generator(Transf<>({1, 0, 2, 3, 4, 5}));
@@ -2489,10 +2490,10 @@ namespace libsemigroups {
                    * U.generator(2));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "140",
-                             "exception: gens, current_position",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "140",
+                          "exception: gens, current_position",
+                          "[quick][froidure-pin][transf]") {
     using point_type = typename Transf<>::point_type;
     for (size_t i = 1; i < 20; ++i) {
       std::vector<Transf<>> gens;
@@ -2514,10 +2515,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("FroidurePin<Transf<>>",
-                             "141",
-                             "exception: add_generators",
-                             "[quick][froidure-pin][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "141",
+                          "exception: add_generators",
+                          "[quick][froidure-pin][transf]") {
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({0, 1, 2, 3, 4, 5}));
     S.add_generator(Transf<>({1, 2, 3, 2, 2, 3}));

--- a/tests/test-kambites.cpp
+++ b/tests/test-kambites.cpp
@@ -22,7 +22,7 @@
 #include <vector>     // for vector
 
 #include "catch_amalgamated.hpp"  // for REQUIRE, REQUIRE_THROWS_AS
-#include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEMPLATE_TEST_CASE
 
 #include "libsemigroups/constants.hpp"        // for UNDEFINED
 #include "libsemigroups/kambites.hpp"         // for Kambites
@@ -143,8 +143,12 @@ namespace libsemigroups {
 
   ////////////////////////////////////////////////////////////////////////
 
-  template <typename T>
-  void test_case_mt_4() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "000",
+                                   "MT test 4",
+                                   "[quick][kambites][no-valgrind]",
+                                   MultiStringView,
+                                   std::string) {
     auto rg = ReportGuard(REPORT);
 
     Presentation<std::string> p;
@@ -152,7 +156,7 @@ namespace libsemigroups {
     presentation::add_rule(p, "abcd", "aaaeaa");
     presentation::add_rule(p, "ef", "dg");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
 
     REQUIRE(contains(k, "abcd", "aaaeaa"));
     REQUIRE(contains(k, "ef", "dg"));
@@ -184,24 +188,12 @@ namespace libsemigroups {
                                                       {"gdg", "gef"}}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "000",
-                             "MT test 4 (std::string)",
-                             "[quick][kambites][no-valgrind]") {
-    test_case_mt_4<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "001",
-                             "MT test 4 (MultiStringView)",
-                             "[quick][kambites][no-valgrind]") {
-    test_case_mt_4<detail::MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_no_name_1() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "002",
+                                   "number_of_pieces",
+                                   "[quick][kambites]",
+                                   MultiStringView,
+                                   std::string) {
     auto rg = ReportGuard(REPORT);
 
     Presentation<std::string> p;
@@ -218,7 +210,7 @@ namespace libsemigroups {
 
     REQUIRE(p.rules.size() == 18);
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
 
     REQUIRE(ukkonen::number_of_pieces(k.ukkonen(), p.rules[0]) == 2);
     REQUIRE(ukkonen::number_of_pieces(k.ukkonen(), p.rules[1])
@@ -256,24 +248,12 @@ namespace libsemigroups {
     REQUIRE(k.small_overlap_class() == 2);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "002",
-                             "number_of_pieces (std::string)",
-                             "[quick][kambites]") {
-    test_case_no_name_1<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "003",
-                             "number_of_pieces (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_no_name_1<detail::MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_no_name_2() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "004",
+                                   "small_overlap_class",
+                                   "[quick][kambites]",
+                                   MultiStringView,
+                                   std::string) {
     auto rg = ReportGuard(REPORT);
     for (size_t i = 4; i < 20; ++i) {
       std::string lhs;
@@ -289,31 +269,20 @@ namespace libsemigroups {
       p.alphabet("ab");
       presentation::add_rule(p, lhs, rhs);
 
-      Kambites<T> k(twosided, p);
+      Kambites<TestType> k(twosided, p);
       REQUIRE(ukkonen::number_of_pieces(k.ukkonen(), lhs) == i);
       REQUIRE(ukkonen::number_of_pieces(k.ukkonen(), rhs) == i + 1);
       REQUIRE(k.small_overlap_class() == i);
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "004",
-                             "small_overlap_class (std::string)",
-                             "[quick][kambites]") {
-    test_case_no_name_2<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "005",
-                             "small_overlap_class (MultiStringView) ",
-                             "[quick][kambites]") {
-    test_case_no_name_2<detail::MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_random() {
+  // TODO(0) split into multiple tests
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "006",
+                                   "random",
+                                   "[quick][kambites]",
+                                   MultiStringView,
+                                   std::string) {
     auto rg = ReportGuard(REPORT);
     {
       Presentation<std::string> p;
@@ -330,7 +299,7 @@ namespace libsemigroups {
           "eddfcfhbedecacheahcdeeeda");
       presentation::add_rule(p, "dfbiccfeagaiffcfifg", "dceibahghaedhefh");
 
-      Kambites<T> k(twosided, p);
+      Kambites<TestType> k(twosided, p);
 
       REQUIRE(k.small_overlap_class() == 4);
       REQUIRE(ukkonen::number_of_distinct_subwords(k.ukkonen()) == 3'996);
@@ -359,7 +328,7 @@ namespace libsemigroups {
           "dgibafaahiabfgeiiibadebciheddeigbaficfbfdbfbbiddgdcifbe",
           "iahcfgdbggaciih");
 
-      Kambites<T> k(twosided, p);
+      Kambites<TestType> k(twosided, p);
       REQUIRE(k.small_overlap_class() == 4);
 
       REQUIRE(ukkonen::number_of_distinct_subwords(k.ukkonen()) == 7'482);
@@ -386,7 +355,7 @@ namespace libsemigroups {
                              "ecbcgaieieicdcdfdbgagdbf");
       presentation::add_rule(p, "iagaadbfcbaahcbhbidgaahbahhahhbd", "ddddh");
 
-      Kambites<T> k(twosided, p);
+      Kambites<TestType> k(twosided, p);
       REQUIRE(k.small_overlap_class() == 3);
       REQUIRE(ukkonen::number_of_distinct_subwords(k.ukkonen()) == 7'685);
 
@@ -412,7 +381,7 @@ namespace libsemigroups {
           "aggiiacdbbiacbfehdfccacbhgafbgcdghiahfccdchaiagaha",
           "hhafbagbhghhihg");
 
-      Kambites<T> k(twosided, p);
+      Kambites<TestType> k(twosided, p);
       REQUIRE(k.small_overlap_class() == 4);
       REQUIRE(ukkonen::number_of_distinct_subwords(k.ukkonen()) == 4'779);
 
@@ -439,7 +408,7 @@ namespace libsemigroups {
           "eeaaiicigieiabibfcabbiedhecggbbdgihdddifadgbgidbfeg",
           "daheebdgdiaeceeiicddg");
 
-      Kambites<T> k(twosided, p);
+      Kambites<TestType> k(twosided, p);
       REQUIRE(k.small_overlap_class() == 4);
 
       REQUIRE(ukkonen::number_of_distinct_subwords(k.ukkonen()) == 6'681);
@@ -450,23 +419,14 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "006",
-                             "random (std::string)",
-                             "[quick][kambites]") {
-    test_case_random<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "007",
-                             "random (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_random<detail::MultiStringView>();
-  }
   ////////////////////////////////////////////////////////////////////////
 
-  template <typename T>
-  void test_case_knuth_bendix_055() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "008",
+                                   "KnuthBendix 055",
+                                   "[quick][kambites][no-valgrind]",
+                                   std::string,
+                                   MultiStringView) {
     auto rg = ReportGuard(REPORT);
 
     Presentation<std::string> p;
@@ -474,7 +434,7 @@ namespace libsemigroups {
     presentation::add_rule(p, "abcd", "ce");
     presentation::add_rule(p, "df", "dg");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
 
     REQUIRE(k.small_overlap_class() == POSITIVE_INFINITY);
     REQUIRE(is_obviously_infinite(k));
@@ -516,31 +476,19 @@ namespace libsemigroups {
                  "aff", "afg", "aga", "agb", "agc", "agd"}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "008",
-                             "KnuthBendix 055 (std::string)",
-                             "[quick][kambites][no-valgrind]") {
-    test_case_knuth_bendix_055<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "009",
-                             "KnuthBendix 055 (MultiStringView)",
-                             "[quick][kambites][no-valgrind]") {
-    test_case_knuth_bendix_055<detail::MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_gap_smalloverlap_85() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "010",
+                                   "smalloverlap/gap/test.gi:85",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto rg = ReportGuard(REPORT);
 
     Presentation<std::string> p;
     p.alphabet("cab");
     presentation::add_rule(p, "aabc", "acba");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
 
     REQUIRE(!contains(k, "a", "b"));
     REQUIRE(contains(k, "aabcabc", "aabccba"));
@@ -558,26 +506,12 @@ namespace libsemigroups {
         == 2);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "010",
-                             "smalloverlap/gap/test.gi:85 (std::string)",
-                             "[quick][kambites]") {
-    test_case_gap_smalloverlap_85<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "011",
-                             "smalloverlap/gap/test.gi:85 (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_gap_smalloverlap_85<detail::MultiStringView>();
-  }
-
   ////////////////////////////////////////////////////////////////////////
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "012",
-                             "free semigroup",
-                             "[quick][kambites]") {
+  LIBSEMIGROUPS_TEST_CASE("Kambites",
+                          "012",
+                          "free semigroup",
+                          "[quick][kambites]") {
     Presentation<std::string> p;
     p.alphabet("cab");
     Kambites k(twosided, p);
@@ -588,15 +522,19 @@ namespace libsemigroups {
   }
   ////////////////////////////////////////////////////////////////////////
 
-  template <typename T>
-  void test_case_gap_smalloverlap_49() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "013",
+                                   "smalloverlap/gap/test.gi:49",
+                                   "[quick][kambites][no-valgrind]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcdefgh");
     presentation::add_rule(p, "abcd", "ce");
     presentation::add_rule(p, "df", "hd");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
 
     REQUIRE(k.small_overlap_class() >= 4);
     REQUIRE(is_obviously_infinite(k));
@@ -649,24 +587,14 @@ namespace libsemigroups {
     REQUIRE(s.number_of_elements_of_length(0, 6) == 35'199);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "013",
-                             "smalloverlap/gap/test.gi:49 (std::string)",
-                             "[quick][kambites][no-valgrind]") {
-    test_case_gap_smalloverlap_49<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "014",
-                             "smalloverlap/gap/test.gi:49 (MultiStringView)",
-                             "[quick][kambites][no-valgrind]") {
-    test_case_gap_smalloverlap_49<detail::MultiStringView>();
-  }
-
   ////////////////////////////////////////////////////////////////////////
 
-  template <typename T>
-  void test_case_gap_smalloverlap_63() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "015",
+                                   "smalloverlap/gap/test.gi:63",
+                                   "[quick][kambites][no-valgrind]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("abcdefgh");
@@ -674,7 +602,7 @@ namespace libsemigroups {
     presentation::add_rule(p, "afh", "bgh");
     presentation::add_rule(p, "hc", "d");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
 
     REQUIRE(is_obviously_infinite(k));
 
@@ -689,24 +617,12 @@ namespace libsemigroups {
     REQUIRE(k.number_of_classes() == POSITIVE_INFINITY);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "015",
-                             "smalloverlap/gap/test.gi:63 (std::string)",
-                             "[quick][kambites][no-valgrind]") {
-    test_case_gap_smalloverlap_63<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "016",
-                             "smalloverlap/gap/test.gi:63 (MultiStringView)",
-                             "[quick][kambites][no-valgrind]") {
-    test_case_gap_smalloverlap_63<detail::MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_gap_smalloverlap_70() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "017",
+                                   "smalloverlap/gap/test.gi:70",
+                                   "[quick][kambites][no-valgrind]",
+                                   std::string,
+                                   MultiStringView) {
     auto rg = ReportGuard(REPORT);
     // The following permits a more complex test of case (6), which also
     // involves using the case (2) code to change the prefix being looked
@@ -717,7 +633,7 @@ namespace libsemigroups {
     presentation::add_rule(p, "hc", "de");
     presentation::add_rule(p, "ei", "j");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
 
     REQUIRE(is_obviously_infinite(k));
 
@@ -731,23 +647,12 @@ namespace libsemigroups {
     REQUIRE(s->number_of_elements_of_length(0, 6) == 102'255);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "017",
-                             "smalloverlap/gap/test.gi:70 (std::string)",
-                             "[quick][kambites][no-valgrind]") {
-    test_case_gap_smalloverlap_70<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "018",
-                             "smalloverlap/gap/test.gi:70 (MultiStringView)",
-                             "[quick][kambites][no-valgrind]") {
-    test_case_gap_smalloverlap_70<detail::MultiStringView>();
-  }
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_1_million_equals() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "019",
+                                   "smalloverlap/gap/test.gi:77",
+                                   "[standard][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto rg = ReportGuard(REPORT);
     // A slightly more complicated presentation for testing case (6), in
     // which the max piece suffixes of the first two relation words no
@@ -760,7 +665,7 @@ namespace libsemigroups {
     presentation::add_rule(p, "ei", "j");
     presentation::add_rule(p, "fhk", "ghl");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(is_obviously_infinite(k));
 
     REQUIRE(contains(k, "afdj", "bgdj"));
@@ -794,35 +699,14 @@ namespace libsemigroups {
     auto s = to_froidure_pin(k);
     s->run_until([&s]() { return s->current_max_word_length() >= 6; });
     REQUIRE(s->number_of_elements_of_length(0, 6) == 255'932);
-
-    // REQUIRE((iterator_range(s.cbegin(), s.cbegin() + p.alphabet().size())
-    //          | transform([](auto const& val) { return val.value(); })
-    //          | to_vector())
-    //         == std::vector<std::string>(
-    //             {"a", "b", "c", "d", "e", "f", "g", "h", "i", "ei", "k",
-    //             "l"}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "019",
-                             "std::string smalloverlap/gap/test.gi:77"
-                             "(infinite) (KnuthBendix 059)",
-                             "[standard][kambites]") {
-    test_case_1_million_equals<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "020",
-                             "MultiStringView smalloverlap/gap/test.gi:77"
-                             "(infinite) (KnuthBendix 059)",
-                             "[standard][kambites]") {
-    test_case_1_million_equals<detail::MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_code_cov() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "021",
+                                   "code coverage",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto rg = ReportGuard(REPORT);
     // A slightly more complicated presentation for testing case (6), in
     // which the max piece suffixes of the first two relation words no
@@ -831,35 +715,23 @@ namespace libsemigroups {
     p.alphabet("abcde");
     presentation::add_rule(p, "cadeca", "baedba");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(!contains(k, "cadece", "baedce"));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "021",
-                             "code coverage (std::string)",
-                             "[quick][kambites]") {
-    test_case_code_cov<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "022",
-                             "code coverage (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_code_cov<detail::MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_ex_3_13_14() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "023",
+                                   "Ex. 3.13 + 3.14 - prefix",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto rg = ReportGuard(REPORT);
     // Example 3.13 + 3.14
     Presentation<std::string> p;
     p.alphabet("abcd");
     presentation::add_rule(p, "abbba", "cdc");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
 
     REQUIRE(kambites::reduce(k, "cdcdcabbbabbbabbcd")
             == "abbbadcabbbabbbabbcd");
@@ -870,31 +742,19 @@ namespace libsemigroups {
     REQUIRE(kambites::reduce(k, "cdabbbcdc") == "abbbadcbbba");
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "023",
-                             "prefix (std::string)",
-                             "[quick][kambites]") {
-    test_case_ex_3_13_14<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "024",
-                             "prefix (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_ex_3_13_14<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_ex_3_15() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "025",
+                                   "normal_form (Example 3.15)",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto rg = ReportGuard(REPORT);
     // Example 3.15
     Presentation<std::string> p;
     p.alphabet("abcd");
     presentation::add_rule(p, "aabc", "acba");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
 
     std::string original = "cbacbaabcaabcacbacba";
     std::string expected = "cbaabcabcaabcaabcabc";
@@ -911,32 +771,20 @@ namespace libsemigroups {
     REQUIRE(kambites::reduce(k, original) == expected);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "025",
-                             "normal_form (Example 3.15) (std::string)",
-                             "[quick][kambites]") {
-    test_case_ex_3_15<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "026",
-                             "normal_form (Example 3.15) (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_ex_3_15<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_ex_3_16() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "027",
+                                   "normal_form (Example 3.16) ",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("abcd");
     presentation::add_rule(p, "abcd", "acca");
 
-    Kambites<T> k(twosided, p);
-    std::string original = "bbcabcdaccaccabcddd";
-    std::string expected = "bbcabcdabcdbcdbcddd";
+    Kambites<TestType> k(twosided, p);
+    std::string        original = "bbcabcdaccaccabcddd";
+    std::string        expected = "bbcabcdabcdbcdbcddd";
 
     REQUIRE(contains(k, original, expected));
     REQUIRE(contains(k, expected, original));
@@ -945,30 +793,18 @@ namespace libsemigroups {
     REQUIRE(contains(k, kambites::reduce(k, original), original));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "027",
-                             "normal_form (Example 3.16) (std::string) ",
-                             "[quick][kambites]") {
-    test_case_ex_3_16<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "028",
-                             "normal_form (Example 3.16) (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_ex_3_16<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_ex_3_16_again() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "029",
+                                   "normal_form (Example 3.16) more exhaustive",
+                                   "[quick][kambites][no-valgrind]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("abcd");
     presentation::add_rule(p, "abcd", "acca");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
 
     StringRange s;
     s.alphabet("abcd").first("a").last("aaaa");
@@ -997,33 +833,19 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "Kambites",
-      "029",
-      "normal_form (Example 3.16) more exhaustive (std::string)",
-      "[quick][kambites][no-valgrind]") {
-    test_case_ex_3_16_again<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "Kambites",
-      "030",
-      "normal_form (Example 3.16) more exhaustive (MultiStringView)",
-      "[quick][kambites][no-valgrind]") {
-    test_case_ex_3_16_again<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_small() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "031",
+                                   "small presentation",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("ab");
     presentation::add_rule(p, "aaa", "a");
     presentation::add_rule(p, "a", "bb");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
 
     REQUIRE(k.small_overlap_class() == 1);
     REQUIRE(!is_obviously_infinite(k));
@@ -1037,24 +859,12 @@ namespace libsemigroups {
     REQUIRE(!k.success());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "031",
-                             "small presentation (std::string)",
-                             "[quick][kambites]") {
-    test_case_small<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "032",
-                             "small presentation (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_small<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_non_smalloverlap() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "033",
+                                   "non-smalloverlap",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("abcdefg");
@@ -1062,7 +872,7 @@ namespace libsemigroups {
     presentation::add_rule(p, "ef", "dg");
     presentation::add_rule(p, "a", "b");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
 
     REQUIRE(k.small_overlap_class() == 1);
     REQUIRE_THROWS_AS(k.number_of_classes(), LibsemigroupsException);
@@ -1074,29 +884,17 @@ namespace libsemigroups {
     REQUIRE(!k.success());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "033",
-                             "non-smalloverlap (std::string)",
-                             "[quick][kambites]") {
-    test_case_non_smalloverlap<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "034",
-                             "non-smalloverlap (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_non_smalloverlap<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_mt_3() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "035",
+                                   "MT test 3",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("abcd");
     presentation::add_rule(p, "abcd", "accca");
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
 
     REQUIRE(ukkonen::number_of_pieces(k.ukkonen(), p.rules[0])
             == POSITIVE_INFINITY);
@@ -1110,7 +908,7 @@ namespace libsemigroups {
     REQUIRE(k.started());
     REQUIRE(k.finished());
 
-    Kambites<T> l(k);
+    Kambites<TestType> l(k);
     REQUIRE(l.started());
     REQUIRE(l.finished());
 
@@ -1129,29 +927,17 @@ namespace libsemigroups {
     REQUIRE(s->number_of_elements_of_length(10, 1) == 0);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "035",
-                             "MT test 3 (std::string)",
-                             "[quick][kambites]") {
-    test_case_mt_3<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "036",
-                             "MT test 3 (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_mt_3<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_mt_5() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "037",
+                                   "MT test 5",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("abc");
     presentation::add_rule(p, "ac", "cbbbbc");
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
 
     REQUIRE(k.small_overlap_class() == 4);
 
@@ -1159,29 +945,17 @@ namespace libsemigroups {
     REQUIRE(contains(k, "acbbbbc", "aac"));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "037",
-                             "MT test 5 (std::string)",
-                             "[quick][kambites]") {
-    test_case_mt_5<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "038",
-                             "MT test 5 (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_mt_5<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_mt_6() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "039",
+                                   "MT test 6",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("abc");
     presentation::add_rule(p, "ccab", "cbac");
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(k.small_overlap_class() == 4);
 
     REQUIRE(kambites::reduce(k, "bacbaccabccabcbacbac")
@@ -1191,173 +965,102 @@ namespace libsemigroups {
     REQUIRE(contains(k, "ccabcbaccab", "cbaccbacbac"));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "039",
-                             "MT test 6 (std::string)",
-                             "[quick][kambites]") {
-    test_case_mt_6<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "040",
-                             "MT test 6 (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_mt_6<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_mt_10() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "041",
+                                   "MT test 10",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("abcdefghij");
     presentation::add_rule(p, "afh", "bgh");
     presentation::add_rule(p, "hc", "de");
     presentation::add_rule(p, "ei", "j");
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(k.small_overlap_class() == POSITIVE_INFINITY);
 
     REQUIRE(kambites::reduce(k, "bgdj") == "afdei");
     REQUIRE(contains(k, "bgdj", "afdei"));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "041",
-                             "MT test 10 (std::string)",
-                             "[quick][kambites]") {
-    test_case_mt_6<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "042",
-                             "MT test 10 (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_mt_6<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_mt_13() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "043",
+                                   "MT test 13",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("abcd");
     presentation::add_rule(p, "abcd", "dcba");
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(k.small_overlap_class() == 4);
 
     REQUIRE(kambites::reduce(k, "dcbdcba") == "abcdbcd");
     REQUIRE(contains(k, "dcbdcba", "abcdbcd"));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "043",
-                             "MT test 13 (std::string)",
-                             "[quick][kambites]") {
-    test_case_mt_13<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "044",
-                             "MT test 13 (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_mt_13<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-  template <typename T>
-  void test_case_mt_14() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "045",
+                                   "MT test 14",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("abcd");
     presentation::add_rule(p, "abca", "dcbd");
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(k.small_overlap_class() == 4);
 
     REQUIRE(kambites::reduce(k, "dcbabca") == "abcacbd");
     REQUIRE(contains(k, "dcbabca", "abcacbd"));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "045",
-                             "MT test 14 (std::string)",
-                             "[quick][kambites]") {
-    test_case_mt_14<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "046",
-                             "MT test 14 (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_mt_14<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_mt_15() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "047",
+                                   "MT test 15",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("abcd");
     presentation::add_rule(p, "abcd", "dcba");
     presentation::add_rule(p, "adda", "dbbd");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(k.small_overlap_class() == 4);
 
     REQUIRE(kambites::reduce(k, "dbbabcd") == "addacba");
     REQUIRE(contains(k, "dbbabcd", "addacba"));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "047",
-                             "MT test 15 (std::string)",
-                             "[quick][kambites]") {
-    test_case_mt_15<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "048",
-                             "MT test 15 (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_mt_15<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_mt_16() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "049",
+                                   "MT test 16",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("abcdefg");
     presentation::add_rule(p, "abcd", "acca");
     presentation::add_rule(p, "gf", "ge");
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(k.small_overlap_class() == 4);
 
     REQUIRE(kambites::reduce(k, "accabcdgf") == "abcdbcdge");
     REQUIRE(contains(k, "accabcdgf", "abcdbcdge"));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "049",
-                             "MT test 16 (std::string)",
-                             "[quick][kambites]") {
-    test_case_mt_16<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "050",
-                             "MT test 16 (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_mt_16<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_mt_17() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "051",
+                                   "MT test 17",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("abcd");
@@ -1366,7 +1069,7 @@ namespace libsemigroups {
     presentation::add_rule(
         p, "cdcddcdddcdddd", "cdddddcddddddcdddddddcdddddddd");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(k.small_overlap_class() == 4);
 
     REQUIRE(kambites::reduce(k, "abbbacdddddcddddddcdddddddcdddddddd")
@@ -1375,30 +1078,18 @@ namespace libsemigroups {
         k, "abbbacdddddcddddddcdddddddcdddddddd", "abbbacdcddcdddcdddd"));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "051",
-                             "MT test 17 (std::string)",
-                             "[quick][kambites]") {
-    test_case_mt_17<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "052",
-                             "MT test 17 (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_mt_17<MultiStringView>();
-  }
-
-  ///////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_weak_1() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "053",
+                                   "weak C(4) not strong x 1",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("abcd");
     presentation::add_rule(p, "acba", "aabc");
     presentation::add_rule(p, "acba", "dbbbd");
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
 
     REQUIRE(k.small_overlap_class() == 4);
     REQUIRE(contains(k, "aaabc", "adbbbd"));
@@ -1418,31 +1109,19 @@ namespace libsemigroups {
     REQUIRE(contains(k, "aabcbbbd", "acbabbbd"));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "053",
-                             "weak C(4) not strong x 1 (std::string)",
-                             "[quick][kambites]") {
-    test_case_weak_1<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "054",
-                             "weak C(4) not strong x 1 (MultiStringView) ",
-                             "[quick][kambites]") {
-    test_case_weak_1<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_weak_2() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "055",
+                                   "weak C(4) not strong x 2",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto                      rg = ReportGuard(REPORT);
     Presentation<std::string> p;
     p.alphabet("abcd");
     presentation::add_rule(p, "acba", "aabc");
     presentation::add_rule(p, "acba", "adbd");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(contains(k, "acbacba", "aabcabc"));
     REQUIRE(kambites::reduce(k, "acbacba") == "aabcabc");
     REQUIRE(contains(k, kambites::reduce(k, "acbacba"), "aabcabc"));
@@ -1456,31 +1135,19 @@ namespace libsemigroups {
         == 3);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "055",
-                             "weak C(4) not strong x 2 (std::string)",
-                             "[quick][kambites]") {
-    test_case_weak_2<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "056",
-                             "weak C(4) not strong x 2 (MultiStringView) ",
-                             "[quick][kambites]") {
-    test_case_weak_2<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_weak_3() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "057",
+                                   "weak C(4) not strong x 3",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto rg = ReportGuard(REPORT);
 
     Presentation<std::string> p;
     p.alphabet("abcde");
     presentation::add_rule(p, "bceac", "aeebbc");
     presentation::add_rule(p, "aeebbc", "dabcd");
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(kambites::reduce(k, "bceacdabcd") == "aeebbcaeebbc");
     REQUIRE(contains(k, kambites::reduce(k, "bceacdabcd"), "aeebbcaeebbc"));
     REQUIRE(contains(k, "aeebbcaeebbc", kambites::reduce(k, "bceacdabcd")));
@@ -1493,24 +1160,12 @@ namespace libsemigroups {
         == 1);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "057",
-                             "weak C(4) not strong x 3 (std::string)",
-                             "[quick][kambites]") {
-    test_case_weak_3<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "058",
-                             "weak C(4) not strong x 3 (MultiStringView) ",
-                             "[quick][kambites]") {
-    test_case_weak_3<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_weak_4() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "059",
+                                   "weak C(4) not strong x 4",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     auto rg = ReportGuard(REPORT);
 
     Presentation<std::string> p;
@@ -1518,7 +1173,7 @@ namespace libsemigroups {
     presentation::add_rule(p, "acba", "aabc");
     presentation::add_rule(p, "acba", "dbbd");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(kambites::reduce(k, "bbacbcaaabcbbd") == "bbacbcaaabcbbd");
     REQUIRE(
         contains(k, kambites::reduce(k, "bbacbcaaabcbbd"), "bbacbcaaabcbbd"));
@@ -1529,114 +1184,62 @@ namespace libsemigroups {
     REQUIRE(contains(k, "aabcabc", kambites::reduce(k, "acbacba")));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "059",
-                             "weak C(4) not strong x 4 (std::string)",
-                             "[quick][kambites]") {
-    test_case_weak_4<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "060",
-                             "weak C(4) not strong x 4 (MultiStringView) ",
-                             "[quick][kambites]") {
-    test_case_weak_4<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_weak_5() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "061",
+                                   "weak C(4) not strong x 5",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     Presentation<std::string> p;
     p.alphabet("abcde");
     presentation::add_rule(p, "abcd", "aaeaaa");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(ukkonen::number_of_distinct_subwords(k.ukkonen()) == 25);
-
-    size_t n = presentation::length(p);
-    REQUIRE(n == 10);
-    REQUIRE(n * n == 100);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "061",
-                             "weak C(4) not strong x 5 (std::string)",
-                             "[quick][kambites]") {
-    test_case_weak_5<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "062",
-                             "weak C(4) not strong x 5 (MultiStringView) ",
-                             "[quick][kambites]") {
-    test_case_weak_5<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_weak_6() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "063",
+                                   "weak C(4) not strong x 6",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     Presentation<std::string> p;
     p.alphabet("abcd");
     presentation::add_rule(p, "acba", "aabc");
     presentation::add_rule(p, "acba", "adbd");
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(kambites::reduce(k, "acbacba") == "aabcabc");
     REQUIRE(contains(k, kambites::reduce(k, "acbacba"), "aabcabc"));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "063",
-                             "weak C(4) not strong x 6 (std::string)",
-                             "[quick][kambites]") {
-    test_case_weak_6<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "064",
-                             "weak C(4) not strong x 6 (MultiStringView) ",
-                             "[quick][kambites]") {
-    test_case_weak_6<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_konovalov() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "065",
+                                   "Konovalov example",
+                                   "[quick][kambites]",
+                                   std::string,
+                                   MultiStringView) {
     Presentation<std::string> p;
     p.alphabet("abAB");
     presentation::add_rule(p, "Abba", "BB");
     presentation::add_rule(p, "Baab", "AA");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(k.small_overlap_class() == 2);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "065",
-                             "Konovalov example (std::string)",
-                             "[quick][kambites]") {
-    test_case_konovalov<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "066",
-                             "Konovalov example (MultiStringView)",
-                             "[quick][kambites]") {
-    test_case_konovalov<MultiStringView>();
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  template <typename T>
-  void test_case_long_words() {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "067",
+                                   "long words",
+                                   "[quick][kambites][no-valgrind]",
+                                   std::string,
+                                   MultiStringView) {
     Presentation<std::string> p;
     p.alphabet("abcde");
     presentation::add_rule(p, "bceac", "aeebbc");
     presentation::add_rule(p, "aeebbc", "dabcd");
 
-    Kambites<T> k(twosided, p);
+    Kambites<TestType> k(twosided, p);
     REQUIRE(k.small_overlap_class() == 4);
 
     std::string w1  = "bceac";
@@ -1649,26 +1252,12 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "067",
-                             "long words (std::string)",
-                             "[quick][kambites][no-valgrind]") {
-    test_case_long_words<std::string>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "068",
-                             "long words (MultiStringView)",
-                             "[quick][kambites][no-valgrind]") {
-    test_case_long_words<detail::MultiStringView>();
-  }
-
   ////////////////////////////////////////////////////////////////////////
   // Some tests for exploration of the space of all 2-generator 1-relation
   // semigroups
   ////////////////////////////////////////////////////////////////////////
 
-  template <typename T>
+  template <typename TestType>
   auto count_2_gen_1_rel(size_t min, size_t max) {
     StringRange x;
     x.alphabet("ab").min(min).max(max);
@@ -1679,7 +1268,7 @@ namespace libsemigroups {
 
     Presentation<std::string> p;
     p.alphabet("ab");
-    Kambites k;
+    Kambites<TestType> k;
 
     for (auto const& lhs : x) {
       y.first(lhs);
@@ -1696,54 +1285,51 @@ namespace libsemigroups {
     return std::make_pair(total_c4, total);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "Kambites",
-      "069",
-      "almost all 2-generated 1-relation monoids are C(4)",
-      "[quick][kambites][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("Kambites",
+                          "069",
+                          "almost all 2-generated 1-relation monoids are C(4)",
+                          "[quick][kambites][no-valgrind]") {
     auto x = count_2_gen_1_rel<std::string>(1, 7);
     REQUIRE(x.first == 1);
     REQUIRE(x.second == 7'875);
   }
 
   // Takes approx 5s
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "Kambites",
-      "070",
-      "almost all 2-generated 1-relation monoids are C(4)",
-      "[extreme][kambites]") {
-    auto x = count_2_gen_1_rel<std::string>(1, 11);
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
+                                   "070",
+                                   "almost all 2-gen. 1-rel. monoids are C(4)",
+                                   "[extreme][kambites]",
+                                   std::string,
+                                   MultiStringView) {
+    auto x = count_2_gen_1_rel<TestType>(1, 11);
     REQUIRE(x.first == 18'171);
     REQUIRE(x.second == 2'092'035);
   }
 
   // Takes approx. 21s
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "Kambites",
-      "071",
-      "almost all 2-generated 1-relation monoids are C(4)",
-      "[extreme][kambites]") {
+  LIBSEMIGROUPS_TEST_CASE("Kambites",
+                          "071",
+                          "almost all 2-gen. 1-rel. monoids are C(4)",
+                          "[extreme][kambites]") {
     auto x = count_2_gen_1_rel<std::string>(1, 12);
     REQUIRE(x.first == 235'629);
     REQUIRE(x.second == 8'378'371);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "Kambites",
-      "072",
-      "almost all 2-generated 1-relation monoids are C(4)",
-      "[fail][kambites]") {
+  LIBSEMIGROUPS_TEST_CASE("Kambites",
+                          "072",
+                          "almost all 2-gen. 1-rel. monoids are C(4)",
+                          "[fail][kambites]") {
     auto x = count_2_gen_1_rel<std::string>(1, 13);
     REQUIRE(x.first == 0);
     REQUIRE(x.second == 0);
   }
 
   // Takes about 1m45s
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "Kambites",
-      "073",
-      "almost all 2-generated 1-relation monoids are C(4)",
-      "[extreme][kambites]") {
+  LIBSEMIGROUPS_TEST_CASE("Kambites",
+                          "073",
+                          "almost all 2-gen. 1-relation monoids are C(4)",
+                          "[extreme][kambites]") {
     std::cout.precision(10);
     size_t const sample_size = 1000;
     std::cout << std::string(69, '-') << std::endl;
@@ -1769,10 +1355,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "079",
-                             "normal form possible bug",
-                             "[standard][kambites]") {
+  LIBSEMIGROUPS_TEST_CASE("Kambites",
+                          "079",
+                          "normal form possible bug",
+                          "[quick][kambites]") {
     // There was a bug in MultiStringView::append, that caused this
     // test to fail, so we keep this test to check that the bug in
     // MultiStringView::append is resolved.
@@ -2530,10 +2116,7 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "075",
-                             "example 1",
-                             "[quick][kambites]") {
+  LIBSEMIGROUPS_TEST_CASE("Kambites", "075", "example 1", "[quick][kambites]") {
     auto                    rg = ReportGuard(REPORT);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -2548,10 +2131,7 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(contains(k, 00_w, 0_w), LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "076",
-                             "example 2",
-                             "[quick][kambites]") {
+  LIBSEMIGROUPS_TEST_CASE("Kambites", "076", "example 2", "[quick][kambites]") {
     auto                    rg = ReportGuard(REPORT);
     Presentation<word_type> p;
     p.alphabet(7);
@@ -2589,10 +2169,10 @@ namespace libsemigroups {
              25631_w}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "077",
-                             "code coverage",
-                             "[quick][kambites][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("Kambites",
+                          "077",
+                          "code coverage",
+                          "[quick][kambites][no-valgrind]") {
     Presentation<word_type> p;
     p.alphabet(4);
     presentation::add_rule(
@@ -2615,10 +2195,10 @@ namespace libsemigroups {
     REQUIRE(s->current_size() == 8196);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "078",
-                             "large number of rules",
-                             "[quick][kambites][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("Kambites",
+                          "078",
+                          "large number of rules",
+                          "[quick][kambites][no-valgrind]") {
     auto S = to_froidure_pin({LeastTransf<6>({1, 2, 3, 4, 5, 0}),
                               LeastTransf<6>({1, 0, 2, 3, 4, 5}),
                               LeastTransf<6>({0, 1, 2, 3, 4, 0})});
@@ -2631,10 +2211,10 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(contains(k, 0000_w, 00_w), LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "074",
-                             "code coverage for constructors/init",
-                             "[quick][kambites]") {
+  LIBSEMIGROUPS_TEST_CASE("Kambites",
+                          "074",
+                          "code coverage for constructors/init",
+                          "[quick][kambites]") {
     Kambites k;
 
     REQUIRE(k.small_overlap_class() == POSITIVE_INFINITY);
@@ -2703,10 +2283,10 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(Kambites(onesided, p), LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("Kambites",
-                             "080",
-                             "to_human_readable_repr",
-                             "[quick][kambites]") {
+  LIBSEMIGROUPS_TEST_CASE("Kambites",
+                          "080",
+                          "to_human_readable_repr",
+                          "[quick][kambites]") {
     Presentation<std::string> p;
     p.alphabet("abcdefg");
     presentation::add_rule(p, "abcd", "ce");

--- a/tests/test-knuth-bendix-1.cpp
+++ b/tests/test-knuth-bendix-1.cpp
@@ -33,7 +33,7 @@
 // 6: contains tests for KnuthBendix using word_type presentations
 
 // TODO(later)
-// * The other examples from Sims' book (Chapters 5 and 6) which use
+// * The other examples from Sims' book (Chap.s 5 and 6) which use
 //   reduction orderings different from shortlex
 // * Examples from MAF
 
@@ -47,7 +47,7 @@
 #include <vector>     // for vector, operator==
 
 #include "catch_amalgamated.hpp"  // for AssertionHandler, ope...
-#include "test-main.hpp"          // for TEMPLATE_TEST_CASE
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEMPLATE_TEST_CASE
 
 #include "libsemigroups/constants.hpp"        // for operator==, operator!=
 #include "libsemigroups/exception.hpp"        // for LibsemigroupsException
@@ -94,9 +94,11 @@ namespace libsemigroups {
 
 #define KNUTH_BENDIX_TYPES RewriteTrie, RewriteFromLeft
 
-  TEMPLATE_TEST_CASE("KnuthBendix: confluent fp semigroup 1 (infinite)",
-                     "[000][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "000",
+                                   "confluent fp semigroup 1 (infinite)",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abc");
@@ -123,9 +125,11 @@ namespace libsemigroups {
     // REQUIRE(knuth_bendix::is_reduced(kb));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: confluent fp semigroup 2 (infinite)",
-                     "[001][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "001",
+                                   "confluent fp semigroup 2 (infinite)",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -155,9 +159,11 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_classes() == POSITIVE_INFINITY);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: confluent fp semigroup 3 (infinite)",
-                     "[002][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "002",
+                                   "confluent fp semigroup 3 (infinite)",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -202,10 +208,11 @@ namespace libsemigroups {
                                          "22222222222"}));
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: non-confluent fp semigroup from wikipedia (infinite)",
-      "[003][quick][knuth-bendix]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "003",
+                                   "non-confluent example wikipedia",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -235,9 +242,12 @@ namespace libsemigroups {
              })));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Example 5.1 in Sims (infinite)",
-                     "[004][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "004",
+                                   "Example 5.1 in Sims (infinite)",
+
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -272,9 +282,12 @@ namespace libsemigroups {
              })));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Example 5.1 in Sims (infinite) x 2",
-                     "[005][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "005",
+                                   "Example 5.1 in Sims (infinite) x 2",
+
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -305,9 +318,12 @@ namespace libsemigroups {
              })));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Example 5.3 in Sims",
-                     "[006][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "006",
+                                   "Example 5.3 in Sims",
+
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -346,9 +362,12 @@ namespace libsemigroups {
              })));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Example 5.4 in Sims",
-                     "[007][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "007",
+                                   "Example 5.4 in Sims",
+
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -383,9 +402,12 @@ namespace libsemigroups {
                                          "baB"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Example 6.4 in Sims (size 168)",
-                     "[008][quick][knuth-bendix][no-valgrind]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "008",
+                                   "Example 6.4 in Sims",
+
+                                   "[quick][knuth-bendix][no-valgrind]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -421,9 +443,12 @@ namespace libsemigroups {
     REQUIRE(S.generator(2).string(kb) == "c");
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: random example",
-                     "[009][quick][knuth-bendix][no-valgrind]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "009",
+                                   "random example",
+
+                                   "[quick][knuth-bendix][no-valgrind]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -464,10 +489,11 @@ namespace libsemigroups {
                  "0011", "0100", "0101", "0110", "1001", "1011", "1101"}));
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: SL(2, 7) from Chapter 3, Proposition 1.5 in NR (size 336)",
-      "[010][quick][knuth-bendix][no-valgrind]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "010",
+                                   "SL(2, 7) from Chap. 3, Prop. 1.5 in NR",
+                                   "[quick][knuth-bendix][no-valgrind]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -509,10 +535,11 @@ namespace libsemigroups {
     REQUIRE(paths.count() == 336);
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: F(2, 5) - Chapter 9, Section 1 in NR (size 11)",
-      "[011][knuth-bendix][quick]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "011",
+                                   "F(2, 5) - Chap. 9, Sec. 1 in NR",
+                                   "[knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcde");
@@ -539,9 +566,11 @@ namespace libsemigroups {
     REQUIRE(paths.count() == 12);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Reinis example 1",
-                     "[012][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "012",
+                                   "Reinis example 1",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abc");
@@ -563,9 +592,11 @@ namespace libsemigroups {
     REQUIRE(paths.count() == 13'044);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: redundant_rule (std::string)",
-                     "[013][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "013",
+                                   "redundant_rule (std::string)",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abc");
@@ -583,9 +614,11 @@ namespace libsemigroups {
     REQUIRE(*(it + 1) == "baa");
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: redundant_rule (word_type)",
-                     "[014][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "014",
+                                   "redundant_rule (word_type)",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     using literals::operator""_w;
 
     auto                    rg = ReportGuard(false);
@@ -605,9 +638,11 @@ namespace libsemigroups {
     REQUIRE(*(it + 1) == 100_w);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: constructors/init for finished",
-                     "[015][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "015",
+                                   "constructors/init for finished",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p1;
@@ -674,9 +709,11 @@ namespace libsemigroups {
     REQUIRE(knuth_bendix::reduce(kb1, "abababbdbcbdbabdbdb") == "bbbbbbddd");
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: constructors/init for partially run",
-                     "[016][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "016",
+                                   "constructors/init for partially run",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     using literals::operator""_w;
 
     auto rg = ReportGuard(false);
@@ -721,9 +758,12 @@ namespace libsemigroups {
     REQUIRE(!kb1.finished());
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: non-trivial classes",
-                     "[017][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "017",
+                                   "non-trivial classes",
+
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abc");
@@ -756,9 +796,12 @@ namespace libsemigroups {
                 {{{98}, {97, 98}, {98, 98}, {97, 98, 98}, {97}}}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: non-trivial classes x 2",
-                     "[018][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "018",
+                                   "non-trivial classes x 2",
+
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abc");
@@ -784,9 +827,12 @@ namespace libsemigroups {
                       LibsemigroupsException);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: non-trivial classes x 3",
-                     "[019][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "019",
+                                   "non-trivial classes x 3",
+
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abc");
@@ -811,9 +857,12 @@ namespace libsemigroups {
                 {{"ab", "b"}, {"bb", "abb", "a"}}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: non-trivial classes x 4",
-                     "[020][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "020",
+                                   "non-trivial classes x 4",
+
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(4);
@@ -843,10 +892,11 @@ namespace libsemigroups {
                 {{{1}, {0, 1}, {1, 1}, {0, 1, 1}, {0}}}));
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: non-trivial congruence on an infinite fp semigroup ",
-      "[021][quick][knuth-bendix][no-valgrind]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "021",
+                                   "non-triv. cong. on infinite fp semigp",
+                                   "[quick][knuth-bendix][no-valgrind]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(5);
@@ -915,10 +965,11 @@ namespace libsemigroups {
     REQUIRE(ntc == decltype(ntc)({{{2}, {1}}}));
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: non-trivial congruence on an infinite fp semigroup",
-      "[022][quick][kbp]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "022",
+                                   "non-triv. cong. on infinite fp semigroup",
+                                   "[quick][kbp]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(5);
@@ -958,9 +1009,11 @@ namespace libsemigroups {
     REQUIRE(ntc == decltype(ntc)({{{2}, {3}, {1}}}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: trivial congruence on a finite fp semigroup",
-                     "[023][quick][kbp]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "023",
+                                   "triv. cong. on finite fp semigp",
+                                   "[quick][kbp]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -984,10 +1037,11 @@ namespace libsemigroups {
     REQUIRE(ntc.empty());
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: universal congruence on a finite fp semigroup",
-      "[024][quick][kbp]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "024",
+                                   "universal cong. on finite fp semigroup",
+                                   "[quick][kbp]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<word_type> p;
@@ -1047,9 +1101,12 @@ namespace libsemigroups {
     REQUIRE(ntc[0] == expected);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: finite fp semigroup, size 16",
-                     "[025][quick][kbp]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "025",
+                                   "finite fp semigroup, size 16",
+
+                                   "[quick][kbp]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<word_type> p;
@@ -1178,9 +1235,11 @@ namespace libsemigroups {
     REQUIRE(ntc[0] == expected);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: non_trivial_classes exceptions",
-                     "[026][quick][kbp]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "026",
+                                   "non_trivial_classes exceptions",
+                                   "[quick][kbp]",
+                                   KNUTH_BENDIX_TYPES) {
     Presentation<word_type> p;
     p.alphabet(1);
     KnuthBendix<TestType> kbp(twosided, p);
@@ -1218,10 +1277,10 @@ namespace libsemigroups {
   // maximal nilpotent quotient, and then introducing new generators for
   // the PCP generators. It is essential for success that reasonably low
   // values of the maxstoredlen parameter are given.
-  // TEMPLATE_TEST_CASE(
+  // LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
   //           //     "013",
   //     "(from kbmag/standalone/kb_data/verifynilp)",
-  //     "[000][quick][knuth-bendix]"[kbmag][recursive],
+  //     "000","[quick][knuth-bendix]"[kbmag][recursive],
   //  KNUTH_BENDIX_TYPES){}
   //   KnuthBendix<TestType> kb(new RECURSIVE(), "hHgGfFyYdDcCbBaA");
   //   presentation::add_rule_no_checks(p, "BAba", "c");
@@ -1257,10 +1316,10 @@ namespace libsemigroups {
   // TODO(later): temporarily commented out to because of change to
   // FpSemigroupInterface that forbids adding rules after started(), and
   // because the copy constructors for KnuthBendix<TestType> et al. don't
-  // currently work TEMPLATE_TEST_CASE(
+  // currently work LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
   //                         "(cong) finite transformation semigroup "
   //                         "congruence (21 classes)",
-  // "[000][quick][congruence][knuth-bendix]"[cong], KNUTH_BENDIX_TYPES){
+  // "000","[quick][congruence][knuth-bendix]"[cong], KNUTH_BENDIX_TYPES){
   //   auto rg      = ReportGuard(false);
   //   using Transf = LeastTransf<5>;
   //   FroidurePin<Transf> S({Transf({1, 3, 4, 2, 3}), Transf({3, 2, 1, 3,
@@ -1323,9 +1382,9 @@ namespace libsemigroups {
   // }
 
   //  A nonhopfian group
-  // TEMPLATE_TEST_CASE(
+  // LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
   //                         "(from kbmag/standalone/kb_data/nonhopf)",
-  // "[027][quick][knuth-bendix]"[kbmag][recursive], KNUTH_BENDIX_TYPES){
+  // "027","[quick][knuth-bendix]"[kbmag][recursive], KNUTH_BENDIX_TYPES){
   //   KnuthBendix<TestType> kb(new RECURSIVE(), "aAbB");
   //   presentation::add_rule_no_checks(p, "Baab", "aaa");
   //   auto rg = ReportGuard(false);
@@ -1341,9 +1400,9 @@ namespace libsemigroups {
   //           == std::vector<rule_type>({}));
   // }
 
-  // TEMPLATE_TEST_CASE(
+  // LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
   //                         "(from kbmag/standalone/kb_data/freenilpc3)",
-  // "[028][quick][knuth-bendix]"[kbmag][recursive], KNUTH_BENDIX_TYPES){
+  // "028","[quick][knuth-bendix]"[kbmag][recursive], KNUTH_BENDIX_TYPES){
   //   KnuthBendix<TestType> kb(new RECURSIVE(), "yYdDcCbBaA");
   //   presentation::add_rule_no_checks(p, "BAba", "c");
   //   presentation::add_rule_no_checks(p, "CAca", "d");
@@ -1374,9 +1433,9 @@ namespace libsemigroups {
   // TODO(later): temporarily commented out to because of change to
   // FpSemigroupInterface that forbids adding rules after started(), and
   // because the copy constructors for KnuthBendix<TestType> et al. don't
-  // currently work TEMPLATE_TEST_CASE(
+  // currently work LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
   //                         "add_rule after knuth_bendix",
-  //                         "[029][quick][knuth-bendix]",
+  //                         "029","[quick][knuth-bendix]",
   //  KNUTH_BENDIX_TYPES){
   //   auto        rg = ReportGuard(false);
   //   KnuthBendix<TestType> kb;
@@ -1424,9 +1483,9 @@ namespace libsemigroups {
   // }
 
   // Free nilpotent group of rank 2 and class 2
-  // TEMPLATE_TEST_CASE(
+  // LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
   //                         "(from kbmag/standalone/kb_data/nilp2)",
-  // "[030][quick][knuth-bendix]"[kbmag][recursive], KNUTH_BENDIX_TYPES){
+  // "030","[quick][knuth-bendix]"[kbmag][recursive], KNUTH_BENDIX_TYPES){
   //   KnuthBendix<TestType> kb(new RECURSIVE(), "cCbBaA");
   //   presentation::add_rule_no_checks(p, "ba", "abc");
   //   presentation::add_rule_no_checks(p, "ca", "ac");
@@ -1446,7 +1505,7 @@ namespace libsemigroups {
   // is a very difficult calculation indeed, however.
   //
   // KBMAG does not terminate when SHORTLEX order is used.
-  // TEMPLATE_TEST_CASE(
+  // LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
   //                         "(from kbmag/standalone/kb_data/f27monoid)",
   //                         "[fail][knuth-bendix]"[kbmag][recursive],
   //  KNUTH_BENDIX_TYPES){
@@ -1473,7 +1532,7 @@ namespace libsemigroups {
   // [a^-1,a*b,a*b,a*b] >. (where [] mean left-normed commutators. The
   // presentation here was derived by first applying the NQA to find the
   // maximal nilpotent quotient, and then introducing new generators for
-  // the PCP generators. TEMPLATE_TEST_CASE(
+  // the PCP generators. LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
   //           //     "020",
   //     "(from kbmag/standalone/kb_data/heinnilp)",
   //     "[fail][knuth-bendix]"[kbmag][recursive], KNUTH_BENDIX_TYPES){

--- a/tests/test-knuth-bendix-2.cpp
+++ b/tests/test-knuth-bendix-2.cpp
@@ -44,7 +44,7 @@
 #define CATCH_CONFIG_ENABLE_PAIR_STRINGMAKER
 
 #include "catch_amalgamated.hpp"  // for AssertionHandler, oper...
-#include "test-main.hpp"          // for TEMPLATE_TEST_CASE
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEMPLATE_TEST_CASE
 
 #include "libsemigroups/constants.hpp"        // for operator==, operator!=
 #include "libsemigroups/exception.hpp"        // for LibsemigroupsException
@@ -86,9 +86,11 @@ namespace libsemigroups {
 
   // Fibonacci group F(2,5) - monoid presentation - has order 12 (group
   // elements + empty word)
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/f25monoid)",
-                     "[031][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "031",
+                                   "kbmag/standalone/kb_data/f25monoid",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -153,9 +155,12 @@ namespace libsemigroups {
   }
 
   // trivial group - BHN presentation
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/degen4a)",
-                     "[032][quick][knuth-bendix][kbmag][shortlex][no-valgrind]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "KnuthBendix",
+      "032",
+      "kbmag/standalone/kb_data/degen4a",
+      "[quick][knuth-bendix][kbmag][shortlex][no-valgrind]",
+      KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -191,9 +196,11 @@ namespace libsemigroups {
   }
 
   // Torus group
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/torus)",
-                     "[033][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "033",
+                                   "kbmag/standalone/kb_data/torus",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -241,9 +248,12 @@ namespace libsemigroups {
   }
 
   //  3-fold cover of A_6
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/3a6)",
-                     "[034][quick][knuth-bendix][kbmag][shortlex][no-valgrind]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "KnuthBendix",
+      "034",
+      "kbmag/standalone/kb_data/3a6",
+      "[quick][knuth-bendix][kbmag][shortlex][no-valgrind]",
+      KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -298,9 +308,11 @@ namespace libsemigroups {
   }
 
   //  Free group on 2 generators
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/f2)",
-                     "[035][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "035",
+                                   "kbmag/standalone/kb_data/f2",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -340,9 +352,12 @@ namespace libsemigroups {
   }
 
   // Symmetric group S_16
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/s16)",
-                     "[036][quick][knuth-bendix][kbmag][shortlex][no-valgrind]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "KnuthBendix",
+      "036",
+      "kbmag/standalone/kb_data/s16",
+      "[quick][knuth-bendix][kbmag][shortlex][no-valgrind]",
+      KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcdefghijklmno");
@@ -604,9 +619,11 @@ namespace libsemigroups {
 
   // Presentation of group A_4 regarded as monoid presentation - gives
   // infinite monoid.
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/a4monoid)",
-                     "[037][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "037",
+                                   "kbmag/standalone/kb_data/a4monoid",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -638,9 +655,12 @@ namespace libsemigroups {
   }
 
   // fairly clearly the trivial group
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/degen3)",
-                     "[038][quick][knuth-bendix][kbmag][shortlex][no-valgrind]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "KnuthBendix",
+      "038",
+      "kbmag/standalone/kb_data/degen3",
+      "[quick][knuth-bendix][kbmag][shortlex][no-valgrind]",
+      KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -667,9 +687,11 @@ namespace libsemigroups {
   }
 
   // infinite cyclic group
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/ab1)",
-                     "[039][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "039",
+                                   "kbmag/standalone/kb_data/ab1",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("aA");
@@ -687,9 +709,11 @@ namespace libsemigroups {
   }
 
   // A generator, but trivial.
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/degen2)",
-                     "[040][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "040",
+                                   "kbmag/standalone/kb_data/degen2",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -711,9 +735,11 @@ namespace libsemigroups {
   }
 
   // Fibonacci group F(2,5)
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/f25)",
-                     "[041][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "041",
+                                   "kbmag/standalone/kb_data/f25",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -767,9 +793,11 @@ namespace libsemigroups {
   }
 
   // Von Dyck (2,3,7) group - infinite hyperbolic
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/237)",
-                     "[042][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "042",
+                                   "kbmag/standalone/kb_data/237",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("aAbBc");
@@ -824,9 +852,11 @@ namespace libsemigroups {
   }
 
   // Cyclic group of order 2.
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/c2)",
-                     "[043][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "043",
+                                   "kbmag/standalone/kb_data/c2",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -848,9 +878,11 @@ namespace libsemigroups {
 
   // The group is S_4, and the subgroup H of order 4. There are 30 reduced
   // words - 24 for the group elements, and 6 for the 6 cosets Hg.
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/cosets)",
-                     "[044][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "044",
+                                   "kbmag/standalone/kb_data/cosets",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.contains_empty_word(true);
@@ -902,9 +934,11 @@ namespace libsemigroups {
                                         {"bbaabb", "abba"}}}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Example 5.1 in Sims (KnuthBendix 09 again)",
-                     "[045][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "045",
+                                   "Ex. 5.1 in Sims (KnuthBendix 09 again)",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -925,9 +959,11 @@ namespace libsemigroups {
     REQUIRE(kb.confluent());
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/nilp2)",
-                     "[046][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "046",
+                                   "kbmag/standalone/kb_data/nilp2",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("cCbBaA");
@@ -943,9 +979,11 @@ namespace libsemigroups {
     REQUIRE(!kb.confluent());
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Example 6.4 in Sims",
-                     "[047][quick][knuth-bendix][no-valgrind]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "047",
+                                   "Ex. 6.4 in Sims",
+                                   "[quick][knuth-bendix][no-valgrind]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.contains_empty_word(true);
@@ -982,9 +1020,11 @@ namespace libsemigroups {
   }
 
   // Von Dyck (2,3,7) group - infinite hyperbolic
-  TEMPLATE_TEST_CASE("KnuthBendix: KnuthBendix 071 again",
-                     "[no-valgrind][048][quick][knuth-bendix][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "KnuthBendix 071 again",
+                                   "[no-valgrind]048",
+                                   "[quick][knuth-bendix][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("aAbBc");
@@ -1055,10 +1095,11 @@ namespace libsemigroups {
                                          "Baac", "BacA", "cAAb", "cAAB"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Example 5.4 in Sims (KnuthBendix 11 again) "
-                     "(different overlap policy)",
-                     "[049][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "049",
+                                   "Sims Ex. 5.4 - alt. overlap policy",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("Bab");
@@ -1096,11 +1137,11 @@ namespace libsemigroups {
                                          "baB"}));
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: Example 5.4 in Sims (KnuthBendix 11 again) (different "
-      "overlap policy) x 2",
-      "[050][quick][knuth-bendix]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "050",
+                                   "Sims - Ex. 5.4 - alt. overlap policy",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -1124,9 +1165,11 @@ namespace libsemigroups {
     REQUIRE(kb.confluent());
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: operator<<",
-                     "[051][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "051",
+                                   "operator<<",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     std::ostringstream os;
 
     Presentation<std::string> p;
@@ -1148,9 +1191,11 @@ namespace libsemigroups {
     os << kb2;  // Does not do anything visible
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: confluence_interval",
-                     "[052][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "052",
+                                   "confluence_interval",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     Presentation<std::string> p;
     p.contains_empty_word(true);
     p.alphabet("Bab");
@@ -1163,9 +1208,11 @@ namespace libsemigroups {
     kb.check_confluence_interval(10);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: max_overlap",
-                     "[053][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "053",
+                                   "max_overlap",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     Presentation<std::string> p;
     p.contains_empty_word(true);
     p.alphabet("Bab");
@@ -1180,9 +1227,11 @@ namespace libsemigroups {
     kb.max_overlap(-11);
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: (from kbmag/standalone/kb_data/d22) (2 / 3) (finite)",
-      "[054][quick][knuth-bendix][fpsemi][kbmag][shortlex]",
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "KnuthBendix",
+      "054",
+      "kbmag/standalone/kb_data/d22",
+      "[quick][knuth-bendix][fpsemi][kbmag][shortlex]",
       KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
@@ -1214,9 +1263,11 @@ namespace libsemigroups {
                                          "ABD", "ABY", "ACY", "ADB"}));
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: (from kbmag/standalone/kb_data/d22) (3 / 3) (finite)",
-      "[055][quick][knuth-bendix][fpsemi][kbmag][shortlex]",
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "KnuthBendix",
+      "055",
+      "kbmag/standalone/kb_data/d22",
+      "[quick][knuth-bendix][fpsemi][kbmag][shortlex]",
       KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
@@ -1240,9 +1291,11 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_classes() == 22);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: small example",
-                     "[056][quick][knuth-bendix][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "056",
+                                   "small example",
+                                   "[quick][knuth-bendix][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -1258,9 +1311,11 @@ namespace libsemigroups {
             == std::vector<std::string>({"a", "b", "aa", "ab", "ba", "bb"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: code coverage",
-                     "[057][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "057",
+                                   "code coverage",
+                                   "[quick]",
+                                   KNUTH_BENDIX_TYPES) {
     KnuthBendix<TestType> kb1;
     KnuthBendix<TestType> kb2(kb1);
     REQUIRE(kb1.number_of_classes() == 0);
@@ -1272,9 +1327,11 @@ namespace libsemigroups {
     REQUIRE(kb3.presentation().rules.size() / 2 == 1);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: small overlap 1",
-                     "[058][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "058",
+                                   "small overlap 1",
+                                   "[quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("BCA");
@@ -1305,9 +1362,11 @@ namespace libsemigroups {
   }
 
   // Symmetric group S_9
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/s9)",
-                     "[059][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "059",
+                                   "kbmag/standalone/kb_data/s9",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -1353,9 +1412,11 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_classes() == 362'880);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: C(4) monoid",
-                     "[060][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "060",
+                                   "C(4) monoid",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     Presentation<std::string> p;
     p.alphabet("abcde");
     presentation::add_rule(p, "bceac", "aeebbc");
@@ -1366,9 +1427,11 @@ namespace libsemigroups {
     REQUIRE(kb.confluent());
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: 1-relation hard case",
-                     "[061][fail][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "061",
+                                   "1-relation hard case",
+                                   "[fail][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -1382,9 +1445,11 @@ namespace libsemigroups {
     REQUIRE(kb.confluent());
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: 1-relation hard case x 2",
-                     "[062][quick][knuth-bendix][no-valgrind]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "062",
+                                   "1-relation hard case x 2",
+                                   "[quick][knuth-bendix][no-valgrind]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.contains_empty_word(true);
@@ -1443,9 +1508,11 @@ namespace libsemigroups {
                  "bdb", "cba", "cbd", "dbc", "bacb", "bdbc", "cbdb", "cbdbc"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: search for a monoid that might not exist",
-                     "[063][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "063",
+                                   "search for a monoid that might not exist",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.contains_empty_word(true);
@@ -1479,12 +1546,14 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_classes() == POSITIVE_INFINITY);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Chinese monoid",
-                     "[064][knuth-bendix][quick][no-valgrind]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "064",
+                                   "Chinese monoid",
+                                   "[knuth-bendix][quick][no-valgrind]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
     // fmt::print(bg(fmt::color::white) | fg(fmt::color::black),
-    //            "[062]: Chinese monoid STARTING . . .\n");
+    //            "062",": Chinese monoid STARTING . . .\n");
 
     std::array<uint64_t, 11> const num
         = {0, 0, 22, 71, 181, 391, 750, 1'317, 2'161, 3'361, 5'006};
@@ -1498,9 +1567,11 @@ namespace libsemigroups {
     }
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: hypostylic",
-                     "[065][todd-coxeter][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "065",
+                                   "hypostylic",
+                                   "[todd-coxeter][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     using namespace literals;
     using words::operator+;
 
@@ -1533,9 +1604,11 @@ namespace libsemigroups {
     //         == to_word_graph<size_t>(5, {{1, 3}, {UNDEFINED, 2}, {}, {4}}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Chinese id monoid",
-                     "[066][todd-coxeter][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "066",
+                                   "Chinese id monoid",
+                                   "[todd-coxeter][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
     auto n  = 4;
     auto p  = fpsemigroup::chinese_monoid(n);
@@ -1550,9 +1623,11 @@ namespace libsemigroups {
     REQUIRE(knuth_bendix::reduce(kb, "cadb") == "cadb");
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: sigma sylvester monoid",
-                     "[067][todd-coxeter][quick][no-valgrind]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "067",
+                                   "sigma sylvester monoid",
+                                   "[todd-coxeter][quick][no-valgrind]",
+                                   KNUTH_BENDIX_TYPES) {
     using namespace literals;
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
@@ -1685,9 +1760,11 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_classes() == 312);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Reinis MFE",
-                     "[027][todd-coxeter][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "027",
+                                   "Reinis MFE",
+                                   "[todd-coxeter][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     using literals::        operator""_w;
     Presentation<word_type> p;
     p.alphabet(2);
@@ -1698,9 +1775,11 @@ namespace libsemigroups {
     REQUIRE(knuth_bendix::contains(kb, "000"_w, "11"_w));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: sigma sylvester monoid x 2",
-                     "[068][todd-coxeter][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "068",
+                                   "sigma sylvester monoid x 2",
+                                   "[todd-coxeter][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     using namespace literals;
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;

--- a/tests/test-knuth-bendix-3.cpp
+++ b/tests/test-knuth-bendix-3.cpp
@@ -39,7 +39,7 @@
 #include <vector>   // for vector, operator==
 
 #include "catch_amalgamated.hpp"  // for operator""_catch_sr
-#include "test-main.hpp"          // for  TEMPLATE_TEST_CASE
+#include "test-main.hpp"          // for  LIBSEMIGROUPS_TEMPLATE_TEST_CASE
 
 #include "libsemigroups/constants.hpp"        // for operator==, PositiveIn...
 #include "libsemigroups/exception.hpp"        // for LibsemigroupsException
@@ -81,10 +81,11 @@ namespace libsemigroups {
     };
   }  // namespace
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: Chapter 11, Lemma 1.8 (q = 6, r = 5) in NR (infinite)",
-      "[069][knuth-bendix][quick]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "069",
+                                   "Chap. 11, Lem. 1.8 (q = 6, r = 5) in NR",
+                                   "[knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ABCabc");
@@ -129,10 +130,11 @@ namespace libsemigroups {
                                          "cc"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Chapter 11, Section 2 (q = 6, r = 2, alpha "
-                     "= abaabba) in NR (size 4)",
-                     "[070][knuth-bendix][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "070",
+                                   "NR Chap. 11, §2 (q=6, r=2, \u03B1=abaabba)",
+                                   "[knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -154,9 +156,11 @@ namespace libsemigroups {
             == std::vector<std::string>({"a", "b", "aa", "ab"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Chapter 8, Theorem 4.2 in NR (infinite) ",
-                     "[071][knuth-bendix][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "071",
+                                   "Chap. 8, Thm. 4.2 in NR ",
+                                   "[knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -192,9 +196,11 @@ namespace libsemigroups {
                                          "bbb"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: equal_to fp semigroup",
-                     "[072][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "072",
+                                   "equal_to fp semigroup",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abc");
@@ -221,9 +227,11 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_classes() == POSITIVE_INFINITY);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: equal_to free semigroup",
-                     "[073][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "073",
+                                   "equal_to free semigroup",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet(2);
@@ -244,10 +252,11 @@ namespace libsemigroups {
     REQUIRE(equal(s, nf));
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: from GAP smalloverlap gap/test.gi (infinite)",
-      "[074][quick][knuth-bendix][smalloverlap]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "074",
+                                   "gap/smalloverlap/gap/test.gi",
+                                   "[quick][knuth-bendix][smalloverlap]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcdefg");
@@ -277,10 +286,11 @@ namespace libsemigroups {
             == std::vector<std::string>({"a", "b", "c", "d", "e", "f", "g"}));
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: from GAP smalloverlap gap/test.gi:49 (infinite)",
-      "[075][quick][knuth-bendix][smalloverlap]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "075",
+                                   "gap/smalloverlap/gap/test.gi:49",
+                                   "[quick][knuth-bendix][smalloverlap]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcdefgh");
@@ -309,10 +319,11 @@ namespace libsemigroups {
         == std::vector<std::string>({"a", "b", "c", "d", "e", "f", "g", "h"}));
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: from GAP smalloverlap gap/test.gi:63 (infinite)",
-      "[076][quick][knuth-bendix][smalloverlap]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "076",
+                                   "gap/smalloverlap/gap/test.gi:63",
+                                   "[quick][knuth-bendix][smalloverlap]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcdefgh");
@@ -338,10 +349,11 @@ namespace libsemigroups {
         == std::vector<std::string>({"a", "b", "c", "d", "e", "f", "g", "h"}));
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: from GAP smalloverlap gap/test.gi:70 (infinite)",
-      "[077][quick][knuth-bendix][smalloverlap]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "077",
+                                   "gap/smalloverlap/gap/test.gi:70",
+                                   "[quick][knuth-bendix][smalloverlap]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
     // The following permits a more complex test of case (6), which also
     // involves using the case (2) code to change the prefix being
@@ -372,9 +384,11 @@ namespace libsemigroups {
                 {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}));
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: from GAP smalloverlap gap/test.gi:77 (infinite)",
-      "[078][quick][knuth-bendix][smalloverlap][no-valgrind]",
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "KnuthBendix",
+      "078",
+      "gap/smalloverlap/gap/test.gi:77",
+      "[quick][knuth-bendix][smalloverlap][no-valgrind]",
       KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
@@ -405,10 +419,11 @@ namespace libsemigroups {
                 {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"}));
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: from GAP smalloverlap gap/test.gi:85 (infinite)",
-      "[079][quick][knuth-bendix][smalloverlap]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "079",
+                                   "gap/pkg/smalloverlap/gap/test.gi:85",
+                                   "[quick][knuth-bendix][smalloverlap]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -431,9 +446,11 @@ namespace libsemigroups {
     REQUIRE(knuth_bendix::normal_forms(kb).min(1).max(6).count() == 356);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Von Dyck (2,3,7) group (infinite)",
-                     "[080][quick][knuth-bendix][kbmag]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "080",
+                                   "Von Dyck (2,3,7) group",
+                                   "[quick][knuth-bendix][kbmag]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -463,10 +480,11 @@ namespace libsemigroups {
             == std::vector<std::string>({"", "A", "B", "a", "b", "c"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Von Dyck (2,3,7) group - different "
-                     "presentation (infinite)",
-                     "[081][no-valgrind][quick][knuth-bendix][kbmag]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "081",
+                                   "Von Dyck (2,3,7) group - alternate",
+                                   "[no-valgrind][quick][knuth-bendix][kbmag]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -491,9 +509,11 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_active_rules() > 250);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: rewriting system from another test",
-                     "[082][quick][knuth-bendix][kbmag]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "082",
+                                   "rewriting system from another test",
+                                   "[quick][knuth-bendix][kbmag]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -544,9 +564,11 @@ namespace libsemigroups {
             == std::vector<std::string>({"a", "b", "c"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: rewriting system from Congruence 20",
-                     "[083][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "083",
+                                   "rewriting system from Congruence 20",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -564,9 +586,11 @@ namespace libsemigroups {
 
   // 2-generator free abelian group (with this ordering KB terminates - but
   // no all)
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/ab2)",
-                     "[084][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "084",
+                                   "(from kbmag/standalone/kb_data/ab2)",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("aAbB");
@@ -593,14 +617,16 @@ namespace libsemigroups {
                  "Ab",  "AB",  "bb",  "BB",  "aaa", "aab", "aaB", "abb", "aBB",
                  "AAA", "AAb", "AAB", "Abb", "ABB", "bbb", "BBB"}));
   }
+
   // This group is actually D_22 (although it wasn't meant to be). All
   // generators are unexpectedly involutory. knuth_bendix does not terminate
   // with the commented out ordering, terminates almost immediately with the
   // uncommented order.
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/d22) (1 / 3)"
-                     "(infinite)",
-                     "[085][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "085",
+                                   "kbmag/standalone/kb_data/d22",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     // Presentation<std::string> p;
@@ -672,9 +698,11 @@ namespace libsemigroups {
   }
 
   // No generators - no anything!
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/degen1)",
-                     "[086][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "086",
+                                   "(from kbmag/standalone/kb_data/degen1)",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     KnuthBendix<TestType> kb;
@@ -689,9 +717,11 @@ namespace libsemigroups {
   }
 
   // Symmetric group S_4
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/s4)",
-                     "[087][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "087",
+                                   "(from kbmag/standalone/kb_data/s4)",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -723,9 +753,11 @@ namespace libsemigroups {
                  "baBa", "Baba", "abaBa", "aBaba", "baBab", "abaBab"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: fp semigroup (infinite)",
-                     "[088][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "088",
+                                   "fp semigroup",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet({0, 1, 2});
@@ -754,10 +786,11 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_classes() == POSITIVE_INFINITY);
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: Chapter 11, Section 1 (q = 4, r = 3) in NR(size 86)",
-      "[089][knuth-bendix][quick]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "089",
+                                   "Chap. 11, Sec. 1 (q = 4, r = 3) in NR",
+                                   "[knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -787,7 +820,7 @@ namespace libsemigroups {
     REQUIRE(knuth_bendix::reduce_no_run(kb, "abbbabb")
             == knuth_bendix::reduce_no_run(kb, "bba"));
 
-    // consequential relations (Chapter 11, Lemma 1.1 in NR)
+    // consequential relations (Chap. 11, Lem. 1.1 in NR)
     REQUIRE(knuth_bendix::reduce_no_run(kb, "babbbb")
             == knuth_bendix::reduce_no_run(kb, "ba"));
     REQUIRE(knuth_bendix::reduce_no_run(kb, "baabbbb")
@@ -810,10 +843,11 @@ namespace libsemigroups {
             == 86);
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: Chapter 11, Section 1 (q = 8, r = 5) in NR (size 746)",
-      "[090][no-valgrind][knuth-bendix][quick]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "090",
+                                   "Chap. 11, Sec. 1 (q = 8, r = 5) in NR",
+                                   "[no-valgrind][knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -839,7 +873,7 @@ namespace libsemigroups {
     REQUIRE(knuth_bendix::reduce_no_run(kb, "abbbbbabb")
             == knuth_bendix::reduce_no_run(kb, "bba"));
 
-    // consequential relations (Chapter 11, Lemma 1.1 in NR)
+    // consequential relations (Chap. 11, Lem. 1.1 in NR)
     REQUIRE(knuth_bendix::reduce_no_run(kb, "babbbbbbbb")
             == knuth_bendix::reduce_no_run(kb, "ba"));
     REQUIRE(knuth_bendix::reduce_no_run(kb, "baabbbbbbbb")
@@ -862,9 +896,11 @@ namespace libsemigroups {
   }
 
   // See KBFP 07 also.
-  TEMPLATE_TEST_CASE("KnuthBendix: Chapter 7, Theorem 3.9 in NR (size 240)",
-                     "[091][no-valgrind][knuth-bendix][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "091",
+                                   "Chap. 7, Thm. 3.9 in NR",
+                                   "[no-valgrind][knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -885,10 +921,11 @@ namespace libsemigroups {
             == 240);
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: F(2, 5) - Chapter 9, Section 1 in NR (size 11) x 2",
-      "[092][knuth-bendix][quick]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "092",
+                                   "F(2, 5) - Chap. 9, Sec. 1 in NR",
+                                   "[knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcde");
@@ -913,9 +950,11 @@ namespace libsemigroups {
             {"a", "b", "c", "d", "e", "aa", "ac", "ad", "bb", "be", "aad"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: F(2, 6) - Chapter 9, Section 1 in NR",
-                     "[093][knuth-bendix][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "093",
+                                   "F(2, 6) - Chap. 9, Sec. 1 in NR",
+                                   "[knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcdef");
@@ -942,9 +981,11 @@ namespace libsemigroups {
             {"", "a", "b", "c", "d", "e", "f", "aa", "ac", "ae", "bd", "df"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Chapter 10, Section 4 in NR (infinite)",
-                     "[094][knuth-bendix][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "094",
+                                   "Chap. 10, Sec. 4 in NR",
+                                   "[knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abc");
@@ -969,10 +1010,11 @@ namespace libsemigroups {
   // Note: the fourth relator in NR's thesis incorrectly has exponent 3, it
   // should be 2. With exponent 3, the presentation defines the trivial group,
   // with exponent of 2, it defines the symmetric group as desired.
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: Sym(5) from Chapter 3, Proposition 1.1 in NR (size 120)",
-      "[095][no-valgrind][knuth-bendix][quick]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "095",
+                                   "Sym(5) - Chap. 3, Prop. 1.1 in NR",
+                                   "[no-valgrind][knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -1007,10 +1049,11 @@ namespace libsemigroups {
                                          "BAb", "BBA", "bAB", "bAb", "bbA"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: SL(2, 7) from Chapter 3, Proposition 1.5 in "
-                     "NR (size 336) x 2",
-                     "[096][no-valgrind][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "096",
+                                   "SL(2, 7) - Chap. 3, Prop. 1.5 in NR",
+                                   "[no-valgrind][quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -1044,9 +1087,11 @@ namespace libsemigroups {
              "bbA", "bAA", "Aba", "AAb", "AAA", "AAB", "ABa", "Baa", "BAA"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: bicyclic monoid (infinite)",
-                     "[097][knuth-bendix][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "097",
+                                   "bicyclic monoid",
+                                   "[knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -1070,9 +1115,11 @@ namespace libsemigroups {
                 {"", "a", "b", "aa", "ba", "bb", "aaa", "baa", "bba", "bbb"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: plactic monoid of degree 2 (infinite)",
-                     "[098][knuth-bendix][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "098",
+                                   "plactic monoid of degree 2",
+                                   "[knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abc");
@@ -1099,10 +1146,11 @@ namespace libsemigroups {
         == std::vector<std::string>({"", "a", "c", "aa", "cc", "aaa", "ccc"}));
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: example before Chapter 7, Proposition 1.1 in NR (infinite)",
-      "[099][knuth-bendix][quick]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "099",
+                                   "before Chap. 7, Prop. 1.1 in NR",
+                                   "[knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -1123,9 +1171,11 @@ namespace libsemigroups {
             == std::vector<std::string>({"a", "b", "ab", "ba", "aba", "bab"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Chapter 7, Theorem 3.6 in NR (size 243)",
-                     "[100][knuth-bendix][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "100",
+                                   "Chap. 7, Thm. 3.6 in NR",
+                                   "[knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -1160,9 +1210,11 @@ namespace libsemigroups {
                                          "bbb"}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: finite semigroup (size 99)",
-                     "[101][knuth-bendix][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "101",
+                                   "finite semigroup",
+                                   "[knuth-bendix][quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -1197,10 +1249,12 @@ namespace libsemigroups {
                                          "bbb"}));
   }
 
-  TEMPLATE_TEST_CASE(
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "KnuthBendix",
+      "999",
       "Giles Gardam in \"A counterexample to the unit conjecture for group "
       "rings\" (https://arxiv.org/abs/2102.11818)",
-      "[999][fail]",
+      "[fail]",
       KNUTH_BENDIX_TYPES) {
     Presentation<std::string> p;
     p.alphabet("bABa");

--- a/tests/test-knuth-bendix-4.cpp
+++ b/tests/test-knuth-bendix-4.cpp
@@ -45,7 +45,7 @@
 #include <vector>         // for vector, operator==
 
 #include "catch_amalgamated.hpp"  // for AssertionHandler, oper...
-#include "test-main.hpp"          // for TEMPLATE_TEST_CASE
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEMPLATE_TEST_CASE
 
 #include "libsemigroups/constants.hpp"        // for operator==, operator!=
 #include "libsemigroups/exception.hpp"        // for LibsemigroupsException
@@ -80,10 +80,11 @@ namespace libsemigroups {
   ////////////////////////////////////////////////////////////////////////
 
   // Takes approx. 2s
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: Example 6.6 in Sims (with limited overlap lengths)",
-      "[102][standard][knuth-bendix]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "102",
+                                   "Sims Ex. 6.6 (limited overlap lengths)",
+                                   "[standard][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -113,9 +114,11 @@ namespace libsemigroups {
   }
 
   // Takes approx. 2s
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/funny3)",
-                     "[103][standard][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "103",
+                                   "kbmag/standalone/kb_data/funny3",
+                                   "[standard][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.contains_empty_word(true);
@@ -151,9 +154,11 @@ namespace libsemigroups {
 
   // Fibonacci group F(2,7) - order 29 - works better with largish tidyint
   // Takes approx. 10s
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: (from kbmag/standalone/kb_data/f27) (finite) (2 / 2)",
-      "[104][extreme][knuth-bendix][kbmag][shortlex]",
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "KnuthBendix",
+      "104",
+      "kbmag/standalone/kb_data/f27) (finite) (2 / 2",
+      "[extreme][knuth-bendix][kbmag][shortlex]",
       KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(true);
 
@@ -182,9 +187,11 @@ namespace libsemigroups {
 
   // Mathieu group M_11
   // Takes approx. 58s (majority in checking confluence)
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/m11)",
-                     "[105][extreme][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "105",
+                                   "kbmag/standalone/kb_data/m11",
+                                   "[extreme][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(true);
 
     Presentation<std::string> p;
@@ -226,9 +233,11 @@ namespace libsemigroups {
 
   // Weyl group E8 (all gens involutory).
   // Takes approx. 5s for KnuthBendix
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/e8)",
-                     "[106][extreme][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "106",
+                                   "kbmag/standalone/kb_data/e8",
+                                   "[extreme][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(true);
 
     Presentation<std::string> p;
@@ -279,9 +288,11 @@ namespace libsemigroups {
   // Works quickest with large value of tidyint
   // Takes > 1m (knuth_bendix), didn't run to the end
   // Takes approx. 6s (knuth_bendix_by_overlap_length)
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/degen4b)",
-                     "[107][extreme][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "107",
+                                   "kbmag/standalone/kb_data/degen4b",
+                                   "[extreme][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(true);
 
     Presentation<std::string> p;
@@ -305,9 +316,11 @@ namespace libsemigroups {
   // value of tidyint works better.
   // Takes approx. 12s (knuth_bendix_by_overlap_length)
   // Takes > 19s (knuth_bendix), didn't run to the end
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/f27_2gen)",
-                     "[108][extreme][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "108",
+                                   "kbmag/standalone/kb_data/f27_2gen",
+                                   "[extreme][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(true);
 
     Presentation<std::string> p;
@@ -327,9 +340,11 @@ namespace libsemigroups {
   }
 
   // Takes approx. 1m8s
-  TEMPLATE_TEST_CASE("KnuthBendix: Example 6.6 in Sims",
-                     "[109][extreme][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "109",
+                                   "Example 6.6 in Sims",
+                                   "[extreme][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.contains_empty_word(true);
@@ -352,9 +367,11 @@ namespace libsemigroups {
 
   // Fibonacci group F(2,7) - without inverses
   // Takes approx. 13s
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: (from kbmag/standalone/kb_data/f27) (infinite) (1 / 2)",
-      "[110][extreme][knuth-bendix][kbmag][shortlex]",
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "KnuthBendix",
+      "110",
+      "kbmag/standalone/kb_data/f27) (infinite) (1 / 2",
+      "[extreme][knuth-bendix][kbmag][shortlex]",
       KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
@@ -381,9 +398,11 @@ namespace libsemigroups {
 
   // An extension of 2^6 be L32
   // Takes approx. 1m7s
-  TEMPLATE_TEST_CASE("KnuthBendix: (from kbmag/standalone/kb_data/l32ext)",
-                     "[111][extreme][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "111",
+                                   "kbmag/standalone/kb_data/l32ext",
+                                   "[extreme][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.contains_empty_word(true);
@@ -416,9 +435,11 @@ namespace libsemigroups {
   // Tests that fail
   ////////////////////////////////////////////////////////////////////////
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Ceitin's undecidable word problem example",
-                     "[112][fail][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "112",
+                                   "Ceitin's undecidable word problem example",
+                                   "[fail][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.contains_empty_word(true);
@@ -436,10 +457,11 @@ namespace libsemigroups {
   }
 
   // kbmag/standalone/kb_data/verifynilp
-  TEMPLATE_TEST_CASE(
-      "(KnuthBendix 050 again) (from kbmag/standalone/kb_data/verifynilp)",
-      "[113][fail][knuth-bendix][kbmag][shortlex]",
-      KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "113",
+                                   "kbmag/standalone/kb_data/verifynilp",
+                                   "[fail][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                rg    = ReportGuard();
     std::string         lphbt = "hHgGfFyYdDcCbBaA";
     std::string         invrs = "HhGgFfYyDdCcBbAa";
@@ -478,9 +500,11 @@ namespace libsemigroups {
     } while (std::next_permutation(perm.begin(), perm.end()));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Sorouhesh",
-                     "[114][quick][knuth-bendix][kbmag][shortlex]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "114",
+                                   "Sorouhesh",
+                                   "[quick][knuth-bendix][kbmag][shortlex]",
+                                   KNUTH_BENDIX_TYPES) {
     using words::pow;
     auto         rg = ReportGuard(false);
     size_t const n  = 2;
@@ -604,9 +628,11 @@ namespace libsemigroups {
     }
   }  // namespace
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: all 2-generated 1-relation semigroups 1 to 10",
-      "[115][fail][knuth-bendix][xxx]",
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "KnuthBendix",
+      "115",
+      "all 2-generated 1-relation semigroups 1 to 10",
+      "[fail][knuth-bendix][xxx]",
       KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
@@ -657,9 +683,11 @@ namespace libsemigroups {
     REQUIRE(total == 2'092'035);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: hard 2-generated 1-relation monoid",
-                     "[116][fail][knuth-bendix][xxx2]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "116",
+                                   "hard 2-generated 1-relation monoid",
+                                   "[fail][knuth-bendix][xxx2]",
+                                   KNUTH_BENDIX_TYPES) {
     Presentation<std::string> p;
     p.contains_empty_word(true);
     p.alphabet("abc");
@@ -672,9 +700,11 @@ namespace libsemigroups {
     REQUIRE(k.active_rules().get() == rule_type({"", ""}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Konovalov",
-                     "[117][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "117",
+                                   "Konovalov",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.contains_empty_word(true);
@@ -687,9 +717,11 @@ namespace libsemigroups {
     REQUIRE(k.number_of_classes() == POSITIVE_INFINITY);
   }
 
-  TEMPLATE_TEST_CASE(
-      "KnuthBendix: https://math.stackexchange.com/questions/2649807",
-      "[118][knuth-bendix][fail]",
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "KnuthBendix",
+      "118",
+      "https://math.stackexchange.com/questions/2649807",
+      "[knuth-bendix][fail]",
       KNUTH_BENDIX_TYPES) {
     do {
       std::string lphbt = "abcABC";
@@ -729,9 +761,11 @@ namespace libsemigroups {
     } while (true);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: example with undecidable word problem",
-                     "[119][knuth-bendix][extreme]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "119",
+                                   "example with undecidable word problem",
+                                   "[knuth-bendix][extreme]",
+                                   KNUTH_BENDIX_TYPES) {
     Presentation<std::string> p;
     p.contains_empty_word(true);
     p.alphabet("ab");
@@ -744,6 +778,7 @@ namespace libsemigroups {
     k.run_for(std::chrono::seconds(10));
     REQUIRE(!k.finished());
   }
+
   LIBSEMIGROUPS_TEST_CASE("KnuthBendix",
                           "136",
                           "partition_monoid(7)",

--- a/tests/test-knuth-bendix-5.cpp
+++ b/tests/test-knuth-bendix-5.cpp
@@ -42,7 +42,7 @@
 #include <vector>         // for vector, operator==
 
 #include "catch_amalgamated.hpp"  // for AssertionHandler, ope...
-#include "test-main.hpp"          // for TEMPLATE_TEST_CASE
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEMPLATE_TEST_CASE
 
 #include "libsemigroups/constants.hpp"        // for operator!=, operator==
 #include "libsemigroups/exception.hpp"        // for LibsemigroupsException
@@ -91,9 +91,11 @@ namespace libsemigroups {
     };
   }  // namespace
 
-  TEMPLATE_TEST_CASE("KnuthBendix: transformation semigroup (size 4)",
-                     "[120][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "120",
+                                   "transformation semigroup (size 4)",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
     auto S  = to_froidure_pin({Transf<>({1, 0}), Transf<>({0, 0})});
     REQUIRE(S.size() == 4);
@@ -109,9 +111,11 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_classes() == 4);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: transformation semigroup (size 9)",
-                     "[121][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "121",
+                                   "transformation semigroup (size 9)",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                  rg = ReportGuard(false);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({1, 3, 4, 2, 3}));
@@ -129,9 +133,11 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_classes() == 9);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: transformation semigroup (size 88)",
-                     "[122][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "122",
+                                   "transformation semigroup (size 88)",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                  rg = ReportGuard(false);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({1, 3, 4, 2, 3}));
@@ -149,9 +155,11 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_classes() == 88);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: internal_string_to_word",
-                     "[123][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "123",
+                                   "internal_string_to_word",
+                                   "[quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                  rg = ReportGuard(false);
     FroidurePin<Transf<>> S;
     S.add_generator(Transf<>({1, 0}));
@@ -165,9 +173,11 @@ namespace libsemigroups {
     REQUIRE(t.generator(0).word(kb) == 0_w);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: internal_string_to_word x 2",
-                     "[124][quick]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "124",
+                                   "internal_string_to_word x 2",
+                                   "[quick]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
     auto S  = to_froidure_pin(
         {Transf<>({1, 3, 4, 2, 3}), Transf<>({3, 2, 1, 3, 3})});
@@ -182,9 +192,11 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_classes() == 88);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: manual onesided congruence",
-                     "[125][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "125",
+                                   "manual onesided congruence",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     using words::operator+;
 
     auto rg = ReportGuard(false);
@@ -278,9 +290,11 @@ namespace libsemigroups {
              {1000100_w, 01000110_w, 10001100_w, 001000100_w, 010001000_w}}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: onesided congruence!!!",
-                     "[126][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "126",
+                                   "onesided congruence!!!",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     using words::operator+;
 
     auto rg = ReportGuard(false);
@@ -384,9 +398,11 @@ namespace libsemigroups {
              {1000100_w, 01000110_w, 10001100_w, 001000100_w, 010001000_w}}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: manual left congruence!!!",
-                     "[127][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "127",
+                                   "manual left congruence!!!",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     using words::operator+;
 
     auto rg = ReportGuard(false);
@@ -447,9 +463,11 @@ namespace libsemigroups {
     REQUIRE(kb.gilman_graph().number_of_nodes() == 51);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: automatic left congruence!!!",
-                     "[128][quick][knuth-bendix][no-valgrind]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "128",
+                                   "automatic left congruence!!!",
+                                   "[quick][knuth-bendix][no-valgrind]",
+                                   KNUTH_BENDIX_TYPES) {
     using words::operator+;
 
     auto rg = ReportGuard(false);

--- a/tests/test-knuth-bendix-6.cpp
+++ b/tests/test-knuth-bendix-6.cpp
@@ -37,7 +37,7 @@
 #include <vector>   // for vector
 
 #include "catch_amalgamated.hpp"  // for operator""_catch_sr
-#include "test-main.hpp"          // for TEMPLATE_TEST_CASE
+#include "test-main.hpp"          // for LIBSEMIGROUPS_TEMPLATE_TEST_CASE
 
 #include "libsemigroups/constants.hpp"        // for operator==, Max, POSIT...
 #include "libsemigroups/fpsemi-examples.hpp"  // for partial_transformation...
@@ -60,9 +60,11 @@ namespace libsemigroups {
 
 #define KNUTH_BENDIX_TYPES RewriteTrie, RewriteFromLeft
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Presentation<word_type>",
-                     "[129][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "129",
+                                   "Presentation<word_type>",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<word_type> p;
@@ -83,9 +85,11 @@ namespace libsemigroups {
     REQUIRE(!knuth_bendix::contains(kb, 0000_w, 000_w));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: free semigroup congruence (6 classes)",
-                     "[130][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "130",
+                                   "free semigroup congruence (6 classes)",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(5);
@@ -114,9 +118,11 @@ namespace libsemigroups {
     // more than 255 generators
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: free semigroup congruence (16 classes)",
-                     "[131][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "131",
+                                   "free semigroup congruence (16 classes)",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     Presentation<word_type> p;
@@ -150,9 +156,11 @@ namespace libsemigroups {
     REQUIRE(knuth_bendix::contains(kb, 2_w, 3_w));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: free semigroup congruence (6 classes) x 2",
-                     "[132][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "132",
+                                   "free semigroup congruence x 2",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(11);
@@ -191,9 +199,11 @@ namespace libsemigroups {
     REQUIRE(knuth_bendix::contains(kb, {3}, {9}));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: free semigroup congruence (240 classes)",
-                     "[133][no-valgrind][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "133",
+                                   "free semigroup congruence (240 classes)",
+                                   "[no-valgrind][quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -207,9 +217,11 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_classes() == 240);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: free semigroup congruence (240 classes) x 2",
-                     "[134][no-valgrind][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "134",
+                                   "free semigroup congruence x 2",
+                                   "[no-valgrind][quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -223,9 +235,11 @@ namespace libsemigroups {
     REQUIRE_NOTHROW(to_froidure_pin(kb));
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: constructors",
-                     "[135][quick][knuth-bendix][no-valgrind]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "135",
+                                   "constructors",
+                                   "[quick][knuth-bendix][no-valgrind]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -244,9 +258,11 @@ namespace libsemigroups {
     REQUIRE(copy.number_of_active_rules() == 105);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: to_froidure_pin",
-                     "[136][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "136",
+                                   "to_froidure_pin",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -258,9 +274,11 @@ namespace libsemigroups {
     REQUIRE(to_froidure_pin(kb).size() == 12);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: number of classes when obv-inf",
-                     "[137][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "137",
+                                   "number of classes when obv-inf",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(3);
@@ -281,9 +299,11 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_classes() == POSITIVE_INFINITY);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: Chinese monoid x 2",
-                     "[138][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "138",
+                                   "Chinese monoid x 2",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p  = fpsemigroup::chinese_monoid(3);
 
@@ -295,9 +315,11 @@ namespace libsemigroups {
     REQUIRE(nf.count() == 1'175);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: partial_transformation_monoid(4)",
-                     "[139][standard][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "139",
+                                   "partial_transformation_monoid(4)",
+                                   "[standard][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(false);
 
     size_t n = 4;
@@ -313,9 +335,11 @@ namespace libsemigroups {
   }
 
   // Takes about 1 minute
-  TEMPLATE_TEST_CASE("KnuthBendix: partial_transformation_monoid5",
-                     "[140][extreme][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "140",
+                                   "partial_transformation_monoid5",
+                                   "[extreme][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(true);
 
     size_t n = 5;
@@ -327,9 +351,11 @@ namespace libsemigroups {
   }
 
   // Takes about 5 seconds
-  TEMPLATE_TEST_CASE("KnuthBendix: full_transformation_monoid Iwahori",
-                     "[141][extreme][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "141",
+                                   "full_transformation_monoid Iwahori",
+                                   "[extreme][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     auto rg = ReportGuard(true);
 
     size_t n = 5;
@@ -341,9 +367,11 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_classes() == 3'125);
   }
 
-  TEMPLATE_TEST_CASE("KnuthBendix: constructors/init for finished x 2",
-                     "[142][quick][knuth-bendix]",
-                     KNUTH_BENDIX_TYPES) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "142",
+                                   "constructors/init for finished x 2",
+                                   "[quick][knuth-bendix]",
+                                   KNUTH_BENDIX_TYPES) {
     using literals::operator""_w;
     auto            rg = ReportGuard(false);
 

--- a/tests/test-konieczny-bmat.cpp
+++ b/tests/test-konieczny-bmat.cpp
@@ -29,123 +29,55 @@ namespace libsemigroups {
 
   constexpr bool REPORT = false;
 
-  ////////////////////////////////////////////////////////////////////////
-  // Test functions
-  ////////////////////////////////////////////////////////////////////////
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Konieczny",
+                                   "000",
+                                   "4x4 boolean matrix semigroup (size 26)",
+                                   "[quick][bmat]",
+                                   BMat<>,
+                                   BMat<4>) {
+    auto                  rg = ReportGuard(REPORT);
+    std::vector<TestType> gens
+        = {TestType({{0, 1, 0, 1}, {1, 0, 0, 0}, {0, 1, 1, 1}, {0, 1, 1, 0}}),
+           TestType({{0, 1, 1, 1}, {1, 1, 0, 0}, {0, 0, 0, 0}, {1, 1, 1, 1}}),
+           TestType({{0, 1, 1, 0}, {0, 1, 1, 0}, {0, 1, 1, 1}, {1, 1, 1, 1}})};
 
-  namespace {
+    Konieczny<TestType> S(gens);
+    REQUIRE(S.size() == 26);
+  }
 
-    template <typename Mat>
-    void test000() {
-      auto             rg = ReportGuard(REPORT);
-      std::vector<Mat> gens
-          = {Mat({{0, 1, 0, 1}, {1, 0, 0, 0}, {0, 1, 1, 1}, {0, 1, 1, 0}}),
-             Mat({{0, 1, 1, 1}, {1, 1, 0, 0}, {0, 0, 0, 0}, {1, 1, 1, 1}}),
-             Mat({{0, 1, 1, 0}, {0, 1, 1, 0}, {0, 1, 1, 1}, {1, 1, 1, 1}})};
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Konieczny",
+                                   "002",
+                                   "4x4 boolean matrix semigroup (size 415)",
+                                   "[quick][bmat][no-valgrind]",
+                                   BMat<>,
+                                   BMat<4>) {
+    auto                  rg = ReportGuard(REPORT);
+    std::vector<TestType> gens
+        = {TestType({{1, 0, 0, 0}, {0, 0, 1, 0}, {1, 0, 0, 1}, {0, 1, 0, 0}}),
+           TestType({{1, 0, 0, 1}, {1, 0, 0, 1}, {1, 1, 1, 1}, {0, 1, 1, 0}}),
+           TestType({{1, 0, 1, 0}, {1, 0, 1, 1}, {0, 0, 1, 1}, {0, 1, 0, 1}}),
+           TestType({{0, 0, 0, 0}, {0, 1, 0, 1}, {1, 1, 1, 0}, {1, 0, 0, 1}}),
+           TestType({{0, 0, 0, 1}, {0, 0, 1, 0}, {1, 0, 0, 1}, {1, 1, 0, 0}})};
 
-      Konieczny<Mat> S(gens);
-      REQUIRE(S.size() == 26);
+    Konieczny<TestType> S(gens);
+    REQUIRE(S.size() == 415);
+  }
+
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
+      "Konieczny",
+      "004",
+      "40x40 boolean matrix semigroup (size 248'017)",
+      "[extreme][bmat]",
+      BMat<40>,
+      BMat<>) {
+    auto                rg = ReportGuard(true);
+    Konieczny<TestType> S;
+    for (auto const& v : konieczny_data::clark_gens) {
+      S.add_generator(TestType(v));
     }
-
-    template <typename Mat>
-    void test001() {
-      auto             rg = ReportGuard(REPORT);
-      std::vector<Mat> gens
-          = {Mat({{1, 0, 0, 0}, {0, 0, 1, 0}, {1, 0, 0, 1}, {0, 1, 0, 0}}),
-             Mat({{1, 0, 0, 1}, {1, 0, 0, 1}, {1, 1, 1, 1}, {0, 1, 1, 0}}),
-             Mat({{1, 0, 1, 0}, {1, 0, 1, 1}, {0, 0, 1, 1}, {0, 1, 0, 1}}),
-             Mat({{0, 0, 0, 0}, {0, 1, 0, 1}, {1, 1, 1, 0}, {1, 0, 0, 1}}),
-             Mat({{0, 0, 0, 1}, {0, 0, 1, 0}, {1, 0, 0, 1}, {1, 1, 0, 0}})};
-
-      Konieczny<Mat> S(gens);
-      REQUIRE(S.size() == 415);
-    }
-
-    template <typename Mat>
-    void test002() {
-      auto           rg = ReportGuard(true);
-      Konieczny<Mat> S;
-      for (auto const& v : konieczny_data::clark_gens) {
-        S.add_generator(Mat(v));
-      }
-      REQUIRE(S.generator(0).number_of_rows() == 40);
-      S.run();
-      REQUIRE(S.size() == 248017);
-    }
-
-    template <typename Mat>
-    void test003() {
-      auto             rg   = ReportGuard(REPORT);
-      std::vector<Mat> gens = {Mat({{0, 1, 1, 1, 0},
-                                    {0, 0, 1, 0, 0},
-                                    {1, 0, 0, 1, 0},
-                                    {1, 1, 1, 0, 0},
-                                    {0, 1, 1, 1, 1}}),
-                               Mat({{0, 0, 0, 1, 0},
-                                    {0, 0, 1, 0, 0},
-                                    {1, 0, 0, 0, 0},
-                                    {0, 0, 0, 0, 0},
-                                    {0, 1, 0, 1, 1}}),
-                               Mat({{0, 0, 0, 1, 0},
-                                    {1, 1, 0, 0, 0},
-                                    {0, 0, 1, 1, 1},
-                                    {1, 1, 0, 0, 1},
-                                    {0, 0, 1, 1, 0}}),
-                               Mat({{0, 1, 0, 0, 1},
-                                    {0, 0, 1, 0, 1},
-                                    {1, 0, 1, 0, 0},
-                                    {0, 1, 1, 1, 0},
-                                    {1, 0, 0, 0, 1}})};
-
-      Konieczny<Mat> S(gens);
-      REQUIRE(S.size() == 513);
-    }
-  }  // namespace
-
-  ////////////////////////////////////////////////////////////////////////
-  // Test cases
-  ////////////////////////////////////////////////////////////////////////
-
-  LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "000",
-                          "test000<BMat<>>",
-                          "[quick][bmat]") {
-    test000<BMat<>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "001",
-                          "test000<BMat<4>>",
-                          "[quick][bmat]") {
-    test000<BMat<4>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "002",
-                          "test001<BMat<>>",
-                          "[quick][bmat][no-valgrind]") {
-    test001<BMat<>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "003",
-                          "test001<BMat<4>>",
-                          "[quick][bmat][no-valgrind]") {
-    test001<BMat<4>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "004",
-                          "BMat<>: generators from Sean Clark",
-                          "[extreme][bmat]") {
-    test002<BMat<>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "005",
-                          "BMat<40>: generators from Sean Clark",
-                          "[extreme][bmat]") {
-    test002<BMat<40>>();
+    REQUIRE(S.generator(0).number_of_rows() == 40);
+    S.run();
+    REQUIRE(S.size() == 248'017);
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny", "006", "exceptions", "[quick][bmat]") {
@@ -158,17 +90,35 @@ namespace libsemigroups {
     // This doesn't throw when using BMat<4>, so there's no test for that
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "007",
-                          "code coverage",
-                          "[quick][bmat][no-valgrind]") {
-    test003<BMat<>>();
-  }
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Konieczny",
+                                   "007",
+                                   "5x5 boolean matrix semigroup (size 513)",
+                                   "[quick][bmat][no-valgrind]",
+                                   BMat<>,
+                                   BMat<5>) {
+    auto                  rg   = ReportGuard(REPORT);
+    std::vector<TestType> gens = {TestType({{0, 1, 1, 1, 0},
+                                            {0, 0, 1, 0, 0},
+                                            {1, 0, 0, 1, 0},
+                                            {1, 1, 1, 0, 0},
+                                            {0, 1, 1, 1, 1}}),
+                                  TestType({{0, 0, 0, 1, 0},
+                                            {0, 0, 1, 0, 0},
+                                            {1, 0, 0, 0, 0},
+                                            {0, 0, 0, 0, 0},
+                                            {0, 1, 0, 1, 1}}),
+                                  TestType({{0, 0, 0, 1, 0},
+                                            {1, 1, 0, 0, 0},
+                                            {0, 0, 1, 1, 1},
+                                            {1, 1, 0, 0, 1},
+                                            {0, 0, 1, 1, 0}}),
+                                  TestType({{0, 1, 0, 0, 1},
+                                            {0, 0, 1, 0, 1},
+                                            {1, 0, 1, 0, 0},
+                                            {0, 1, 1, 1, 0},
+                                            {1, 0, 0, 0, 1}})};
 
-  LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "008",
-                          "code coverage",
-                          "[quick][bmat][no-valgrind]") {
-    test003<BMat<5>>();
+    Konieczny<TestType> S(gens);
+    REQUIRE(S.size() == 513);
   }
 }  // namespace libsemigroups

--- a/tests/test-main.cpp
+++ b/tests/test-main.cpp
@@ -110,7 +110,7 @@ struct LibsemigroupsListener : Catch::EventListenerBase {
 
     SectionStats(Catch::SectionStats const& ss, SectionInfo const& si)
         : duration(std::chrono::nanoseconds(
-              static_cast<uint64_t>(ss.durationInSeconds * std::pow(10, 9)))),
+            static_cast<uint64_t>(ss.durationInSeconds * std::pow(10, 9)))),
           name(si.name) {}
   };
 

--- a/tests/test-main.cpp
+++ b/tests/test-main.cpp
@@ -119,7 +119,7 @@ struct LibsemigroupsListener : Catch::EventListenerBase {
       name   = testInfo.name;
       number = find_tag_starting_with(testInfo, LIBSEMIGROUPS_TEST_NUM);
 
-      for (std::string const& cat : {"quick", "standard", "extreme", "fail"}) {
+      for (char const* cat : {"quick", "standard", "extreme", "fail"}) {
         if (find_tag(testInfo, cat)) {
           category = cat;
           break;
@@ -206,7 +206,7 @@ struct LibsemigroupsListener : Catch::EventListenerBase {
 
     SectionStats(Catch::SectionStats const& ss, SectionInfo const& si)
         : duration(std::chrono::nanoseconds(
-            static_cast<uint64_t>(ss.durationInSeconds * std::pow(10, 9)))),
+              static_cast<uint64_t>(ss.durationInSeconds * std::pow(10, 9)))),
           name(si.name) {}
   };
 

--- a/tests/test-main.cpp
+++ b/tests/test-main.cpp
@@ -206,7 +206,7 @@ struct LibsemigroupsListener : Catch::EventListenerBase {
 
     SectionStats(Catch::SectionStats const& ss, SectionInfo const& si)
         : duration(std::chrono::nanoseconds(
-              static_cast<uint64_t>(ss.durationInSeconds * std::pow(10, 9)))),
+            static_cast<uint64_t>(ss.durationInSeconds * std::pow(10, 9)))),
           name(si.name) {}
   };
 

--- a/tests/test-main.cpp
+++ b/tests/test-main.cpp
@@ -34,70 +34,7 @@
 #include "libsemigroups/detail/string.hpp"  // for to_string, unicode_string_length
 #include "libsemigroups/detail/timer.hpp"  // for Timer
 
-struct LibsemigroupsListener : Catch::EventListenerBase {
-  using EventListenerBase::EventListenerBase;  // inherit constructor
-
-  void extreme_test_divider(std::string_view sv) const {
-    using libsemigroups::detail::unicode_string_length;
-    auto msg  = fmt::format(fmt::emphasis::bold,
-                           "* [{}]: {} - {} *\n",
-                           test_number(),
-                           test_name(),
-                           sv);
-    auto rule = fmt::format(
-        fmt::emphasis::bold, "{:*^{w}}\n", "", fmt::arg("w", msg.size() - 9));
-    fmt::print(rule + msg + rule);
-  }
-
-  std::string_view test_name(Catch::TestCaseInfo const& testInfo) {
-    _test_name = testInfo.name;
-    return _test_name;
-  }
-
-  std::string_view test_name() const {
-    return _test_name;
-  }
-
-  std::string_view test_number(Catch::TestCaseInfo const& testInfo) {
-    for (auto const& tag : testInfo.tags) {
-      if (tag.original.size() == 3
-          && std::all_of(tag.original.begin(),
-                         tag.original.end(),
-                         [](auto const& c) { return std::isdigit(c); })) {
-        _test_number = std::string(tag.original);
-        return _test_number;
-      }
-    }
-    return "";
-  }
-
-  std::string_view test_number() const {
-    return _test_number;
-  }
-
-  std::string_view test_category(Catch::TestCaseInfo const& testInfo) {
-    if (find_tag(testInfo, "quick")) {
-      _test_category = "quick";
-    } else if (find_tag(testInfo, "standard")) {
-      _test_category = "standard";
-    } else if (find_tag(testInfo, "extreme")) {
-      _test_category = "extreme";
-    } else if (find_tag(testInfo, "fail")) {
-      _test_category = "fail";
-    }
-    return _test_category;
-  }
-
-  std::string_view test_category() const {
-    return _test_category;
-  }
-
-  std::string section_time(Catch::SectionStats const& sectionStats) {
-    auto t = static_cast<uint64_t>(sectionStats.durationInSeconds
-                                   * std::pow(10, 9));
-    return libsemigroups::detail::string_time(std::chrono::nanoseconds(t));
-  }
-
+namespace {
   bool find_tag(Catch::TestCaseInfo const& testInfo, std::string tag) {
     std::transform(tag.begin(), tag.end(), tag.begin(), ::tolower);
 
@@ -113,9 +50,90 @@ struct LibsemigroupsListener : Catch::EventListenerBase {
                         })
            != testInfo.tags.cend();
   }
+}  // namespace
+
+struct LibsemigroupsListener : Catch::EventListenerBase {
+  using EventListenerBase::EventListenerBase;  // inherit constructor
+
+  // Catch::TestCaseInfo is non-copyable so we have our own version here.
+  struct TestCaseInfo {
+    std::string category;
+    std::string name;
+    std::string number;
+
+    TestCaseInfo() = default;
+
+    explicit TestCaseInfo(Catch::TestCaseInfo const& testInfo)
+        : TestCaseInfo() {
+      *this = testInfo;
+    }
+
+    TestCaseInfo& operator=(Catch::TestCaseInfo const& testInfo) {
+      name = testInfo.name;
+      for (auto const& tag : testInfo.tags) {
+        if (tag.original.size() == 3
+            && std::all_of(tag.original.begin(),
+                           tag.original.end(),
+                           [](auto const& c) { return std::isdigit(c); })) {
+          number = std::string(tag.original);
+          break;
+        }
+      }
+
+      for (std::string const& cat : {"quick", "standard", "extreme", "fail"}) {
+        if (find_tag(testInfo, cat)) {
+          category = cat;
+          break;
+        }
+      }
+      return *this;
+    }
+  };
+
+  // Catch::SectionInfo is non-copyable so we have our own version here.
+  struct SectionInfo {
+    std::string name;
+
+    SectionInfo& operator=(Catch::SectionInfo const& si) {
+      name = si.name;
+      return *this;
+    }
+  };
+
+  // Catch::SectionStats is non-copyable so we have our own version here.
+  struct SectionStats {
+    std::chrono::nanoseconds duration;
+    std::string              name;
+    // We could store the SectionStats.sectionInfo here instead of "name", but
+    // the name we want is the most nested one, and the
+    // SectionStats.sectionInfo.name is the least nested one.
+
+    SectionStats(Catch::SectionStats const& ss, SectionInfo const& si)
+        : duration(std::chrono::nanoseconds(
+              static_cast<uint64_t>(ss.durationInSeconds * std::pow(10, 9)))),
+          name(si.name) {}
+  };
+
+  void print_extreme_test_divider(std::string_view sv) const {
+    auto msg  = fmt::format(_extreme_emph,
+                           "[{}]: {} - {}\n",
+                           current_test_case_info().number,
+                           current_test_case_info().name,
+                           sv);
+    auto rule = fmt::format(
+        _extreme_emph, "{:=>{}}\n", "", std::max(_line_cols, msg.size() - 9));
+    fmt::print(rule + msg + rule);
+  }
 
   // Not currently used
   // void check_category(Catch::TestCaseInfo const& testInfo) {
+  //     for (std::string const& cat : {"quick", "standard", "extreme", "fail"})
+  //     {
+  //       if (find_tag(testInfo, cat)) {
+  //         category = cat;
+  //         break;
+  //       }
+  //     }
   //   if (!(find_tag(testInfo, "quick") || find_tag(testInfo, "standard")
   //         || find_tag(testInfo, "extreme") || find_tag(testInfo, "fail"))) {
   //     {
@@ -129,93 +147,147 @@ struct LibsemigroupsListener : Catch::EventListenerBase {
   //   }
   // }
 
-  void init_test_case(Catch::TestCaseInfo const& testInfo) {
-    test_name(testInfo);
-    test_number(testInfo);
-    test_category(testInfo);
-    _section_number = 0;
-    _test_time      = 0;
+  void set_current_test_case_info(Catch::TestCaseInfo const& testInfo) {
+    _current_test_case_info = testInfo;
+    _section_depth          = 0;
+  }
+
+  TestCaseInfo const& current_test_case_info() const noexcept {
+    return _current_test_case_info;
+  }
+
+  void set_most_recent_section_info(Catch::SectionInfo const& sectionInfo) {
+    _most_recent_section_info = sectionInfo;
+  }
+
+  SectionInfo const& most_recent_section_info() const {
+    return _most_recent_section_info;
+  }
+
+  std::string string_current_test_case_info() const {
+    auto const prefix = fmt::format("[{}]: ", current_test_case_info().number);
+    auto const prefix_pad = _prefix_cols - prefix.size() - 1;
+
+    std::string const trunc_name(
+        current_test_case_info().name.begin(),
+        current_test_case_info().name.begin()
+            + std::min(prefix_pad, current_test_case_info().name.size()));
+    // This is the prefix of length (_line_cols - _time_cols)
+    return fmt::format("{}{:<{}} ", prefix, trunc_name, prefix_pad);
   }
 
   void testCaseStarting(Catch::TestCaseInfo const& testInfo) override {
-    init_test_case(testInfo);
-    if (test_category() != "extreme") {
-      auto const prefix_prefix = fmt::format("[{}]: ", test_number());
-      auto const prefix_pad    = prefix_cols - prefix_prefix.size() - 1;
-
-      std::string const trunc_name(
-          testInfo.name.begin(),
-          testInfo.name.begin() + std::min(prefix_pad, testInfo.name.size()));
-      // This is the prefix of length (line_cols - time_cols)
-      fmt::print("{}{:<{}} ", prefix_prefix, trunc_name, prefix_pad);
+    _current_section_name = testInfo.name;
+    set_current_test_case_info(testInfo);
+    if (current_test_case_info().category != "extreme") {
+      fmt::print("{}", string_current_test_case_info());
     } else {
-      extreme_test_divider("START");
+      print_extreme_test_divider("START");
     }
   }
 
   void sectionStarting(Catch::SectionInfo const& sectionInfo) override {
-    if (test_category() != "extreme" && _section_number == 1) {
-      constexpr std::string_view prefix_prefix = "\n-- with ";
-      auto const prefix_pad = prefix_cols - prefix_prefix.size() + 1;
-
-      fmt::print("{}{: <{}}", prefix_prefix, sectionInfo.name, prefix_pad);
+    // TODO handle arbitrary depth subsections
+    set_most_recent_section_info(sectionInfo);
+    if (current_test_case_info().category != "extreme") {
+      if (_section_depth == 1 && _current_section_name != sectionInfo.name) {
+        _current_section_name             = sectionInfo.name;
+        constexpr std::string_view prefix = "\n-- with ";
+        auto const prefix_pad             = _prefix_cols - prefix.size() + 1;
+        fmt::print("{}{: <{}}", prefix, sectionInfo.name, prefix_pad);
+      } else if (_section_depth == 2) {
+        constexpr std::string_view prefix = "\n---- ";
+        auto const prefix_pad             = _prefix_cols - prefix.size() + 1;
+        fmt::print("{}{: <{}}", prefix, sectionInfo.name, prefix_pad);
+      }
+    } else {
+      if (_section_depth > 0) {
+        print_extreme_test_divider(sectionInfo.name + " - START");
+      }
     }
-    _section_number++;
+    _section_depth++;
   }
 
   void sectionEnded(Catch::SectionStats const& sectionStats) override {
-    auto section_ns = static_cast<uint64_t>(sectionStats.durationInSeconds
-                                            * std::pow(10, 9));
-    _total_time += section_ns;
-    _test_time += section_ns;
-    if (test_category() != "extreme") {
-      if (_section_number == 1) {
-        fmt::print("{:.>{}}", section_time(sectionStats), time_cols);
+    using libsemigroups::detail::string_time;
+
+    _section_depth--;
+
+    if (_section_depth == 0) {
+      _section_stats.emplace_back(sectionStats, most_recent_section_info());
+      _total_time += _section_stats.back().duration;
+      std::string section_duration
+          = string_time(_section_stats.back().duration);
+      if (current_test_case_info().category != "extreme") {
+        fmt::print("{:.>{}}", section_duration, _time_cols);
+      } else {
+        if (most_recent_section_info().name != current_test_case_info().name) {
+          // In this case the leaf section that was run was a proper
+          // subsection, and not just the entire test case, so we print the end
+          // of that proper subsection.
+          print_extreme_test_divider(most_recent_section_info().name + " - "
+                                     + section_duration + " - STOP");
+        }
       }
-    } else {
-      extreme_test_divider("END - " + section_time(sectionStats));
     }
-    _section_number--;
   }
 
   void testCaseEnded(Catch::TestCaseStats const&) override {
-    if (test_category() != "extreme") {
+    using libsemigroups::detail::string_time;
+
+    if (current_test_case_info().category == "extreme") {
+      auto section_duration = string_time(_total_time);
+
+      print_extreme_test_divider(section_duration + " - STOP");
+      if (_section_stats.size() > 1) {
+        fmt::print(_extreme_emph, "{:=>{}}\n", "", _line_cols);
+        fmt::print(
+            _extreme_emph, "Summary for {}", string_current_test_case_info());
+        constexpr std::string_view prefix = "\n-- with ";
+        for (SectionStats const& ss : _section_stats) {
+          auto const prefix_pad = _prefix_cols - prefix.size() + 1;
+          fmt::print(_extreme_emph, "{}{: <{}}", prefix, ss.name, prefix_pad);
+          fmt::print(
+              _extreme_emph, "{:.>{}}", string_time(ss.duration), _time_cols);
+        }
+        fmt::print(_extreme_emph, "\n{:=>{}}", "", _line_cols);
+        fmt::print("\n");
+      }
+    } else {
       fmt::print("\n");
     }
-    // TODO(0) not sure if this is required or not
-    // else {
-    //  extreme_test_divider("END - "
-    //                       + libsemigroups::detail::string_time(
-    //                           std::chrono::nanoseconds(_test_time)));
-    // }
+    _section_stats.clear();
   }
 
   void testRunEnded(Catch::TestRunStats const&) override {
     using libsemigroups::detail::string_time;
-    using std::chrono::nanoseconds;
 
-    auto const emph
-        = fmt::emphasis::bold | fg(fmt::terminal_color::bright_green);
-    constexpr std::string_view prefix = "Total time ";
-    auto const                 t      = string_time(nanoseconds(_total_time));
-    auto const                 prefix_pad = line_cols - prefix.size();
+    constexpr std::string_view prefix     = "Total time ";
+    auto const                 t          = string_time(_total_time);
+    auto const                 prefix_pad = _line_cols - prefix.size();
 
-    fmt::print(emph, "{:=>{}}\n", "", line_cols);
-    fmt::print(emph, "{}{:.>{}}\n", prefix, t, prefix_pad);
+    fmt::print(_run_end_emph, "{:=>{}}\n", "", _line_cols);
+    fmt::print(_run_end_emph, "{}{:.>{}}\n", prefix, t, prefix_pad);
+    // The following =s fill in the line printed by catch to make it the same
+    // width as _line_cols
+    fmt::print(_run_end_emph, "{:=>{}}", "", _line_cols - 79);
   }
 
-  size_t _total_time = 0;
+  std::chrono::nanoseconds _total_time = std::chrono::nanoseconds(0);
+  size_t                   _section_depth;
+  std::string              _current_section_name;
 
-  size_t _section_number;
+  TestCaseInfo              _current_test_case_info;
+  SectionInfo               _most_recent_section_info;
+  std::vector<SectionStats> _section_stats;
 
-  std::string _test_name;
-  std::string _test_number;
-  std::string _test_category;
-  uint64_t    _test_time;
+  static constexpr size_t _line_cols   = 90;
+  static constexpr size_t _time_cols   = 12;
+  static constexpr size_t _prefix_cols = _line_cols - _time_cols;
 
-  static constexpr size_t line_cols   = 79;
-  static constexpr size_t time_cols   = 12;
-  static constexpr size_t prefix_cols = line_cols - time_cols;
+  static constexpr auto _extreme_emph = fmt::emphasis::bold;
+  static constexpr auto _run_end_emph
+      = fmt::emphasis::bold | fg(fmt::terminal_color::bright_green);
 };
 
 CATCH_REGISTER_LISTENER(LibsemigroupsListener)

--- a/tests/test-main.hpp
+++ b/tests/test-main.hpp
@@ -16,28 +16,34 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include <type_traits>  // for is_reference
+
 #ifndef LIBSEMIGROUPS_TESTS_TEST_MAIN_HPP_
 #define LIBSEMIGROUPS_TESTS_TEST_MAIN_HPP_
 
 #define CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS
-#include "libsemigroups/paths.hpp"
-#include "libsemigroups/runner.hpp"
-#include "libsemigroups/types.hpp"
 
 #define STR2(X) #X
 #define STR(X) STR2(X)
 
-// TODO(0) remove the nr from the prefix
+#define LIBSEMIGROUPS_TEST_NUM "LIBSEMIGROUPS_TEST_NUM="
+#define LIBSEMIGROUPS_TEST_PREFIX "LIBSEMIGROUPS_TEST_PREFIX="
 
-#define LIBSEMIGROUPS_TEST_CASE(classname, nr, msg, tags)             \
-  TEST_CASE(classname " " nr ": " msg,                                \
-            "[" classname " " nr "][" classname "][" nr "][" __FILE__ \
-            "][" STR(__LINE__) "]" tags)
+// Note that TEST_NUM_ID and TEST_PREFIX_ID allow us to locate these
+// tags in the listener
+#define LIBSEMIGROUPS_TEST_CASE(classname, nr, msg, tags)                 \
+  TEST_CASE(classname ": " msg,                                           \
+            "[" LIBSEMIGROUPS_TEST_PREFIX classname " " nr "][" classname \
+            " " nr "][" classname "][" nr "][" LIBSEMIGROUPS_TEST_NUM nr  \
+            "][" __FILE__ "][" STR(__LINE__) "]" tags)
 
-#define LIBSEMIGROUPS_TEST_CASE_V3(classname, nr, msg, tags)          \
-  TEST_CASE(classname ": " msg,                                       \
-            "[" classname " " nr "][" classname "][" nr "][" __FILE__ \
-            "][" STR(__LINE__) "]" tags)
+#define LIBSEMIGROUPS_TEMPLATE_TEST_CASE(classname, nr, msg, tags, ...) \
+  TEMPLATE_TEST_CASE(classname ": " msg,                                \
+                     "[" LIBSEMIGROUPS_TEST_PREFIX classname " " nr     \
+                     "][" classname " " nr "][" classname "][" nr       \
+                     "][" LIBSEMIGROUPS_TEST_NUM nr "][" __FILE__       \
+                     "][" STR(__LINE__) "]" tags,                       \
+                     __VA_ARGS__)
 
 namespace libsemigroups {
 
@@ -69,27 +75,5 @@ namespace libsemigroups {
     REQUIRE(*it == *copy);
   }
 }  // namespace libsemigroups
-
-CATCH_REGISTER_ENUM(libsemigroups::tril,
-                    libsemigroups::tril::TRUE,
-                    libsemigroups::tril::FALSE,
-                    libsemigroups::tril::unknown);
-
-CATCH_REGISTER_ENUM(libsemigroups::paths::algorithm,
-                    libsemigroups::paths::algorithm::dfs,
-                    libsemigroups::paths::algorithm::matrix,
-                    libsemigroups::paths::algorithm::acyclic,
-                    libsemigroups::paths::algorithm::automatic,
-                    libsemigroups::paths::algorithm::trivial)
-
-CATCH_REGISTER_ENUM(libsemigroups::Runner::state,
-                    libsemigroups::Runner::state::never_run,
-                    libsemigroups::Runner::state::running_to_finish,
-                    libsemigroups::Runner::state::running_for,
-                    libsemigroups::Runner::state::running_until,
-                    libsemigroups::Runner::state::timed_out,
-                    libsemigroups::Runner::state::stopped_by_predicate,
-                    libsemigroups::Runner::state::not_running,
-                    libsemigroups::Runner::state::dead);
 
 #endif  // LIBSEMIGROUPS_TESTS_TEST_MAIN_HPP_

--- a/tests/test-matrix.cpp
+++ b/tests/test-matrix.cpp
@@ -122,777 +122,184 @@ namespace libsemigroups {
       std::swap(buf, rows);
     }
 
-    ////////////////////////////////////////////////////////////////////////
-    // Test functions - BMat
-    ////////////////////////////////////////////////////////////////////////
-
-    // Line 166 triggers a warning with gcc-13 that originates in a standard
-    // library header, so we ignore that warning.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
-    template <typename Mat>
-    void test_BMat000() {
-      auto rg = ReportGuard(REPORT);
-      {
-        Mat m = to_matrix<Mat>({{0, 1}, {0, 1}});
-        REQUIRE_NOTHROW(matrix::throw_if_bad_entry(m));
-        REQUIRE(m == Mat({{0, 1}, {0, 1}}));
-        REQUIRE(!(m == Mat({{0, 0}, {0, 1}})));
-        REQUIRE(m == Mat({{0, 1}, {0, 1}}));
-        m.product_inplace_no_checks(Mat({{0, 0}, {0, 0}}),
-                                    Mat({{0, 0}, {0, 0}}));
-        REQUIRE(m == Mat({{0, 0}, {0, 0}}));
-        m.product_inplace_no_checks(Mat({{0, 0}, {0, 0}}),
-                                    Mat({{1, 1}, {1, 1}}));
-        REQUIRE(m == Mat({{0, 0}, {0, 0}}));
-        m.product_inplace_no_checks(Mat({{1, 1}, {1, 1}}),
-                                    Mat({{0, 0}, {0, 0}}));
-        REQUIRE(m == Mat({{0, 0}, {0, 0}}));
-
-        m.product_inplace_no_checks(Mat({{0, 1}, {1, 0}}),
-                                    Mat({{1, 0}, {1, 0}}));
-        REQUIRE(m == Mat({{1, 0}, {1, 0}}));
-        size_t const M = detail::BitSetCapacity<Mat>::value;
-        detail::StaticVector1<BitSet<M>, M> result;
-        matrix::bitset_rows(m, result);
-        REQUIRE(result.size() == 2);
-        REQUIRE(matrix::bitset_rows(m).size() == 2);
-        result.clear();
-        matrix::bitset_row_basis(m, result);
-        REQUIRE(result.size() == 1);
-        REQUIRE(matrix::bitset_row_basis(m).size() == 1);
-        REQUIRE(std::vector<bool>(m.cbegin(), m.cend())
-                == std::vector<bool>({true, false, true, false}));
-        REQUIRE(std::vector<bool>(m.begin(), m.end())
-                == std::vector<bool>({true, false, true, false}));
-      }
-
-      {
-        Mat m({{1, 1}, {0, 0}});
-        using RowView = typename Mat::RowView;
-
-        auto r = matrix::rows(m);
-        REQUIRE(std::vector<bool>(r[0].cbegin(), r[0].cend())
-                == std::vector<bool>({true, true}));
-        REQUIRE(std::vector<bool>(r[1].cbegin(), r[1].cend())
-                == std::vector<bool>({false, false}));
-        REQUIRE(r.size() == 2);
-        std::sort(
-            r.begin(), r.end(), [](RowView const& rv1, RowView const& rv2) {
-              return std::lexicographical_compare(
-                  rv1.begin(), rv1.end(), rv2.begin(), rv2.end());
-            });
-        REQUIRE(std::vector<bool>(r[0].cbegin(), r[0].cend())
-                == std::vector<bool>({false, false}));
-        REQUIRE(std::vector<bool>(r[1].cbegin(), r[1].cend())
-                == std::vector<bool>({true, true}));
-      }
-
-      {
-        using Row = typename Mat::Row;
-
-        Mat A(2, 2);
-        std::fill(A.begin(), A.end(), false);
-        REQUIRE(A.number_of_rows() == 2);
-        REQUIRE(A.number_of_cols() == 2);
-        REQUIRE(A == Mat({{false, false}, {false, false}}));
-
-        A(0, 0) = true;
-        A(1, 1) = true;
-        REQUIRE(A == Mat({{true, false}, {false, true}}));
-
-        Mat B(2, 2);
-        B(0, 1) = true;
-        B(1, 0) = true;
-        B(0, 0) = false;
-        B(1, 1) = false;
-        REQUIRE(B == Mat({{false, true}, {true, false}}));
-
-        REQUIRE(A + B == Mat({{true, true}, {true, true}}));
-        REQUIRE(A * B == B);
-        REQUIRE(B * A == B);
-        REQUIRE(B * B == A);
-        REQUIRE((A + B) * B == Mat({{true, true}, {true, true}}));
-
-        Row C({0, 1});
-        REQUIRE(C.number_of_rows() == 1);
-        REQUIRE(C.number_of_cols() == 2);
-
-        auto rv = A.row(0);
-        Row  D(rv);
-        REQUIRE(D.number_of_rows() == 1);
-        REQUIRE(D.number_of_cols() == 2);
-        REQUIRE(D != C);
-        auto views = matrix::rows(A);
-        REQUIRE(B < A);
-        B.swap(A);
-        REQUIRE(A < B);
-        std::swap(B, A);
-        REQUIRE(B < A);
-        REQUIRE(views[0] == Row({true, false}));
-        REQUIRE(Row({true, false}) == views[0]);
-        REQUIRE(Row({true, true}) != views[0]);
-        REQUIRE(Row({false, false}) < views[0]);
-        REQUIRE(A.hash_value() != 0);
-        A *= false;
-        REQUIRE(A == Mat({{false, false}, {false, false}}));
-        auto r = Row({true, false});
-        views  = matrix::rows(B);
-        REQUIRE(views[0].size() == 2);
-        r += views[0];
-        REQUIRE(r.number_of_cols() == 2);
-        REQUIRE(r.number_of_rows() == 1);
-        REQUIRE(r == Row({true, true}));
-
-        auto E = Mat::one(2);
-        REQUIRE(E.number_of_rows() == 2);
-        REQUIRE(E.number_of_cols() == 2);
-        auto viewse = matrix::rows(E);
-        REQUIRE(viewse.size() == 2);
-
-        std::ostringstream oss;
-        oss << E;  // Does not do anything visible
-
-        std::stringbuf buff;
-        std::ostream   os(&buff);
-        os << E;  // Also does not do anything visible
-      }
-      {
-        Mat m({{0, 0}, {0, 0}});
-        using scalar_type = typename Mat::scalar_type;
-        auto it           = m.cbegin();
-        REQUIRE(m.coords(it) == std::pair<scalar_type, scalar_type>({0, 0}));
-        REQUIRE(m.coords(++it) == std::pair<scalar_type, scalar_type>({0, 1}));
-        REQUIRE(m.coords(++it) == std::pair<scalar_type, scalar_type>({1, 0}));
-        REQUIRE(m.coords(++it) == std::pair<scalar_type, scalar_type>({1, 1}));
-      }
-      {
-        REQUIRE_THROWS_AS(to_matrix<Mat>({{0, 0}, {0, 2}}),
-                          LibsemigroupsException);
-      }
-    }
-#pragma GCC diagnostic pop
-
-    template <typename Mat>
-    void test_BMat001() {
-      auto x = Mat({{1, 0, 1}, {0, 1, 0}, {0, 1, 0}});
-      auto y = Mat({{0, 0, 0}, {0, 0, 0}, {0, 0, 0}});
-      auto z = Mat({{0, 0, 0}, {0, 0, 0}, {0, 0, 0}});
-      REQUIRE(y == z);
-      z.product_inplace_no_checks(x, y);
-      REQUIRE(y == z);
-      z.product_inplace_no_checks(y, x);
-      REQUIRE(y == z);
-      REQUIRE(!(y < z));
-      auto id = x.one();
-      z.product_inplace_no_checks(id, x);
-      REQUIRE(z == x);
-      z.product_inplace_no_checks(x, id);
-      REQUIRE(z == x);
-      REQUIRE(x.hash_value() != 0);
-    }
-
-    template <typename Mat>
-    void test_BMat002() {
-      using RowView = typename Mat::RowView;
-      auto x        = to_matrix<Mat>({{1, 0, 0}, {1, 0, 0}, {1, 0, 0}});
-      REQUIRE(matrix::row_basis(x).size() == 1);
-      REQUIRE(matrix::row_space_size(x) == 1);
-      x = to_matrix<Mat>({{1, 0, 0}, {1, 1, 0}, {1, 1, 1}});
-      REQUIRE(matrix::row_basis(x).size() == 3);
-      REQUIRE_THROWS_AS(x.row(3), LibsemigroupsException);
-      std::vector<RowView> v = {x.row(0), x.row(2)};
-      REQUIRE(matrix::row_basis<Mat>(v).size() == 2);
-      REQUIRE(matrix::row_space_size(x) == 3);
-      x = to_matrix<Mat>({{1, 0, 0}, {0, 1, 1}, {1, 1, 1}});
-      REQUIRE(matrix::row_basis(x).size() == 2);
-      REQUIRE(matrix::row_space_size(x) == 3);
-      x = to_matrix<Mat>({{1, 0, 0}, {0, 0, 1}, {0, 1, 0}});
-      REQUIRE(matrix::row_space_size(x) == 7);
-      std::vector<typename Mat::RowView> views;
-      std::vector<typename Mat::RowView> result;
-      matrix::row_basis<Mat, std::vector<typename Mat::RowView>&>(views,
-                                                                  result);
-    }
-
-    ////////////////////////////////////////////////////////////////////////
-    // Test functions - NTPMat
-    ////////////////////////////////////////////////////////////////////////
-
-    template <typename Mat>
-    void test_NTPMat000(NTPSemiring<> const* sr = nullptr) {
-      using Row = typename Mat::Row;
-      auto rg   = ReportGuard(REPORT);
-      Mat  m(sr, 3, 3);
-      // REQUIRE(matrix::throw_if_bad_entry(m)); // m might not be valid!
-      m.product_inplace_no_checks(
-          to_matrix<Mat>(sr, {{1, 1, 0}, {0, 0, 1}, {1, 0, 1}}),
-          to_matrix<Mat>(sr, {{1, 0, 1}, {0, 0, 1}, {1, 1, 0}}));
-      REQUIRE(m == to_matrix<Mat>(sr, {{1, 0, 2}, {1, 1, 0}, {2, 1, 1}}));
-      REQUIRE(m.row(0) == Row(sr, {1, 0, 2}));
-      REQUIRE(m.row(0).size() == 3);
-      auto r = matrix::rows(m);
-      REQUIRE(r[0] == Row(sr, {1, 0, 2}));
-      REQUIRE(r[1] == Row(sr, {1, 1, 0}));
-      REQUIRE(r[2] == Row(sr, {2, 1, 1}));
-      REQUIRE(m * Mat::one(sr, 3) == m);
-      REQUIRE(Mat::one(sr, 3) * m == m);
-    }
-
-    template <typename Mat>
-    void test_NTPMat001(NTPSemiring<> const* sr = nullptr) {
-      using Row         = typename Mat::Row;
-      using RowView     = typename Mat::RowView;
-      using scalar_type = typename Mat::scalar_type;
-
-      auto rg = ReportGuard(REPORT);
-
-      Mat m = to_matrix<Mat>(
-          sr, {{1, 1, 0, 0}, {2, 0, 2, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}});
-      REQUIRE(m.number_of_cols() == 4);
-      REQUIRE(m.number_of_rows() == 4);
-      auto r = matrix::rows(m);
-      REQUIRE(r.size() == 4);
-      REQUIRE(std::vector<scalar_type>(r[0].cbegin(), r[0].cend())
-              == std::vector<scalar_type>({1, 1, 0, 0}));
-      r[0] += r[1];
-      REQUIRE(std::vector<scalar_type>(r[0].cbegin(), r[0].cend())
-              == std::vector<scalar_type>({3, 1, 2, 0}));
-      REQUIRE(std::vector<scalar_type>(r[1].cbegin(), r[1].cend())
-              == std::vector<scalar_type>({2, 0, 2, 0}));
-      REQUIRE(
-          m
-          == to_matrix<Mat>(
-              sr, {{3, 1, 2, 0}, {2, 0, 2, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}}));
-      REQUIRE(r[0][0] == 3);
-      REQUIRE(r[0](0) == 3);
-      REQUIRE(r[2](3) == 9);
-      std::sort(r[0].begin(), r[0].end());
-      REQUIRE(std::vector<scalar_type>(r[0].cbegin(), r[0].cend())
-              == std::vector<scalar_type>({0, 1, 2, 3}));
-      REQUIRE(
-          m
-          == to_matrix<Mat>(
-              sr, {{0, 1, 2, 3}, {2, 0, 2, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}}));
-      r[0] += 9;
-      REQUIRE(std::vector<scalar_type>(r[0].cbegin(), r[0].cend())
-              == std::vector<scalar_type>({9, 0, 1, 2}));
-      REQUIRE(
-          m
-          == to_matrix<Mat>(
-              sr, {{9, 0, 1, 2}, {2, 0, 2, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}}));
-      r[1] *= 3;
-      REQUIRE(
-          m
-          == to_matrix<Mat>(
-              sr, {{9, 0, 1, 2}, {6, 0, 6, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}}));
-      REQUIRE(std::vector<scalar_type>(r[1].cbegin(), r[1].cend())
-              == std::vector<scalar_type>({6, 0, 6, 0}));
-      REQUIRE(r[2] < r[1]);
-      r[1] = r[2];
-      REQUIRE(
-          m
-          == to_matrix<Mat>(
-              sr, {{9, 0, 1, 2}, {6, 0, 6, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}}));
-      REQUIRE(r[1] == r[2]);
-      REQUIRE(r[1] == to_matrix<Row>(sr, {{1, 2, 3, 9}}));
-
-      RowView rv;
-      {
-        rv = r[0];
-        REQUIRE(rv == r[0]);
-        REQUIRE(&rv != &r[0]);
-      }
-    }
-
-    template <typename Mat>
-    void test_NTPMat002(NTPSemiring<> const* sr = nullptr) {
-      using Row = typename Mat::Row;
-
-      auto rg = ReportGuard(REPORT);
-      Mat  m(sr, {{1, 1, 0, 0}, {2, 0, 2, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}});
-      REQUIRE(m.number_of_cols() == 4);
-      REQUIRE(m.number_of_rows() == 4);
-      auto r = matrix::rows(m);
-      REQUIRE(r.size() == 4);
-      REQUIRE(r[0] == to_matrix<Row>(sr, {{1, 1, 0, 0}}));
-      REQUIRE(r[1] == to_matrix<Row>(sr, {{2, 0, 2, 0}}));
-      REQUIRE(r[0] != to_matrix<Row>(sr, {{2, 0, 2, 0}}));
-      REQUIRE(r[1] != to_matrix<Row>(sr, {{1, 1, 0, 0}}));
-      REQUIRE(to_matrix<Row>(sr, {{1, 1, 0, 0}}) == r[0]);
-      REQUIRE(to_matrix<Row>(sr, {{2, 0, 2, 0}}) == r[1]);
-      REQUIRE(to_matrix<Row>(sr, {{2, 0, 2, 0}}) != r[0]);
-      REQUIRE(to_matrix<Row>(sr, {{1, 1, 0, 0}}) != r[1]);
-      REQUIRE(to_matrix<Row>(sr, {{1, 1, 0, 0}}) < Row(sr, {{9, 9, 9, 9}}));
-      REQUIRE(r[0] < to_matrix<Row>(sr, {{9, 9, 9, 9}}));
-      REQUIRE(!(to_matrix<Row>(sr, {{9, 9, 9, 9}}) < r[0]));
-      Row x(r[3]);
-      x *= 3;
-      REQUIRE(x == to_matrix<Row>(sr, {{0, 0, 0, 1}}));
-      REQUIRE(x.number_of_rows() == 1);
-      REQUIRE(x.number_of_cols() == 4);
-      REQUIRE(r[3] == to_matrix<Row>(sr, {{0, 0, 0, 7}}));
-      REQUIRE(r[3] != x);
-      REQUIRE(x != r[3]);
-      REQUIRE(!(x != x));
-    }
-
-    template <typename Mat>
-    void test_NTPMat003(NTPSemiring<> const* sr = nullptr) {
-      auto x        = to_matrix<Mat>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
-      auto expected = to_matrix<Mat>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
-      REQUIRE(x == expected);
-      REQUIRE(x.number_of_cols() == 3);
-      REQUIRE(x.number_of_rows() == 3);
-
-      auto y = to_matrix<Mat>(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}});
-      REQUIRE(!(x == y));
-
-      y.product_inplace_no_checks(x, x);
-      expected = to_matrix<Mat>(sr, {{34, 34, 0}, {34, 34, 0}, {33, 33, 1}});
-      REQUIRE(y == expected);
-
-      REQUIRE(x < y);
-      auto id = x.one();
-      y.product_inplace_no_checks(id, x);
-      REQUIRE(y == x);
-      y.product_inplace_no_checks(x, id);
-      REQUIRE(y == x);
-      REQUIRE(Hash<Mat>()(y) != 0);
-    }
-
-    ////////////////////////////////////////////////////////////////////////
-    // Test functions - MaxPlusTruncMat
-    ////////////////////////////////////////////////////////////////////////
-
-    template <typename Mat>
-    void test_MaxPlusTruncMat000(MaxPlusTruncSemiring<> const* sr = nullptr) {
-      using scalar_type = typename Mat::scalar_type;
-      {
-        Mat m1(sr, 2, 2);
-        std::fill(m1.begin(), m1.end(), NEGATIVE_INFINITY);
-        REQUIRE(m1
-                == to_matrix<Mat>(sr,
-                                  {{NEGATIVE_INFINITY, NEGATIVE_INFINITY},
-                                   {NEGATIVE_INFINITY, NEGATIVE_INFINITY}}));
-        Mat m2(sr, 2, 2);
-        std::fill(m2.begin(), m2.end(), 4);
-        REQUIRE(m1 + m2 == m2);
-        REQUIRE(m2(0, 1) == 4);
-      }
-
-      auto rg = ReportGuard(REPORT);
-      {
-        std::vector<std::array<scalar_type, 2>> expected;
-        expected.push_back({1, 1});
-        expected.push_back({0, 0});
-        tropical_max_plus_row_basis<2, 5>(expected);
-        REQUIRE(expected.size() == 1);
-        REQUIRE(expected.at(0) == std::array<scalar_type, 2>({0, 0}));
-
-        Mat  m(sr, {{1, 1}, {0, 0}});
-        auto r = matrix::row_basis(m);
-        REQUIRE(r.size() == 1);
-        REQUIRE(std::vector<scalar_type>(r[0].cbegin(), r[0].cend())
-                == std::vector<scalar_type>({0, 0}));
-      }
-      {
-        Mat m(sr, {{1, 1}, {0, 0}});
-        m      = m.one();
-        auto r = matrix::row_basis(m);
-        REQUIRE(r.size() == 2);
-        REQUIRE(std::vector<scalar_type>(r[0].cbegin(), r[0].cend())
-                == std::vector<scalar_type>({NEGATIVE_INFINITY, 0}));
-        REQUIRE(std::vector<scalar_type>(r[1].cbegin(), r[1].cend())
-                == std::vector<scalar_type>({0, NEGATIVE_INFINITY}));
-      }
-      std::vector<typename Mat::RowView> views;
-      std::vector<typename Mat::RowView> result;
-      matrix::row_basis<Mat>(views, result);
-    }
-
-    template <typename Mat>
-    void test_MaxPlusTruncMat001(MaxPlusTruncSemiring<> const* sr = nullptr) {
-      // Threshold 5, 4 x 4
-      using scalar_type = typename Mat::scalar_type;
-      using Row         = typename Mat::Row;
-
-      auto m  = to_matrix<Mat>(sr,
-                              {{2, 2, 0, 1},
-                                {0, 0, 1, 3},
-                                {1, NEGATIVE_INFINITY, 0, 0},
-                                {0, 1, 0, 1}});
-      auto rg = ReportGuard(REPORT);
-      auto r  = matrix::row_basis(m);
-      REQUIRE(r.size() == 4);
-      REQUIRE(r[0] == to_matrix<Row>(sr, {0, 0, 1, 3}));
-      REQUIRE(r[1] == to_matrix<Row>(sr, {0, 1, 0, 1}));
-      REQUIRE(r[2] == to_matrix<Row>(sr, {1, NEGATIVE_INFINITY, 0, 0}));
-      REQUIRE(r[3] == to_matrix<Row>(sr, {2, 2, 0, 1}));
-      m.transpose();
-      REQUIRE(m
-              == to_matrix<Mat>(sr,
-                                {{2, 0, 1, 0},
-                                 {2, 0, NEGATIVE_INFINITY, 1},
-                                 {0, 1, 0, 0},
-                                 {1, 3, 0, 1}}));
-      m.transpose();
-      REQUIRE(m
-              == to_matrix<Mat>(sr,
-                                {{2, 2, 0, 1},
-                                 {0, 0, 1, 3},
-                                 {1, NEGATIVE_INFINITY, 0, 0},
-                                 {0, 1, 0, 1}}));
-
-      std::vector<std::array<scalar_type, 4>> expected;
-      expected.push_back({2, 2, 0, 1});
-      expected.push_back({0, 0, 1, 3});
-      expected.push_back({1, NEGATIVE_INFINITY, 0, 0});
-      expected.push_back({0, 1, 0, 1});
-      tropical_max_plus_row_basis<4, 5>(expected);
-      REQUIRE(expected.size() == 4);
-      REQUIRE(m * Mat::one(sr, 4) == m);
-      REQUIRE(Mat::one(sr, 4) * m == m);
-    }
-
-    template <typename Mat>
-    void test_MaxPlusTruncMat002(MaxPlusTruncSemiring<> const* sr = nullptr) {
-      auto x        = Mat(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
-      auto expected = Mat(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
-      REQUIRE(x == expected);
-
-      REQUIRE_THROWS_AS(
-          to_matrix<Mat>(sr, {{-100, 0, 0}, {0, 1, 0}, {1, -1, 0}}),
-          LibsemigroupsException);
-      auto y = Mat(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}});
-      REQUIRE(!(x == y));
-
-      y.product_inplace_no_checks(x, x);
-      expected = Mat(sr, {{33, 33, 22}, {32, 32, 10}, {33, 33, 32}});
-      REQUIRE(y == expected);
-
-      REQUIRE(x < y);
-      auto id = x.one();
-      y.product_inplace_no_checks(id, x);
-      REQUIRE(y == x);
-      y.product_inplace_no_checks(x, id);
-      REQUIRE(y == x);
-      REQUIRE(Hash<Mat>()(y) != 0);
-      REQUIRE(x * Mat::one(sr, 3) == x);
-      REQUIRE(Mat::one(sr, 3) * x == x);
-    }
-
-    ////////////////////////////////////////////////////////////////////////
-    // Test functions - IntMat
-    ////////////////////////////////////////////////////////////////////////
-
-    template <typename Mat>
-    void test_IntMat000() {
-      {
-        auto x        = Mat({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
-        auto expected = Mat({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
-        REQUIRE(x == expected);
-
-        auto y = Mat({{-100, 0, 0}, {0, 1, 0}, {1, -1, 0}});
-        REQUIRE(!(x == y));
-
-        y.product_inplace_no_checks(x, x);
-        expected = Mat({{2, -4, 0}, {2, -2, 0}, {2, -1, 1}});
-        REQUIRE(y == expected);
-        REQUIRE(y.number_of_rows() == 3);
-
-        REQUIRE(x < y);
-        REQUIRE(Degree<Mat>()(x) == 3);
-        REQUIRE(Degree<Mat>()(y) == 3);
-        REQUIRE(Complexity<Mat>()(x) == 27);
-        REQUIRE(Complexity<Mat>()(y) == 27);
-        auto id = x.one();
-        y.product_inplace_no_checks(id, x);
-        REQUIRE(y == x);
-        y.product_inplace_no_checks(x, id);
-        REQUIRE(y == x);
-      }
-      {
-        auto x        = Mat({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
-        auto expected = Mat({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
-        REQUIRE(x == expected);
-
-        auto y = Mat({{-100, 0, 0}, {0, 1, 0}, {1, -1, 0}});
-        REQUIRE(!(x == y));
-
-        y.product_inplace_no_checks(x, x);
-        expected = Mat({{2, -4, 0}, {2, -2, 0}, {2, -1, 1}});
-        REQUIRE(y == expected);
-
-        REQUIRE(x < y);
-        auto id = x.one();
-        y.product_inplace_no_checks(id, x);
-        REQUIRE(y == x);
-        y.product_inplace_no_checks(x, id);
-        REQUIRE(y == x);
-        REQUIRE(Hash<Mat>()(y) != 0);
-      }
-    }
-
-    ////////////////////////////////////////////////////////////////////////
-    // Test functions - MaxPlusMat
-    ////////////////////////////////////////////////////////////////////////
-
-    template <typename Mat>
-    void test_MaxPlusMat000() {
-      auto x        = Mat({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
-      auto expected = Mat({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
-      REQUIRE(x == expected);
-
-      auto y = Mat{{-100, 0, 0}, {0, 1, 0}, {1, -1, 0}};
-      REQUIRE(!(x == y));
-      REQUIRE(x != y);
-
-      y.product_inplace_no_checks(x, x);
-      expected = Mat({{1, 2, 2}, {1, 1, 1}, {2, 3, 2}});
-      REQUIRE(y == expected);
-
-      REQUIRE(x < y);
-      REQUIRE(Degree<Mat>()(x) == 3);
-      REQUIRE(Degree<Mat>()(y) == 3);
-      REQUIRE(Complexity<Mat>()(x) == 27);
-      REQUIRE(Complexity<Mat>()(y) == 27);
-      auto id = x.one();
-      y.product_inplace_no_checks(id, x);
-      REQUIRE(y == x);
-      y.product_inplace_no_checks(x, id);
-      REQUIRE(y == x);
-      REQUIRE(Hash<Mat>()(y) != 0);
-    }
-
-    ////////////////////////////////////////////////////////////////////////
-    // Test functions - MinPlusMat
-    ////////////////////////////////////////////////////////////////////////
-
-    template <typename Mat>
-    void test_MinPlusMat000() {
-      {
-        auto x        = Mat({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
-        auto expected = Mat({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
-        // Just testing the below doesn't compile
-        // matrix::row_basis(x);
-        REQUIRE(x == expected);
-
-        auto y = Mat({{-100, 0, 0}, {0, 1, 0}, {1, -1, 0}});
-        REQUIRE(!(x == y));
-
-        y.product_inplace_no_checks(x, x);
-        expected = Mat({{-4, -3, -2}, {-3, -3, -1}, {-4, -3, -3}});
-        REQUIRE(y == expected);
-
-        REQUIRE(!(x < y));
-        REQUIRE(Degree<Mat>()(x) == 3);
-        REQUIRE(Degree<Mat>()(y) == 3);
-        REQUIRE(Complexity<Mat>()(x) == 27);
-        REQUIRE(Complexity<Mat>()(y) == 27);
-        auto id = x.one();
-        y.product_inplace_no_checks(id, x);
-        REQUIRE(y == x);
-        y.product_inplace_no_checks(x, id);
-        REQUIRE(y == x);
-      }
-      {
-        auto x        = Mat({{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
-        auto expected = Mat({{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
-        REQUIRE(x == expected);
-
-        auto y = Mat({{10, 0, 0}, {0, 1, 0}, {1, 1, 0}});
-        REQUIRE(!(x == y));
-
-        y.product_inplace_no_checks(x, x);
-        REQUIRE(y == Mat({{1, 21, 1}, {1, 0, 0}, {2, 22, 1}}));
-
-        REQUIRE(x > y);
-        REQUIRE(Degree<Mat>()(x) == 3);
-        REQUIRE(Degree<Mat>()(y) == 3);
-        REQUIRE(Complexity<Mat>()(x) == 27);
-        REQUIRE(Complexity<Mat>()(y) == 27);
-        auto id = x.one();
-        y.product_inplace_no_checks(id, x);
-        REQUIRE(y == x);
-        y.product_inplace_no_checks(x, id);
-        REQUIRE(y == x);
-        REQUIRE(Hash<Mat>()(y) != 0);
-      }
-    }
-
-    ////////////////////////////////////////////////////////////////////////
-    // Test functions - MinPlusTruncMat
-    ////////////////////////////////////////////////////////////////////////
-
-    template <typename Mat>
-    void test_MinPlusTruncMat000(MinPlusTruncSemiring<> const* sr = nullptr) {
-      auto x = Mat(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
-
-      auto expected = to_matrix<Mat>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
-      REQUIRE(x == expected);
-
-      auto y = Mat(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}});
-      REQUIRE(!(x == y));
-
-      y.product_inplace_no_checks(x, x);
-      expected = Mat(sr, {{1, 21, 1}, {1, 0, 0}, {2, 22, 1}});
-      REQUIRE(y == expected);
-
-      REQUIRE(!(x < y));
-      REQUIRE(Degree<Mat>()(x) == 3);
-      REQUIRE(Degree<Mat>()(y) == 3);
-      REQUIRE(Complexity<Mat>()(x) == 27);
-      REQUIRE(Complexity<Mat>()(y) == 27);
-      auto id = x.one();
-      y.product_inplace_no_checks(id, x);
-      REQUIRE(y == x);
-      y.product_inplace_no_checks(x, id);
-      REQUIRE(y == x);
-      REQUIRE(Hash<Mat>()(y) != 0);
-      REQUIRE_THROWS_AS(
-          to_matrix<Mat>(sr, {{-22, 21, 0}, {10, 0, 0}, {1, 32, 1}}),
-          LibsemigroupsException);
-      REQUIRE(x * Mat::one(sr, 3) == x);
-      REQUIRE(Mat::one(sr, 3) * x == x);
-    }
-
-    ////////////////////////////////////////////////////////////////////////
-    // Test functions - ProjMaxPlusMat
-    ////////////////////////////////////////////////////////////////////////
-
-    template <typename Mat>
-    void test_ProjMaxPlusMat000() {
-      using Row     = typename Mat::Row;
-      auto x        = to_matrix<Mat>({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
-      auto expected = to_matrix<Mat>({{-4, 0, -2}, {-3, -2, -2}, {-1, -5, -1}});
-      REQUIRE(x == expected);
-      REQUIRE(x.scalar_zero() == NEGATIVE_INFINITY);
-      REQUIRE(x.scalar_one() == 0);
-
-      auto y
-          = to_matrix<Mat>({{NEGATIVE_INFINITY, 0, 0}, {0, 1, 0}, {1, -1, 0}});
-      expected = to_matrix<Mat>(
-          {{NEGATIVE_INFINITY, -1, -1}, {-1, 0, -1}, {0, -2, -1}});
-      REQUIRE(y == expected);
-      REQUIRE(!(x == y));
-
-      y.product_inplace_no_checks(x, x);
-      expected = Mat({{-2, -1, -1}, {-2, -2, -2}, {-1, 0, -1}});
-      REQUIRE(y == expected);
-
-      REQUIRE(x < y);
-      REQUIRE(y > x);
-      REQUIRE(Degree<Mat>()(x) == 3);
-      REQUIRE(Degree<Mat>()(y) == 3);
-      REQUIRE(Complexity<Mat>()(x) == 27);
-      REQUIRE(Complexity<Mat>()(y) == 27);
-      auto id = x.one();
-      y.product_inplace_no_checks(id, x);
-      REQUIRE(y == x);
-      y.product_inplace_no_checks(x, id);
-      REQUIRE(y == x);
-
-      REQUIRE(to_matrix<Mat>({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}}).hash_value()
-              != 0);
-
-      y = x;
-      REQUIRE(&x != &y);
-      REQUIRE(x == y);
-      // TODO uncomment or remove
-      // REQUIRE(y
-      //         == to_matrix<Mat>(nullptr, {{-2, 2, 0}, {-1, 0, 0}, {1, -3,
-      //         1}}));
-
-      auto yy(y);
-      REQUIRE(yy == y);
-
-      std::ostringstream oss;
-      oss << y;  // Does not do anything visible
-      std::stringbuf buff;
-      std::ostream   os(&buff);
-      os << y;  // Also does not do anything visible
-
-      REQUIRE(y.row(0) == to_matrix<Row>({-4, 0, -2}));
-      REQUIRE(y.row(1) == Row({-3, -2, -2}));
-      REQUIRE(Row(y.row(0)) == y.row(0));
-
-      auto zz(std::move(y));
-
-      Mat tt;
-      REQUIRE(tt != zz);
-      REQUIRE(Mat::one(3)
-              == Mat({{0, NEGATIVE_INFINITY, NEGATIVE_INFINITY},
-                      {NEGATIVE_INFINITY, 0, NEGATIVE_INFINITY},
-                      {NEGATIVE_INFINITY, NEGATIVE_INFINITY, 0}}));
-      REQUIRE(zz(0, 0) == -4);
-      REQUIRE(zz.number_of_cols() == 3);
-      zz += zz;
-      REQUIRE(zz == Mat({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}}));
-      zz *= 2;
-      REQUIRE(zz == Mat({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}}));
-      REQUIRE(zz + x == Mat({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}}));
-      REQUIRE(zz * x == Mat({{-2, -1, -1}, {-2, -2, -2}, {-1, 0, -1}}));
-      REQUIRE(std::accumulate(zz.cbegin(), zz.cend(), 0) == -20);
-      REQUIRE(std::accumulate(zz.begin(), zz.end(), 0) == -20);
-      x.transpose();
-      REQUIRE(x == Mat({{-4, -3, -1}, {0, -2, -5}, {-2, -2, -1}}));
-      x.swap(zz);
-      REQUIRE(zz == Mat({{-4, -3, -1}, {0, -2, -5}, {-2, -2, -1}}));
-      REQUIRE(matrix::pow(x, 100)
-              == Mat({{-1, 0, -1}, {-2, -1, -2}, {-1, 0, -1}}));
-      REQUIRE_THROWS_AS(matrix::pow(x, -100), LibsemigroupsException);
-      REQUIRE(matrix::pow(x, 1)
-              == Mat({{-4, 0, -2}, {-3, -2, -2}, {-1, -5, -1}}));
-      REQUIRE(matrix::pow(x, 0) == Mat::one(3));
-    }
-
   }  // namespace
 
   ////////////////////////////////////////////////////////////////////////
   // Test cases - BMat
   ////////////////////////////////////////////////////////////////////////
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "000", "BMat<2>", "[quick]") {
-    test_BMat000<BMat<2>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "001", "BMat<>", "[quick]") {
-    test_BMat000<BMat<>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "002", "BMat<3> + BMat<>", "[quick]") {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "000",
+                                   "boolean matrix - test 1",
+                                   "[quick]",
+                                   BMat<2>,
+                                   BMat<>) {
     auto rg = ReportGuard(REPORT);
     {
-      BMat<3> m;
-      m.product_inplace_no_checks(BMat<3>({{1, 1, 0}, {0, 0, 1}, {1, 0, 1}}),
-                                  BMat<3>({{1, 0, 1}, {0, 0, 1}, {1, 1, 0}}));
-      REQUIRE(m == BMat<3>({{1, 0, 1}, {1, 1, 0}, {1, 1, 1}}));
+      TestType m = to_matrix<TestType>({{0, 1}, {0, 1}});
+      REQUIRE_NOTHROW(matrix::throw_if_bad_entry(m));
+      REQUIRE(m == TestType({{0, 1}, {0, 1}}));
+      REQUIRE(!(m == TestType({{0, 0}, {0, 1}})));
+      REQUIRE(m == TestType({{0, 1}, {0, 1}}));
+      m.product_inplace_no_checks(TestType({{0, 0}, {0, 0}}),
+                                  TestType({{0, 0}, {0, 0}}));
+      REQUIRE(m == TestType({{0, 0}, {0, 0}}));
+      m.product_inplace_no_checks(TestType({{0, 0}, {0, 0}}),
+                                  TestType({{1, 1}, {1, 1}}));
+      REQUIRE(m == TestType({{0, 0}, {0, 0}}));
+      m.product_inplace_no_checks(TestType({{1, 1}, {1, 1}}),
+                                  TestType({{0, 0}, {0, 0}}));
+      REQUIRE(m == TestType({{0, 0}, {0, 0}}));
+
+      m.product_inplace_no_checks(TestType({{0, 1}, {1, 0}}),
+                                  TestType({{1, 0}, {1, 0}}));
+      REQUIRE(m == TestType({{1, 0}, {1, 0}}));
+      size_t const M = detail::BitSetCapacity<TestType>::value;
+      detail::StaticVector1<BitSet<M>, M> result;
+      matrix::bitset_rows(m, result);
+      REQUIRE(result.size() == 2);
+      REQUIRE(matrix::bitset_rows(m).size() == 2);
+      result.clear();
+      matrix::bitset_row_basis(m, result);
+      REQUIRE(result.size() == 1);
+      REQUIRE(matrix::bitset_row_basis(m).size() == 1);
+      REQUIRE(std::vector<bool>(m.cbegin(), m.cend())
+              == std::vector<bool>({true, false, true, false}));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+      REQUIRE(std::vector<bool>(m.begin(), m.end())  // ****
+              == std::vector<bool>({true, false, true, false}));
+#pragma GCC diagnostic pop
+    }
+
+    {
+      TestType m({{1, 1}, {0, 0}});
+      using RowView = typename TestType::RowView;
+
+      auto r = matrix::rows(m);
+      REQUIRE(std::vector<bool>(r[0].cbegin(), r[0].cend())
+              == std::vector<bool>({true, true}));
+      REQUIRE(std::vector<bool>(r[1].cbegin(), r[1].cend())
+              == std::vector<bool>({false, false}));
+      REQUIRE(r.size() == 2);
+      std::sort(r.begin(), r.end(), [](RowView const& rv1, RowView const& rv2) {
+        return std::lexicographical_compare(
+            rv1.begin(), rv1.end(), rv2.begin(), rv2.end());
+      });
+      REQUIRE(std::vector<bool>(r[0].cbegin(), r[0].cend())
+              == std::vector<bool>({false, false}));
+      REQUIRE(std::vector<bool>(r[1].cbegin(), r[1].cend())
+              == std::vector<bool>({true, true}));
+    }
+
+    {
+      using Row = typename TestType::Row;
+
+      TestType A(2, 2);
+      std::fill(A.begin(), A.end(), false);
+      REQUIRE(A.number_of_rows() == 2);
+      REQUIRE(A.number_of_cols() == 2);
+      REQUIRE(A == TestType({{false, false}, {false, false}}));
+
+      A(0, 0) = true;
+      A(1, 1) = true;
+      REQUIRE(A == TestType({{true, false}, {false, true}}));
+
+      TestType B(2, 2);
+      B(0, 1) = true;
+      B(1, 0) = true;
+      B(0, 0) = false;
+      B(1, 1) = false;
+      REQUIRE(B == TestType({{false, true}, {true, false}}));
+
+      REQUIRE(A + B == TestType({{true, true}, {true, true}}));
+      REQUIRE(A * B == B);
+      REQUIRE(B * A == B);
+      REQUIRE(B * B == A);
+      REQUIRE((A + B) * B == TestType({{true, true}, {true, true}}));
+
+      Row C({0, 1});
+      REQUIRE(C.number_of_rows() == 1);
+      REQUIRE(C.number_of_cols() == 2);
+
+      auto rv = A.row(0);
+      Row  D(rv);
+      REQUIRE(D.number_of_rows() == 1);
+      REQUIRE(D.number_of_cols() == 2);
+      REQUIRE(D != C);
+      auto views = matrix::rows(A);
+      REQUIRE(B < A);
+      B.swap(A);
+      REQUIRE(A < B);
+      std::swap(B, A);
+      REQUIRE(B < A);
+      REQUIRE(views[0] == Row({true, false}));
+      REQUIRE(Row({true, false}) == views[0]);
+      REQUIRE(Row({true, true}) != views[0]);
+      REQUIRE(Row({false, false}) < views[0]);
+      REQUIRE(A.hash_value() != 0);
+      A *= false;
+      REQUIRE(A == TestType({{false, false}, {false, false}}));
+      auto r = Row({true, false});
+      views  = matrix::rows(B);
+      REQUIRE(views[0].size() == 2);
+      r += views[0];
+      REQUIRE(r.number_of_cols() == 2);
+      REQUIRE(r.number_of_rows() == 1);
+      REQUIRE(r == Row({true, true}));
+
+      auto E = TestType::one(2);
+      REQUIRE(E.number_of_rows() == 2);
+      REQUIRE(E.number_of_cols() == 2);
+      auto viewse = matrix::rows(E);
+      REQUIRE(viewse.size() == 2);
+
+      std::ostringstream oss;
+      oss << E;  // Does not do anything visible
+
+      std::stringbuf buff;
+      std::ostream   os(&buff);
+      os << E;  // Also does not do anything visible
     }
     {
-      BMat<> m(3, 3);
-      m.product_inplace_no_checks(BMat<>({{1, 1, 0}, {0, 0, 1}, {1, 0, 1}}),
-                                  BMat<>({{1, 0, 1}, {0, 0, 1}, {1, 1, 0}}));
-      REQUIRE(m == BMat<>({{1, 0, 1}, {1, 1, 0}, {1, 1, 1}}));
+      TestType m({{0, 0}, {0, 0}});
+      using scalar_type = typename TestType::scalar_type;
+      auto it           = m.cbegin();
+      REQUIRE(m.coords(it) == std::pair<scalar_type, scalar_type>({0, 0}));
+      REQUIRE(m.coords(++it) == std::pair<scalar_type, scalar_type>({0, 1}));
+      REQUIRE(m.coords(++it) == std::pair<scalar_type, scalar_type>({1, 0}));
+      REQUIRE(m.coords(++it) == std::pair<scalar_type, scalar_type>({1, 1}));
     }
     {
-      BMat<>* A = new BMat<>();
-      delete A;
-      BMat<3>* B = new BMat<3>();
-      delete B;
-      BMat<3>::Row* C = new BMat<3>::Row();
-      delete C;
-      BMat<2>::Row* D = new BMat<2>::Row();
-      delete D;
-      BMat<2>* E = new BMat<2>();
-      delete E;
+      REQUIRE_THROWS_AS(to_matrix<TestType>({{0, 0}, {0, 2}}),
+                        LibsemigroupsException);
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "003", "BMat<2> + BMat<>", "[quick]") {
-    BMat<2> AB;
-    BMat<2> A;
-    BMat<2> B;
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "002",
+                                   "boolean matrix - test 2",
+                                   "[quick]",
+                                   BMat<3>,
+                                   BMat<>) {
+    auto     rg = ReportGuard(REPORT);
+    TestType m(3, 3);
+    m.product_inplace_no_checks(TestType({{1, 1, 0}, {0, 0, 1}, {1, 0, 1}}),
+                                TestType({{1, 0, 1}, {0, 0, 1}, {1, 1, 0}}));
+    REQUIRE(m == TestType({{1, 0, 1}, {1, 1, 0}, {1, 1, 1}}));
+    TestType* A = new TestType();
+    delete A;
+    typename TestType::Row* B = new typename TestType::Row();
+    delete B;
+  }
+
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "003",
+                                   "boolean matrix - test 3",
+                                   "[quick]",
+                                   BMat<2>,
+                                   BMat<>) {
+    TestType AB(2, 2), A(2, 2), B(2, 2);
     std::fill(A.begin(), A.end(), false);
     std::fill(B.begin(), B.end(), false);
     std::fill(AB.begin(), AB.end(), false);
@@ -900,49 +307,119 @@ namespace libsemigroups {
 
     AB.product_inplace_no_checks(A, B);
     REQUIRE(AB == B);
-
-    REQUIRE(A.one() == BMat<2>({{true, false}, {false, true}}));
-
-    BMat<> CD(2, 2);
-    BMat<> C(2, 2);
-    BMat<> D(2, 2);
-
-    std::fill(CD.begin(), CD.end(), false);
-    std::fill(D.begin(), D.end(), false);
-    C(1, 1) = true;
-    CD.product_inplace_no_checks(C, D);
-    REQUIRE(CD == D);
-    REQUIRE(D.one() == BMat<>({{true, false}, {false, true}}));
+    REQUIRE(A.one() == TestType({{true, false}, {false, true}}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "004", "BMat<3>", "[quick]") {
-    test_BMat001<BMat<3>>();
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "004",
+                                   "boolean matrix - test 4",
+                                   "[quick]",
+                                   BMat<3>,
+                                   BMat<>) {
+    auto x = TestType({{1, 0, 1}, {0, 1, 0}, {0, 1, 0}});
+    auto y = TestType({{0, 0, 0}, {0, 0, 0}, {0, 0, 0}});
+    auto z = TestType({{0, 0, 0}, {0, 0, 0}, {0, 0, 0}});
+    REQUIRE(y == z);
+    z.product_inplace_no_checks(x, y);
+    REQUIRE(y == z);
+    z.product_inplace_no_checks(y, x);
+    REQUIRE(y == z);
+    REQUIRE(!(y < z));
+    auto id = x.one();
+    z.product_inplace_no_checks(id, x);
+    REQUIRE(z == x);
+    z.product_inplace_no_checks(x, id);
+    REQUIRE(z == x);
+    REQUIRE(x.hash_value() != 0);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "005", "BMat<>", "[quick]") {
-    test_BMat001<BMat<>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "006", "BMat<3> row_basis", "[quick]") {
-    test_BMat002<BMat<3>>();
-  }
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "007", "BMat<> row_basis", "[quick]") {
-    test_BMat002<BMat<>>();
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "006",
+                                   "boolean matrix - row_basis",
+                                   "[quick]",
+                                   BMat<3>,
+                                   BMat<>) {
+    using RowView = typename TestType::RowView;
+    auto x        = to_matrix<TestType>({{1, 0, 0}, {1, 0, 0}, {1, 0, 0}});
+    REQUIRE(matrix::row_basis(x).size() == 1);
+    REQUIRE(matrix::row_space_size(x) == 1);
+    x = to_matrix<TestType>({{1, 0, 0}, {1, 1, 0}, {1, 1, 1}});
+    REQUIRE(matrix::row_basis(x).size() == 3);
+    REQUIRE_THROWS_AS(x.row(3), LibsemigroupsException);
+    std::vector<RowView> v = {x.row(0), x.row(2)};
+    REQUIRE(matrix::row_basis<TestType>(v).size() == 2);
+    REQUIRE(matrix::row_space_size(x) == 3);
+    x = to_matrix<TestType>({{1, 0, 0}, {0, 1, 1}, {1, 1, 1}});
+    REQUIRE(matrix::row_basis(x).size() == 2);
+    REQUIRE(matrix::row_space_size(x) == 3);
+    x = to_matrix<TestType>({{1, 0, 0}, {0, 0, 1}, {0, 1, 0}});
+    REQUIRE(matrix::row_space_size(x) == 7);
+    std::vector<typename TestType::RowView> views;
+    std::vector<typename TestType::RowView> result;
+    matrix::row_basis<TestType, std::vector<typename TestType::RowView>&>(
+        views, result);
   }
 
   ////////////////////////////////////////////////////////////////////////
   // Test cases - IntMat
   ////////////////////////////////////////////////////////////////////////
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "008", "IntMat<3>", "[quick]") {
-    test_IntMat000<IntMat<3>>();
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "008",
+                                   "integer matrix - test 1",
+                                   "[quick]",
+                                   IntMat<3>,
+                                   IntMat<>) {
+    {
+      auto x        = TestType({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
+      auto expected = TestType({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
+      REQUIRE(x == expected);
+
+      auto y = TestType({{-100, 0, 0}, {0, 1, 0}, {1, -1, 0}});
+      REQUIRE(!(x == y));
+
+      y.product_inplace_no_checks(x, x);
+      expected = TestType({{2, -4, 0}, {2, -2, 0}, {2, -1, 1}});
+      REQUIRE(y == expected);
+      REQUIRE(y.number_of_rows() == 3);
+
+      REQUIRE(x < y);
+      REQUIRE(Degree<TestType>()(x) == 3);
+      REQUIRE(Degree<TestType>()(y) == 3);
+      REQUIRE(Complexity<TestType>()(x) == 27);
+      REQUIRE(Complexity<TestType>()(y) == 27);
+      auto id = x.one();
+      y.product_inplace_no_checks(id, x);
+      REQUIRE(y == x);
+      y.product_inplace_no_checks(x, id);
+      REQUIRE(y == x);
+    }
+    {
+      auto x        = TestType({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
+      auto expected = TestType({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
+      REQUIRE(x == expected);
+
+      auto y = TestType({{-100, 0, 0}, {0, 1, 0}, {1, -1, 0}});
+      REQUIRE(!(x == y));
+
+      y.product_inplace_no_checks(x, x);
+      expected = TestType({{2, -4, 0}, {2, -2, 0}, {2, -1, 1}});
+      REQUIRE(y == expected);
+
+      REQUIRE(x < y);
+      auto id = x.one();
+      y.product_inplace_no_checks(id, x);
+      REQUIRE(y == x);
+      y.product_inplace_no_checks(x, id);
+      REQUIRE(y == x);
+      REQUIRE(Hash<TestType>()(y) != 0);
+    }
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "009", "IntMat<>", "[quick]") {
-    test_IntMat000<IntMat<>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "010", "IntMat code cov", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Matrix",
+                          "010",
+                          "integer matrix - code cov",
+                          "[quick]") {
     IntMat<>* A = new IntMat<>();
     delete A;
     IntMat<3>* B = new IntMat<3>();
@@ -966,12 +443,35 @@ namespace libsemigroups {
   // Test cases - MaxPlusMat
   ////////////////////////////////////////////////////////////////////////
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "011", "MaxPlusMat<3>", "[quick]") {
-    test_MaxPlusMat000<MaxPlusMat<3>>();
-  }
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "011",
+                                   "max-plus matrix - test 1",
+                                   "[quick]",
+                                   MaxPlusMat<>,
+                                   MaxPlusMat<3>) {
+    auto x        = TestType({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
+    auto expected = TestType({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
+    REQUIRE(x == expected);
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "012", "MaxPlusMat<>", "[quick]") {
-    test_MaxPlusMat000<MaxPlusMat<>>();
+    auto y = TestType{{-100, 0, 0}, {0, 1, 0}, {1, -1, 0}};
+    REQUIRE(!(x == y));
+    REQUIRE(x != y);
+
+    y.product_inplace_no_checks(x, x);
+    expected = TestType({{1, 2, 2}, {1, 1, 1}, {2, 3, 2}});
+    REQUIRE(y == expected);
+
+    REQUIRE(x < y);
+    REQUIRE(Degree<TestType>()(x) == 3);
+    REQUIRE(Degree<TestType>()(y) == 3);
+    REQUIRE(Complexity<TestType>()(x) == 27);
+    REQUIRE(Complexity<TestType>()(y) == 27);
+    auto id = x.one();
+    y.product_inplace_no_checks(id, x);
+    REQUIRE(y == x);
+    y.product_inplace_no_checks(x, id);
+    REQUIRE(y == x);
+    REQUIRE(Hash<TestType>()(y) != 0);
   }
 
   LIBSEMIGROUPS_TEST_CASE("Matrix", "013", "MaxPlusMat code cov", "[quick]") {
@@ -985,12 +485,60 @@ namespace libsemigroups {
   // Test cases - MinPlusMat
   ////////////////////////////////////////////////////////////////////////
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "014", "MinPlusMat<3>", "[quick]") {
-    test_MinPlusMat000<MinPlusMat<3>>();
-  }
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "014",
+                                   "min-plus matrix - test 1",
+                                   "[quick]",
+                                   MinPlusMat<3>,
+                                   MinPlusMat<>) {
+    {
+      auto x        = TestType({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
+      auto expected = TestType({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
+      // Just testing the below doesn't compile
+      // matrix::row_basis(x);
+      REQUIRE(x == expected);
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "015", "MinPlusMat<>", "[quick]") {
-    test_MinPlusMat000<MinPlusMat<>>();
+      auto y = TestType({{-100, 0, 0}, {0, 1, 0}, {1, -1, 0}});
+      REQUIRE(!(x == y));
+
+      y.product_inplace_no_checks(x, x);
+      expected = TestType({{-4, -3, -2}, {-3, -3, -1}, {-4, -3, -3}});
+      REQUIRE(y == expected);
+
+      REQUIRE(!(x < y));
+      REQUIRE(Degree<TestType>()(x) == 3);
+      REQUIRE(Degree<TestType>()(y) == 3);
+      REQUIRE(Complexity<TestType>()(x) == 27);
+      REQUIRE(Complexity<TestType>()(y) == 27);
+      auto id = x.one();
+      y.product_inplace_no_checks(id, x);
+      REQUIRE(y == x);
+      y.product_inplace_no_checks(x, id);
+      REQUIRE(y == x);
+    }
+    {
+      auto x        = TestType({{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
+      auto expected = TestType({{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
+      REQUIRE(x == expected);
+
+      auto y = TestType({{10, 0, 0}, {0, 1, 0}, {1, 1, 0}});
+      REQUIRE(!(x == y));
+
+      y.product_inplace_no_checks(x, x);
+      REQUIRE(y == TestType({{1, 21, 1}, {1, 0, 0}, {2, 22, 1}}));
+
+      REQUIRE(x > y);
+      REQUIRE(Degree<TestType>()(x) == 3);
+      REQUIRE(Degree<TestType>()(y) == 3);
+      REQUIRE(Complexity<TestType>()(x) == 27);
+      REQUIRE(Complexity<TestType>()(y) == 27);
+      auto id = x.one();
+      y.product_inplace_no_checks(id, x);
+      REQUIRE(y == x);
+      y.product_inplace_no_checks(x, id);
+      REQUIRE(y == x);
+      REQUIRE(Hash<TestType>()(y) != 0);
+    }
   }
 
   LIBSEMIGROUPS_TEST_CASE("Matrix", "016", "MinPlusMat code cov", "[quick]") {
@@ -1004,58 +552,154 @@ namespace libsemigroups {
   // Test cases - MaxPlusTruncMat
   ////////////////////////////////////////////////////////////////////////
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "017", "MaxPlusTruncMat<5, 2>", "[quick]") {
-    // Threshold 5, 2 x 2
-    test_MaxPlusTruncMat000<MaxPlusTruncMat<5, 2>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "018", "MaxPlusTruncMat<5>", "[quick]") {
-    // Threshold 5, 2 x 2
-    test_MaxPlusTruncMat000<MaxPlusTruncMat<5>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "019", "MaxPlusTruncMat<>", "[quick]") {
-    // Threshold 5, 2 x 2 (specified in test_MaxPlusTruncMat000)
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "017",
+                                   "max-plus trunc. matrix - test 1",
+                                   "[quick]",
+                                   (MaxPlusTruncMat<5, 2>),
+                                   MaxPlusTruncMat<5>,
+                                   MaxPlusTruncMat<>) {
     REQUIRE_THROWS_AS(MaxPlusTruncSemiring<>(-1), LibsemigroupsException);
-    MaxPlusTruncSemiring<> const* sr = new MaxPlusTruncSemiring<>(5);
-    test_MaxPlusTruncMat000<MaxPlusTruncMat<>>(sr);
+    // Threshold 5, 2 x 2
+    MaxPlusTruncSemiring<>* sr = nullptr;
+    if constexpr (!std::is_same_v<typename TestType::semiring_type, void>) {
+      sr = new MaxPlusTruncSemiring(5);
+    }
+    using scalar_type = typename TestType::scalar_type;
+    {
+      TestType m1(sr, 2, 2);
+      std::fill(m1.begin(), m1.end(), NEGATIVE_INFINITY);
+      REQUIRE(m1
+              == to_matrix<TestType>(sr,
+                                     {{NEGATIVE_INFINITY, NEGATIVE_INFINITY},
+                                      {NEGATIVE_INFINITY, NEGATIVE_INFINITY}}));
+      TestType m2(sr, 2, 2);
+      std::fill(m2.begin(), m2.end(), 4);
+      REQUIRE(m1 + m2 == m2);
+      REQUIRE(m2(0, 1) == 4);
+    }
+
+    auto rg = ReportGuard(REPORT);
+    {
+      std::vector<std::array<scalar_type, 2>> expected;
+      expected.push_back({1, 1});
+      expected.push_back({0, 0});
+      tropical_max_plus_row_basis<2, 5>(expected);
+      REQUIRE(expected.size() == 1);
+      REQUIRE(expected.at(0) == std::array<scalar_type, 2>({0, 0}));
+
+      TestType m(sr, {{1, 1}, {0, 0}});
+      auto     r = matrix::row_basis(m);
+      REQUIRE(r.size() == 1);
+      REQUIRE(std::vector<scalar_type>(r[0].cbegin(), r[0].cend())
+              == std::vector<scalar_type>({0, 0}));
+    }
+    {
+      TestType m(sr, {{1, 1}, {0, 0}});
+      m      = m.one();
+      auto r = matrix::row_basis(m);
+      REQUIRE(r.size() == 2);
+      REQUIRE(std::vector<scalar_type>(r[0].cbegin(), r[0].cend())
+              == std::vector<scalar_type>({NEGATIVE_INFINITY, 0}));
+      REQUIRE(std::vector<scalar_type>(r[1].cbegin(), r[1].cend())
+              == std::vector<scalar_type>({0, NEGATIVE_INFINITY}));
+    }
+    std::vector<typename TestType::RowView> views;
+    std::vector<typename TestType::RowView> result;
+    matrix::row_basis<TestType>(views, result);
     delete sr;
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "020", "MaxPlusTruncMat<5, 4>", "[quick]") {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "020",
+                                   "max-plus trunc. matrix - test 2",
+                                   "[quick]",
+                                   (MaxPlusTruncMat<5, 4>),
+                                   MaxPlusTruncMat<5>,
+                                   MaxPlusTruncMat<>) {
     // Threshold 5, 4 x 4
-    test_MaxPlusTruncMat001<MaxPlusTruncMat<5, 4>>();
-  }
+    using scalar_type = typename TestType::scalar_type;
+    using Row         = typename TestType::Row;
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "021", "MaxPlusTruncMat<5>", "[quick]") {
-    // Threshold 5, 4 x 4
-    test_MaxPlusTruncMat001<MaxPlusTruncMat<5>>();
-  }
+    MaxPlusTruncSemiring<>* sr = nullptr;
+    if constexpr (!std::is_same_v<typename TestType::semiring_type, void>) {
+      sr = new MaxPlusTruncSemiring(5);
+    }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "022", "MaxPlusTruncMat<>", "[quick]") {
-    // Threshold 5, 4 x 4
-    MaxPlusTruncSemiring<> const* sr = new MaxPlusTruncSemiring<>(5);
-    test_MaxPlusTruncMat001<MaxPlusTruncMat<>>(sr);
+    auto m  = to_matrix<TestType>(sr,
+                                 {{2, 2, 0, 1},
+                                   {0, 0, 1, 3},
+                                   {1, NEGATIVE_INFINITY, 0, 0},
+                                   {0, 1, 0, 1}});
+    auto rg = ReportGuard(REPORT);
+    auto r  = matrix::row_basis(m);
+    REQUIRE(r.size() == 4);
+    REQUIRE(r[0] == to_matrix<Row>(sr, {0, 0, 1, 3}));
+    REQUIRE(r[1] == to_matrix<Row>(sr, {0, 1, 0, 1}));
+    REQUIRE(r[2] == to_matrix<Row>(sr, {1, NEGATIVE_INFINITY, 0, 0}));
+    REQUIRE(r[3] == to_matrix<Row>(sr, {2, 2, 0, 1}));
+    m.transpose();
+    REQUIRE(m
+            == to_matrix<TestType>(sr,
+                                   {{2, 0, 1, 0},
+                                    {2, 0, NEGATIVE_INFINITY, 1},
+                                    {0, 1, 0, 0},
+                                    {1, 3, 0, 1}}));
+    m.transpose();
+    REQUIRE(m
+            == to_matrix<TestType>(sr,
+                                   {{2, 2, 0, 1},
+                                    {0, 0, 1, 3},
+                                    {1, NEGATIVE_INFINITY, 0, 0},
+                                    {0, 1, 0, 1}}));
+
+    std::vector<std::array<scalar_type, 4>> expected;
+    expected.push_back({2, 2, 0, 1});
+    expected.push_back({0, 0, 1, 3});
+    expected.push_back({1, NEGATIVE_INFINITY, 0, 0});
+    expected.push_back({0, 1, 0, 1});
+    tropical_max_plus_row_basis<4, 5>(expected);
+    REQUIRE(expected.size() == 4);
+    REQUIRE(m * TestType::one(sr, 4) == m);
+    REQUIRE(TestType::one(sr, 4) * m == m);
     delete sr;
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix",
-                          "023",
-                          "MaxPlusTruncMat<33, 3>",
-                          "[quick]") {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "023",
+                                   "max-plus trunc. matrix - test 3",
+                                   "[quick]",
+                                   (MaxPlusTruncMat<33, 3>),
+                                   MaxPlusTruncMat<33>,
+                                   MaxPlusTruncMat<>) {
     // Threshold 33, 3 x 3
-    test_MaxPlusTruncMat002<MaxPlusTruncMat<33, 3>>();
-  }
+    MaxPlusTruncSemiring<>* sr = nullptr;
+    if constexpr (!std::is_same_v<typename TestType::semiring_type, void>) {
+      sr = new MaxPlusTruncSemiring(33);
+    }
+    auto x        = TestType(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
+    auto expected = TestType(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
+    REQUIRE(x == expected);
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "024", "MaxPlusTruncMat<33>", "[quick]") {
-    // Threshold 33, 3 x 3
-    test_MaxPlusTruncMat002<MaxPlusTruncMat<33>>();
-  }
+    REQUIRE_THROWS_AS(
+        to_matrix<TestType>(sr, {{-100, 0, 0}, {0, 1, 0}, {1, -1, 0}}),
+        LibsemigroupsException);
+    auto y = TestType(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}});
+    REQUIRE(!(x == y));
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "025", "MaxPlusTruncMat<>", "[quick]") {
-    // Threshold 33, 3 x 3
-    MaxPlusTruncSemiring<> const* sr = new MaxPlusTruncSemiring<>(33);
-    test_MaxPlusTruncMat002<MaxPlusTruncMat<>>(sr);
+    y.product_inplace_no_checks(x, x);
+    expected = TestType(sr, {{33, 33, 22}, {32, 32, 10}, {33, 33, 32}});
+    REQUIRE(y == expected);
+
+    REQUIRE(x < y);
+    auto id = x.one();
+    y.product_inplace_no_checks(id, x);
+    REQUIRE(y == x);
+    y.product_inplace_no_checks(x, id);
+    REQUIRE(y == x);
+    REQUIRE(Hash<TestType>()(y) != 0);
+    REQUIRE(x * TestType::one(sr, 3) == x);
+    REQUIRE(TestType::one(sr, 3) * x == x);
     delete sr;
   }
 
@@ -1078,90 +722,230 @@ namespace libsemigroups {
   // Test cases - MinPlusTruncMat
   ////////////////////////////////////////////////////////////////////////
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix",
-                          "027",
-                          "MinPlusTruncMat<33, 3>",
-                          "[quick]") {
-    // 3 x 3 matrices with threshold 33
-    test_MinPlusTruncMat000<MinPlusTruncMat<33, 3>>();
-  }
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "027",
+                                   "min-plus trunc. matrix - test 1",
+                                   "[quick]",
+                                   (MinPlusTruncMat<33, 3>),
+                                   MinPlusTruncMat<33>,
+                                   MinPlusTruncMat<>) {
+    // Threshold 33, 3 x 3
+    MinPlusTruncSemiring<>* sr = nullptr;
+    if constexpr (!std::is_same_v<typename TestType::semiring_type, void>) {
+      sr = new MinPlusTruncSemiring(33);
+    }
+    auto x = TestType(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "028", "MinPlusTruncMat<33>", "[quick]") {
-    // 3 x 3 matrices with threshold 33
-    test_MinPlusTruncMat000<MinPlusTruncMat<33>>();
-  }
+    auto expected
+        = to_matrix<TestType>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
+    REQUIRE(x == expected);
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "029", "MinPlusTruncMat<>", "[quick]") {
-    // 3 x 3 matrices with threshold 33
-    REQUIRE_THROWS_AS(MinPlusTruncSemiring<>(-1), LibsemigroupsException);
-    MinPlusTruncSemiring<> const* sr = new MinPlusTruncSemiring<>(33);
-    test_MinPlusTruncMat000<MinPlusTruncMat<>>(sr);
+    auto y = TestType(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}});
+    REQUIRE(!(x == y));
+
+    y.product_inplace_no_checks(x, x);
+    expected = TestType(sr, {{1, 21, 1}, {1, 0, 0}, {2, 22, 1}});
+    REQUIRE(y == expected);
+
+    REQUIRE(!(x < y));
+    REQUIRE(Degree<TestType>()(x) == 3);
+    REQUIRE(Degree<TestType>()(y) == 3);
+    REQUIRE(Complexity<TestType>()(x) == 27);
+    REQUIRE(Complexity<TestType>()(y) == 27);
+    auto id = x.one();
+    y.product_inplace_no_checks(id, x);
+    REQUIRE(y == x);
+    y.product_inplace_no_checks(x, id);
+    REQUIRE(y == x);
+    REQUIRE(Hash<TestType>()(y) != 0);
+    REQUIRE_THROWS_AS(
+        to_matrix<TestType>(sr, {{-22, 21, 0}, {10, 0, 0}, {1, 32, 1}}),
+        LibsemigroupsException);
+    REQUIRE(x * TestType::one(sr, 3) == x);
+    REQUIRE(TestType::one(sr, 3) * x == x);
     delete sr;
   }
-
   ////////////////////////////////////////////////////////////////////////
   // Test cases - NTPMat
   ////////////////////////////////////////////////////////////////////////
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "030", "NTPMat<0, 3, 3, 3>", "[quick]") {
-    test_NTPMat000<NTPMat<0, 3, 3, 3>>();
-    test_NTPMat000<NTPMat<0, 3, 3>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "031", "NTPMat<0, 3>", "[quick]") {
-    test_NTPMat000<NTPMat<0, 3>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "032", "NTPMat<>", "[quick]") {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "030",
+                                   "3x3 matrix, t = 0, p = 3",
+                                   "[quick]",
+                                   (NTPMat<0, 3, 3, 3>),
+                                   (NTPMat<0, 3, 3>),
+                                   NTPMat<>) {
     REQUIRE_THROWS_AS(NTPSemiring<int>(4, -1), LibsemigroupsException);
     REQUIRE_THROWS_AS(NTPSemiring<int>(-1, -1), LibsemigroupsException);
-    NTPSemiring<> const* sr = new NTPSemiring<>(0, 3);
-    test_NTPMat000<NTPMat<>>(sr);
+
+    NTPSemiring<>* sr = nullptr;
+    if constexpr (!std::is_same_v<typename TestType::semiring_type, void>) {
+      sr = new NTPSemiring<>(0, 3);
+    }
+    using Row   = typename TestType::Row;
+    auto     rg = ReportGuard(REPORT);
+    TestType m(sr, 3, 3);
+    // REQUIRE(matrix::throw_if_bad_entry(m)); // m might not be valid!
+    m.product_inplace_no_checks(
+        to_matrix<TestType>(sr, {{1, 1, 0}, {0, 0, 1}, {1, 0, 1}}),
+        to_matrix<TestType>(sr, {{1, 0, 1}, {0, 0, 1}, {1, 1, 0}}));
+    REQUIRE(m == to_matrix<TestType>(sr, {{1, 0, 2}, {1, 1, 0}, {2, 1, 1}}));
+    REQUIRE(m.row(0) == Row(sr, {1, 0, 2}));
+    REQUIRE(m.row(0).size() == 3);
+    auto r = matrix::rows(m);
+    REQUIRE(r[0] == Row(sr, {1, 0, 2}));
+    REQUIRE(r[1] == Row(sr, {1, 1, 0}));
+    REQUIRE(r[2] == Row(sr, {2, 1, 1}));
+    REQUIRE(m * TestType::one(sr, 3) == m);
+    REQUIRE(TestType::one(sr, 3) * m == m);
     delete sr;
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "033", "NTPMat<0, 10, 4, 4>", "[quick]") {
-    test_NTPMat001<NTPMat<0, 10, 4, 4>>();
-    test_NTPMat001<NTPMat<0, 10, 4>>();
-  }
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "034",
+                                   "4x4 matrix, t = 0, p = 10",
+                                   "[quick]",
+                                   (NTPMat<0, 10>),
+                                   NTPMat<>) {
+    NTPSemiring<>* sr = nullptr;
+    if constexpr (!std::is_same_v<typename TestType::semiring_type, void>) {
+      sr = new NTPSemiring<>(0, 10);
+    }
+    using Row         = typename TestType::Row;
+    using RowView     = typename TestType::RowView;
+    using scalar_type = typename TestType::scalar_type;
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "034", "NTPMat<0, 10>", "[quick]") {
-    test_NTPMat001<NTPMat<0, 10>>();
-  }
+    auto rg = ReportGuard(REPORT);
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "035", "NTPMat<>", "[quick]") {
-    NTPSemiring<> const* sr = new NTPSemiring<>(0, 10);
-    test_NTPMat001<NTPMat<>>(sr);
+    TestType m = to_matrix<TestType>(
+        sr, {{1, 1, 0, 0}, {2, 0, 2, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}});
+    REQUIRE(m.number_of_cols() == 4);
+    REQUIRE(m.number_of_rows() == 4);
+    auto r = matrix::rows(m);
+    REQUIRE(r.size() == 4);
+    REQUIRE(std::vector<scalar_type>(r[0].cbegin(), r[0].cend())
+            == std::vector<scalar_type>({1, 1, 0, 0}));
+    r[0] += r[1];
+    REQUIRE(std::vector<scalar_type>(r[0].cbegin(), r[0].cend())
+            == std::vector<scalar_type>({3, 1, 2, 0}));
+    REQUIRE(std::vector<scalar_type>(r[1].cbegin(), r[1].cend())
+            == std::vector<scalar_type>({2, 0, 2, 0}));
+    REQUIRE(m
+            == to_matrix<TestType>(
+                sr, {{3, 1, 2, 0}, {2, 0, 2, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}}));
+    REQUIRE(r[0][0] == 3);
+    REQUIRE(r[0](0) == 3);
+    REQUIRE(r[2](3) == 9);
+    std::sort(r[0].begin(), r[0].end());
+    REQUIRE(std::vector<scalar_type>(r[0].cbegin(), r[0].cend())
+            == std::vector<scalar_type>({0, 1, 2, 3}));
+    REQUIRE(m
+            == to_matrix<TestType>(
+                sr, {{0, 1, 2, 3}, {2, 0, 2, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}}));
+    r[0] += 9;
+    REQUIRE(std::vector<scalar_type>(r[0].cbegin(), r[0].cend())
+            == std::vector<scalar_type>({9, 0, 1, 2}));
+    REQUIRE(m
+            == to_matrix<TestType>(
+                sr, {{9, 0, 1, 2}, {2, 0, 2, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}}));
+    r[1] *= 3;
+    REQUIRE(m
+            == to_matrix<TestType>(
+                sr, {{9, 0, 1, 2}, {6, 0, 6, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}}));
+    REQUIRE(std::vector<scalar_type>(r[1].cbegin(), r[1].cend())
+            == std::vector<scalar_type>({6, 0, 6, 0}));
+    REQUIRE(r[2] < r[1]);
+    r[1] = r[2];
+    REQUIRE(m
+            == to_matrix<TestType>(
+                sr, {{9, 0, 1, 2}, {6, 0, 6, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}}));
+    REQUIRE(r[1] == r[2]);
+    REQUIRE(r[1] == to_matrix<Row>(sr, {{1, 2, 3, 9}}));
+
+    RowView rv;
+    {
+      rv = r[0];
+      REQUIRE(rv == r[0]);
+      REQUIRE(&rv != &r[0]);
+    }
     delete sr;
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "036", "NTPMat<0, 10, 4, 4>", "[quick]") {
-    test_NTPMat002<NTPMat<0, 10, 4, 4>>();
-    test_NTPMat002<NTPMat<0, 10, 4>>();
-  }
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "036",
+                                   "4x4 matrix, t = 0, p = 10",
+                                   "[quick]",
+                                   (NTPMat<0, 10, 4, 4>),
+                                   (NTPMat<0, 10, 4>),
+                                   (NTPMat<0, 10>),
+                                   NTPMat<>) {
+    using Row         = typename TestType::Row;
+    NTPSemiring<>* sr = nullptr;
+    if constexpr (!std::is_same_v<typename TestType::semiring_type, void>) {
+      sr = new NTPSemiring<>(0, 10);
+    }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "037", "NTPMat<0, 10>", "[quick]") {
-    test_NTPMat002<NTPMat<0, 10>>();
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "038", "NTPMat<>", "[quick]") {
-    NTPSemiring<> const* sr = new NTPSemiring<>(0, 10);
-    test_NTPMat002<NTPMat<>>(sr);
+    auto     rg = ReportGuard(REPORT);
+    TestType m(sr, {{1, 1, 0, 0}, {2, 0, 2, 0}, {1, 2, 3, 9}, {0, 0, 0, 7}});
+    REQUIRE(m.number_of_cols() == 4);
+    REQUIRE(m.number_of_rows() == 4);
+    auto r = matrix::rows(m);
+    REQUIRE(r.size() == 4);
+    REQUIRE(r[0] == to_matrix<Row>(sr, {{1, 1, 0, 0}}));
+    REQUIRE(r[1] == to_matrix<Row>(sr, {{2, 0, 2, 0}}));
+    REQUIRE(r[0] != to_matrix<Row>(sr, {{2, 0, 2, 0}}));
+    REQUIRE(r[1] != to_matrix<Row>(sr, {{1, 1, 0, 0}}));
+    REQUIRE(to_matrix<Row>(sr, {{1, 1, 0, 0}}) == r[0]);
+    REQUIRE(to_matrix<Row>(sr, {{2, 0, 2, 0}}) == r[1]);
+    REQUIRE(to_matrix<Row>(sr, {{2, 0, 2, 0}}) != r[0]);
+    REQUIRE(to_matrix<Row>(sr, {{1, 1, 0, 0}}) != r[1]);
+    REQUIRE(to_matrix<Row>(sr, {{1, 1, 0, 0}}) < Row(sr, {{9, 9, 9, 9}}));
+    REQUIRE(r[0] < to_matrix<Row>(sr, {{9, 9, 9, 9}}));
+    REQUIRE(!(to_matrix<Row>(sr, {{9, 9, 9, 9}}) < r[0]));
+    Row x(r[3]);
+    x *= 3;
+    REQUIRE(x == to_matrix<Row>(sr, {{0, 0, 0, 1}}));
+    REQUIRE(x.number_of_rows() == 1);
+    REQUIRE(x.number_of_cols() == 4);
+    REQUIRE(r[3] == to_matrix<Row>(sr, {{0, 0, 0, 7}}));
+    REQUIRE(r[3] != x);
+    REQUIRE(x != r[3]);
+    REQUIRE(!(x != x));
     delete sr;
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "039", "NTPMat<33, 2, 3, 3>", "[quick]") {
-    test_NTPMat003<NTPMat<33, 2, 3, 3>>();
-    test_NTPMat003<NTPMat<33, 2, 3>>();
-  }
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "038",
+                                   "3x3 matrix, t = 33, p = 2",
+                                   "[quick]",
+                                   (NTPMat<33, 2>),
+                                   NTPMat<>) {
+    NTPSemiring<>* sr = nullptr;
+    if constexpr (!std::is_same_v<typename TestType::semiring_type, void>) {
+      sr = new NTPSemiring<>(33, 2);
+    }
+    auto x = to_matrix<TestType>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
+    auto expected
+        = to_matrix<TestType>(sr, {{22, 21, 0}, {10, 0, 0}, {1, 32, 1}});
+    REQUIRE(x == expected);
+    REQUIRE(x.number_of_cols() == 3);
+    REQUIRE(x.number_of_rows() == 3);
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "040", "NTPMat<33, 2>", "[quick]") {
-    test_NTPMat003<NTPMat<33, 2>>();
-  }
+    auto y = to_matrix<TestType>(sr, {{10, 0, 0}, {0, 1, 0}, {1, 1, 0}});
+    REQUIRE(!(x == y));
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "041", "NTPMat<>", "[quick]") {
-    NTPSemiring<> const* sr = new NTPSemiring<>(33, 2);
-    test_NTPMat003<NTPMat<>>(sr);
+    y.product_inplace_no_checks(x, x);
+    expected = to_matrix<TestType>(sr, {{34, 34, 0}, {34, 34, 0}, {33, 33, 1}});
+    REQUIRE(y == expected);
+
+    REQUIRE(x < y);
+    auto id = x.one();
+    y.product_inplace_no_checks(id, x);
+    REQUIRE(y == x);
+    y.product_inplace_no_checks(x, id);
+    REQUIRE(y == x);
+    REQUIRE(Hash<TestType>()(y) != 0);
     delete sr;
   }
 
@@ -1169,13 +953,97 @@ namespace libsemigroups {
   // Test cases - ProjMaxPlusMat
   ////////////////////////////////////////////////////////////////////////
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "042", "ProjMaxPlusMat<3>", "[quick]") {
-    test_ProjMaxPlusMat000<ProjMaxPlusMat<3, 3>>();
-    test_ProjMaxPlusMat000<ProjMaxPlusMat<3>>();
-  }
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "042",
+                                   "3x3 matrix",
+                                   "[quick]",
+                                   (ProjMaxPlusMat<3, 3>),
+                                   ProjMaxPlusMat<3>,
+                                   ProjMaxPlusMat<>) {
+    using Row = typename TestType::Row;
+    auto x    = to_matrix<TestType>({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
+    auto expected
+        = to_matrix<TestType>({{-4, 0, -2}, {-3, -2, -2}, {-1, -5, -1}});
+    REQUIRE(x == expected);
+    REQUIRE(x.scalar_zero() == NEGATIVE_INFINITY);
+    REQUIRE(x.scalar_one() == 0);
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "043", "ProjMaxPlusMat<>", "[quick]") {
-    test_ProjMaxPlusMat000<ProjMaxPlusMat<>>();
+    auto y = to_matrix<TestType>(
+        {{NEGATIVE_INFINITY, 0, 0}, {0, 1, 0}, {1, -1, 0}});
+    expected = to_matrix<TestType>(
+        {{NEGATIVE_INFINITY, -1, -1}, {-1, 0, -1}, {0, -2, -1}});
+    REQUIRE(y == expected);
+    REQUIRE(!(x == y));
+
+    y.product_inplace_no_checks(x, x);
+    expected = TestType({{-2, -1, -1}, {-2, -2, -2}, {-1, 0, -1}});
+    REQUIRE(y == expected);
+
+    REQUIRE(x < y);
+    REQUIRE(y > x);
+    REQUIRE(Degree<TestType>()(x) == 3);
+    REQUIRE(Degree<TestType>()(y) == 3);
+    REQUIRE(Complexity<TestType>()(x) == 27);
+    REQUIRE(Complexity<TestType>()(y) == 27);
+    auto id = x.one();
+    y.product_inplace_no_checks(id, x);
+    REQUIRE(y == x);
+    y.product_inplace_no_checks(x, id);
+    REQUIRE(y == x);
+
+    REQUIRE(
+        to_matrix<TestType>({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}}).hash_value()
+        != 0);
+
+    y = x;
+    REQUIRE(&x != &y);
+    REQUIRE(x == y);
+    // TODO uncomment or remove
+    // REQUIRE(y
+    //         == to_matrix<TestType>(nullptr, {{-2, 2, 0}, {-1, 0, 0}, {1, -3,
+    //         1}}));
+
+    auto yy(y);
+    REQUIRE(yy == y);
+
+    std::ostringstream oss;
+    oss << y;  // Does not do anything visible
+    std::stringbuf buff;
+    std::ostream   os(&buff);
+    os << y;  // Also does not do anything visible
+
+    REQUIRE(y.row(0) == to_matrix<Row>({-4, 0, -2}));
+    REQUIRE(y.row(1) == Row({-3, -2, -2}));
+    REQUIRE(Row(y.row(0)) == y.row(0));
+
+    auto zz(std::move(y));
+
+    TestType tt;
+    REQUIRE(tt != zz);
+    REQUIRE(TestType::one(3)
+            == TestType({{0, NEGATIVE_INFINITY, NEGATIVE_INFINITY},
+                         {NEGATIVE_INFINITY, 0, NEGATIVE_INFINITY},
+                         {NEGATIVE_INFINITY, NEGATIVE_INFINITY, 0}}));
+    REQUIRE(zz(0, 0) == -4);
+    REQUIRE(zz.number_of_cols() == 3);
+    zz += zz;
+    REQUIRE(zz == TestType({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}}));
+    zz *= 2;
+    REQUIRE(zz == TestType({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}}));
+    REQUIRE(zz + x == TestType({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}}));
+    REQUIRE(zz * x == TestType({{-2, -1, -1}, {-2, -2, -2}, {-1, 0, -1}}));
+    REQUIRE(std::accumulate(zz.cbegin(), zz.cend(), 0) == -20);
+    REQUIRE(std::accumulate(zz.begin(), zz.end(), 0) == -20);
+    x.transpose();
+    REQUIRE(x == TestType({{-4, -3, -1}, {0, -2, -5}, {-2, -2, -1}}));
+    x.swap(zz);
+    REQUIRE(zz == TestType({{-4, -3, -1}, {0, -2, -5}, {-2, -2, -1}}));
+    REQUIRE(matrix::pow(x, 100)
+            == TestType({{-1, 0, -1}, {-2, -1, -2}, {-1, 0, -1}}));
+    REQUIRE_THROWS_AS(matrix::pow(x, -100), LibsemigroupsException);
+    REQUIRE(matrix::pow(x, 1)
+            == TestType({{-4, 0, -2}, {-3, -2, -2}, {-1, -5, -1}}));
+    REQUIRE(matrix::pow(x, 0) == TestType::one(3));
   }
 
   LIBSEMIGROUPS_TEST_CASE("Matrix", "044", "exceptions", "[quick][element]") {

--- a/tests/test-obvinf.cpp
+++ b/tests/test-obvinf.cpp
@@ -38,10 +38,10 @@ namespace libsemigroups {
 
   using namespace literals;
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "001",
-                             "Multiple rule additions",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "001",
+                          "Multiple rule additions",
+                          "[quick]") {
     IsObviouslyInfinite      ioi(3);
     std::vector<std::string> v
         = {"aababbaccabbc", "a", "aaabbbbaaabbbbacbbb", "bb"};
@@ -70,42 +70,40 @@ namespace libsemigroups {
     REQUIRE(!ioi.result());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ObviouslyInfinite",
-      "002",
-      "A power of the generator 'b' does not occur on its own in any relation",
-      "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "002",
+                          "b^n does not occur on its own in any relation",
+                          "[quick]") {
     IsObviouslyInfinite      ioi(2);
     std::vector<std::string> v = {"ab", "a", "aba", "ba"};
     ioi.add_rules_no_checks("ab", v.cbegin(), v.cend());
     REQUIRE(ioi.result());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ObviouslyInfinite",
-      "003",
-      "Preserves the number of occurrences of the generator 'a'",
-      "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "003",
+                          "Preserves occurrences of the generator 'a'",
+                          "[quick]") {
     IsObviouslyInfinite      ioi(2);
     std::vector<std::string> v = {"aba", "aa", "bb", "b", "abab", "abbba"};
     ioi.add_rules_no_checks("ab", v.cbegin(), v.cend());
     REQUIRE(ioi.result());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "004",
-                             "Less relations than generators",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "004",
+                          "Less relations than generators",
+                          "[quick]") {
     IsObviouslyInfinite      ioi(3);
     std::vector<std::string> v = {"aba", "bc", "ca", "b"};
     ioi.add_rules_no_checks("abc", v.cbegin(), v.cend());
     REQUIRE(ioi.result());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "005",
-                             "Relations preserve length",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "005",
+                          "Relations preserve length",
+                          "[quick]") {
     IsObviouslyInfinite      ioi(3);
     std::vector<std::string> v
         = {"aaa", "bbc", "cccc", "bcba", "bb", "cb", "cba", "bbc"};
@@ -113,10 +111,10 @@ namespace libsemigroups {
     REQUIRE(ioi.result());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "006",
-                             "Matrix has non empty kernel",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "006",
+                          "Matrix has non empty kernel",
+                          "[quick]") {
     IsObviouslyInfinite    ioi(2);
     std::vector<word_type> vv = {"aa"_w, "bba"_w, "bbaa"_w, "bbbbbb"_w};
     ioi.add_rules_no_checks(vv.cbegin(), vv.cend());
@@ -130,20 +128,20 @@ namespace libsemigroups {
     require_true_if_eigen_enabled(ioi);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "007",
-                             "Free product of trivial semigroups",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "007",
+                          "Free product of trivial semigroups",
+                          "[quick]") {
     IsObviouslyInfinite      ioi(2);
     std::vector<std::string> v = {"a", "aa", "b", "bb"};
     ioi.add_rules_no_checks("ab", v.cbegin(), v.cend());
     REQUIRE(ioi.result());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "008",
-                             "Another free product",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "008",
+                          "Another free product",
+                          "[quick]") {
     IsObviouslyInfinite      ioi(5);
     std::vector<std::string> v
         = {"a", "aa", "b", "bb", "abe", "eee", "dc", "c", "cc", "ddd"};
@@ -151,10 +149,10 @@ namespace libsemigroups {
     REQUIRE(ioi.result());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "009",
-                             "Infinite but not obviously so",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "009",
+                          "Infinite but not obviously so",
+                          "[quick]") {
     IsObviouslyInfinite      ioi(2);
     std::vector<std::string> v = {"a", "abb", "b", "baa"};
     ioi.add_rules_no_checks("ab", v.cbegin(), v.cend());
@@ -163,10 +161,10 @@ namespace libsemigroups {
     // is infinite! Contains (ab)^n for all n.
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "010",
-                             "Finite semigroup",
-                             "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "010",
+                          "Finite semigroup",
+                          "[quick]") {
     IsObviouslyInfinite      ioi(3);
     std::vector<std::string> v
         = {"a", "aa", "b", "bb", "", "cc", "ac", "cb", "abab", "ab"};
@@ -176,10 +174,10 @@ namespace libsemigroups {
     // we should never detect it as obviously infinite
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "011",
-                             "Multiple rule additions",
-                             "[quick][integer-alphabet]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "011",
+                          "Multiple rule additions",
+                          "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(3);
     auto                   w = 00_w;
     std::vector<word_type> v
@@ -206,42 +204,40 @@ namespace libsemigroups {
     REQUIRE(!ioi.result());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ObviouslyInfinite",
-      "012",
-      "A power of the generator 'b' does not occur on its own in any relation",
-      "[quick][integer-alphabet]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "012",
+                          "b^n does not occur on its own in any relation",
+                          "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(2);
     std::vector<word_type> v = {01_w, 0_w, 010_w, 10_w};
     ioi.add_rules_no_checks(v.cbegin(), v.cend());
     REQUIRE(ioi.result());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ObviouslyInfinite",
-      "013",
-      "Preserves the number of occurrences of the generator 'a'",
-      "[quick][integer-alphabet]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "013",
+                          "Preserves occurrences of the generator 'a'",
+                          "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(2);
     std::vector<word_type> v = {010_w, 00_w, 11_w, 1_w, 0101_w, 01110_w};
     ioi.add_rules_no_checks(v.cbegin(), v.cend());
     REQUIRE(ioi.result());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "014",
-                             "Less relations than generators",
-                             "[quick][integer-alphabet]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "014",
+                          "Less relations than generators",
+                          "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(3);
     std::vector<word_type> v = {010_w, 12_w, 20_w, 1_w};
     ioi.add_rules_no_checks(v.cbegin(), v.cend());
     REQUIRE(ioi.result());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "015",
-                             "Relations preserve length",
-                             "[quick][integer-alphabet]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "015",
+                          "Relations preserve length",
+                          "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(3);
     std::vector<word_type> v
         = {000_w, 112_w, 2222_w, 1210_w, 11_w, 21_w, 210_w, 112_w};
@@ -249,30 +245,30 @@ namespace libsemigroups {
     REQUIRE(ioi.result());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "016",
-                             "Matrix has non empty kernel",
-                             "[quick][integer-alphabet]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "016",
+                          "Matrix has non empty kernel",
+                          "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(2);
     std::vector<word_type> v = {00_w, 110_w, 1100_w, 111111_w};
     ioi.add_rules_no_checks(v.cbegin(), v.cend());
     require_true_if_eigen_enabled(ioi);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "017",
-                             "Free product of trivial semigroups",
-                             "[quick][integer-alphabet]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "017",
+                          "Free product of trivial semigroups",
+                          "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(2);
     std::vector<word_type> v = {0_w, 00_w, 1_w, 11_w};
     ioi.add_rules_no_checks(v.cbegin(), v.cend());
     REQUIRE(ioi.result());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "018",
-                             "Another free product",
-                             "[quick][integer-alphabet]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "018",
+                          "Another free product",
+                          "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(5);
     std::vector<word_type> v
         = {0_w, 00_w, 1_w, 11_w, 014_w, 444_w, 32_w, 2_w, 22_w, 333_w};
@@ -280,10 +276,10 @@ namespace libsemigroups {
     REQUIRE(ioi.result());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "019",
-                             "Infinite but not obviously so",
-                             "[quick][integer-alphabet]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "019",
+                          "Infinite but not obviously so",
+                          "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(2);
     std::vector<word_type> v = {0_w, 011_w, 1_w, 100_w};
     ioi.add_rules_no_checks(v.cbegin(), v.cend());
@@ -292,10 +288,10 @@ namespace libsemigroups {
     // is infinite! Contains (ab)^n for all n.
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ObviouslyInfinite",
-                             "020",
-                             "Finite semigroup",
-                             "[quick][integer-alphabet]") {
+  LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
+                          "020",
+                          "Finite semigroup",
+                          "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(3);
     std::vector<word_type> v
         = {0_w, 00_w, 1_w, 11_w, {}, 22_w, 02_w, 21_w, 0101_w, 01_w};

--- a/tests/test-runner.cpp
+++ b/tests/test-runner.cpp
@@ -18,13 +18,17 @@
 
 // The purpose of this file is to test the Runner class.
 
-#include <chrono>
+#include <chrono>   // for operator==, seconds, mill...
 #include <cstddef>  // for size_t
+#include <string>   // for operator==, basic_string
+#include <thread>   // for sleep_for
+#include <utility>  // for move, forward
 
-#include "catch_amalgamated.hpp"  // for REQUIRE, REQUIRE_NOTHROW
+#include "catch_amalgamated.hpp"  // for SourceLineInfo, operator"...
 #include "test-main.hpp"          // for LIBSEMIGROUPS_TEST_CASE
 
-#include "libsemigroups/runner.hpp"  // for Runner
+#include "libsemigroups/exception.hpp"  // for LibsemigroupsException
+#include "libsemigroups/runner.hpp"     // for Reporter, Runner, delta
 
 #include "libsemigroups/detail/report.hpp"  // for ReportGuard
 
@@ -274,6 +278,7 @@ namespace libsemigroups {
                             "011",
                             "run throws an exception",
                             "[quick][no-valgrind]") {
+      auto        rg = ReportGuard(REPORT);
       TestRunner4 tr;
       REQUIRE_THROWS_AS(tr.run(), LibsemigroupsException);
       REQUIRE(tr.current_state() == Runner::state::not_running);
@@ -288,7 +293,6 @@ namespace libsemigroups {
                         LibsemigroupsException);
       REQUIRE_THROWS_AS(tr.run(), LibsemigroupsException);
       REQUIRE(tr.finished());
-      auto rg = ReportGuard();
       REQUIRE_NOTHROW(tr.run_for(std::chrono::seconds(1)));
     }
 

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -22,7 +22,7 @@
 
 #include "catch_amalgamated.hpp"  // for TEST_CASE
 #include "libsemigroups/constants.hpp"
-#include "test-main.hpp"  // for LIBSEMIGROUPS_TEST_CASE_V3
+#include "test-main.hpp"  // for LIBSEMIGROUPS_TEST_CASE
 
 #include "libsemigroups/bmat8.hpp"
 #include "libsemigroups/fpsemi-examples.hpp"  // for dual_symmetric_...
@@ -288,10 +288,10 @@ namespace libsemigroups {
     }
   }  // namespace
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "000",
-                             "small 2-sided congruence",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "000",
+                          "small 2-sided congruence",
+                          "[todd-coxeter][quick]") {
     using namespace rx;
     auto rg = ReportGuard(false);
 
@@ -335,10 +335,10 @@ namespace libsemigroups {
     check_normal_forms(tc, tc.number_of_classes());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "001",
-                             "small 2-sided congruence x 2",
-                             "[no-valgrind][todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "001",
+                          "small 2-sided congruence x 2",
+                          "[no-valgrind][todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
 
     Presentation<word_type> p;
@@ -433,10 +433,10 @@ namespace libsemigroups {
   }
 
   // Felsch is actually faster here!
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "002",
-                             "Example 6.6 in Sims (see also KnuthBendix 013)",
-                             "[todd-coxeter][standard]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "002",
+                          "Example 6.6 in Sims (see also KnuthBendix 013)",
+                          "[todd-coxeter][standard]") {
     auto rg = ReportGuard(false);
 
     Presentation<word_type> p;
@@ -504,11 +504,10 @@ namespace libsemigroups {
                 {0_w, 1_w, 2_w, 3_w, 12_w, 13_w, 21_w, 31_w, 121_w, 131_w}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "003",
-      "constructed from FroidurePin",
-      "[no-valgrind][todd-coxeter][quick][no-coverage]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "003",
+                          "constructed from FroidurePin",
+                          "[no-valgrind][todd-coxeter][quick][no-coverage]") {
     auto rg = ReportGuard(false);
 
     FroidurePin<BMat8> S = to_froidure_pin(
@@ -569,10 +568,10 @@ namespace libsemigroups {
     check_normal_forms(tc, tc.number_of_classes());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "004",
-                             "2-sided congruence from FroidurePin",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "004",
+                          "2-sided congruence from FroidurePin",
+                          "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
 
     using Transf = LeastTransf<5>;
@@ -621,10 +620,10 @@ namespace libsemigroups {
     check_normal_forms(tc, tc.number_of_classes());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "005",
-                             "non-trivial two-sided from relations",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "005",
+                          "non-trivial two-sided from relations",
+                          "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
 
     Presentation<word_type> p;
@@ -654,10 +653,10 @@ namespace libsemigroups {
     check_normal_forms(tc, tc.number_of_classes());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "006",
-                             "small onesided cong. on free semigroup",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "006",
+                          "small onesided cong. on free semigroup",
+                          "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -679,10 +678,10 @@ namespace libsemigroups {
     check_normal_forms(tc, tc.number_of_classes());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "007",
-                             "left cong. on free semigroup",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "007",
+                          "left cong. on free semigroup",
+                          "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -716,10 +715,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "008",
-                             "for small fp semigroup",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "008",
+                          "for small fp semigroup",
+                          "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -744,10 +743,10 @@ namespace libsemigroups {
   }
 
   // TODO move to test-to-todd-coxeter
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "009",
-                             "2-sided cong. trans. semigroup",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "009",
+                          "2-sided cong. trans. semigroup",
+                          "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
     auto S  = to_froidure_pin(
         {Transf<>({1, 3, 4, 2, 3}), Transf<>({3, 2, 1, 3, 3})});
@@ -855,10 +854,10 @@ namespace libsemigroups {
     }
   }  // namespace
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "010",
-                             "left congruence on transformation semigroup",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "010",
+                          "left congruence on transformation semigroup",
+                          "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
     auto S  = to_froidure_pin(
         {Transf<>({1, 3, 4, 2, 3}), Transf<>({3, 2, 1, 3, 3})});
@@ -904,10 +903,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "011",
-                             "onesided cong. trans. semigroup",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "011",
+                          "onesided cong. trans. semigroup",
+                          "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
     auto S  = to_froidure_pin(
         {Transf<>({1, 3, 4, 2, 3}), Transf<>({3, 2, 1, 3, 3})});
@@ -970,10 +969,10 @@ namespace libsemigroups {
     REQUIRE(index_of(tc, w5) == index_of(tc, w6));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "012",
-                             "trans. semigroup (size 88)",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "012",
+                          "trans. semigroup (size 88)",
+                          "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
 
     FroidurePin<Transf<>> S;
@@ -1008,10 +1007,10 @@ namespace libsemigroups {
     REQUIRE(index_of(tc, w3) == index_of(tc, w4));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "015",
-                             "finite fp-semigroup, dihedral group of order 6 ",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "015",
+                          "finite fp-semigroup, dihedral group of order 6 ",
+                          "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
 
     Presentation<word_type> p;
@@ -1036,10 +1035,10 @@ namespace libsemigroups {
     REQUIRE(index_of(tc, {1}) == index_of(tc, {2}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "016",
-                             "finite fp-semigroup, size 16",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "016",
+                          "finite fp-semigroup, size 16",
+                          "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(4);
@@ -1078,10 +1077,10 @@ namespace libsemigroups {
     REQUIRE(index_of(tc, {2}) == index_of(tc, {3}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "017",
-                             "finite fp-semigroup, size 16 x 2",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "017",
+                          "finite fp-semigroup, size 16 x 2",
+                          "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(11);
@@ -1155,10 +1154,10 @@ namespace libsemigroups {
     REQUIRE(index_of(tc, {3}) == index_of(tc, {9}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "018",
-                             "test lookahead",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "018",
+                          "test lookahead",
+                          "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -1194,10 +1193,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "020",
-                             "2-sided cong. on free semigroup",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "020",
+                          "2-sided cong. on free semigroup",
+                          "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(1);
@@ -1214,10 +1213,10 @@ namespace libsemigroups {
     REQUIRE(!contains(tc, 00_w, 0_w));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "021",
-                             "calling run when obviously infinite",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "021",
+                          "calling run when obviously infinite",
+                          "[todd-coxeter][quick]") {
     Presentation<word_type> p;
     p.alphabet(5);
     ToddCoxeter tc(twosided, p);
@@ -1232,10 +1231,10 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(tc.run(), LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "022",
-                             "stellar_monoid S3",
-                             "[todd-coxeter][quick][hivert]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "022",
+                          "stellar_monoid S3",
+                          "[todd-coxeter][quick][hivert]") {
     auto rg = ReportGuard(false);
 
     Presentation<word_type> p;
@@ -1298,10 +1297,10 @@ namespace libsemigroups {
     os << TCE(32);  // Does not do anything visible
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "023",
-                             "finite semigroup (size 5)",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "023",
+                          "finite semigroup (size 5)",
+                          "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     presentation::add_rule_no_checks(p, 000_w, 0_w);
@@ -1321,10 +1320,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 5);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "024",
-                             "exceptions",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "024",
+                          "exceptions",
+                          "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -1367,10 +1366,10 @@ namespace libsemigroups {
     // semigroup with 2 generators
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "025",
-                             "obviously infinite",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "025",
+                          "obviously infinite",
+                          "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(3);
@@ -1390,10 +1389,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "026",
-                             "exceptions x 2",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "026",
+                          "exceptions x 2",
+                          "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     presentation::add_rule_no_checks(p, 000_w, 0_w);
@@ -1434,10 +1433,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "028",
-                             "quotient ToddCoxeter",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "028",
+                          "quotient ToddCoxeter",
+                          "[todd-coxeter][quick]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -1464,10 +1463,10 @@ namespace libsemigroups {
   }
 
   // TODO move to to-todd-coxeter.hpp
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "029",
-                             "from KnuthBendix",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "029",
+                          "from KnuthBendix",
+                          "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -1512,10 +1511,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 1);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "031",
-                             "KnuthBendix.finished()",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "031",
+                          "KnuthBendix.finished()",
+                          "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -1547,10 +1546,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "032",
-                             "from WordGraph",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "032",
+                          "from WordGraph",
+                          "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
 
     WordGraph<uint32_t> d(1, 2);
@@ -1559,10 +1558,10 @@ namespace libsemigroups {
     REQUIRE_NOTHROW(ToddCoxeter(twosided, d));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "033",
-                             "congruence of ToddCoxeter",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "033",
+                          "congruence of ToddCoxeter",
+                          "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -1583,10 +1582,10 @@ namespace libsemigroups {
     REQUIRE(tc2.number_of_classes() == 3);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "034",
-                             "congruence of ToddCoxeter x 2",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "034",
+                          "congruence of ToddCoxeter x 2",
+                          "[todd-coxeter][quick]") {
     auto rg      = ReportGuard(false);
     using Transf = LeastTransf<5>;
     FroidurePin<Transf> S
@@ -1607,10 +1606,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 1);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "035",
-                             "congruence over fp semigroup",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "035",
+                          "congruence over fp semigroup",
+                          "[todd-coxeter][quick]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abe");
@@ -1672,10 +1671,10 @@ namespace libsemigroups {
                  {"babaaa"}}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "037",
-                             "copy constructor",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "037",
+                          "copy constructor",
+                          "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -1720,7 +1719,7 @@ namespace libsemigroups {
     REQUIRE(tc.current_word_graph() == copy.current_word_graph());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
+  LIBSEMIGROUPS_TEST_CASE(
       "ToddCoxeter",
       "039",
       "stylic_monoid",
@@ -1757,10 +1756,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 115'975);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "040",
-                             "fibonacci_semigroup(4, 6)",
-                             "[todd-coxeter][fail]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "040",
+                          "fibonacci_semigroup(4, 6)",
+                          "[todd-coxeter][fail]") {
     using fpsemigroup::fibonacci_semigroup;
 
     auto        rg = ReportGuard();
@@ -1769,10 +1768,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 0);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "041",
-                             "some finite classes",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "041",
+                          "some finite classes",
+                          "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
 
     Presentation<word_type> p;
@@ -1852,10 +1851,10 @@ namespace libsemigroups {
   }
 
   // Takes about 1.8s
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "042",
-                             "symmetric_group(9, Moore)",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "042",
+                          "symmetric_group(9, Moore)",
+                          "[todd-coxeter][extreme]") {
     using fpsemigroup::author;
     using fpsemigroup::symmetric_group;
 
@@ -1885,10 +1884,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 362'880);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "043",
-                             "symmetric_group(7, Coxeter + Moser)",
-                             "[todd-coxeter][quick][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "043",
+                          "symmetric_group(7, Coxeter + Moser)",
+                          "[todd-coxeter][quick][no-valgrind]") {
     using fpsemigroup::author;
     using fpsemigroup::symmetric_group;
 
@@ -1915,10 +1914,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 5'040);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "116",
-                             "symmetric_group(7, Burnside + Miller)",
-                             "[todd-coxeter][quick][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "116",
+                          "symmetric_group(7, Burnside + Miller)",
+                          "[todd-coxeter][quick][no-valgrind]") {
     using fpsemigroup::author;
     using fpsemigroup::symmetric_group;
     auto rg = ReportGuard(false);
@@ -1937,11 +1936,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 5'040);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "046",
-      "Easdown-East-FitzGerald DualSymInv(5)",
-      "[todd-coxeter][quick][no-valgrind][no-coverage]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "046",
+                          "Easdown-East-FitzGerald DualSymInv(5)",
+                          "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     auto        rg = ReportGuard(false);
     auto const  n  = 5;
     auto        p  = fpsemigroup::dual_symmetric_inverse_monoid(n);
@@ -1958,10 +1956,10 @@ namespace libsemigroups {
     check_complete_compatible(tc);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "047",
-                             "uniform_block_bijection_monoid(3) (FitzGerald) ",
-                             "[todd-coxeter][quick][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "047",
+                          "uniform_block_bijection_monoid(3) (FitzGerald) ",
+                          "[todd-coxeter][quick][no-valgrind]") {
     using fpsemigroup::author;
     using fpsemigroup::uniform_block_bijection_monoid;
 
@@ -1982,11 +1980,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 1496);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "048",
-      "stellar_monoid(7) (Gay-Hivert)",
-      "[todd-coxeter][quick][no-valgrind][no-coverage]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "048",
+                          "stellar_monoid(7) (Gay-Hivert)",
+                          "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     using fpsemigroup::stellar_monoid;
 
     auto         rg = ReportGuard(false);
@@ -2005,11 +2002,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 13'700);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "049",
-      "partition_monoid(4) (East)",
-      "[todd-coxeter][quick][no-valgrind][no-coverage]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "049",
+                          "partition_monoid(4) (East)",
+                          "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     auto rg = ReportGuard(false);
     using fpsemigroup::author;
     using fpsemigroup::partition_monoid;
@@ -2029,11 +2025,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 4'140);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "050",
-      "singular_brauer_monoid(6) (Maltcev + Mazorchuk)",
-      "[todd-coxeter][quick][no-valgrind][no-coverage]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "050",
+                          "singular_brauer_monoid(6) (Maltcev + Mazorchuk)",
+                          "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     using fpsemigroup::singular_brauer_monoid;
 
     auto         rg = ReportGuard(false);
@@ -2053,11 +2048,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 9);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "051",
-      "orientation_preserving_monoid(6) (Ruskuc + Arthur)",
-      "[todd-coxeter][quick][no-valgrind][no-coverage]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "051",
+                          "orientation_preserving_monoid(6) (Ruskuc + Arthur)",
+                          "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     using fpsemigroup::orientation_preserving_monoid;
     auto         rg = ReportGuard(false);
     size_t const n  = 4;
@@ -2076,11 +2070,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 128);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "052",
-      "orientation_preserving_reversing_monoid(5) (Ruskuc + Arthur)",
-      "[todd-coxeter][quick][no-valgrind][no-coverage]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "052",
+                          "POPR(5) (Ruskuc + Arthur)",
+                          "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     using fpsemigroup::orientation_preserving_reversing_monoid;
     auto         rg = ReportGuard(false);
     size_t const n  = 5;
@@ -2097,11 +2090,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 1'015);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "053",
-      "temperley_lieb_monoid(10) (East)",
-      "[todd-coxeter][quick][no-valgrind][no-coverage]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "053",
+                          "temperley_lieb_monoid(10) (East)",
+                          "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     using fpsemigroup::temperley_lieb_monoid;
     auto         rg = ReportGuard(false);
     size_t const n  = 10;
@@ -2125,7 +2117,7 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 16'796);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
+  LIBSEMIGROUPS_TEST_CASE(
       "ToddCoxeter",
       "054",
       "Generate GAP benchmarks for stellar_monoid(n) (Gay-Hivert)",
@@ -2139,7 +2131,7 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
+  LIBSEMIGROUPS_TEST_CASE(
       "ToddCoxeter",
       "055",
       "Generate GAP benchmarks for partition_monoid(n) (East)",
@@ -2156,12 +2148,11 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "056",
-      "Generate GAP benchmarks for dual symmetric inverse "
-      "monoid (Easdown + East + FitzGerald)",
-      "[todd-coxeter][fail]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "056",
+                          "Generate GAP benchmarks for dual symmetric inverse "
+                          "monoid (Easdown + East + FitzGerald)",
+                          "[todd-coxeter][fail]") {
     using fpsemigroup::author;
     using fpsemigroup::dual_symmetric_inverse_monoid;
     auto rg = ReportGuard(true);
@@ -2174,11 +2165,11 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "057",
-                             "Generate GAP benchmarks for "
-                             "uniform_block_bijection_monoid (FitzGerald)",
-                             "[todd-coxeter][fail]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "057",
+                          "Generate GAP benchmarks for "
+                          "uniform_block_bijection_monoid (FitzGerald)",
+                          "[todd-coxeter][fail]") {
     using fpsemigroup::author;
     using fpsemigroup::uniform_block_bijection_monoid;
 
@@ -2192,10 +2183,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "058",
-                             "Generate GAP benchmarks for stylic monoids",
-                             "[todd-coxeter][fail]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "058",
+                          "Generate GAP benchmarks for stylic monoids",
+                          "[todd-coxeter][fail]") {
     using fpsemigroup::stylic_monoid;
 
     auto rg = ReportGuard(true);
@@ -2206,10 +2197,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "059",
-                             "Generate GAP benchmarks for OP_n",
-                             "[todd-coxeter][fail]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "059",
+                          "Generate GAP benchmarks for OP_n",
+                          "[todd-coxeter][fail]") {
     using fpsemigroup::orientation_preserving_monoid;
 
     auto rg = ReportGuard(true);
@@ -2220,10 +2211,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "060",
-                             "Generate GAP benchmarks for OR_n",
-                             "[todd-coxeter][fail]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "060",
+                          "Generate GAP benchmarks for OR_n",
+                          "[todd-coxeter][fail]") {
     using fpsemigroup::orientation_preserving_reversing_monoid;
 
     auto rg = ReportGuard(true);
@@ -2235,7 +2226,7 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
+  LIBSEMIGROUPS_TEST_CASE(
       "ToddCoxeter",
       "061",
       "Generate GAP benchmarks for temperley_lieb_monoid(n)",
@@ -2251,7 +2242,7 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
+  LIBSEMIGROUPS_TEST_CASE(
       "ToddCoxeter",
       "062",
       "Generate GAP benchmarks for singular_brauer_monoid(n)",
@@ -2267,10 +2258,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "111",
-                             "partition_monoid(2)",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "111",
+                          "partition_monoid(2)",
+                          "[todd-coxeter][quick]") {
     using fpsemigroup::author;
     using fpsemigroup::partition_monoid;
 
@@ -2287,11 +2278,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 15);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "112",
-      "brauer_monoid(4) (Kudryavtseva + Mazorchuk)",
-      "[todd-coxeter][quick][no-valgrind][no-coverage]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "112",
+                          "brauer_monoid(4) (Kudryavtseva + Mazorchuk)",
+                          "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     using fpsemigroup::brauer_monoid;
 
     auto         rg = ReportGuard(false);
@@ -2309,10 +2299,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 105);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "113",
-                             "symmetric_inverse_monoid(5, Sutov)",
-                             "[todd-coxeter][quick][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "113",
+                          "symmetric_inverse_monoid(5, Sutov)",
+                          "[todd-coxeter][quick][no-valgrind]") {
     using fpsemigroup::author;
     using fpsemigroup::symmetric_inverse_monoid;
 
@@ -2329,10 +2319,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 1'546);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "114",
-                             "partial_transformation_monoid(5, Sutov)",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "114",
+                          "partial_transformation_monoid(5, Sutov)",
+                          "[todd-coxeter][extreme]") {
     using fpsemigroup::author;
     using fpsemigroup::partial_transformation_monoid;
 
@@ -2351,10 +2341,10 @@ namespace libsemigroups {
   }
 
   // stop_early in lookahead really helps in this example
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "115",
-                             "full_transformation_monoid(7, Iwahori)",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "115",
+                          "full_transformation_monoid(7, Iwahori)",
+                          "[todd-coxeter][extreme]") {
     using fpsemigroup::author;
     using fpsemigroup::full_transformation_monoid;
 
@@ -2382,10 +2372,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 823'543);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "063",
-                             "add_rule",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "063",
+                          "add_rule",
+                          "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
     {
       Presentation<std::string> p;
@@ -2479,10 +2469,10 @@ namespace libsemigroups {
   }
 
   // KnuthBendix methods fail for this one
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "064",
-                             "from kbmag/standalone/kb_data/s4",
-                             "[todd-coxeter][quick][kbmag]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "064",
+                          "from kbmag/standalone/kb_data/s4",
+                          "[todd-coxeter][quick][kbmag]") {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -2517,11 +2507,11 @@ namespace libsemigroups {
 
   // Second of BHN's series of increasingly complicated presentations
   // of 1. Doesn't terminate
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "065",
-                             "(from kbmag/standalone/kb_data/degen4b) "
-                             "(KnuthBendix 065)",
-                             "[fail][todd-coxeter][kbmag][shortlex]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "065",
+                          "(from kbmag/standalone/kb_data/degen4b) "
+                          "(KnuthBendix 065)",
+                          "[fail][todd-coxeter][kbmag][shortlex]") {
     auto rg = ReportGuard(true);
 
     Presentation<std::string> p;
@@ -2557,10 +2547,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 1);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "067",
-                             "Repeated construction from same FroidurePin",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "067",
+                          "Repeated construction from same FroidurePin",
+                          "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
 
     using Transf = LeastTransf<5>;
@@ -2610,10 +2600,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "068",
-                             "Sym(5) from Chapter 3, Proposition 1.1 in NR",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "068",
+                          "Sym(5) from Chapter 3, Proposition 1.1 in NR",
+                          "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -2659,10 +2649,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 120);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "069",
-                             "Chapter 7, Theorem 3.6 in NR (size 243)",
-                             "[no-valgrind][todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "069",
+                          "Chapter 7, Theorem 3.6 in NR (size 243)",
+                          "[no-valgrind][todd-coxeter][quick]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -2682,10 +2672,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 243);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "070",
-                             "finite semigroup (size 99)",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "070",
+                          "finite semigroup (size 99)",
+                          "[todd-coxeter][quick]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -2711,10 +2701,10 @@ namespace libsemigroups {
 
   // The following 8 examples are from Trevor Walker's Thesis: Semigroup
   // enumeration - computer implementation and applications, p41.
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "071",
-                             "Walker 1",
-                             "[todd-coxeter][standard][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "071",
+                          "Walker 1",
+                          "[todd-coxeter][standard][no-valgrind]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcABCDEFGHIXYZ");
@@ -2790,11 +2780,10 @@ namespace libsemigroups {
 
   // The following example is a good one for using the lookahead.
   // This is no longer extreme with the preprocessing
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "072",
-      "Walker 2",
-      "[todd-coxeter][quick][no-coverage][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "072",
+                          "Walker 2",
+                          "[todd-coxeter][quick][no-coverage][no-valgrind]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -2853,10 +2842,10 @@ namespace libsemigroups {
     REQUIRE(contains(tc, "dd", "a"));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "073",
-                             "Walker 3",
-                             "[todd-coxeter][standard]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "073",
+                          "Walker 3",
+                          "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -2882,10 +2871,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 20'490);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "074",
-                             "Walker 4",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "074",
+                          "Walker 4",
+                          "[todd-coxeter][extreme]") {
     auto                      rg = ReportGuard();
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -2933,10 +2922,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 36'412);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "075",
-                             "Walker 5",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "075",
+                          "Walker 5",
+                          "[todd-coxeter][extreme]") {
     auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -2977,10 +2966,10 @@ namespace libsemigroups {
     check_complete_compatible(tc);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "076",
-                             "not Walker 6",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "076",
+                          "not Walker 6",
+                          "[todd-coxeter][extreme]") {
     auto                      rg = ReportGuard();
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -3023,10 +3012,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 8);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "077",
-                             "Walker 6",
-                             "[todd-coxeter][standard]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "077",
+                          "Walker 6",
+                          "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -3072,10 +3061,10 @@ namespace libsemigroups {
   }
 
   // Felsch is faster here too!
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "078",
-                             "Walker 7",
-                             "[todd-coxeter][standard]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "078",
+                          "Walker 7",
+                          "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcde");
@@ -3115,10 +3104,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 153'500);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "079",
-                             "Walker 8",
-                             "[todd-coxeter][standard]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "079",
+                          "Walker 8",
+                          "[todd-coxeter][standard]") {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -3157,11 +3146,10 @@ namespace libsemigroups {
   }
 
   // This is a good example of why large collapse is required
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "080",
-      "KnuthBendix 098",
-      "[todd-coxeter][quick][no-valgrind][no-coverage]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "080",
+                          "KnuthBendix 098",
+                          "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("aAbBcCdDyYfFgGe");
@@ -3187,10 +3175,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 29);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "081",
-                             "Holt 2 - SL(2, p)",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "081",
+                          "Holt 2 - SL(2, p)",
+                          "[todd-coxeter][extreme]") {
     auto                        rg     = ReportGuard();
     std::array<size_t, 4> const sizes  = {24, 120, 336, 1'320};
     std::array<size_t, 4> const primes = {3, 5, 7, 11};
@@ -3207,10 +3195,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "082",
-                             "Holt 3",
-                             "[todd-coxeter][standard]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "082",
+                          "Holt 3",
+                          "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("aAbBcC");
@@ -3235,10 +3223,10 @@ namespace libsemigroups {
     check_normal_forms(tc, 0);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "083",
-                             "Holt 3 x 2",
-                             "[todd-coxeter][fail]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "083",
+                          "Holt 3 x 2",
+                          "[todd-coxeter][fail]") {
     auto                      rg = ReportGuard();
     Presentation<std::string> p;
     p.alphabet("aAbBcC");
@@ -3263,10 +3251,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 6'561);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "084",
-                             "Campbell-Reza 1",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "084",
+                          "Campbell-Reza 1",
+                          "[todd-coxeter][quick]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -3306,11 +3294,10 @@ namespace libsemigroups {
   }
 
   // The next example demonstrates why we require deferred standardization
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "085",
-      "Renner monoid type D4 (Gay-Hivert), q = 1",
-      "[no-valgrind][quick][todd-coxeter][no-coverage]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "085",
+                          "Renner monoid type D4 (Gay-Hivert), q = 1",
+                          "[no-valgrind][quick][todd-coxeter][no-coverage]") {
     auto rg = ReportGuard(false);
 
     ToddCoxeter tc(twosided, fpsemigroup::renner_type_D_monoid(4, 1));
@@ -3339,11 +3326,10 @@ namespace libsemigroups {
   }
 
   // Felsch very slow here
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "086",
-      "trivial semigroup",
-      "[no-valgrind][todd-coxeter][quick][no-coverage]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "086",
+                          "trivial semigroup",
+                          "[no-valgrind][todd-coxeter][quick][no-coverage]") {
     auto rg = ReportGuard(false);
 
     for (size_t N = 2; N < 1000; N += 199) {
@@ -3367,10 +3353,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "087",
-                             "ACE --- 2p17-2p14 - HLT",
-                             "[todd-coxeter][standard][ace]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "087",
+                          "ACE --- 2p17-2p14 - HLT",
+                          "[todd-coxeter][standard][ace]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcABC");
@@ -3401,10 +3387,10 @@ namespace libsemigroups {
                  "cAaC", "cBbC"}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "088",
-                             "ACE --- 2p17-2p3 - HLT",
-                             "[todd-coxeter][standard][ace]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "088",
+                          "ACE --- 2p17-2p3 - HLT",
+                          "[todd-coxeter][standard][ace]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcABC");
@@ -3432,10 +3418,10 @@ namespace libsemigroups {
 
   // In this example large_collapse makes a huge difference to the run time,
   // 73ms versus 1173ms for the save case.
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "089",
-                             "ACE --- 2p17-1a - HLT",
-                             "[todd-coxeter][standard][ace]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "089",
+                          "ACE --- 2p17-1a - HLT",
+                          "[todd-coxeter][standard][ace]") {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -3463,10 +3449,10 @@ namespace libsemigroups {
     REQUIRE(H.number_of_classes() == 1);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "090",
-                             "ACE --- F27",
-                             "[todd-coxeter][standard][ace]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "090",
+                          "ACE --- F27",
+                          "[todd-coxeter][standard][ace]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcdxyzABCDXYZ");
@@ -3492,10 +3478,10 @@ namespace libsemigroups {
     REQUIRE(H.number_of_classes() == 29);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "091",
-                             "ACE --- SL219 - HLT",
-                             "[todd-coxeter][standard][ace]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "091",
+                          "ACE --- SL219 - HLT",
+                          "[todd-coxeter][standard][ace]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abAB");
@@ -3541,10 +3527,10 @@ namespace libsemigroups {
     REQUIRE(H.number_of_classes() == 180);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "092",
-                             "ACE --- perf602p5",
-                             "[no-valgrind][todd-coxeter][quick][ace]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "092",
+                          "ACE --- perf602p5",
+                          "[no-valgrind][todd-coxeter][quick][ace]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abstuvdABSTUVD");
@@ -3592,10 +3578,10 @@ namespace libsemigroups {
     REQUIRE(H.number_of_classes() == 480);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "093",
-                             "ACE --- M12",
-                             "[todd-coxeter][standard][ace]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "093",
+                          "ACE --- M12",
+                          "[todd-coxeter][standard][ace]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcABC");
@@ -3626,10 +3612,10 @@ namespace libsemigroups {
     REQUIRE(H.number_of_classes() == 95'040);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "094",
-                             "ACE --- C5",
-                             "[todd-coxeter][quick][ace]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "094",
+                          "ACE --- C5",
+                          "[todd-coxeter][quick][ace]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abAB");
@@ -3651,10 +3637,10 @@ namespace libsemigroups {
     REQUIRE(H.number_of_classes() == 5);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "095",
-                             "ACE --- A5-C5",
-                             "[todd-coxeter][quick][ace]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "095",
+                          "ACE --- A5-C5",
+                          "[todd-coxeter][quick][ace]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abAB");
@@ -3679,10 +3665,10 @@ namespace libsemigroups {
     REQUIRE(H.number_of_classes() == 12);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "096",
-                             "ACE --- A5",
-                             "[todd-coxeter][quick][ace]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "096",
+                          "ACE --- A5",
+                          "[todd-coxeter][quick][ace]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abAB");
@@ -3709,10 +3695,10 @@ namespace libsemigroups {
   // stands out as being the cause of this, in v2 this takes about 1.4s in v3
   // 1.5s or so.
   // Seems to have gotten worse still since the comment about up to 1.8s
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "097",
-                             "relation ordering",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "097",
+                          "relation ordering",
+                          "[todd-coxeter][extreme]") {
     auto rg = ReportGuard(true);
     // Sorting the rules makes this twice as slow...
     auto p = fpsemigroup::renner_type_D_monoid(5, 1);
@@ -3729,10 +3715,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 258'661);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "098",
-                             "relation ordering x 2",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "098",
+                          "relation ordering x 2",
+                          "[todd-coxeter][quick]") {
     Presentation<word_type> p;
     p.alphabet(10);
     presentation::add_rule(p, 01_w, 0_w);
@@ -3838,10 +3824,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 10);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "099",
-                             "short circuit size in obviously infinite",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "099",
+                          "short circuit size in obviously infinite",
+                          "[todd-coxeter][quick]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abc");
@@ -3850,11 +3836,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == POSITIVE_INFINITY);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "100",
-      "http://brauer.maths.qmul.ac.uk/Atlas/misc/24A8/mag/24A8G1-P1.M",
-      "[todd-coxeter][standard]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "100",
+                          "http://brauer.maths.qmul.ac.uk/Atlas/misc/24A8",
+                          "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("xyXY");
@@ -3883,11 +3868,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 322'560);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "101",
-      "http://brauer.maths.qmul.ac.uk/Atlas/spor/M11/mag/M11G1-P1.M",
-      "[todd-coxeter][quick][no-coverage][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "101",
+                          "http://brauer.maths.qmul.ac.uk/Atlas/spor/M11/",
+                          "[todd-coxeter][quick][no-coverage][no-valgrind]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("xyXY");
@@ -3926,11 +3910,10 @@ namespace libsemigroups {
     REQUIRE(normal_forms(tc).get() == word_type({}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "102",
-      "http://brauer.maths.qmul.ac.uk/Atlas/spor/M12/mag/M12G1-P1.M",
-      "[todd-coxeter][standard]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "102",
+                          "http://brauer.maths.qmul.ac.uk/Atlas/spor/M12/",
+                          "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("xyXY");
@@ -3954,11 +3937,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 95'040);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "103",
-      "http://brauer.maths.qmul.ac.uk/Atlas/spor/M22/mag/M22G1-P1.M",
-      "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "103",
+                          "http://brauer.maths.qmul.ac.uk/Atlas/spor/M22",
+                          "[todd-coxeter][extreme]") {
     ReportGuard               rg(true);
     Presentation<std::string> p;
     p.alphabet("xyXY");
@@ -3981,11 +3963,10 @@ namespace libsemigroups {
 
   // Takes about 4 minutes (2021 - MacBook Air M1 - 8GB RAM)
   // with Felsch (3.5mins or 2.5mins with lowerbound) or HLT (4.5mins)
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "104",
-      "http://brauer.maths.qmul.ac.uk/Atlas/spor/M23/mag/M23G1-P1.M",
-      "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "104",
+                          "http://brauer.maths.qmul.ac.uk/Atlas/spor/M23",
+                          "[todd-coxeter][extreme]") {
     Presentation<std::string> p;
     p.alphabet("xyXY");
     p.contains_empty_word(true);
@@ -4024,11 +4005,10 @@ namespace libsemigroups {
   }
 
   // Takes about 3 minutes (with HLT)
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "105",
-      "http://brauer.maths.qmul.ac.uk/Atlas/clas/S62/mag/S62G1-P1.M",
-      "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "105",
+                          "http://brauer.maths.qmul.ac.uk/Atlas/clas/S62",
+                          "[todd-coxeter][extreme]") {
     Presentation<std::string> p;
     p.alphabet("xyXY");
     p.contains_empty_word(true);
@@ -4067,11 +4047,10 @@ namespace libsemigroups {
   }
 
   // Approx. 32 minutes (2021 - MacBook Air M1 - 8GB RAM)
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "106",
-      "http://brauer.maths.qmul.ac.uk/Atlas/spor/HS/mag/HSG1-P1.M",
-      "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "106",
+                          "http://brauer.maths.qmul.ac.uk/Atlas/spor/HS",
+                          "[todd-coxeter][extreme]") {
     auto rg = ReportGuard();
 
     Presentation<std::string> p;
@@ -4106,11 +4085,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 4'032'000);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "107",
-      "http://brauer.maths.qmul.ac.uk/Atlas/spor/J1/mag/J1G1-P1.M",
-      "[todd-coxeter][standard]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "107",
+                          "http://brauer.maths.qmul.ac.uk/Atlas/spor/J1",
+                          "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("xyXY");
@@ -4129,11 +4107,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 175'560);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "108",
-      "http://brauer.maths.qmul.ac.uk/Atlas/lin/L34/mag/L34G1-P1.M",
-      "[todd-coxeter][quick][no-coverage][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "108",
+                          "http://brauer.maths.qmul.ac.uk/Atlas/lin/L34/",
+                          "[todd-coxeter][quick][no-coverage][no-valgrind]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("xyXY");
@@ -4160,11 +4137,10 @@ namespace libsemigroups {
   }
 
   // Takes about 10 seconds (2021 - MacBook Air M1 - 8GB RAM)
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "109",
-      "http://brauer.maths.qmul.ac.uk/Atlas/clas/S62/mag/S62G1-P1.M x 2",
-      "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "109",
+                          "http://brauer.maths.qmul.ac.uk/Atlas/clas/S62 x 2",
+                          "[todd-coxeter][extreme]") {
     Presentation<std::string> p;
     p.alphabet("xyXY");
     p.contains_empty_word(true);
@@ -4186,10 +4162,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 1'451'520);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "013",
-                             "redundant rule x1",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "013",
+                          "redundant rule x1",
+                          "[todd-coxeter][quick]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.contains_empty_word(true);
@@ -4214,10 +4190,10 @@ namespace libsemigroups {
     REQUIRE(it == p.rules.end());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "120",
-                             "redundant rule x2",
-                             "[todd-coxeter][standard]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "120",
+                          "redundant rule x2",
+                          "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abc");
@@ -4235,10 +4211,10 @@ namespace libsemigroups {
     REQUIRE(*(it + 1) == "baa");
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "014",
-                             "hypo plactic id monoid",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "014",
+                          "hypo plactic id monoid",
+                          "[todd-coxeter][extreme]") {
     std::array<uint64_t, 11> const num
         = {0, 0, 4, 13, 40, 121, 364, 1'093, 3'280, 9'841, 29'524};
     // A003462
@@ -4268,10 +4244,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "019",
-                             "Chinese id monoid",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "019",
+                          "Chinese id monoid",
+                          "[todd-coxeter][extreme]") {
     std::array<uint64_t, 11> const num = {
         0, 0, 4, 14, 50, 187, 730, 2'949, 12'234, 51'821, 223'190};  // A007317
     std::vector<std::vector<uint64_t>> tri
@@ -4310,10 +4286,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "030",
-                             "Chinese id monoid x 2",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "030",
+                          "Chinese id monoid x 2",
+                          "[todd-coxeter][extreme]") {
     auto n = 5;
     auto p = fpsemigroup::chinese_monoid(n);
     p.contains_empty_word(true);
@@ -4412,10 +4388,10 @@ namespace libsemigroups {
             == std::vector<std::string>());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "027",
-                             "plactic (n, 1)-id monoid",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "027",
+                          "plactic (n, 1)-id monoid",
+                          "[todd-coxeter][extreme]") {
     // auto                          r = 3, s = 2;
     // std::array<uint64_t, 7> const size = {1, 3, 14, 95, 885, 10'858,
     // 170'209};
@@ -4572,10 +4548,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "036",
-                             "plactic (n, 1)-id monoid x 2",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "036",
+                          "plactic (n, 1)-id monoid x 2",
+                          "[todd-coxeter][extreme]") {
     using words::pow;
     using words::operator+;
     // #include "Plact4-1_3_last.txt"
@@ -4614,10 +4590,10 @@ namespace libsemigroups {
     //  }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "038",
-                             "sigma-stylic monoid",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "038",
+                          "sigma-stylic monoid",
+                          "[todd-coxeter][extreme]") {
     auto p = fpsemigroup::sigma_stylic_monoid({2, 2, 2});
     p.contains_empty_word(true);
     ToddCoxeter tc(twosided, p);
@@ -4644,10 +4620,10 @@ namespace libsemigroups {
     REQUIRE((normal_forms(tc) | to_vector()) == std::vector<word_type>());
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "044",
-                             "2-sylvester monoid",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "044",
+                          "2-sylvester monoid",
+                          "[todd-coxeter][extreme]") {
     using words::pow;
     size_t                  n = 4;
     Presentation<word_type> p;
@@ -4689,11 +4665,10 @@ namespace libsemigroups {
   }
 
   // Takes nearly 13 hours to complete
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "045",
-      "Whyte's 8-generator 4-relation full transf monoid 8",
-      "[todd-coxeter][fail]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "045",
+                          "Whyte's 8-generator 4-relation full transf monoid 8",
+                          "[todd-coxeter][fail]") {
     auto                    rg = ReportGuard(true);
     Presentation<word_type> p;
     p.rules = {
@@ -4802,11 +4777,10 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "066",
-      "Whyte's 2-generator 4-relation full transf monoid 8",
-      "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "066",
+                          "Whyte's 2-generator 4-relation full transf monoid 8",
+                          "[todd-coxeter][extreme]") {
     auto                    rg = ReportGuard(true);
     Presentation<word_type> p;
     p.rules = {00_w,
@@ -4853,7 +4827,7 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 0);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3(
+  LIBSEMIGROUPS_TEST_CASE(
       "ToddCoxeter",
       "110",
       "minimal E-disjunctive idempotent pure onesided congruence",
@@ -4886,11 +4860,10 @@ namespace libsemigroups {
   }
 
   // Takes about 2 minutes
-  LIBSEMIGROUPS_TEST_CASE_V3(
-      "ToddCoxeter",
-      "10X",
-      "https://brauer.maths.qmul.ac.uk/Atlas/exc/TF42/mag/TF42G1-P1.M",
-      "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "10X",
+                          "https://brauer.maths.qmul.ac.uk/Atlas/exc/TF42",
+                          "[todd-coxeter][extreme]") {
     Presentation<std::string> p;
     p.contains_empty_word(true).alphabet("xyXY");
     presentation::add_inverse_rules(p, "XYxy");
@@ -4913,10 +4886,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 17'971'200);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "10Y",
-                             "cyclic groups",
-                             "[todd-coxeter][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "10Y",
+                          "cyclic groups",
+                          "[todd-coxeter][quick]") {
     Presentation<std::string> p;
     p.contains_empty_word(true).alphabet("xyz");
 
@@ -4928,10 +4901,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 5);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "117",
-                             "Rudvalis group",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "117",
+                          "Rudvalis group",
+                          "[todd-coxeter][extreme]") {
     auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.alphabet("abctABCT").contains_empty_word(true);
@@ -4965,10 +4938,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 7'238'400);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "118",
-                             "alternating group 8",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "118",
+                          "alternating group 8",
+                          "[todd-coxeter][extreme]") {
     auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.alphabet("abcABC").contains_empty_word(true);
@@ -4990,10 +4963,10 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 20'160);
   }
 
-  LIBSEMIGROUPS_TEST_CASE_V3("ToddCoxeter",
-                             "119",
-                             "full transf. monoid 6 (maybe)",
-                             "[todd-coxeter][extreme]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "119",
+                          "full transf. monoid 6 (maybe)",
+                          "[todd-coxeter][extreme]") {
     ReportGuard             rg(true);
     Presentation<word_type> p;
     p.contains_empty_word(true);

--- a/tests/test-transf.cpp
+++ b/tests/test-transf.cpp
@@ -32,84 +32,6 @@ namespace libsemigroups {
 
   namespace {
     template <typename T>
-    void test_transf000() {
-      static_assert(IsTransf<T>, "IsTransf<T> must be true!");
-      auto x = T({0, 1, 0});
-      auto y = T({0, 1, 0});
-      REQUIRE(x == y);
-      REQUIRE(y * y == x);
-      REQUIRE((x < y) == false);
-
-      auto z = T({0, 1, 0, 3});
-      REQUIRE(x < z);
-      REQUIRE(image(z) == std::vector<typename T::point_type>({0, 1, 3}));
-
-      auto expected = T({0, 0, 0});
-      REQUIRE(expected < x);
-
-      REQUIRE(z.degree() == 4);
-      REQUIRE(Complexity<T>()(z) == 4);
-      REQUIRE(z.rank() == 3);
-      auto id = one(z);
-
-      expected = T({0, 1, 2, 3});
-      REQUIRE(id == expected);
-
-      if (IsDynamic<T>) {
-        x.increase_degree_by(10);
-        REQUIRE(x.degree() == 13);
-        REQUIRE(x.end() - x.begin() == 13);
-      } else {
-        REQUIRE_THROWS_AS(x.increase_degree_by(10), LibsemigroupsException);
-      }
-      auto t = to<Transf<>>({9, 7, 3, 5, 3, 4, 2, 7, 7, 1});
-      REQUIRE(t.hash_value() != 0);
-      REQUIRE_NOTHROW(t.undef());
-    }
-
-    template <typename T>
-    void test_pperm001() {
-      static_assert(IsPPerm<T>, "IsPPerm<T> must be true!");
-      auto x = T({4, 5, 0}, {9, 0, 1}, 10);
-      auto y = T({4, 5, 0}, {9, 0, 1}, 10);
-      REQUIRE(x.undef() == UNDEFINED);
-      REQUIRE(x == y);
-      auto yy = x * x;
-      REQUIRE(yy[0] == UNDEFINED);
-      REQUIRE(yy[1] == UNDEFINED);
-      REQUIRE(yy.at(2) == UNDEFINED);
-      REQUIRE(yy.at(3) == UNDEFINED);
-      REQUIRE(yy.at(4) == UNDEFINED);
-      REQUIRE(yy.at(5) == 1);
-
-      REQUIRE(yy > y);
-      REQUIRE(!(x < x));
-      auto expected = T({UNDEFINED, UNDEFINED, UNDEFINED});
-      REQUIRE(expected > x);
-
-      REQUIRE(x.degree() == 10);
-      REQUIRE(y.degree() == 10);
-      REQUIRE(Complexity<T>()(x) == 10);
-      REQUIRE(Complexity<T>()(y) == 10);
-      REQUIRE(yy.rank() == 1);
-      REQUIRE(y.rank() == 3);
-      REQUIRE(x.rank() == 3);
-
-      auto id  = one(x);
-      expected = T({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
-      REQUIRE(id == expected);
-
-      if (IsDynamic<T>) {
-        x.increase_degree_by(10);
-        REQUIRE(x.degree() == 20);
-        REQUIRE(x.end() >= x.begin());
-        REQUIRE(static_cast<size_t>(x.end() - x.begin()) == x.degree());
-      } else {
-        REQUIRE_THROWS_AS(x.increase_degree_by(10), LibsemigroupsException);
-      }
-      REQUIRE(x.hash_value() != 0);
-    }
-    template <typename T>
     bool test_inverse(T const& p) {
       return p * inverse(p) == one(p) && inverse(p) * p == one(p);
     }
@@ -126,9 +48,44 @@ namespace libsemigroups {
     // REQUIRE(to_string(x, "{}") == "Transf<0, uint32_t>({0, 1, 0})");
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Transf", "001", "mem fns", "[quick][transf]") {
-    test_transf000<Transf<>>();
-    test_transf000<Transf<4>>();
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Transf",
+                                   "001",
+                                   "mem fns",
+                                   "[quick][transf]",
+                                   Transf<>,
+                                   Transf<4>) {
+    static_assert(IsTransf<TestType>, "IsTransf<TestType> must be true!");
+    auto x = TestType({0, 1, 0});
+    auto y = TestType({0, 1, 0});
+    REQUIRE(x == y);
+    REQUIRE(y * y == x);
+    REQUIRE((x < y) == false);
+
+    auto z = TestType({0, 1, 0, 3});
+    REQUIRE(x < z);
+    REQUIRE(image(z) == std::vector<typename TestType::point_type>({0, 1, 3}));
+
+    auto expected = TestType({0, 0, 0});
+    REQUIRE(expected < x);
+
+    REQUIRE(z.degree() == 4);
+    REQUIRE(Complexity<TestType>()(z) == 4);
+    REQUIRE(z.rank() == 3);
+    auto id = one(z);
+
+    expected = TestType({0, 1, 2, 3});
+    REQUIRE(id == expected);
+
+    if (IsDynamic<TestType>) {
+      x.increase_degree_by(10);
+      REQUIRE(x.degree() == 13);
+      REQUIRE(x.end() - x.begin() == 13);
+    } else {
+      REQUIRE_THROWS_AS(x.increase_degree_by(10), LibsemigroupsException);
+    }
+    auto t = to<Transf<>>({9, 7, 3, 5, 3, 4, 2, 7, 7, 1});
+    REQUIRE(t.hash_value() != 0);
+    REQUIRE_NOTHROW(t.undef());
   }
 
   LIBSEMIGROUPS_TEST_CASE("Transf",
@@ -170,9 +127,51 @@ namespace libsemigroups {
                       LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("PPerm", "004", "mem fns", "[quick][pperm]") {
-    test_pperm001<PPerm<>>();
-    test_pperm001<PPerm<10>>();
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("PPerm",
+                                   "004",
+                                   "mem fns",
+                                   "[quick][pperm]",
+                                   PPerm<>,
+                                   PPerm<10>) {
+    static_assert(IsPPerm<TestType>, "IsPPerm<TestType> must be true!");
+    auto x = TestType({4, 5, 0}, {9, 0, 1}, 10);
+    auto y = TestType({4, 5, 0}, {9, 0, 1}, 10);
+    REQUIRE(x.undef() == UNDEFINED);
+    REQUIRE(x == y);
+    auto yy = x * x;
+    REQUIRE(yy[0] == UNDEFINED);
+    REQUIRE(yy[1] == UNDEFINED);
+    REQUIRE(yy.at(2) == UNDEFINED);
+    REQUIRE(yy.at(3) == UNDEFINED);
+    REQUIRE(yy.at(4) == UNDEFINED);
+    REQUIRE(yy.at(5) == 1);
+
+    REQUIRE(yy > y);
+    REQUIRE(!(x < x));
+    auto expected = TestType({UNDEFINED, UNDEFINED, UNDEFINED});
+    REQUIRE(expected > x);
+
+    REQUIRE(x.degree() == 10);
+    REQUIRE(y.degree() == 10);
+    REQUIRE(Complexity<TestType>()(x) == 10);
+    REQUIRE(Complexity<TestType>()(y) == 10);
+    REQUIRE(yy.rank() == 1);
+    REQUIRE(y.rank() == 3);
+    REQUIRE(x.rank() == 3);
+
+    auto id  = one(x);
+    expected = TestType({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+    REQUIRE(id == expected);
+
+    if (IsDynamic<TestType>) {
+      x.increase_degree_by(10);
+      REQUIRE(x.degree() == 20);
+      REQUIRE(x.end() >= x.begin());
+      REQUIRE(static_cast<size_t>(x.end() - x.begin()) == x.degree());
+    } else {
+      REQUIRE_THROWS_AS(x.increase_degree_by(10), LibsemigroupsException);
+    }
+    REQUIRE(x.hash_value() != 0);
   }
 
   LIBSEMIGROUPS_TEST_CASE("PPerm",

--- a/tests/test-ukkonen.cpp
+++ b/tests/test-ukkonen.cpp
@@ -30,6 +30,8 @@
 #include "libsemigroups/ukkonen.hpp"     // for Ukkonen, Ukkonen::State
 #include "libsemigroups/word-range.hpp"  // for literals
 
+#include "libsemigroups/detail/int-range.hpp"  // for IntRange
+
 namespace libsemigroups {
 
   using literals::operator""_w;

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -26,6 +26,7 @@
 #include "word-graph-test-common.hpp"  // for add_clique etc
 
 #include "libsemigroups/forest.hpp"      // for Forest
+#include "libsemigroups/paths.hpp"       // for cbegin_pilo
 #include "libsemigroups/word-graph.hpp"  // for WordGraph
 #include "libsemigroups/word-range.hpp"  // for literals, WordRange
 


### PR DESCRIPTION
This PR improves the test listener which governs the output when running any of the test executables. The main change when running quick or standard tests is to increase the number of columns to 90 to be more consistent with the output reported by libsemigroups itself. Subsections are now reported properly.

For extreme tests, the section names are now included in the output too, and a summary of the run times is printed at the end of every test case with multiple sections. 