### PR TITLE
Fix some doc inconsistencies and typos

### DIFF
--- a/include/libsemigroups/presentation-examples.hpp
+++ b/include/libsemigroups/presentation-examples.hpp
@@ -1113,7 +1113,10 @@ namespace libsemigroups {
     //! are not important.
     //!
     //! \sa
-    //! `partition_monoid_Eas11` and `partition_monoid_HR05`.
+    //! For a specific %presentation of the full transformation monoid, see
+    //! %one of the following functions:
+    //! * `partition_monoid_Eas11`;
+    //! * `partition_monoid_HR05`.
     [[nodiscard]] inline Presentation<word_type> partition_monoid(size_t n) {
       return partition_monoid_Eas11(n);
     }

--- a/include/libsemigroups/presentation-examples.hpp
+++ b/include/libsemigroups/presentation-examples.hpp
@@ -85,7 +85,7 @@ namespace libsemigroups {
     //!
     //! The functions documented below provide specific presentations for
     //! various semigroups and monoids, usually accompanied by a reference to
-    //! a the source of the presentation. There may be several presentations
+    //! the source of the presentation. There may be several presentations
     //! for any semigroup or monoid.
     //!
     //! For each semigroup or monoid, there is a corresponding default


### PR DESCRIPTION
This PR addresses some typos and inconsistencies I missed in #632. It only touches comments.