### PR TITLE
Cong hpp doc

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -307,7 +307,9 @@ ALIASES                = "exceptions=\par Exceptions" \
                          "cong_common_throws_if_started=\throws LibsemigroupsException if \ref started returns \c true." \
                          "cong_common_throws_if_letters_out_of_bounds=\throws LibsemigroupsException if any of the values pointed at by the iterators is out of range, i.e. they do not belong to `presentation().alphabet()` and `Presentation::validate_word` throws." \
                          "ref_todd_coxeter=\ref todd_coxeter_class_group \"ToddCoxeter\"" \
-                         "ref_knuth_bendix=\ref knuth_bendix_class_group \"KnuthBendix\""
+                         "ref_knuth_bendix=\ref knuth_bendix_class_group \"KnuthBendix\"" \
+                         "ref_kambites=\ref kambites_class_group \"Kambites\"" \
+                         "ref_congruence=\ref congruence_class_group \"Congruence\"" 
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For

--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -145,7 +145,7 @@
         <tab type="user" visible="yes" url="@ref congruence_class_intf_group" title = "Common member functions"/>
         <tab type="user" visible="yes" url="@ref congruence_class_accessors_group" title = "Accessors"/>
       </tab>
-      <tab type="user" visible="yes" url="@ref libsemigroups::congruence" title="Congruence helper functions"/>
+      <tab type="user" visible="yes" url="@ref congruence_helpers_group" title="Congruence helper functions"/>
     </tab>
     <tab type="user" visible="yes" url="@ref froidure_pin_group" title="Froidure-Pin" />
     <tab type="usergroup" visible="yes" url="@ref kambites_group" title="Kambites">
@@ -155,7 +155,7 @@
         <tab type="user" visible="yes" url="@ref kambites_class_intf_group" title = "Common member functions"/>
         <tab type="user" visible="yes" url="@ref kambites_class_accessors_group" title = "Accessors"/>
       </tab>
-      <tab type="user" visible="yes" url="@ref libsemigroups::kambites" title="Kambites helper functions" />
+      <tab type="user" visible="yes" url="@ref kambites_helpers_group" title="Kambites helper functions" />
     </tab>
     <tab type="usergroup" visible="yes" url="@ref knuth_bendix_group" title="Knuth-Bendix">
       <tab type="usergroup" visible="yes" url="@ref knuth_bendix_class_group" title="The KnuthBendix class">

--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -138,7 +138,13 @@
         <tab type="user" visible="yes" url="@ref cong_common_helpers_partition_group" title="Partitioning"/>
       </tab>
     <tab type="usergroup" visible="yes" url="@ref congruence_group" title="Congruence">
-      <tab type="user" visible="yes" url="@ref congruence_class_group" title="The Congruence class"/>
+      <tab type="usergroup" visible="yes" url="@ref congruence_class_group" title="The Congruence class">
+        <tab type="user" visible="yes" url="@ref congruence_class_mem_types_group" title = "Member types"/>
+        <tab type="user" visible="yes" url="@ref congruence_class_init_group" title = "Constructors + Initializers"/>
+        <tab type="user" visible="yes" url="@ref congruence_class_settings_group" title = "Settings"/>
+        <tab type="user" visible="yes" url="@ref congruence_class_intf_group" title = "Common member functions"/>
+        <tab type="user" visible="yes" url="@ref congruence_class_accessors_group" title = "Accessors"/>
+      </tab>
       <tab type="user" visible="yes" url="@ref libsemigroups::congruence" title="Congruence helper functions"/>
     </tab>
     <tab type="user" visible="yes" url="@ref froidure_pin_group" title="Froidure-Pin" />

--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -143,7 +143,12 @@
     </tab>
     <tab type="user" visible="yes" url="@ref froidure_pin_group" title="Froidure-Pin" />
     <tab type="usergroup" visible="yes" url="@ref kambites_group" title="Kambites">
-      <tab type="user" visible="yes" url="@ref libsemigroups::Kambites" title="The Kambites class" />
+      <tab type="usergroup" visible="yes" url="@ref kambites_class_group" title="The Kambites class">
+        <tab type="user" visible="yes" url="@ref kambites_class_mem_types_group" title = "Member types"/>
+        <tab type="user" visible="yes" url="@ref kambites_class_init_group" title = "Constructors + Initializers"/>
+        <tab type="user" visible="yes" url="@ref kambites_class_intf_group" title = "Common member functions"/>
+        <tab type="user" visible="yes" url="@ref kambites_class_accessors_group" title = "Accessors"/>
+      </tab>
       <tab type="user" visible="yes" url="@ref libsemigroups::kambites" title="Kambites helper functions" />
     </tab>
     <tab type="usergroup" visible="yes" url="@ref knuth_bendix_group" title="Knuth-Bendix">

--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -147,7 +147,13 @@
       <tab type="user" visible="yes" url="@ref libsemigroups::kambites" title="Kambites helper functions" />
     </tab>
     <tab type="usergroup" visible="yes" url="@ref knuth_bendix_group" title="Knuth-Bendix">
-      <tab type="user" visible="yes" url="@ref knuth_bendix_class_group" title="The KnuthBendix class"/>
+      <tab type="usergroup" visible="yes" url="@ref knuth_bendix_class_group" title="The KnuthBendix class">
+        <tab type="user" visible="yes" url="@ref knuth_bendix_class_mem_types_group" title = "Member types"/>
+        <tab type="user" visible="yes" url="@ref knuth_bendix_class_init_group" title = "Constructors + Initializers"/>
+        <tab type="user" visible="yes" url="@ref knuth_bendix_class_settings_group" title = "Settings"/>
+        <tab type="user" visible="yes" url="@ref knuth_bendix_class_intf_group" title = "Common member functions"/>
+        <tab type="user" visible="yes" url="@ref knuth_bendix_class_accessors_group" title = "Accessors"/>
+      </tab>
       <tab type="user" visible="yes" url="@ref knuth_bendix_helpers_group" title="Knuth-Bendix helper functions"/>
     </tab>
     <tab type="user" visible="yes" url="@ref freeband_group" title="Radoszewski-Rytter" />

--- a/include/libsemigroups/cong-class.hpp
+++ b/include/libsemigroups/cong-class.hpp
@@ -184,6 +184,8 @@ namespace libsemigroups {
     // Congruence - constructors - public
     //////////////////////////////////////////////////////////////////////////
 
+    //! \ingroup congruence_class_init_group
+    //!
     //! \brief Default constructor.
     //!
     //! This function default constructs an uninitialised Congruence instance.
@@ -195,6 +197,8 @@ namespace libsemigroups {
       init();
     }
 
+    //! \ingroup congruence_class_init_group
+    //!
     //! \brief Re-initialize a Congruence instance.
     //!
     //! This function puts a Congruence instance back into the state that it
@@ -206,20 +210,38 @@ namespace libsemigroups {
     //! \no_libsemigroups_except
     Congruence& init();
 
+    //! \ingroup congruence_class_init_group
+    //!
+    //! \brief Copy constructor.
+    //!
     //! Copy constructor.
     Congruence(Congruence const&) = default;
 
+    //! \ingroup congruence_class_init_group
+    //!
+    //! \brief Move constructor.
+    //!
     //! Move constructor.
     Congruence(Congruence&&) = default;
 
+    //! \ingroup congruence_class_init_group
+    //!
+    //! \brief Copy assignment operator.
+    //!
     //! Copy assignment operator.
     Congruence& operator=(Congruence const&) = default;
 
+    //! \ingroup congruence_class_init_group
+    //!
+    //! \brief Move assignment operator.
+    //!
     //! Move assignment operator.
     Congruence& operator=(Congruence&&) = default;
 
     ~Congruence() = default;
 
+    //! \ingroup congruence_class_init_group
+    //!
     //! \brief Construct from \ref congruence_kind and Presentation.
     //!
     //! This function constructs a Congruence instance representing a
@@ -236,6 +258,8 @@ namespace libsemigroups {
       init(knd, p);
     }
 
+    //! \ingroup congruence_class_init_group
+    //!
     //! \brief Re-initialize a Congruence instance.
     //!
     //! This function puts a Congruence instance back into the state that it
@@ -251,6 +275,8 @@ namespace libsemigroups {
     // NOTE:  No rvalue ref version because we anyway must copy p multiple times
     Congruence& init(congruence_kind knd, Presentation<Word> const& p);
 
+    //! \ingroup congruence_class_init_group
+    //!
     //! \brief Construct from congruence_kind, FroidurePin, and WordGraph.
     //!
     //! Constructs a Congruence over the FroidurePin instance \p S
@@ -276,6 +302,8 @@ namespace libsemigroups {
       init(knd, S, wg);
     }
 
+    //! \ingroup congruence_class_init_group
+    //!
     //! \brief Re-initialize from congruence_kind, FroidurePin, and WordGraph.
     //!
     //! This function re-initializes a Congruence instance as if it had been
@@ -586,6 +614,8 @@ namespace libsemigroups {
     // Congruence - interface requirements - throw_if_letter_out_of_bounds
     ////////////////////////////////////////////////////////////////////////
 
+    //! \ingroup congruence_class_init_group
+    //!
     //! \brief Throws if any letter in a range is out of bounds.
     //!
     //! This function throws a LibsemigroupsException if any value pointed at

--- a/include/libsemigroups/cong-class.hpp
+++ b/include/libsemigroups/cong-class.hpp
@@ -102,11 +102,11 @@ namespace libsemigroups {
   //! \ingroup congruence_class_group
   //!
   //! \brief Documentation of common member functions of \ref Congruence,
-  //! \ref Kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
+  //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
   //!
   //! This page contains documentation of the member functions of
   //! \ref Congruence that are implemented in all of the classes Congruence,
-  //! \ref Kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
+  //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
 
   //! \defgroup congruence_class_accessors_group Accessors
   //!
@@ -126,7 +126,7 @@ namespace libsemigroups {
   //!
   //! \ingroup congruence_group
   //!
-  //! \brief Class for running Kambites, \ref_knuth_bendix, and
+  //! \brief Class for running \ref_kambites, \ref_knuth_bendix, and
   //! \ref_todd_coxeter in parallel.
   //!
   //! Defined in `cong-class.hpp`.
@@ -137,7 +137,7 @@ namespace libsemigroups {
   //! algorithm from `libsemigroups` (and some variants of the same algorithm)
   //! in parallel. This class is provided for convenience, at present it is not
   //! very customisable, and lacks some of the fine grained control offered by
-  //! the classes implementing individual algorithms, such as Kambites,
+  //! the classes implementing individual algorithms, such as \ref_kambites,
   //! \ref_knuth_bendix, and \ref_todd_coxeter.
   //!
   //! \tparam Word the type of the words used in the \ref presentation and

--- a/include/libsemigroups/cong-class.hpp
+++ b/include/libsemigroups/cong-class.hpp
@@ -73,8 +73,8 @@ namespace libsemigroups {
 
   //! \ingroup congruence_class_group
   //!
-  //! \brief Class for running Kambites, KnuthBendix, and \ref_todd_coxeter
-  //! in parallel.
+  //! \brief Class for running Kambites, \ref_knuth_bendix, and
+  //! \ref_todd_coxeter in parallel.
   //!
   //! Defined in `cong-class.hpp`.
   //!
@@ -85,7 +85,7 @@ namespace libsemigroups {
   //! in parallel. This class is provided for convenience, at present it is not
   //! very customisable, and lacks some of the fine grained control offered by
   //! the classes implementing individual algorithms, such as Kambites,
-  //! KnuthBendix, and \ref_todd_coxeter.
+  //! \ref_knuth_bendix, and \ref_todd_coxeter.
   //!
   //! \tparam Word the type of the words used in the \ref presentation and
   //! \ref generating_pairs.

--- a/include/libsemigroups/cong-class.hpp
+++ b/include/libsemigroups/cong-class.hpp
@@ -333,6 +333,8 @@ namespace libsemigroups {
     // Congruence - interface requirements - add_generating_pair
     //////////////////////////////////////////////////////////////////////////
 
+    //! \ingroup congruence_class_intf_group
+    //!
     //! \brief Add generating pair via iterators.
     //!
     //! This function adds a generating pair to the congruence represented by a
@@ -360,6 +362,8 @@ namespace libsemigroups {
           Congruence>(first1, last1, first2, last2);
     }
 
+    //! \ingroup congruence_class_intf_group
+    //!
     //! \brief Add generating pair via iterators.
     //!
     //! This function adds a generating pair to the congruence represented by a
@@ -389,6 +393,8 @@ namespace libsemigroups {
     // Congruence - interface requirements - number_of_classes
     ////////////////////////////////////////////////////////////////////////
 
+    //! \ingroup congruence_class_intf_group
+    //!
     //! \brief Compute the number of classes in the congruence.
     //!
     //! This function computes the number of classes in the congruence
@@ -407,6 +413,8 @@ namespace libsemigroups {
     // Congruence - interface requirements - contains
     ////////////////////////////////////////////////////////////////////////
 
+    //! \ingroup congruence_class_intf_group
+    //!
     //! \brief Check containment of a pair of words via iterators.
     //!
     //! This function checks whether or not the words represented by the ranges
@@ -432,6 +440,8 @@ namespace libsemigroups {
                                                     Iterator3 first2,
                                                     Iterator4 last2) const;
 
+    //! \ingroup congruence_class_intf_group
+    //!
     //! \brief Check containment of a pair of words via iterators.
     //!
     //! This function checks whether or not the words represented by the ranges
@@ -460,6 +470,8 @@ namespace libsemigroups {
           first1, last1, first2, last2);
     }
 
+    //! \ingroup congruence_class_intf_group
+    //!
     //! \brief Check containment of a pair of words via iterators.
     //!
     //! This function checks whether or not the words represented by the ranges
@@ -491,6 +503,8 @@ namespace libsemigroups {
           first1, last1, first2, last2);
     }
 
+    //! \ingroup congruence_class_intf_group
+    //!
     //! \brief Check containment of a pair of words via iterators.
     //!
     //! This function checks whether or not the words represented by the ranges
@@ -522,6 +536,8 @@ namespace libsemigroups {
     // Congruence - interface requirements - reduce
     ////////////////////////////////////////////////////////////////////////
 
+    //! \ingroup congruence_class_intf_group
+    //!
     //! \brief Reduce a word with no computation or checks.
     //!
     //! This function writes a reduced word equivalent to the input word
@@ -542,6 +558,8 @@ namespace libsemigroups {
                                            Iterator1      first,
                                            Iterator2      last) const;
 
+    //! \ingroup congruence_class_intf_group
+    //!
     //! \brief Reduce a word with no computation.
     //!
     //! This function writes a reduced word equivalent to the input word
@@ -565,6 +583,8 @@ namespace libsemigroups {
           d_first, first, last);
     }
 
+    //! \ingroup congruence_class_intf_group
+    //!
     //! \brief Reduce a word with no checks.
     //!
     //! This function fully computes the congruence and then writes
@@ -588,6 +608,8 @@ namespace libsemigroups {
           d_first, first, last);
     }
 
+    //! \ingroup congruence_class_intf_group
+    //!
     //! \brief Reduce a word.
     //!
     //! This function fully computes the congruence and then writes

--- a/include/libsemigroups/cong-class.hpp
+++ b/include/libsemigroups/cong-class.hpp
@@ -62,15 +62,6 @@ namespace libsemigroups {
   //! identical, because there are no helper functions that only apply to the
   //! Congruence class template.
 
-  //! \defgroup congruence_class_group The Congruence class
-  //! \ingroup congruence_group
-  //!
-  //! \brief This page contains links to the documentation related to the
-  //! Congruence class.
-  //!
-  //! This page contains links to the documentation related to the
-  //! Congruence class.
-
   //! \defgroup congruence_class_mem_types_group Member Types
   //!
   //! \ingroup congruence_class_group
@@ -131,7 +122,9 @@ namespace libsemigroups {
   //! Those functions with the prefix `current_` do not perform any
   //! further enumeration.
 
-  //! \ingroup congruence_class_group
+  //! \defgroup congruence_class_group The Congruence class
+  //!
+  //! \ingroup congruence_group
   //!
   //! \brief Class for running Kambites, \ref_knuth_bendix, and
   //! \ref_todd_coxeter in parallel.

--- a/include/libsemigroups/cong-class.hpp
+++ b/include/libsemigroups/cong-class.hpp
@@ -171,6 +171,8 @@ namespace libsemigroups {
     // Interface requirements - native-types
     ////////////////////////////////////////////////////////////////////////
 
+    //! \ingroup congruence_class_mem_types_group
+    //!
     //! \brief Type of the words in the relations of the presentation stored in
     //! a \ref Congruence instance.
     //!

--- a/include/libsemigroups/cong-class.hpp
+++ b/include/libsemigroups/cong-class.hpp
@@ -96,6 +96,22 @@ namespace libsemigroups {
   //! instance as if it had just been constructed; but without necessarily
   //! releasing any previous allocated memory.
 
+  //! \defgroup congruence_class_settings_group Settings
+  //! \ingroup congruence_class_group
+  //!
+  //! \brief Settings that control the behaviour of a Congruence
+  //! instance.
+  //!
+  //! This page contains information about the member functions of the
+  //! Congruence that control various settings that influence the
+  //! running of the congruence-based algorithms.
+  //!
+  //! There are a fairly large number of settings, they can profoundly alter
+  //! the run time, but it is hard to predict what settings will work best for
+  //! any particular input.
+  //!
+  //! See also \ref Runner for further settings.
+
   //! \defgroup congruence_class_intf_group Common member functions
   //!
   //! \ingroup congruence_class_group
@@ -660,6 +676,8 @@ namespace libsemigroups {
     // Congruence - member functions - public
     //////////////////////////////////////////////////////////////////////////
 
+    //! \ingroup congruence_class_accessors_group
+    //!
     //! \brief Get a derived class of detail::CongruenceCommon being used to
     //! compute a Congruence instance.
     //!
@@ -679,6 +697,8 @@ namespace libsemigroups {
     template <typename Thing>
     std::shared_ptr<Thing> get() const;
 
+    //! \ingroup congruence_class_accessors_group
+    //!
     //! \brief Check if a derived class of detail::CongruenceCommon being used
     //! to compute a Congruence instance.
     //!
@@ -699,6 +719,8 @@ namespace libsemigroups {
     template <typename Thing>
     [[nodiscard]] bool has() const;
 
+    //! \ingroup congruence_class_settings_group
+    //!
     //! \brief Get the current maximum number of threads.
     //!
     //! This function returns the current maximum number of threads that a
@@ -716,6 +738,8 @@ namespace libsemigroups {
       return _race.max_threads();
     }
 
+    //! \ingroup congruence_class_settings_group
+    //!
     //! \brief Set the maximum number of threads.
     //!
     //! This function can be used to set the maximum number of threads that a
@@ -735,6 +759,8 @@ namespace libsemigroups {
       return *this;
     }
 
+    //! \ingroup congruence_class_settings_group
+    //!
     //! \brief Get the number of runners.
     //!
     //! This function returns the number of distinct detail::CongruenceCommon
@@ -748,6 +774,8 @@ namespace libsemigroups {
       return _race.number_of_runners();
     }
 
+    //! \ingroup congruence_class_intf_group
+    //!
     //! \brief Get the presentation defining the parent semigroup of the
     //! congruence.
     //!
@@ -760,6 +788,8 @@ namespace libsemigroups {
     //! construct or initialise the object.
     [[nodiscard]] Presentation<Word> const& presentation() const;
 
+    //! \ingroup congruence_class_intf_group
+    //!
     //! \brief Get the generating pairs of the congruence.
     //!
     //! This function returns the generating pairs of the congruence, as added

--- a/include/libsemigroups/cong-class.hpp
+++ b/include/libsemigroups/cong-class.hpp
@@ -102,15 +102,9 @@ namespace libsemigroups {
   //! \brief Settings that control the behaviour of a Congruence
   //! instance.
   //!
-  //! This page contains information about the member functions of the
+  //! This page contains information about the member functions of
   //! Congruence that control various settings that influence the
   //! running of the congruence-based algorithms.
-  //!
-  //! There are a fairly large number of settings, they can profoundly alter
-  //! the run time, but it is hard to predict what settings will work best for
-  //! any particular input.
-  //!
-  //! See also \ref Runner for further settings.
 
   //! \defgroup congruence_class_intf_group Common member functions
   //!

--- a/include/libsemigroups/cong-class.hpp
+++ b/include/libsemigroups/cong-class.hpp
@@ -71,6 +71,56 @@ namespace libsemigroups {
   //! This page contains links to the documentation related to the
   //! Congruence class.
 
+  //! \defgroup congruence_class_mem_types_group Member Types
+  //!
+  //! \ingroup congruence_class_group
+  //!
+  //! \brief Public member types
+  //!
+  //! This page contains the documentation of the public member types of a
+  //! \ref Congruence instance.
+
+  //! \defgroup congruence_class_init_group Constructors + initializers
+  //!
+  //! \ingroup congruence_class_group
+  //!
+  //! \brief Construct or re-initialize a \ref Congruence
+  //! instance (public member function).
+  //!
+  //! This page documents the constructors and initialisers for the
+  //! \ref Congruence class.
+  //!
+  //! Every constructor (except the move + copy constructors, and the move
+  //! and copy assignment operators) has a matching `init` function with the
+  //! same signature that can be used to re-initialize a Congruence
+  //! instance as if it had just been constructed; but without necessarily
+  //! releasing any previous allocated memory.
+
+  //! \defgroup congruence_class_intf_group Common member functions
+  //!
+  //! \ingroup congruence_class_group
+  //!
+  //! \brief Documentation of common member functions of \ref Congruence,
+  //! \ref Kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
+  //!
+  //! This page contains documentation of the member functions of
+  //! \ref Congruence that are implemented in all of the classes Congruence,
+  //! \ref Kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
+
+  //! \defgroup congruence_class_accessors_group Accessors
+  //!
+  //! \ingroup congruence_class_group
+  //!
+  //! \brief Member functions that can be used to access the state of a
+  //! \ref Congruence instance.
+  //!
+  //! This page contains the documentation of the various member functions of
+  //! the \ref Congruence class that can be used to access the state of an
+  //! instance.
+  //!
+  //! Those functions with the prefix `current_` do not perform any
+  //! further enumeration.
+
   //! \ingroup congruence_class_group
   //!
   //! \brief Class for running Kambites, \ref_knuth_bendix, and

--- a/include/libsemigroups/cong-class.hpp
+++ b/include/libsemigroups/cong-class.hpp
@@ -54,13 +54,13 @@ namespace libsemigroups {
   //! \defgroup congruence_group Congruence
   //!
   //! This page contains links documentation related to the class template
-  //! Congruence.
+  //! \ref_congruence.
   //!
-  //! Helper functions for the class template Congruence can be found in the
-  //! namespaces \ref cong_common_helpers_group "congruence_common" and \ref
+  //! Helper functions for the class template \ref_congruence can be found in
+  //! the namespaces \ref cong_common_helpers_group "congruence_common" and \ref
   //! congruence. At present the helper functions in these two namespaces are
   //! identical, because there are no helper functions that only apply to the
-  //! Congruence class template.
+  //! \ref_congruence class template.
 
   //! \defgroup congruence_class_mem_types_group Member Types
   //!
@@ -69,54 +69,54 @@ namespace libsemigroups {
   //! \brief Public member types
   //!
   //! This page contains the documentation of the public member types of a
-  //! \ref Congruence instance.
+  //! \ref_congruence instance.
 
   //! \defgroup congruence_class_init_group Constructors + initializers
   //!
   //! \ingroup congruence_class_group
   //!
-  //! \brief Construct or re-initialize a \ref Congruence
+  //! \brief Construct or re-initialize a \ref_congruence
   //! instance (public member function).
   //!
   //! This page documents the constructors and initialisers for the
-  //! \ref Congruence class.
+  //! \ref_congruence class.
   //!
   //! Every constructor (except the move + copy constructors, and the move
   //! and copy assignment operators) has a matching `init` function with the
-  //! same signature that can be used to re-initialize a Congruence
+  //! same signature that can be used to re-initialize a \ref_congruence
   //! instance as if it had just been constructed; but without necessarily
   //! releasing any previous allocated memory.
 
   //! \defgroup congruence_class_settings_group Settings
   //! \ingroup congruence_class_group
   //!
-  //! \brief Settings that control the behaviour of a Congruence
+  //! \brief Settings that control the behaviour of a \ref_congruence
   //! instance.
   //!
   //! This page contains information about the member functions of
-  //! Congruence that control various settings that influence the
+  //! \ref_congruence that control various settings that influence the
   //! running of the congruence-based algorithms.
 
   //! \defgroup congruence_class_intf_group Common member functions
   //!
   //! \ingroup congruence_class_group
   //!
-  //! \brief Documentation of common member functions of \ref Congruence,
+  //! \brief Documentation of common member functions of \ref_congruence,
   //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
   //!
   //! This page contains documentation of the member functions of
-  //! \ref Congruence that are implemented in all of the classes Congruence,
-  //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
+  //! \ref_congruence that are implemented in all of the classes
+  //! \ref_congruence, \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
 
   //! \defgroup congruence_class_accessors_group Accessors
   //!
   //! \ingroup congruence_class_group
   //!
   //! \brief Member functions that can be used to access the state of a
-  //! \ref Congruence instance.
+  //! \ref_congruence instance.
   //!
   //! This page contains the documentation of the various member functions of
-  //! the \ref Congruence class that can be used to access the state of an
+  //! the \ref_congruence class that can be used to access the state of an
   //! instance.
   //!
   //! Those functions with the prefix `current_` do not perform any
@@ -132,7 +132,7 @@ namespace libsemigroups {
   //! Defined in `cong-class.hpp`.
   //!
   //! On this page we describe the functionality relating to the class template
-  //! Congruence in `libsemigroups`. This class can be used for computing a
+  //! \ref_congruence in `libsemigroups`. This class can be used for computing a
   //! congruence over a semigroup or monoid by running every applicable
   //! algorithm from `libsemigroups` (and some variants of the same algorithm)
   //! in parallel. This class is provided for convenience, at present it is not
@@ -140,11 +140,11 @@ namespace libsemigroups {
   //! the classes implementing individual algorithms, such as \ref_kambites,
   //! \ref_knuth_bendix, and \ref_todd_coxeter.
   //!
-  //! \tparam Word the type of the words used in the \ref presentation and
-  //! \ref generating_pairs.
+  //! \tparam Word the type of the words used in the \ref
+  //! Congruence::presentation and \ref Congruence::generating_pairs.
   //!
   //! \sa \ref cong_common_helpers_group for information about helper functions
-  //! for the Congruence class template.
+  //! for the \ref_congruence class template.
   //!
   //! \par Example
   //! \code
@@ -177,10 +177,10 @@ namespace libsemigroups {
     //! \ingroup congruence_class_mem_types_group
     //!
     //! \brief Type of the words in the relations of the presentation stored in
-    //! a \ref Congruence instance.
+    //! a \ref_congruence instance.
     //!
     //! The template parameter \c Word, which is the type of the words in the
-    //! relations of the presentation stored in a \ref Congruence instance.
+    //! relations of the presentation stored in a \ref_congruence instance.
     using native_word_type = Word;
 
     //////////////////////////////////////////////////////////////////////////
@@ -191,7 +191,8 @@ namespace libsemigroups {
     //!
     //! \brief Default constructor.
     //!
-    //! This function default constructs an uninitialised Congruence instance.
+    //! This function default constructs an uninitialised \ref_congruence
+    //! instance.
     Congruence()
         : detail::CongruenceCommon(),
           _race(),
@@ -202,10 +203,10 @@ namespace libsemigroups {
 
     //! \ingroup congruence_class_init_group
     //!
-    //! \brief Re-initialize a Congruence instance.
+    //! \brief Re-initialize a \ref_congruence instance.
     //!
-    //! This function puts a Congruence instance back into the state that it
-    //! would have been in if it had just been newly default constructed.
+    //! This function puts a \ref_congruence instance back into the state that
+    //! it would have been in if it had just been newly default constructed.
     //!
     //! \returns A reference to `*this`.
     //!
@@ -247,7 +248,7 @@ namespace libsemigroups {
     //!
     //! \brief Construct from \ref congruence_kind and Presentation.
     //!
-    //! This function constructs a Congruence instance representing a
+    //! This function constructs a \ref_congruence instance representing a
     //! congruence of kind \p knd over the semigroup or monoid defined by the
     //! presentation \p p.
     //!
@@ -263,11 +264,11 @@ namespace libsemigroups {
 
     //! \ingroup congruence_class_init_group
     //!
-    //! \brief Re-initialize a Congruence instance.
+    //! \brief Re-initialize a \ref_congruence instance.
     //!
-    //! This function puts a Congruence instance back into the state that it
-    //! would have been in if it had just been newly constructed from \p knd and
-    //! \p p.
+    //! This function puts a \ref_congruence instance back into the state that
+    //! it would have been in if it had just been newly constructed from \p knd
+    //! and \p p.
     //!
     //! \param knd the kind (onesided or twosided) of the congruence.
     //! \param p the presentation.
@@ -282,7 +283,7 @@ namespace libsemigroups {
     //!
     //! \brief Construct from congruence_kind, FroidurePin, and WordGraph.
     //!
-    //! Constructs a Congruence over the FroidurePin instance \p S
+    //! Constructs a \ref_congruence over the FroidurePin instance \p S
     //! representing a 1- or 2-sided congruence according to \p knd.
     //!
     //! \tparam Node the type of the nodes in the 3rd argument \p wg (word
@@ -309,9 +310,9 @@ namespace libsemigroups {
     //!
     //! \brief Re-initialize from congruence_kind, FroidurePin, and WordGraph.
     //!
-    //! This function re-initializes a Congruence instance as if it had been
-    //! newly constructed over the FroidurePin instance \p S representing a 1-
-    //! or 2-sided congruence according to \p knd.
+    //! This function re-initializes a \ref_congruence instance as if it had
+    //! been newly constructed over the FroidurePin instance \p S representing a
+    //! 1- or 2-sided congruence according to \p knd.
     //!
     //! \tparam Node the type of the nodes in the 3rd argument \p wg (word
     //! graph).
@@ -341,7 +342,7 @@ namespace libsemigroups {
     //! \brief Add generating pair via iterators.
     //!
     //! This function adds a generating pair to the congruence represented by a
-    //! \ref Congruence instance.
+    //! \ref_congruence instance.
     //!
     //! \cong_common_params_contains
     //!
@@ -370,7 +371,7 @@ namespace libsemigroups {
     //! \brief Add generating pair via iterators.
     //!
     //! This function adds a generating pair to the congruence represented by a
-    //! Congruence instance.
+    //! \ref_congruence instance.
     //!
     //! \cong_common_params_contains
     //!
@@ -401,10 +402,10 @@ namespace libsemigroups {
     //! \brief Compute the number of classes in the congruence.
     //!
     //! This function computes the number of classes in the congruence
-    //! represented by a \ref Congruence instance by running the congruence
+    //! represented by a \ref_congruence instance by running the congruence
     //! enumeration until it terminates.
     //!
-    //! \returns The number of congruences classes of a \ref Congruence
+    //! \returns The number of congruences classes of a \ref_congruence
     //! instance if this number is finite, or \ref POSITIVE_INFINITY in some
     //! cases if this number is not finite.
     //!
@@ -422,7 +423,7 @@ namespace libsemigroups {
     //!
     //! This function checks whether or not the words represented by the ranges
     //! \p first1 to \p last1 and \p first2 to \p last2 are already known to be
-    //! contained in the congruence represented by a \ref Congruence instance.
+    //! contained in the congruence represented by a \ref_congruence instance.
     //! This function performs no enumeration, so it is possible for the words
     //! to be contained in the congruence, but that this is not currently known.
     //!
@@ -449,7 +450,7 @@ namespace libsemigroups {
     //!
     //! This function checks whether or not the words represented by the ranges
     //! \p first1 to \p last1 and \p first2 to \p last2 are already known to be
-    //! contained in the congruence represented by a \ref Congruence instance.
+    //! contained in the congruence represented by a \ref_congruence instance.
     //! This function performs no enumeration, so it is possible for the words
     //! to be contained in the congruence, but that this is not currently known.
     //!
@@ -479,7 +480,7 @@ namespace libsemigroups {
     //!
     //! This function checks whether or not the words represented by the ranges
     //! \p first1 to \p last1 and \p first2 to \p last2 are already known to be
-    //! contained in the congruence represented by a \ref Congruence instance.
+    //! contained in the congruence represented by a \ref_congruence instance.
     //! This function performs no enumeration, so it is possible for the words
     //! to be contained in the congruence, but that this is not currently known.
     //!
@@ -512,7 +513,7 @@ namespace libsemigroups {
     //!
     //! This function checks whether or not the words represented by the ranges
     //! \p first1 to \p last1 and \p first2 to \p last2 are contained in the
-    //! congruence represented by a \ref Congruence instance. This function
+    //! congruence represented by a \ref_congruence instance. This function
     //! triggers a full enumeration, which may never terminate.
     //!
     //! \cong_common_params_contains
@@ -546,7 +547,7 @@ namespace libsemigroups {
     //! This function writes a reduced word equivalent to the input word
     //! described by the iterator \p first and \p last to the output iterator \p
     //! d_first. If \ref finished returns \c true, then the word output by this
-    //! function is a normal form for the input word. If the \ref Congruence
+    //! function is a normal form for the input word. If the \ref_congruence
     //! instance is not \ref finished, then it might be that equivalent input
     //! words produce different output words.
     //!
@@ -568,7 +569,7 @@ namespace libsemigroups {
     //! This function writes a reduced word equivalent to the input word
     //! described by the iterator \p first and \p last to the output iterator \p
     //! d_first. If \ref finished returns \c true, then the word output by this
-    //! function is a normal form for the input word. If the \ref Congruence
+    //! function is a normal form for the input word. If the \ref_congruence
     //! instance is not \ref finished, then it might be that equivalent input
     //! words produce different output words.
     //!
@@ -646,7 +647,7 @@ namespace libsemigroups {
     //! This function throws a LibsemigroupsException if any value pointed at
     //! by an iterator in the range \p first to \p last is out of bounds (i.e.
     //! does not belong to the alphabet of the \ref presentation used to
-    //! construct the \ref Congruence instance).
+    //! construct the \ref_congruence instance).
     //!
     //! \tparam Iterator1 the type of first argument \p first.
     //! \tparam Iterator2 the type of second argument \p last.
@@ -666,11 +667,11 @@ namespace libsemigroups {
     //! \ingroup congruence_class_accessors_group
     //!
     //! \brief Get a derived class of detail::CongruenceCommon being used to
-    //! compute a Congruence instance.
+    //! compute a \ref_congruence instance.
     //!
     //! This function returns a std::shared_ptr to a \p Thing if such an object
     //! is being used or could be used to compute the congruence represented by
-    //! a Congruence instance. If no such \p Thing is available, then an
+    //! a \ref_congruence instance. If no such \p Thing is available, then an
     //! exception is thrown.
     //!
     //! \tparam Thing the type of the detail::CongruenceCommon object being
@@ -687,17 +688,17 @@ namespace libsemigroups {
     //! \ingroup congruence_class_accessors_group
     //!
     //! \brief Check if a derived class of detail::CongruenceCommon being used
-    //! to compute a Congruence instance.
+    //! to compute a \ref_congruence instance.
     //!
     //! This function returns \c true if a \p Thing is being used or could be
-    //! used to compute the congruence represented by a Congruence instance; or
-    //! \c false if not.
+    //! used to compute the congruence represented by a \ref_congruence
+    //! instance; or \c false if not.
     //!
     //! \tparam Thing the type of the detail::CongruenceCommon object being
     //! sought.
     //!
     //! \returns Whether or not a \p Thing is being used to compute the
-    //! Congruence instance.
+    //! \ref_congruence instance.
     //!
     //! \exceptions
     //! \no_libsemigroups_except
@@ -711,7 +712,7 @@ namespace libsemigroups {
     //! \brief Get the current maximum number of threads.
     //!
     //! This function returns the current maximum number of threads that a
-    //! Congruence instance can use.
+    //! \ref_congruence instance can use.
     //!
     //! \returns
     //! The maximum number of threads to use.
@@ -730,7 +731,7 @@ namespace libsemigroups {
     //! \brief Set the maximum number of threads.
     //!
     //! This function can be used to set the maximum number of threads that a
-    //! Congruence instance can use.
+    //! \ref_congruence instance can use.
     //!
     //! \param val the number of threads.
     //!
@@ -751,7 +752,7 @@ namespace libsemigroups {
     //! \brief Get the number of runners.
     //!
     //! This function returns the number of distinct detail::CongruenceCommon
-    //! instances that are contained in a Congruence object.
+    //! instances that are contained in a \ref_congruence object.
     //!
     //! \returns The number of runners.
     //!
@@ -766,8 +767,8 @@ namespace libsemigroups {
     //! \brief Get the presentation defining the parent semigroup of the
     //! congruence.
     //!
-    //! This function returns the presentation used to construct a Congruence
-    //! object.
+    //! This function returns the presentation used to construct a
+    //! \ref_congruence object.
     //!
     //! \returns The presentation.
     //!
@@ -880,15 +881,14 @@ namespace libsemigroups {
 
   //! \ingroup congruence_group
   //!
-  //! \brief Return a human readable representation of a \ref
-  //! Congruence object.
+  //! \brief Return a human readable representation of a \ref_congruence object.
   //!
   //! Defined in `cong-class.hpp`.
   //!
   //! This function returns a human readable representation of a
-  //! \ref Congruence object.
+  //! \ref_congruence object.
   //!
-  //! \param c the \ref Congruence object.
+  //! \param c the \ref_congruence object.
   //!
   //! \returns A std::string containing the representation.
   //!

--- a/include/libsemigroups/cong-common-helpers.hpp
+++ b/include/libsemigroups/cong-common-helpers.hpp
@@ -72,7 +72,7 @@ namespace libsemigroups {
     //! \defgroup cong_common_helpers_group Common congruence helpers
     //!
     //! This page contains documentation for helper functions for the classes
-    //! Congruence, Kambites, KnuthBendix, and \ref_todd_coxeter. The
+    //! Congruence, Kambites, \ref_knuth_bendix, and \ref_todd_coxeter. The
     //! functions documented on this page belong to all of the namespaces
     //! \ref cong_common_helpers_group "congruence_common", \ref congruence,
     //! \ref kambites, \ref knuth_bendix, and \ref todd_coxeter.
@@ -101,7 +101,7 @@ namespace libsemigroups {
     //! using objects themselves rather than iterators.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, KnuthBendix, \ref_todd_coxeter, or Congruence.
+    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to add generating pairs to.
     //! \param u the left hand side of the pair to add.
@@ -192,7 +192,7 @@ namespace libsemigroups {
     //! using objects themselves rather than iterators.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, KnuthBendix, \ref_todd_coxeter, or Congruence.
+    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to add generating pairs to.
     //! \param u the left hand side of the pair to add.
@@ -290,7 +290,7 @@ namespace libsemigroups {
     //! These helper functions can be applied to objects of the types:
     //! * Congruence
     //! * Kambites
-    //! * KnuthBendix
+    //! * \ref_knuth_bendix
     //! * \ref_todd_coxeter
     //!
     //! Functions with the prefix `currently_` do not perform any enumeration
@@ -311,7 +311,7 @@ namespace libsemigroups {
     //! known.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, KnuthBendix, \ref_todd_coxeter, or Congruence.
+    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to check containment in.
     //! \param u the first word.
@@ -414,7 +414,7 @@ namespace libsemigroups {
     //! known.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, KnuthBendix, \ref_todd_coxeter, or Congruence.
+    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to check containment in.
     //! \param u the first word.
@@ -505,7 +505,7 @@ namespace libsemigroups {
     //! triggers a full enumeration of \p thing, which may never terminate.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, KnuthBendix, \ref_todd_coxeter, or Congruence.
+    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to check containment in.
     //! \param u the left hand side of the pair to add.
@@ -598,7 +598,7 @@ namespace libsemigroups {
     //! triggers a full enumeration of \p thing, which may never terminate.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, KnuthBendix, \ref_todd_coxeter, or Congruence.
+    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to check containment in.
     //! \param u the left hand side of the pair to add.
@@ -695,7 +695,7 @@ namespace libsemigroups {
     //! These helper functions can be applied to objects of the types:
     //! * Congruence
     //! * Kambites
-    //! * KnuthBendix
+    //! * \ref_knuth_bendix
     //! * \ref_todd_coxeter
     //!
     //! Functions with the suffix `_no_run` do not perform any enumeration of
@@ -718,7 +718,7 @@ namespace libsemigroups {
     //! equivalent input words produce different output words.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, KnuthBendix, \ref_todd_coxeter, or Congruence.
+    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to reduce words in.
     //! \param w the word to reduce.
@@ -779,7 +779,7 @@ namespace libsemigroups {
     //! equivalent input words produce different output words.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, KnuthBendix, \ref_todd_coxeter, or Congruence.
+    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to reduce words in.
     //! \param w the word to reduce.
@@ -834,7 +834,7 @@ namespace libsemigroups {
     //! word.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, KnuthBendix, \ref_todd_coxeter, or Congruence.
+    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to reduce words in.
     //! \param w the word to reduce.
@@ -888,7 +888,7 @@ namespace libsemigroups {
     //! word.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, KnuthBendix, \ref_todd_coxeter, or Congruence.
+    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to reduce words in.
     //! \param w the word to reduce.
@@ -976,7 +976,7 @@ namespace libsemigroups {
     //! enumeration of \p thing.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, KnuthBendix, \ref_todd_coxeter, or Congruence.
+    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \tparam Range the type of the input range of words, must satisfy
     //! `std::enable_if_t<rx::is_input_or_sink_v<Range>>` and
@@ -1021,7 +1021,7 @@ namespace libsemigroups {
     //! This function triggers a full enumeration of \p thing.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, KnuthBendix, \ref_todd_coxeter, or Congruence.
+    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \tparam Range the type of the input range of words, must satisfy
     //! `std::enable_if_t<rx::is_input_or_sink_v<Range>>` and

--- a/include/libsemigroups/cong-common-helpers.hpp
+++ b/include/libsemigroups/cong-common-helpers.hpp
@@ -72,10 +72,10 @@ namespace libsemigroups {
     //! \defgroup cong_common_helpers_group Common congruence helpers
     //!
     //! This page contains documentation for helper functions for the classes
-    //! Congruence, Kambites, \ref_knuth_bendix, and \ref_todd_coxeter. The
+    //! Congruence, \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter. The
     //! functions documented on this page belong to all of the namespaces
     //! \ref cong_common_helpers_group "congruence_common", \ref congruence,
-    //! \ref kambites, \ref knuth_bendix, and \ref todd_coxeter.
+    //! \ref_kambites, \ref knuth_bendix, and \ref todd_coxeter.
 
     ////////////////////////////////////////////////////////////////////////
     // Interface helpers - add_generating_pair
@@ -101,7 +101,7 @@ namespace libsemigroups {
     //! using objects themselves rather than iterators.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to add generating pairs to.
     //! \param u the left hand side of the pair to add.
@@ -192,7 +192,7 @@ namespace libsemigroups {
     //! using objects themselves rather than iterators.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to add generating pairs to.
     //! \param u the left hand side of the pair to add.
@@ -289,7 +289,7 @@ namespace libsemigroups {
     //!
     //! These helper functions can be applied to objects of the types:
     //! * Congruence
-    //! * Kambites
+    //! * \ref_kambites
     //! * \ref_knuth_bendix
     //! * \ref_todd_coxeter
     //!
@@ -311,7 +311,7 @@ namespace libsemigroups {
     //! known.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to check containment in.
     //! \param u the first word.
@@ -414,7 +414,7 @@ namespace libsemigroups {
     //! known.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to check containment in.
     //! \param u the first word.
@@ -505,7 +505,7 @@ namespace libsemigroups {
     //! triggers a full enumeration of \p thing, which may never terminate.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to check containment in.
     //! \param u the left hand side of the pair to add.
@@ -598,7 +598,7 @@ namespace libsemigroups {
     //! triggers a full enumeration of \p thing, which may never terminate.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to check containment in.
     //! \param u the left hand side of the pair to add.
@@ -694,7 +694,7 @@ namespace libsemigroups {
     //!
     //! These helper functions can be applied to objects of the types:
     //! * Congruence
-    //! * Kambites
+    //! * \ref_kambites
     //! * \ref_knuth_bendix
     //! * \ref_todd_coxeter
     //!
@@ -718,7 +718,7 @@ namespace libsemigroups {
     //! equivalent input words produce different output words.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to reduce words in.
     //! \param w the word to reduce.
@@ -779,7 +779,7 @@ namespace libsemigroups {
     //! equivalent input words produce different output words.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to reduce words in.
     //! \param w the word to reduce.
@@ -834,7 +834,7 @@ namespace libsemigroups {
     //! word.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to reduce words in.
     //! \param w the word to reduce.
@@ -888,7 +888,7 @@ namespace libsemigroups {
     //! word.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \param thing the object to reduce words in.
     //! \param w the word to reduce.
@@ -976,7 +976,7 @@ namespace libsemigroups {
     //! enumeration of \p thing.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \tparam Range the type of the input range of words, must satisfy
     //! `std::enable_if_t<rx::is_input_or_sink_v<Range>>` and
@@ -1021,7 +1021,7 @@ namespace libsemigroups {
     //! This function triggers a full enumeration of \p thing.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! Kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
     //!
     //! \tparam Range the type of the input range of words, must satisfy
     //! `std::enable_if_t<rx::is_input_or_sink_v<Range>>` and

--- a/include/libsemigroups/cong-common-helpers.hpp
+++ b/include/libsemigroups/cong-common-helpers.hpp
@@ -72,10 +72,11 @@ namespace libsemigroups {
     //! \defgroup cong_common_helpers_group Common congruence helpers
     //!
     //! This page contains documentation for helper functions for the classes
-    //! Congruence, \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter. The
-    //! functions documented on this page belong to all of the namespaces
-    //! \ref cong_common_helpers_group "congruence_common", \ref congruence,
-    //! \ref_kambites, \ref knuth_bendix, and \ref todd_coxeter.
+    //! \ref_congruence, \ref_kambites, \ref_knuth_bendix, and
+    //! \ref_todd_coxeter. The functions documented on this page belong to all
+    //! of the namespaces \ref cong_common_helpers_group "congruence_common",
+    //! \ref_congruence, \ref_kambites, \ref knuth_bendix, and \ref
+    //! todd_coxeter.
 
     ////////////////////////////////////////////////////////////////////////
     // Interface helpers - add_generating_pair
@@ -101,7 +102,7 @@ namespace libsemigroups {
     //! using objects themselves rather than iterators.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or \ref_congruence.
     //!
     //! \param thing the object to add generating pairs to.
     //! \param u the left hand side of the pair to add.
@@ -192,7 +193,7 @@ namespace libsemigroups {
     //! using objects themselves rather than iterators.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or \ref_congruence.
     //!
     //! \param thing the object to add generating pairs to.
     //! \param u the left hand side of the pair to add.
@@ -288,7 +289,7 @@ namespace libsemigroups {
     //! variety of different argument types.
     //!
     //! These helper functions can be applied to objects of the types:
-    //! * Congruence
+    //! * \ref_congruence
     //! * \ref_kambites
     //! * \ref_knuth_bendix
     //! * \ref_todd_coxeter
@@ -311,7 +312,7 @@ namespace libsemigroups {
     //! known.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or \ref_congruence.
     //!
     //! \param thing the object to check containment in.
     //! \param u the first word.
@@ -414,7 +415,7 @@ namespace libsemigroups {
     //! known.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or \ref_congruence.
     //!
     //! \param thing the object to check containment in.
     //! \param u the first word.
@@ -505,7 +506,7 @@ namespace libsemigroups {
     //! triggers a full enumeration of \p thing, which may never terminate.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or \ref_congruence.
     //!
     //! \param thing the object to check containment in.
     //! \param u the left hand side of the pair to add.
@@ -598,7 +599,7 @@ namespace libsemigroups {
     //! triggers a full enumeration of \p thing, which may never terminate.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or \ref_congruence.
     //!
     //! \param thing the object to check containment in.
     //! \param u the left hand side of the pair to add.
@@ -693,7 +694,7 @@ namespace libsemigroups {
     //! types.
     //!
     //! These helper functions can be applied to objects of the types:
-    //! * Congruence
+    //! * \ref_congruence
     //! * \ref_kambites
     //! * \ref_knuth_bendix
     //! * \ref_todd_coxeter
@@ -718,7 +719,7 @@ namespace libsemigroups {
     //! equivalent input words produce different output words.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or \ref_congruence.
     //!
     //! \param thing the object to reduce words in.
     //! \param w the word to reduce.
@@ -779,7 +780,7 @@ namespace libsemigroups {
     //! equivalent input words produce different output words.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or \ref_congruence.
     //!
     //! \param thing the object to reduce words in.
     //! \param w the word to reduce.
@@ -834,7 +835,7 @@ namespace libsemigroups {
     //! word.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or \ref_congruence.
     //!
     //! \param thing the object to reduce words in.
     //! \param w the word to reduce.
@@ -888,7 +889,7 @@ namespace libsemigroups {
     //! word.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or \ref_congruence.
     //!
     //! \param thing the object to reduce words in.
     //! \param w the word to reduce.
@@ -976,7 +977,7 @@ namespace libsemigroups {
     //! enumeration of \p thing.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or \ref_congruence.
     //!
     //! \tparam Range the type of the input range of words, must satisfy
     //! `std::enable_if_t<rx::is_input_or_sink_v<Range>>` and
@@ -1021,7 +1022,7 @@ namespace libsemigroups {
     //! This function triggers a full enumeration of \p thing.
     //!
     //! \tparam Thing the type of the first parameter must be one of
-    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or Congruence.
+    //! \ref_kambites, \ref_knuth_bendix, \ref_todd_coxeter, or \ref_congruence.
     //!
     //! \tparam Range the type of the input range of words, must satisfy
     //! `std::enable_if_t<rx::is_input_or_sink_v<Range>>` and

--- a/include/libsemigroups/cong-helpers.hpp
+++ b/include/libsemigroups/cong-helpers.hpp
@@ -64,7 +64,8 @@ namespace libsemigroups {
 
   }  // namespace congruence_common
 
-  //! Helper functions for the Congruence class template
+  //! \ingroup congruence_group
+  //! \brief Helper functions for the Congruence class template
   //!
   //! Defined in \c cong-helpers.hpp.
   //!

--- a/include/libsemigroups/cong-helpers.hpp
+++ b/include/libsemigroups/cong-helpers.hpp
@@ -64,7 +64,10 @@ namespace libsemigroups {
 
   }  // namespace congruence_common
 
+  //! \defgroup congruence_helpers_group Congruence helper functions
+  //!
   //! \ingroup congruence_group
+  //!
   //! \brief Helper functions for the Congruence class template
   //!
   //! Defined in \c cong-helpers.hpp.
@@ -76,6 +79,11 @@ namespace libsemigroups {
   //! the underlying objects. The helpers documented on this page all belong
   //! to the namespace
   //! \ref congruence and \ref cong_common_helpers_group "congruence_common".
+
+  //! This page contains documentation for everything in the namespace \ref
+  //! congruence. This includes everything from \ref cong_common_helpers_group,
+  //! at present there are no helper functions, beyond those in \ref
+  //! cong_common_helpers_group, for the \ref Congruence class template.
   namespace congruence {
 
     ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/cong-helpers.hpp
+++ b/include/libsemigroups/cong-helpers.hpp
@@ -68,17 +68,18 @@ namespace libsemigroups {
   //!
   //! \ingroup congruence_group
   //!
-  //! \brief Helper functions for the \ref_congruence class template
+  //! \brief Helper functions for the \ref_congruence class template.
   //!
   //! Defined in \c cong-helpers.hpp.
   //!
-  //! This page contains documentation for many helper functions for the
-  //! \ref_congruence class template. In particular, these functions include
-  //! versions of several of the member functions of the \ref_congruence class
-  //! template (that accept iterators) whose parameters are not iterators, but
-  //! the underlying objects. The helpers documented on this page all belong
-  //! to the namespace
-  //! \ref_congruence and \ref cong_common_helpers_group "congruence_common".
+  //! This page would contain documentation for helper functions for the
+  //! \ref_congruence class template. However, at present, there are no helper
+  //! functions beyond those in \ref cong_common_helpers_group for the
+  //! \ref_congruence class template.
+  //!
+  //! \sa
+  //! * \ref cong_common_helpers_group; and
+  //! * the \ref congruence namespace.
 
   //! This page contains documentation for everything in the namespace \ref
   //! congruence. This includes everything from \ref cong_common_helpers_group,

--- a/include/libsemigroups/cong-helpers.hpp
+++ b/include/libsemigroups/cong-helpers.hpp
@@ -68,22 +68,22 @@ namespace libsemigroups {
   //!
   //! \ingroup congruence_group
   //!
-  //! \brief Helper functions for the Congruence class template
+  //! \brief Helper functions for the \ref_congruence class template
   //!
   //! Defined in \c cong-helpers.hpp.
   //!
   //! This page contains documentation for many helper functions for the
-  //! Congruence class template. In particular, these functions include
-  //! versions of several of the member functions of the Congruence class
+  //! \ref_congruence class template. In particular, these functions include
+  //! versions of several of the member functions of the \ref_congruence class
   //! template (that accept iterators) whose parameters are not iterators, but
   //! the underlying objects. The helpers documented on this page all belong
   //! to the namespace
-  //! \ref congruence and \ref cong_common_helpers_group "congruence_common".
+  //! \ref_congruence and \ref cong_common_helpers_group "congruence_common".
 
   //! This page contains documentation for everything in the namespace \ref
   //! congruence. This includes everything from \ref cong_common_helpers_group,
   //! at present there are no helper functions, beyond those in \ref
-  //! cong_common_helpers_group, for the \ref Congruence class template.
+  //! cong_common_helpers_group, for the \ref_congruence class template.
   namespace congruence {
 
     ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/detail/knuth-bendix-impl.hpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.hpp
@@ -110,11 +110,11 @@ namespace libsemigroups {
     //! \ingroup knuth_bendix_class_group
     //!
     //! \brief Documentation of common member functions of \ref Congruence,
-    //! \ref Kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
+    //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
     //!
     //! This page contains documentation of the member functions of
     //! \ref_knuth_bendix that are implemented in all of the classes Congruence,
-    //! Kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
+    //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
 
     //! \defgroup knuth_bendix_class_accessors_group Accessors
     //!

--- a/include/libsemigroups/detail/knuth-bendix-impl.hpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.hpp
@@ -109,12 +109,13 @@ namespace libsemigroups {
     //! \defgroup knuth_bendix_class_intf_group Common member functions
     //! \ingroup knuth_bendix_class_group
     //!
-    //! \brief Documentation of common member functions of \ref Congruence,
+    //! \brief Documentation of common member functions of \ref_congruence,
     //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
     //!
     //! This page contains documentation of the member functions of
-    //! \ref_knuth_bendix that are implemented in all of the classes Congruence,
-    //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
+    //! \ref_knuth_bendix that are implemented in all of the classes
+    //! \ref_congruence, \ref_kambites, \ref_knuth_bendix, and
+    //! \ref_todd_coxeter.
 
     //! \defgroup knuth_bendix_class_accessors_group Accessors
     //!

--- a/include/libsemigroups/detail/knuth-bendix-impl.hpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.hpp
@@ -96,7 +96,7 @@ namespace libsemigroups {
     //! \brief Settings that control the behaviour of a \ref_knuth_bendix
     //! instance.
     //!
-    //! This page contains information about the member functions of the
+    //! This page contains information about the member functions of
     //! \ref_knuth_bendix that control various settings that influence the
     //! running of the Knuth-Bendix algorithm.
     //!

--- a/include/libsemigroups/detail/knuth-bendix-impl.hpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.hpp
@@ -408,9 +408,9 @@ namespace libsemigroups {
       //! \p d_first. This function triggers no enumeration. The word output by
       //! this function is equivalent to the input word in the congruence
       //! defined by a
-      //! \ref KnuthBendixImpl instance. If the \ref KnuthBendixImpl instance is
+      //! \ref_knuth_bendix instance. If the \ref_knuth_bendix instance is
       //! \ref finished, then the output word is a normal form for the input
-      //! word. If the \ref KnuthBendixImpl instance is not \ref finished, then
+      //! word. If the \ref_knuth_bendix instance is not \ref finished, then
       //! it might be that equivalent input words produce different output
       //! words.
       //!
@@ -449,7 +449,7 @@ namespace libsemigroups {
       //! \p last to the output iterator \p d_first. The word output by this
       //! function is equivalent to the input word in the congruence defined by
       //! a
-      //! \ref KnuthBendixImpl instance. In other words, the output word is a
+      //! \ref_knuth_bendix instance. In other words, the output word is a
       //! normal form for the input word or equivalently a canconical
       //! representative of its congruence class.
       //!
@@ -587,7 +587,7 @@ namespace libsemigroups {
         return _settings.check_confluence_interval;
       }
 
-      //! \ingroup knuth_bendix_class_settings_roup
+      //! \ingroup knuth_bendix_class_settings_group
       //!
       //! \brief Set the maximum length of overlaps to be considered.
       //!

--- a/include/libsemigroups/detail/rewriters.hpp
+++ b/include/libsemigroups/detail/rewriters.hpp
@@ -119,9 +119,9 @@ namespace libsemigroups {
       //! \brief Return the left-hand side of the rule.
       //!
       //! Return the left-hand side of the rule. If this rule was create by a
-      //! \ref KnuthBendixImpl, this is guaranteed to be greater than its
+      //! \ref_knuth_bendix, this is guaranteed to be greater than its
       //! right-hand side according to the reduction ordering of that \ref
-      //! KnuthBendixImpl.
+      //! \ref_knuth_bendix.
       //!
       //! \returns A pointer to the left-hand side.
       //!
@@ -132,7 +132,7 @@ namespace libsemigroups {
       //! Constant.
       //!
       //! \sa
-      //! \ref KnuthBendixImpl
+      //! \ref_knuth_bendix
       [[nodiscard]] internal_string_type* lhs() const noexcept {
         return _lhs;
       }
@@ -140,8 +140,8 @@ namespace libsemigroups {
       //! \brief Return the right-hand side of the rule.
       //!
       //! Return the right-hand side of the rule. If this rule was create by a
-      //! \ref KnuthBendixImpl, this is guaranteed to be less than its left-hand
-      //! side according to the reduction ordering of that \ref KnuthBendixImpl.
+      //! \ref_knuth_bendix, this is guaranteed to be less than its left-hand
+      //! side according to the reduction ordering of that \ref_knuth_bendix.
       //!
       //! \returns A pointer to the right-hand side.
       //!
@@ -152,7 +152,7 @@ namespace libsemigroups {
       //! Constant.
       //!
       //! \sa
-      //! \ref KnuthBendixImpl
+      //! \ref_knuth_bendix
       [[nodiscard]] internal_string_type* rhs() const noexcept {
         return _rhs;
       }

--- a/include/libsemigroups/detail/todd-coxeter-impl.hpp
+++ b/include/libsemigroups/detail/todd-coxeter-impl.hpp
@@ -126,7 +126,7 @@ namespace libsemigroups {
   //!
   //! This page contains documentation of the member functions of
   //! \ref_todd_coxeter that are implemented in all of the classes Congruence,
-  //! Kambites, KnuthBendix, and \ref_todd_coxeter.
+  //! Kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
 
   //! \defgroup todd_coxeter_class_accessors_group Accessors
   //!

--- a/include/libsemigroups/detail/todd-coxeter-impl.hpp
+++ b/include/libsemigroups/detail/todd-coxeter-impl.hpp
@@ -121,12 +121,12 @@ namespace libsemigroups {
   //! \defgroup todd_coxeter_class_intf_group Common member functions
   //! \ingroup todd_coxeter_class_group
   //!
-  //! \brief Documentation of common member functions of \ref Congruence,
+  //! \brief Documentation of common member functions of \ref_congruence,
   //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
   //!
   //! This page contains documentation of the member functions of
-  //! \ref_todd_coxeter that are implemented in all of the classes Congruence,
-  //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
+  //! \ref_todd_coxeter that are implemented in all of the classes
+  //! \ref_congruence, \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
 
   //! \defgroup todd_coxeter_class_accessors_group Accessors
   //!

--- a/include/libsemigroups/detail/todd-coxeter-impl.hpp
+++ b/include/libsemigroups/detail/todd-coxeter-impl.hpp
@@ -122,11 +122,11 @@ namespace libsemigroups {
   //! \ingroup todd_coxeter_class_group
   //!
   //! \brief Documentation of common member functions of \ref Congruence,
-  //! \ref Kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
+  //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
   //!
   //! This page contains documentation of the member functions of
   //! \ref_todd_coxeter that are implemented in all of the classes Congruence,
-  //! Kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
+  //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
 
   //! \defgroup todd_coxeter_class_accessors_group Accessors
   //!

--- a/include/libsemigroups/froidure-pin.hpp
+++ b/include/libsemigroups/froidure-pin.hpp
@@ -371,7 +371,7 @@ namespace libsemigroups {
     //! stated given by the parameter \p stt. This constructor only exists if
     //! \ref state_type is not \c void. This is used when the elements require
     //! some shared state to define their multiplication, such as, for example
-    //! an instance of KnuthBendixImpl or ToddCoxeterImpl.
+    //! an instance of \ref_knuth_bendix or ToddCoxeterImpl.
     //!
     //! \param stt a std::shared_ptr to a state object.
     //!
@@ -405,7 +405,7 @@ namespace libsemigroups {
     //! stated given by the parameter \p stt. This constructor only exists if
     //! \ref state_type is not \c void. This is used when the elements require
     //! some shared state to define their multiplication, such as, for example
-    //! an instance of KnuthBendixImpl or ToddCoxeterImpl.
+    //! an instance of \ref_knuth_bendix or ToddCoxeterImpl.
     //!
     //! \param stt a const reference to a state object.
     //!

--- a/include/libsemigroups/kambites-class.hpp
+++ b/include/libsemigroups/kambites-class.hpp
@@ -102,11 +102,11 @@ namespace libsemigroups {
   //!
   //! \ingroup kambites_class_group
   //!
-  //! \brief Documentation of common member functions of \ref Congruence,
+  //! \brief Documentation of common member functions of \ref_congruence,
   //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
   //!
   //! This page contains documentation of the member functions of
-  //! \ref_kambites that are implemented in all of the classes Congruence,
+  //! \ref_kambites that are implemented in all of the classes \ref_congruence,
   //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
 
   //! \defgroup kambites_class_accessors_group Accessors
@@ -272,7 +272,7 @@ namespace libsemigroups {
     //! congruences, and so the first parameter \p knd must always be
     //! congruence_kind::twosided. The parameter \p knd is included for
     //! uniformity of interface between with \ref_knuth_bendix, \ref
-    //! \ref_kambites, and \ref Congruence.
+    //! \ref_kambites, and \ref_congruence.
     //!
     //! \param knd the kind (onesided or twosided) of the congruence.
     //! \param p the presentation.
@@ -296,7 +296,7 @@ namespace libsemigroups {
     //! congruences, and so the first parameter \p knd must always be
     //! congruence_kind::twosided. The parameter \p knd is included for
     //! uniformity of interface between with \ref_knuth_bendix, \ref
-    //! \ref_kambites, and \ref Congruence.
+    //! \ref_kambites, and \ref_congruence.
     //!
     //! \param knd the kind (onesided or twosided) of the congruence.
     //! \param p the presentation.

--- a/include/libsemigroups/kambites-class.hpp
+++ b/include/libsemigroups/kambites-class.hpp
@@ -160,6 +160,8 @@ namespace libsemigroups {
     // Kambites - aliases - public
     ////////////////////////////////////////////////////////////////////////
 
+    //! \ingroup kambites_class_mem_types_group
+    //!
     //! \brief Type of the words in the relations of the presentation stored in
     //! a Kambites instance.
     //!

--- a/include/libsemigroups/kambites-class.hpp
+++ b/include/libsemigroups/kambites-class.hpp
@@ -702,6 +702,8 @@ namespace libsemigroups {
     // Kambites - member functions - public
     ////////////////////////////////////////////////////////////////////////
 
+    //! \ingroup kambites_class_accessors_group
+    //!
     //! \brief Get the small overlap class.
     //!
     //! If \f$S\f$ is a finitely presented semigroup with generating set
@@ -735,6 +737,8 @@ namespace libsemigroups {
     // not noexcept because number_of_pieces_no_checks isn't
     [[nodiscard]] size_t small_overlap_class();
 
+    //! \ingroup kambites_class_accessors_group
+    //!
     //! \brief Get the current value of the small overlap class.
     //!
     //! See \ref small_overlap_class() for more details.
@@ -746,6 +750,8 @@ namespace libsemigroups {
     //! \noexcept
     [[nodiscard]] size_t small_overlap_class() const noexcept;
 
+    //! \ingroup kambites_class_accessors_group
+    //!
     //! \brief Returns the suffix tree used to compute pieces.
     //!
     //! This function returns a const reference to the generalised suffix

--- a/include/libsemigroups/kambites-class.hpp
+++ b/include/libsemigroups/kambites-class.hpp
@@ -104,7 +104,7 @@ namespace libsemigroups {
   //!
   //! Every constructor (except the move + copy constructors, and the move
   //! and copy assignment operators) has a matching `init` function with the
-  //! same signature that can be used to re-initialize a \ref_knuth_bendix
+  //! same signature that can be used to re-initialize a Kambites
   //! instance as if it had just been constructed; but without necessarily
   //! releasing any previous allocated memory.
 

--- a/include/libsemigroups/kambites-class.hpp
+++ b/include/libsemigroups/kambites-class.hpp
@@ -74,6 +74,7 @@ namespace libsemigroups {
   //! Kambites class template.
 
   //! \defgroup kambites_class_group The Kambites class
+  //!
   //! \ingroup kambites_group
   //!
   //! \brief This page contains links to the documentation related to the
@@ -81,6 +82,56 @@ namespace libsemigroups {
   //!
   //! This page contains links to the documentation related to the
   //! Kambites class.
+
+  //! \defgroup kambites_class_mem_types_group Member Types
+  //!
+  //! \ingroup kambites_class_group
+  //!
+  //! \brief Public member types
+  //!
+  //! This page contains the documentation of the public member types of a
+  //! \ref Kambites instance.
+
+  //! \defgroup kambites_class_init_group Constructors + initializers
+  //!
+  //! \ingroup kambites_class_group
+  //!
+  //! \brief Construct or re-initialize a \ref Kambites
+  //! instance (public member function).
+  //!
+  //! This page documents the constructors and initialisers for the
+  //! \ref Kambites class.
+  //!
+  //! Every constructor (except the move + copy constructors, and the move
+  //! and copy assignment operators) has a matching `init` function with the
+  //! same signature that can be used to re-initialize a \ref_knuth_bendix
+  //! instance as if it had just been constructed; but without necessarily
+  //! releasing any previous allocated memory.
+
+  //! \defgroup kambites_class_intf_group Common member functions
+  //!
+  //! \ingroup kambites_class_group
+  //!
+  //! \brief Documentation of common member functions of \ref Congruence,
+  //! \ref Kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
+  //!
+  //! This page contains documentation of the member functions of
+  //! \ref Kambites that are implemented in all of the classes Congruence,
+  //! \ref Kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
+
+  //! \defgroup kambites_class_accessors_group Accessors
+  //!
+  //! \ingroup kambites_class_group
+  //!
+  //! \brief Member functions that can be used to access the state of a
+  //! \ref Kambites instance.
+  //!
+  //! This page contains the documentation of the various member functions of
+  //! the \ref Kambites class that can be used to access the state of an
+  //! instance.
+  //!
+  //! Those functions with the prefix `current_` do not perform any
+  //! further enumeration.
 
   //! \ingroup kambites_class_group
   //! \hideinheritancegraph

--- a/include/libsemigroups/kambites-class.hpp
+++ b/include/libsemigroups/kambites-class.hpp
@@ -67,11 +67,11 @@ namespace libsemigroups {
   //! authors of `libsemigroups`; see \cite Kambites2009aa,
   //! \cite Kambites2009ab, and \cite Mitchell2021aa.
   //!
-  //! Helper functions for the class template Kambites can be found in the
-  //! namespace \ref cong_common_helpers_group "congruence_common" and \ref
-  //! kambites. At present the helper functions in these two namespaces are
+  //! Helper functions for the class template \ref_kambites can be found in the
+  //! namespace \ref cong_common_helpers_group "congruence_common" and
+  //! \ref_kambites. At present the helper functions in these two namespaces are
   //! identical, because there are no helper functions that only apply to the
-  //! Kambites class template.
+  //! \ref_kambites class template.
 
   //! \defgroup kambites_class_mem_types_group Member Types
   //!
@@ -80,21 +80,21 @@ namespace libsemigroups {
   //! \brief Public member types
   //!
   //! This page contains the documentation of the public member types of a
-  //! \ref Kambites instance.
+  //! \ref_kambites instance.
 
   //! \defgroup kambites_class_init_group Constructors + initializers
   //!
   //! \ingroup kambites_class_group
   //!
-  //! \brief Construct or re-initialize a \ref Kambites
+  //! \brief Construct or re-initialize a \ref_kambites
   //! instance (public member function).
   //!
   //! This page documents the constructors and initialisers for the
-  //! \ref Kambites class.
+  //! \ref_kambites class.
   //!
   //! Every constructor (except the move + copy constructors, and the move
   //! and copy assignment operators) has a matching `init` function with the
-  //! same signature that can be used to re-initialize a Kambites
+  //! same signature that can be used to re-initialize a \ref_kambites
   //! instance as if it had just been constructed; but without necessarily
   //! releasing any previous allocated memory.
 
@@ -103,21 +103,21 @@ namespace libsemigroups {
   //! \ingroup kambites_class_group
   //!
   //! \brief Documentation of common member functions of \ref Congruence,
-  //! \ref Kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
+  //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
   //!
   //! This page contains documentation of the member functions of
-  //! \ref Kambites that are implemented in all of the classes Congruence,
-  //! \ref Kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
+  //! \ref_kambites that are implemented in all of the classes Congruence,
+  //! \ref_kambites, \ref_knuth_bendix, and \ref_todd_coxeter.
 
   //! \defgroup kambites_class_accessors_group Accessors
   //!
   //! \ingroup kambites_class_group
   //!
   //! \brief Member functions that can be used to access the state of a
-  //! \ref Kambites instance.
+  //! \ref_kambites instance.
   //!
   //! This page contains the documentation of the various member functions of
-  //! the \ref Kambites class that can be used to access the state of an
+  //! the \ref_kambites class that can be used to access the state of an
   //! instance.
   //!
   //! Those functions with the prefix `current_` do not perform any
@@ -134,15 +134,16 @@ namespace libsemigroups {
   //!
   //! Defined in `kambites.hpp`.
   //!
-  //! This page describes the class template Kambites for determining the
+  //! This page describes the class template \ref_kambites for determining the
   //! small overlap class of a presentation, and, for small overlap monoids
   //! (those with small overlap class 4 or higher) checking equality of words
   //! and for computing normal forms.
   //!
-  //! Note that a Kambites instance represents a congruence on the free monoid
-  //! or semigroup containing the rules of a presentation used to construct the
-  //! instance, and the \ref generating_pairs. As such generating pairs or rules
-  //! are interchangeable in the context of Kambites objects.
+  //! Note that a \ref_kambites instance represents a congruence on the free
+  //! monoid or semigroup containing the rules of a presentation used to
+  //! construct the instance, and the \ref generating_pairs. As such generating
+  //! pairs or rules are interchangeable in the context of \ref_kambites
+  //! objects.
   //!
   //! \tparam Word the type of the words in the presentation.
   // TODO(1) example
@@ -156,10 +157,10 @@ namespace libsemigroups {
     //! \ingroup kambites_class_mem_types_group
     //!
     //! \brief Type of the words in the relations of the presentation stored in
-    //! a Kambites instance.
+    //! a \ref_kambites instance.
     //!
     //! Type of the words in the relations of the presentation stored in
-    //! a Kambites instance.
+    //! a \ref_kambites instance.
     using native_word_type
         = std::conditional_t<std::is_same_v<Word, detail::MultiStringView>,
                              std::string,
@@ -212,15 +213,15 @@ namespace libsemigroups {
     //!
     //! \brief Default constructor.
     //!
-    //! This function default constructs an uninitialised \ref Kambites
+    //! This function default constructs an uninitialised \ref_kambites
     //! instance.
     Kambites();
 
     //! \ingroup kambites_class_init_group
     //!
-    //! \brief Re-initialize a \ref Kambites instance.
+    //! \brief Re-initialize a \ref_kambites instance.
     //!
-    //! This function puts a \ref Kambites instance back into the state that it
+    //! This function puts a \ref_kambites instance back into the state that it
     //! would have been in if it had just been newly default constructed.
     //!
     //! \returns A reference to `*this`.
@@ -263,15 +264,15 @@ namespace libsemigroups {
     //!
     //! \brief Construct from \ref congruence_kind and Presentation.
     //!
-    //! This function constructs a  \ref Kambites instance representing a
+    //! This function constructs a  \ref_kambites instance representing a
     //! congruence of kind \p knd over the semigroup or monoid defined by the
     //! presentation \p p.
     //!
-    //! Kambites instances can only be used to compute two-sided congruences,
-    //! and so the first parameter \p knd must always be
+    //! \ref_kambites instances can only be used to compute two-sided
+    //! congruences, and so the first parameter \p knd must always be
     //! congruence_kind::twosided. The parameter \p knd is included for
     //! uniformity of interface between with \ref_knuth_bendix, \ref
-    //! Kambites, and \ref Congruence.
+    //! \ref_kambites, and \ref Congruence.
     //!
     //! \param knd the kind (onesided or twosided) of the congruence.
     //! \param p the presentation.
@@ -285,17 +286,17 @@ namespace libsemigroups {
 
     //! \ingroup kambites_class_init_group
     //!
-    //! \brief Re-initialize a \ref Kambites instance.
+    //! \brief Re-initialize a \ref_kambites instance.
     //!
-    //! This function puts a \ref Kambites instance back into the state that
+    //! This function puts a \ref_kambites instance back into the state that
     //! it would have been in if it had just been newly constructed from \p knd
     //! and \p p.
     //!
-    //! Kambites instances can only be used to compute two-sided congruences,
-    //! and so the first parameter \p knd must always be
+    //! \ref_kambites instances can only be used to compute two-sided
+    //! congruences, and so the first parameter \p knd must always be
     //! congruence_kind::twosided. The parameter \p knd is included for
     //! uniformity of interface between with \ref_knuth_bendix, \ref
-    //! Kambites, and \ref Congruence.
+    //! \ref_kambites, and \ref Congruence.
     //!
     //! \param knd the kind (onesided or twosided) of the congruence.
     //! \param p the presentation.
@@ -328,10 +329,10 @@ namespace libsemigroups {
 
     //! \ingroup kambites_class_intf_group
     //!
-    //! \brief Get the presentation used to define a \ref Kambites instance
+    //! \brief Get the presentation used to define a \ref_kambites instance
     //! (if any).
     //!
-    //! If a \ref Kambites instance is constructed or initialised using a
+    //! If a \ref_kambites instance is constructed or initialised using a
     //! presentation, then a const reference to this presentation is returned by
     //! this function.
     //!
@@ -371,7 +372,7 @@ namespace libsemigroups {
     //! \brief Add generating pair via iterators.
     //!
     //! This function adds a generating pair to the congruence represented by a
-    //! \ref Kambites instance.
+    //! \ref_kambites instance.
     //!
     //! \cong_common_params_contains
     //!
@@ -391,7 +392,7 @@ namespace libsemigroups {
     //! \brief Add generating pair via iterators.
     //!
     //! This function adds a generating pair to the congruence represented by a
-    //! \ref Kambites instance.
+    //! \ref_kambites instance.
     //!
     //! \cong_common_params_contains
     //!
@@ -419,14 +420,14 @@ namespace libsemigroups {
     //! \brief Compute the number of classes in the congruence.
     //!
     //! This function computes the number of classes in the congruence
-    //! represented by a \ref Kambites instance if the \ref
-    //! small_overlap_class is at least \f$4\f$. \ref Kambites instances can
+    //! represented by a \ref_kambites instance if the \ref
+    //! small_overlap_class is at least \f$4\f$. \ref_kambites instances can
     //! only compute the number of classes if the condition of the previous
     //! sentence is fulfilled, and in this case the number of classes is
     //! always \ref POSITIVE_INFINITY. Otherwise an exception is thrown.
     //!
-    //! \returns The number of congruences classes of a \ref
-    //! Kambites if \ref small_overlap_class is at least \f$4\f$.
+    //! \returns The number of congruences classes of a
+    //! \ref_kambites if \ref small_overlap_class is at least \f$4\f$.
     //!
     //! \throws LibsemigroupsException if it is not possible to compute the
     //! number of classes of the congruence because the small overlap class
@@ -447,7 +448,7 @@ namespace libsemigroups {
     //!
     //! This function checks whether or not the words represented by the ranges
     //! \p first1 to \p last1 and \p first2 to \p last2 are already known to be
-    //! contained in the congruence represented by a \ref Kambites instance.
+    //! contained in the congruence represented by a \ref_kambites instance.
     //! This function performs no enumeration, so it is possible for the words
     //! to be contained in the congruence, but that this is not currently known.
     //!
@@ -485,7 +486,7 @@ namespace libsemigroups {
     //!
     //! This function checks whether or not the words represented by the ranges
     //! \p first1 to \p last1 and \p first2 to \p last2 are already known to be
-    //! contained in the congruence represented by a \ref Kambites instance.
+    //! contained in the congruence represented by a \ref_kambites instance.
     //! This function performs no enumeration, so it is possible for the words
     //! to be contained in the congruence, but that this is not currently known.
     //!
@@ -517,7 +518,7 @@ namespace libsemigroups {
     //!
     //! This function checks whether or not the words represented by the ranges
     //! \p first1 to \p last1 and \p first2 to \p last2 are contained in the
-    //! congruence represented by a \ref Kambites instance.
+    //! congruence represented by a \ref_kambites instance.
     //!
     //! \cong_common_params_contains
     //!
@@ -545,7 +546,7 @@ namespace libsemigroups {
     //!
     //! This function checks whether or not the words represented by the ranges
     //! \p first1 to \p last1 and \p first2 to \p last2 are contained in the
-    //! congruence represented by a \ref Kambites instance.
+    //! congruence represented by a \ref_kambites instance.
     //!
     //! \cong_common_params_contains
     //!
@@ -748,7 +749,7 @@ namespace libsemigroups {
     //! \brief Returns the suffix tree used to compute pieces.
     //!
     //! This function returns a const reference to the generalised suffix
-    //! tree Ukkonoen object containing the relation words of a Kambites
+    //! tree Ukkonoen object containing the relation words of a \ref_kambites
     //! object, that is used to determine the pieces, and decompositions of
     //! the relation words.
     //!
@@ -772,7 +773,7 @@ namespace libsemigroups {
     //! This function throws a LibsemigroupsException if any value pointed
     //! at by an iterator in the range \p first to \p last is out of bounds
     //! (i.e. does not belong to the alphabet of the \ref presentation used
-    //! to construct the \ref Kambites instance).
+    //! to construct the \ref_kambites instance).
     //!
     //! \tparam Iterator1 the type of first argument \p first.
     //! \tparam Iterator2 the type of second argument \p last.
@@ -1079,14 +1080,14 @@ namespace libsemigroups {
 
   //! \ingroup kambites_group
   //!
-  //! \brief Return a human readable representation of a Kambites object.
+  //! \brief Return a human readable representation of a \ref_kambites object.
   //!
   //! Defined in `kambites.hpp`.
   //!
   //! This function returns a human readable representation of a
-  //! Kambites object.
+  //! \ref_kambites object.
   //!
-  //! \param k the \ref Kambites object.
+  //! \param k the \ref_kambites object.
   //!
   //! \returns A std::string containing the representation.
   //!

--- a/include/libsemigroups/kambites-class.hpp
+++ b/include/libsemigroups/kambites-class.hpp
@@ -215,12 +215,16 @@ namespace libsemigroups {
     // Kambites - Constructors, destructor, initialisation - public
     ////////////////////////////////////////////////////////////////////////
 
+    //! \ingroup kambites_class_init_group
+    //!
     //! \brief Default constructor.
     //!
-    //! This function default constructs an uninitialised \ref
-    //! Kambites instance.
+    //! This function default constructs an uninitialised \ref Kambites
+    //! instance.
     Kambites();
 
+    //! \ingroup kambites_class_init_group
+    //!
     //! \brief Re-initialize a \ref Kambites instance.
     //!
     //! This function puts a \ref Kambites instance back into the state that it
@@ -232,20 +236,38 @@ namespace libsemigroups {
     //! \no_libsemigroups_except
     Kambites& init();
 
+    //! \ingroup kambites_class_init_group
+    //!
+    //! \brief Default copy constructor.
+    //!
     //! Default copy constructor.
     Kambites(Kambites const&);
 
+    //! \ingroup kambites_class_init_group
+    //!
+    //! \brief Default move constructor.
+    //!
     //! Default move constructor.
     Kambites(Kambites&&);
 
+    //! \ingroup kambites_class_init_group
+    //!
+    //! \brief Default copy assignment operator.
+    //!
     //! Default copy assignment operator.
     Kambites& operator=(Kambites const&);
 
+    //! \ingroup kambites_class_init_group
+    //!
+    //! \brief Default move assignment operator.
+    //!
     //! Default move assignment operator.
     Kambites& operator=(Kambites&&);
 
     ~Kambites();
 
+    //! \ingroup kambites_class_init_group
+    //!
     //! \brief Construct from \ref congruence_kind and Presentation.
     //!
     //! This function constructs a  \ref Kambites instance representing a
@@ -268,6 +290,8 @@ namespace libsemigroups {
         // call the rval ref constructor
         : Kambites(knd, Presentation<native_word_type>(p)) {}
 
+    //! \ingroup kambites_class_init_group
+    //!
     //! \brief Re-initialize a \ref Kambites instance.
     //!
     //! This function puts a \ref Kambites instance back into the state that
@@ -294,6 +318,8 @@ namespace libsemigroups {
       return init(knd, Presentation<native_word_type>(p));
     }
 
+    //! \ingroup kambites_class_init_group
+    //!
     //! \copydoc Kambites(congruence_kind, Presentation<native_word_type>
     //! const&)
     Kambites(congruence_kind knd, Presentation<native_word_type>&& p)
@@ -301,6 +327,8 @@ namespace libsemigroups {
       init(knd, std::move(p));
     }
 
+    //! \ingroup kambites_class_init_group
+    //!
     //! \copydoc init(congruence_kind, Presentation<native_word_type>
     //! const&)
     Kambites& init(congruence_kind knd, Presentation<native_word_type>&& p);

--- a/include/libsemigroups/kambites-class.hpp
+++ b/include/libsemigroups/kambites-class.hpp
@@ -772,6 +772,8 @@ namespace libsemigroups {
     // Kambites - validation functions - public
     ////////////////////////////////////////////////////////////////////////
 
+    //! \ingroup kambites_class_init_group
+    //!
     //! \brief Throws if any letter in a range is out of bounds.
     //!
     //! This function throws a LibsemigroupsException if any value pointed
@@ -793,6 +795,8 @@ namespace libsemigroups {
       _presentation.validate_word(first, last);
     }
 
+    //! \ingroup kambites_class_init_group
+    //!
     //! \brief Throws if \ref small_overlap_class isn't at least \f$4\f$.
     //!
     //! This function throws an exception if the \ref small_overlap_class is
@@ -802,6 +806,8 @@ namespace libsemigroups {
     //! least \f$4\f$.
     void throw_if_not_C4();
 
+    //! \ingroup kambites_class_init_group
+    //!
     //! \brief Throws if \ref small_overlap_class isn't at least \f$4\f$ if it
     //! is known.
     //!
@@ -812,6 +818,8 @@ namespace libsemigroups {
     //! not at least \f$4\f$.
     void throw_if_not_C4() const;
 
+    //! \ingroup kambites_class_init_group
+    //!
     //! \brief Check if the small overlap class has been computed and is at
     //! least 4.
     //!

--- a/include/libsemigroups/kambites-class.hpp
+++ b/include/libsemigroups/kambites-class.hpp
@@ -333,6 +333,8 @@ namespace libsemigroups {
     //! const&)
     Kambites& init(congruence_kind knd, Presentation<native_word_type>&& p);
 
+    //! \ingroup kambites_class_intf_group
+    //!
     //! \brief Get the presentation used to define a \ref Kambites instance
     //! (if any).
     //!
@@ -349,6 +351,8 @@ namespace libsemigroups {
       return _presentation;
     }
 
+    //! \ingroup kambites_class_intf_group
+    //!
     //! \brief Get the generating pairs of the congruence.
     //!
     //! This function returns the generating pairs of the congruence. The words
@@ -369,6 +373,8 @@ namespace libsemigroups {
     // Interface requirements - add_pairs
     ////////////////////////////////////////////////////////////////////////
 
+    //! \ingroup kambites_class_intf_group
+    //!
     //! \brief Add generating pair via iterators.
     //!
     //! This function adds a generating pair to the congruence represented by a
@@ -387,7 +393,8 @@ namespace libsemigroups {
                                             Iterator2 last1,
                                             Iterator3 first2,
                                             Iterator4 last2);
-
+    //! \ingroup kambites_class_intf_group
+    //!
     //! \brief Add generating pair via iterators.
     //!
     //! This function adds a generating pair to the congruence represented by a
@@ -414,6 +421,8 @@ namespace libsemigroups {
     // Interface requirements - number_of_classes
     ////////////////////////////////////////////////////////////////////////
 
+    //! \ingroup kambites_class_intf_group
+    //!
     //! \brief Compute the number of classes in the congruence.
     //!
     //! This function computes the number of classes in the congruence
@@ -439,6 +448,8 @@ namespace libsemigroups {
     // Interface requirements - contains
     ////////////////////////////////////////////////////////////////////////
 
+    //! \ingroup kambites_class_intf_group
+    //!
     //! \brief Check containment of a pair of words via iterators.
     //!
     //! This function checks whether or not the words represented by the ranges
@@ -475,6 +486,8 @@ namespace libsemigroups {
                                                     Iterator3 first2,
                                                     Iterator4 last2) const;
 
+    //! \ingroup kambites_class_intf_group
+    //!
     //! \brief Check containment of a pair of words via iterators.
     //!
     //! This function checks whether or not the words represented by the ranges
@@ -505,7 +518,8 @@ namespace libsemigroups {
                                           Iterator2 last1,
                                           Iterator3 first2,
                                           Iterator4 last2) const;
-
+    //! \ingroup kambites_class_intf_group
+    //!
     //! \brief Check containment of a pair of words via iterators.
     //!
     //! This function checks whether or not the words represented by the ranges
@@ -532,6 +546,8 @@ namespace libsemigroups {
           first1, last1, first2, last2);
     }
 
+    //! \ingroup kambites_class_intf_group
+    //!
     //! \brief Check containment of a pair of words via iterators.
     //!
     //! This function checks whether or not the words represented by the ranges
@@ -564,6 +580,8 @@ namespace libsemigroups {
                                native_word_type const& w) const;
 
    public:
+    //! \ingroup kambites_class_intf_group
+    //!
     //! \brief Reduce a word with no computation of the small_overlap_class
     //! or checks.
     //!
@@ -589,6 +607,8 @@ namespace libsemigroups {
                                            Iterator1      first,
                                            Iterator2      last) const;
 
+    //! \ingroup kambites_class_intf_group
+    //!
     //! \brief Reduce a word with no computation of the small_overlap_class.
     //!
     //! This function writes a reduced word equivalent to the input word
@@ -617,6 +637,8 @@ namespace libsemigroups {
           d_first, first, last);
     }
 
+    //! \ingroup kambites_class_intf_group
+    //!
     //! \brief Reduce a word with no checks.
     //!
     //! This function computes the \ref small_overlap_class and then writes
@@ -646,6 +668,8 @@ namespace libsemigroups {
           d_first, first, last);
     }
 
+    //! \ingroup kambites_class_intf_group
+    //!
     //! \brief Reduce a word.
     //!
     //! This function computes the \ref small_overlap_class and then writes

--- a/include/libsemigroups/kambites-class.hpp
+++ b/include/libsemigroups/kambites-class.hpp
@@ -73,16 +73,6 @@ namespace libsemigroups {
   //! identical, because there are no helper functions that only apply to the
   //! Kambites class template.
 
-  //! \defgroup kambites_class_group The Kambites class
-  //!
-  //! \ingroup kambites_group
-  //!
-  //! \brief This page contains links to the documentation related to the
-  //! Kambites class.
-  //!
-  //! This page contains links to the documentation related to the
-  //! Kambites class.
-
   //! \defgroup kambites_class_mem_types_group Member Types
   //!
   //! \ingroup kambites_class_group
@@ -133,11 +123,14 @@ namespace libsemigroups {
   //! Those functions with the prefix `current_` do not perform any
   //! further enumeration.
 
-  //! \ingroup kambites_class_group
-  //! \hideinheritancegraph
+  //! \defgroup kambites_class_group The Kambites class
+  //!
+  //! \ingroup kambites_group
   //!
   //! \brief Class template implementing small overlap class, equality, and
   //! normal forms for small overlap monoids.
+  //!
+  //! \hideinheritancegraph
   //!
   //! Defined in `kambites.hpp`.
   //!

--- a/include/libsemigroups/kambites-class.hpp
+++ b/include/libsemigroups/kambites-class.hpp
@@ -202,7 +202,7 @@ namespace libsemigroups {
     //! Kambites instances can only be used to compute two-sided congruences,
     //! and so the first parameter \p knd must always be
     //! congruence_kind::twosided. The parameter \p knd is included for
-    //! uniformity of interface between with \ref KnuthBendixImpl, \ref
+    //! uniformity of interface between with \ref_knuth_bendix, \ref
     //! Kambites, and \ref Congruence.
     //!
     //! \param knd the kind (onesided or twosided) of the congruence.
@@ -224,7 +224,7 @@ namespace libsemigroups {
     //! Kambites instances can only be used to compute two-sided congruences,
     //! and so the first parameter \p knd must always be
     //! congruence_kind::twosided. The parameter \p knd is included for
-    //! uniformity of interface between with \ref KnuthBendixImpl, \ref
+    //! uniformity of interface between with \ref_knuth_bendix, \ref
     //! Kambites, and \ref Congruence.
     //!
     //! \param knd the kind (onesided or twosided) of the congruence.

--- a/include/libsemigroups/kambites-helpers.hpp
+++ b/include/libsemigroups/kambites-helpers.hpp
@@ -65,7 +65,6 @@ namespace libsemigroups {
     }
   }  // namespace congruence_common
 
-  // TODO at the moment the below topic is empty. Should it still be documented?
   //! \defgroup kambites_helpers_group Kambites helper functions
   //! \ingroup kambites_group
   //!
@@ -73,13 +72,14 @@ namespace libsemigroups {
   //!
   //! Defined in \c kambites.hpp.
   //!
-  //! This page contains documentation for many helper functions for the
-  //! \ref_kambites class template. In particular, these functions include
-  //! versions of several of the member functions of \ref_kambites (that accept
-  //! iterators) whose parameters are not iterators, but objects instead. The
-  //! helpers documented on this page all belong to the namespace `kambites`.
+  //! This page would contain documentation for helper functions for the
+  //! \ref_kambites class template. However, at present, there are no helper
+  //! functions beyond those in \ref cong_common_helpers_group for the
+  //! \ref_kambites class template.
   //!
-  //! \sa \ref cong_common_helpers_group
+  //! \sa
+  //! * \ref cong_common_helpers_group; and
+  //! * the \ref kambites namespace.
 
   //! This page contains documentation for everything in the namespace
   //! \ref_kambites. This includes everything from \ref

--- a/include/libsemigroups/kambites-helpers.hpp
+++ b/include/libsemigroups/kambites-helpers.hpp
@@ -64,6 +64,8 @@ namespace libsemigroups {
     }
   }  // namespace congruence_common
 
+  //! \ingroup kambites_group
+  //!
   //! \brief Helper functions for the \ref Kambites class template.
   //!
   //! Defined in \c kambites.hpp.

--- a/include/libsemigroups/kambites-helpers.hpp
+++ b/include/libsemigroups/kambites-helpers.hpp
@@ -64,6 +64,8 @@ namespace libsemigroups {
     }
   }  // namespace congruence_common
 
+  // TODO at the moment the below topic is empty. Should it still be documented?
+  //! \defgroup kambites_helpers_group Kambites helper functions
   //! \ingroup kambites_group
   //!
   //! \brief Helper functions for the \ref Kambites class template.

--- a/include/libsemigroups/kambites-helpers.hpp
+++ b/include/libsemigroups/kambites-helpers.hpp
@@ -126,7 +126,6 @@ namespace libsemigroups {
     // kambites::normal_forms(k2)) (as in ToddCoxeterImpl) because there are
     // infinitely many normal_forms.
 
-    //! @}
   }  // namespace kambites
 }  // namespace libsemigroups
 #endif  // LIBSEMIGROUPS_KAMBITES_HELPERS_HPP_

--- a/include/libsemigroups/kambites-helpers.hpp
+++ b/include/libsemigroups/kambites-helpers.hpp
@@ -45,11 +45,12 @@ namespace libsemigroups {
     //! Defined in \c kambites.hpp.
     //!
     //! This function returns a range object containing short-lex normal forms
-    //! of the classes of the congruence represented by a Kambites instance.
+    //! of the classes of the congruence represented by a \ref_kambites
+    //! instance.
     //!
     //! \tparam Word the type of the words contained in the parameter \p k.
     //!
-    //! \param k the \ref Kambites instance.
+    //! \param k the \ref_kambites instance.
     //!
     //! \returns A range object.
     //!
@@ -68,22 +69,23 @@ namespace libsemigroups {
   //! \defgroup kambites_helpers_group Kambites helper functions
   //! \ingroup kambites_group
   //!
-  //! \brief Helper functions for the \ref Kambites class template.
+  //! \brief Helper functions for the \ref_kambites class template.
   //!
   //! Defined in \c kambites.hpp.
   //!
-  //! This page contains documentation for many helper functions for the \ref
-  //! Kambites class template. In particular, these functions include versions
-  //! of several of the member functions of \ref Kambites (that accept
+  //! This page contains documentation for many helper functions for the
+  //! \ref_kambites class template. In particular, these functions include
+  //! versions of several of the member functions of \ref_kambites (that accept
   //! iterators) whose parameters are not iterators, but objects instead. The
   //! helpers documented on this page all belong to the namespace `kambites`.
   //!
   //! \sa \ref cong_common_helpers_group
 
-  //! This page contains documentation for everything in the namespace \ref
-  //! kambites. This includes everything from \ref cong_common_helpers_group, at
-  //! present there are no helper functions, beyond those in \ref
-  //! cong_common_helpers_group, for the \ref Kambites class template.
+  //! This page contains documentation for everything in the namespace
+  //! \ref_kambites. This includes everything from \ref
+  //! cong_common_helpers_group, at present there are no helper functions,
+  //! beyond those in \ref cong_common_helpers_group, for the \ref_kambites
+  //! class template.
   namespace kambites {
     using congruence_common::add_generating_pair;
     using congruence_common::add_generating_pair_no_checks;

--- a/include/libsemigroups/knuth-bendix-class.hpp
+++ b/include/libsemigroups/knuth-bendix-class.hpp
@@ -141,8 +141,8 @@ namespace libsemigroups {
     //!
     //! \brief Default constructor.
     //!
-    //! This function default constructs an uninitialised \ref
-    //! KnuthBendix instance.
+    //! This function default constructs an uninitialised \ref KnuthBendix
+    //! instance.
     KnuthBendix() = default;
 
     //! \ingroup knuth_bendix_class_init_group

--- a/include/libsemigroups/knuth-bendix-class.hpp
+++ b/include/libsemigroups/knuth-bendix-class.hpp
@@ -75,7 +75,7 @@ namespace libsemigroups {
   //! presentation::add_rule_no_checks(p, "cd", "");
   //! presentation::add_rule_no_checks(p, "dc", "");
   //!
-  //! KnuthBendix kb(twosided, p);
+  //! KnuthBendix<> kb(twosided, p);
   //!
   //! !kb.confluent();              // true
   //! kb.run();

--- a/include/libsemigroups/knuth-bendix-class.hpp
+++ b/include/libsemigroups/knuth-bendix-class.hpp
@@ -75,7 +75,7 @@ namespace libsemigroups {
   //! presentation::add_rule_no_checks(p, "cd", "");
   //! presentation::add_rule_no_checks(p, "dc", "");
   //!
-  //! KnuthBendix<> kb(twosided, p);
+  //! KnuthBendix kb(twosided, p);
   //!
   //! !kb.confluent();              // true
   //! kb.run();

--- a/include/libsemigroups/knuth-bendix-class.hpp
+++ b/include/libsemigroups/knuth-bendix-class.hpp
@@ -40,6 +40,10 @@ namespace libsemigroups {
   //!
   //! This page contains links to the documentation related to the
   //! implementation of the Knuth-Bendix algorithm in `libsemigroups`.
+  //!
+  //! The purpose of this algorithm is to find a locally confluent presentation
+  //! for a semigroup or monoid, with respect to some alphabet order and
+  //! reduction ordering.
 
   //! \defgroup knuth_bendix_class_group KnuthBendix class
   //! \ingroup knuth_bendix_group

--- a/include/libsemigroups/knuth-bendix-class.hpp
+++ b/include/libsemigroups/knuth-bendix-class.hpp
@@ -105,7 +105,7 @@ namespace libsemigroups {
       //! \brief Values for specifying how to measure the length of an
       //! overlap.
       //!
-      //! The values in this enum determine how a KnuthBendixImpl instance
+      //! The values in this enum determine how a \ref_knuth_bendix instance
       //! measures the length \f$d(AB, BC)\f$ of the overlap of two words
       //! \f$AB\f$ and \f$BC\f$:
       //!
@@ -124,10 +124,10 @@ namespace libsemigroups {
     //! \ingroup knuth_bendix_class_mem_types_group
     //!
     //! \brief Type of the letters in the relations of the presentation stored
-    //! in a \ref KnuthBendix instance.
+    //! in a \ref_knuth_bendix instance.
     //!
     //! Type of the letters in the relations of the presentation stored
-    //! in a \ref KnuthBendix instance.
+    //! in a \ref_knuth_bendix instance.
     using native_word_type = Word;
 
     //! \ingroup knuth_bendix_class_mem_types_group
@@ -141,7 +141,7 @@ namespace libsemigroups {
     //!
     //! \brief Default constructor.
     //!
-    //! This function default constructs an uninitialised \ref KnuthBendix
+    //! This function default constructs an uninitialised \ref_knuth_bendix
     //! instance.
     KnuthBendix() = default;
 
@@ -150,7 +150,7 @@ namespace libsemigroups {
     //! \brief Remove the presentation and rewriter data
     //!
     //! This function clears the rewriter, presentation, settings and stats
-    //! from the KnuthBendix object, putting it back into the state it
+    //! from the \ref_knuth_bendix object, putting it back into the state it
     //! would be in if it was newly default constructed.
     //!
     //! \returns
@@ -168,12 +168,12 @@ namespace libsemigroups {
     //!
     //! Copy constructor.
     //!
-    //! \param that the KnuthBendix instance to copy.
+    //! \param that the \ref_knuth_bendix instance to copy.
     //!
     //! \complexity
     //! \f$O(n)\f$ where \f$n\f$ is the sum of the lengths of the words in
     //! rules of \p that.
-    KnuthBendix(KnuthBendix const&) = default;
+    KnuthBendix(KnuthBendix const& that) = default;
 
     //! \ingroup knuth_bendix_class_init_group
     //!
@@ -208,7 +208,7 @@ namespace libsemigroups {
     //!
     //! \brief Construct from \ref congruence_kind and Presentation.
     //!
-    //! This function constructs a \ref KnuthBendix instance representing
+    //! This function constructs a \ref_knuth_bendix instance representing
     //! a congruence of kind \p knd over the semigroup or monoid defined by
     //! the presentation \p p.
     //!
@@ -222,9 +222,9 @@ namespace libsemigroups {
 
     //! \ingroup knuth_bendix_class_init_group
     //!
-    //! \brief Re-initialize a \ref KnuthBendix instance.
+    //! \brief Re-initialize a \ref_knuth_bendix instance.
     //!
-    //! This function puts a \ref KnuthBendix instance back into the state
+    //! This function puts a \ref_knuth_bendix instance back into the state
     //! that it would have been in if it had just been newly constructed from
     //! \p knd and \p p.
     //!
@@ -246,7 +246,7 @@ namespace libsemigroups {
     //! This function throws a LibsemigroupsException if any value pointed
     //! at by an iterator in the range \p first to \p last is out of bounds
     //! (i.e. does not belong to the alphabet of the \ref presentation used
-    //! to construct the \ref KnuthBendix instance).
+    //! to construct the \ref_knuth_bendix instance).
     //!
     //! \tparam Iterator1 the type of first argument \p first.
     //! \tparam Iterator2 the type of second argument \p last.
@@ -315,10 +315,10 @@ namespace libsemigroups {
     //! \ingroup knuth_bendix_class_intf_group
     //!
     //! \brief Return the presentation used to construct or initialize a
-    //! KnuthBendix object.
+    //! \ref_knuth_bendix object.
     //!
     //! This function returns the presentation used to construct or initialize
-    //! a KnuthBendix object.
+    //! a \ref_knuth_bendix object.
     //!
     //! \returns
     //! A const reference to the presentation.
@@ -341,7 +341,7 @@ namespace libsemigroups {
     //! \brief Add generating pair via iterators.
     //!
     //! This function adds a generating pair to the congruence represented by a
-    //! \ref KnuthBendix instance.
+    //! \ref_knuth_bendix instance.
     //!
     //! \cong_common_params_contains
     //!
@@ -366,7 +366,7 @@ namespace libsemigroups {
     //! \brief Add generating pair via iterators.
     //!
     //! This function adds a generating pair to the congruence represented by a
-    //! \ref KnuthBendix instance.
+    //! \ref_knuth_bendix instance.
     //!
     //! \cong_common_params_contains
     //!
@@ -402,7 +402,7 @@ namespace libsemigroups {
     //!
     //! This function checks whether or not the words represented by the ranges
     //! \p first1 to \p last1 and \p first2 to \p last2 are already known to be
-    //! contained in the congruence represented by a \ref KnuthBendix instance.
+    //! contained in the congruence represented by a \ref_knuth_bendix instance.
     //! This function performs no enumeration, so it is possible for the words
     //! to be contained in the congruence, but that this is not currently known.
     //!
@@ -434,7 +434,7 @@ namespace libsemigroups {
     //!
     //! This function checks whether or not the words represented by the ranges
     //! \p first1 to \p last1 and \p first2 to \p last2 are contained in the
-    //! congruence represented by a \ref KnuthBendix
+    //! congruence represented by a \ref_knuth_bendix
     //! instance. This function triggers a full enumeration,
     //! which may never terminate.
     //!
@@ -469,10 +469,10 @@ namespace libsemigroups {
     //! described by the iterator \p first and \p last to the output iterator \p
     //! d_first. This function triggers no enumeration. The word output by this
     //! function is equivalent to the input word in the congruence defined by a
-    //! \ref KnuthBendix instance. If the KnuthBendix instance is \ref finished,
-    //! then the output word is a normal form for the input word. If the
-    //! KnuthBendix instance is not \ref finished, then it might be that
-    //! equivalent input words produce different output words.
+    //! \ref_knuth_bendix instance. If the \ref_knuth_bendix instance is \ref
+    //! finished, then the output word is a normal form for the input word. If
+    //! the \ref_knuth_bendix instance is not \ref finished, then it might be
+    //! that equivalent input words produce different output words.
     //!
     //! \cong_common_params_reduce
     //!
@@ -500,9 +500,9 @@ namespace libsemigroups {
     //! word equivalent to the input word described by the iterator \p first and
     //! \p last to the output iterator \p d_first. The word output by this
     //! function is equivalent to the input word in the congruence defined by a
-    //! KnuthBendix instance. In other words, the output word is a normal form
-    //! for the input word or equivalently a canconical representative of its
-    //! congruence class.
+    //! \ref_knuth_bendix instance. In other words, the output word is a normal
+    //! form for the input word or equivalently a canconical representative of
+    //! its congruence class.
     //!
     //! \cong_common_params_reduce
     //!
@@ -532,9 +532,9 @@ namespace libsemigroups {
     //! \brief Return a range object containing the active rules.
     //!
     //! This function returns a range object containing the pairs of
-    //! strings which represent the rules of a KnuthBendix instance. The
+    //! strings which represent the rules of a \ref_knuth_bendix instance. The
     //! \c first entry in every such pair is greater than the \c second
-    //! according to the reduction ordering of the KnuthBendix instance.
+    //! according to the reduction ordering of the \ref_knuth_bendix instance.
     //!
     //! \returns
     //! A range object containing the current active rules.

--- a/include/libsemigroups/knuth-bendix-helpers.hpp
+++ b/include/libsemigroups/knuth-bendix-helpers.hpp
@@ -57,17 +57,17 @@ namespace libsemigroups {
     //! Defined in \c knuth-bendix-helpers.hpp.
     //!
     //! This function returns a range object containing normal forms of the
-    //! classes of the congruence represented by an instance of KnuthBendix.
-    //! The order of the classes, and the normal form that is returned, are
-    //! controlled by the reduction order used to construct \p kb. This function
-    //! triggers a full enumeration of \p kb.
+    //! classes of the congruence represented by an instance of
+    //! \ref_knuth_bendix. The order of the classes, and the normal form that is
+    //! returned, are controlled by the reduction order used to construct \p kb.
+    //! This function triggers a full enumeration of \p kb.
     //!
     //! \tparam Word the type of the words contained in the output range.
-    //! \tparam Rewriter the first template parameter for KnuthBendix.
+    //! \tparam Rewriter the first template parameter for \ref_knuth_bendix.
     //! \tparam ReductionOrder the second template parameter for
-    //! KnuthBendix.
+    //! \ref_knuth_bendix.
     //!
-    //! \param kb the \ref KnuthBendix instance.
+    //! \param kb the \ref_knuth_bendix instance.
     //!
     //! \returns A range object.
     //!
@@ -87,7 +87,7 @@ namespace libsemigroups {
     ////////////////////////////////////////////////////////////////////////
 
     //! \brief Find the non-trivial classes of the quotient of one
-    //! KnuthBendix instance in another.
+    //! \ref_knuth_bendix instance in another.
     //!
     //! Defined in \c knuth-bendix-helpers.hpp.
     //!
@@ -105,12 +105,12 @@ namespace libsemigroups {
     //!
     //! \tparam Word the type of the words contained in the output range
     //! (default: std::string).
-    //! \tparam Rewriter the first template parameter for KnuthBendix.
+    //! \tparam Rewriter the first template parameter for \ref_knuth_bendix.
     //! \tparam ReductionOrder the second template parameter for
-    //! KnuthBendix.
+    //! \ref_knuth_bendix.
     //!
-    //! \param kb1 the first \ref KnuthBendix instance.
-    //! \param kb2 the second \ref KnuthBendix instance.
+    //! \param kb1 the first \ref_knuth_bendix instance.
+    //! \param kb2 the second \ref_knuth_bendix instance.
     //!
     //! \returns The non-trivial classes of \p kb1 in \p kb2.
     //!
@@ -121,7 +121,7 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if the alphabets of the
     //! presentations of \p kb1 and \p kb2 are not equal.
     //!
-    //! \throws LibsemigroupsException if the \ref KnuthBendix::gilman_graph
+    //! \throws LibsemigroupsException if the \ref_knuth_bendix::gilman_graph
     //! of
     //! \p kb1 has fewer nodes than that of \p kb2.
     //!
@@ -136,13 +136,13 @@ namespace libsemigroups {
   //! \defgroup knuth_bendix_helpers_group Knuth-Bendix helper functions
   //! \ingroup knuth_bendix_group
   //!
-  //! \brief Helper functions for the \ref KnuthBendix class.
+  //! \brief Helper functions for the \ref_knuth_bendix class.
   //!
   //! Defined in \c knuth-bendix-helpers.hpp.
   //!
-  //! This page contains documentation for some helper functions for the \ref
-  //! KnuthBendix class. In particular, these functions include versions of
-  //! several of the member functions of \ref KnuthBendix (that accept
+  //! This page contains documentation for some helper functions for the
+  //! \ref_knuth_bendix class. In particular, these functions include versions
+  //! of several of the member functions of \ref_knuth_bendix (that accept
   //! iterators) whose parameters are not iterators, but objects instead. The
   //! helpers documented on this page all belong to the namespace
   //! \ref knuth_bendix.
@@ -166,23 +166,23 @@ namespace libsemigroups {
     //! Defined in \c knuth-bendix-helpers.hpp.
     //!
     //! This function runs the Knuth-Bendix algorithm on the rewriting
-    //! system represented by a KnuthBendix instance by considering all
+    //! system represented by a \ref_knuth_bendix instance by considering all
     //! overlaps of a given length \f$n\f$ (according to the \ref
     //! KnuthBendix::options::overlap) before those overlaps of length \f$n
     //! + 1\f$.
     //!
     //! \tparam Word the type of the words in the \ref
     //! KnuthBendix::presentation.
-    //! \tparam Rewriter the first template parameter for KnuthBendix.
+    //! \tparam Rewriter the first template parameter for \ref_knuth_bendix.
     //! \tparam ReductionOrder the second template parameter for
-    //! KnuthBendix.
+    //! \ref_knuth_bendix.
     //!
-    //! \param kb the KnuthBendix instance.
+    //! \param kb the \ref_knuth_bendix instance.
     //!
     //! \complexity
     //! See warning.
     //!
-    //! \warning This will terminate when the KnuthBendix instance is
+    //! \warning This will terminate when the \ref_knuth_bendix instance is
     //! confluent, which might be never.
     //!
     //! \sa KnuthBendix::run.
@@ -197,16 +197,16 @@ namespace libsemigroups {
     //!
     //! \tparam Word the type of the words in the \ref
     //! KnuthBendix::presentation.
-    //! \tparam Rewriter the first template parameter for KnuthBendix.
+    //! \tparam Rewriter the first template parameter for \ref_knuth_bendix.
     //! \tparam ReductionOrder the second template parameter for
-    //! KnuthBendix.
+    //! \ref_knuth_bendix.
     //!
-    //! \param kb the KnuthBendix instance defining the rules that are to be
-    //! checked for being reduced.
+    //! \param kb the \ref_knuth_bendix instance defining the rules that are to
+    //! be checked for being reduced.
     //!
     //! \returns \c true if for each pair \f$(A, B)\f$ and \f$(C, D)\f$ of rules
-    //! stored within the KnuthBendix instance, \f$C\f$ is neither a subword
-    //! of \f$A\f$ nor \f$B\f$. Returns \c false otherwise.
+    //! stored within the \ref_knuth_bendix instance, \f$C\f$ is neither a
+    //! subword of \f$A\f$ nor \f$B\f$. Returns \c false otherwise.
 #ifndef PARSED_BY_DOXYGEN
     template <typename Rewriter, typename ReductionOrder>
     [[nodiscard]] bool
@@ -289,7 +289,7 @@ namespace libsemigroups {
     //! \tparam Time type of the 2nd parameter (time to try running
     //! Knuth-Bendix).
     //! \param p the presentation.
-    //! \param t time to run KnuthBendix for every omitted rule.
+    //! \param t time to run \ref_knuth_bendix for every omitted rule.
     //!
     //! \warning The progress of the Knuth-Bendix algorithm may differ between
     //! different calls to this function even if the parameters are identical.

--- a/include/libsemigroups/obvinf.hpp
+++ b/include/libsemigroups/obvinf.hpp
@@ -490,14 +490,14 @@ namespace libsemigroups {
   //! classes.
   //!
   //! This function returns \c true if the quotient of the finitely presented
-  //! semigroup or monoid defined by the Congruence object \p c is obviously
-  //! infinite; \c false is returned if it is not.
+  //! semigroup or monoid defined by the \ref_congruence object \p c is
+  //! obviously infinite; \c false is returned if it is not.
   //!
   //! This function exists to make it simpler to call an IsObviouslyInfinite
   //! object a single time, and uses some information from the (possible
-  //! incomplete) Congruence object to assist in this determination.
+  //! incomplete) \ref_congruence object to assist in this determination.
   //!
-  //! \param c the Congruence instance.
+  //! \param c the \ref_congruence instance.
   //!
   //! \returns Whether or not the congruence obviously has infinitely many
   //! classes.

--- a/include/libsemigroups/obvinf.hpp
+++ b/include/libsemigroups/obvinf.hpp
@@ -511,21 +511,21 @@ namespace libsemigroups {
   //! \ingroup obvinf_group
   //!
   //! \brief Function for checking if the finitely presented semigroup or
-  //! monoid defined by a Kambites object obviously has infinite many
+  //! monoid defined by a \ref_kambites object obviously has infinite many
   //! classes.
   //!
   //! This function returns \c true if the finitely presented semigroup or
-  //! monoid defined by a Kambites object is obviously infinite; \c false is
-  //! returned if it is not.
+  //! monoid defined by a \ref_kambites object is obviously infinite; \c false
+  //! is returned if it is not.
   //!
   //! This function exists to make it simpler to call an IsObviouslyInfinite
   //! object a single time, and uses some information from the (possible
-  //! incomplete) Kambites object to assist in this determination.
+  //! incomplete) \ref_kambites object to assist in this determination.
   //!
-  //! \param k the Kambites instance.
+  //! \param k the \ref_kambites instance.
   //!
   //! \returns Whether or not the finitely presented semigroup or
-  //! monoid defined by a Kambites object is obviously infinite.
+  //! monoid defined by a \ref_kambites object is obviously infinite.
   //!
   //! \note If this function returns \c false, it is still possible that the
   //! finitely presented semigroup or monoid defined by \p k is infinite.

--- a/include/libsemigroups/obvinf.hpp
+++ b/include/libsemigroups/obvinf.hpp
@@ -543,24 +543,24 @@ namespace libsemigroups {
   //! \ingroup obvinf_group
   //!
   //! \brief Function for checking if the quotient of a finitely presented
-  //! semigroup or monoid defined by a KnuthBendixImpl object is obviously
+  //! semigroup or monoid defined by a \ref_knuth_bendix object is obviously
   //! infinite or not.
   //!
   //! This function returns \c true if the quotient of the finitely presented
-  //! semigroup or monoid defined by the KnuthBendixImpl object \p kb is
+  //! semigroup or monoid defined by the \ref_knuth_bendix object \p kb is
   //! obviously infinite; \c false is returned if it is not.
   //!
   //! This function exists to make it simpler to call an IsObviouslyInfinite
   //! object a single time, and uses some information from the (possible
-  //! incomplete) KnuthBendixImpl object to assist in this determination.
+  //! incomplete) \ref_knuth_bendix object to assist in this determination.
   //!
-  //! \param kb the KnuthBendixImpl instance.
+  //! \param kb the \ref_knuth_bendix instance.
   //!
-  //! \returns Whether or not the quotient defined by a KnuthBendixImpl instance
-  //! is obviously infinite.
+  //! \returns Whether or not the quotient defined by a \ref_knuth_bendix
+  //! instance is obviously infinite.
   //!
   //! \note If this function returns \c false, it is still possible that the
-  //! quotient defined by the KnuthBendixImpl object \p kb is infinite.
+  //! quotient defined by the \ref_knuth_bendix object \p kb is infinite.
   template <typename Rewriter, typename ReductionOrder>
   bool
   is_obviously_infinite(detail::KnuthBendixImpl<Rewriter, ReductionOrder>& kb) {

--- a/include/libsemigroups/sims.hpp
+++ b/include/libsemigroups/sims.hpp
@@ -3169,7 +3169,7 @@ namespace libsemigroups {
     //! \param p the presentation.
     //!
     //! \warning
-    //! This method assumes that KnuthBendixImpl terminates on the input
+    //! This method assumes that \ref_knuth_bendix terminates on the input
     //! presentation \p p. If this is not the case then th pruner may not
     //! terminate on certain inputs.
     template <typename Word>
@@ -3200,7 +3200,7 @@ namespace libsemigroups {
     //! thrown.
     //!
     //! \warning
-    //! This method assumes that KnuthBendix terminates on the input
+    //! This method assumes that \ref_knuth_bendix terminates on the input
     //! presentation \p p. If this is not the case then th pruner may not
     //! terminate on certain inputs.
     //!
@@ -3233,7 +3233,7 @@ namespace libsemigroups {
     //! returns `true`.
     //!
     //! \warning
-    //! This method assumes that KnuthBendixImpl terminates on the underlying
+    //! This method assumes that \ref_knuth_bendix terminates on the underlying
     //! presentation that was used to construct the SimsRefinerIdeals object. If
     //! this is not the case then th pruner may not terminate on certain inputs.
     bool operator()(Sims1::word_graph_type const& wg);

--- a/include/libsemigroups/todd-coxeter-class.hpp
+++ b/include/libsemigroups/todd-coxeter-class.hpp
@@ -1489,7 +1489,7 @@ namespace libsemigroups {
   //! \brief Return a human readable representation of a \ref_todd_coxeter
   //! object.
   //!
-  //! Defined in `todd-coxeter.hpp`.
+  //! Defined in `todd-coxeter-class.hpp`.
   //!
   //! This function returns a human readable representation of a
   //! \ref_todd_coxeter object.

--- a/include/libsemigroups/todd-coxeter-helpers.hpp
+++ b/include/libsemigroups/todd-coxeter-helpers.hpp
@@ -99,7 +99,7 @@ namespace libsemigroups {
     //!
     //! \tparam Word the type of the second argument \p w.
     //!
-    //! \param tc the ToddCoxeter instance.
+    //! \param tc the \ref_todd_coxeter instance.
     //! \param w the word.
     //!
     //! \returns The current index of the class containing the word.


### PR DESCRIPTION
This PR homogenises the doc between the various congruence-like classes:
 - `ToddCoxeter`;
 - `KnuthBendix`;
 - `Kambites`; and
 - `Congruence`.
