### PR TITLE
Fix more compiler warnings

### DIFF
--- a/include/libsemigroups/todd-coxeter-helpers.hpp
+++ b/include/libsemigroups/todd-coxeter-helpers.hpp
@@ -755,7 +755,16 @@ namespace libsemigroups {
     template <typename Word>
     [[nodiscard]] auto class_of(ToddCoxeter<Word>& tc, char const* w) {
       detail::throw_if_nullptr(w, "2nd");
+      LIBSEMIGROUPS_ASSERT(w != nullptr);
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull"
+#endif
       return class_of(tc, w, w + std::strlen(w));
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/word-range.hpp
+++ b/include/libsemigroups/word-range.hpp
@@ -1380,8 +1380,15 @@ namespace libsemigroups {
     }
   };
 
+  // NOTE: This is a terrible hack to avoid compiler warnings. Maybe remove in
+  // the future?
+#if defined(__clang__)
+  template <typename InputRange>
+  ToString::Range<InputRange>::~Range<InputRange>() = default;
+#elif defined(__GNUC__)
   template <typename InputRange>
   ToString::Range<InputRange>::~Range() = default;
+#endif
 
   //! \ingroup words_group
   //!

--- a/include/libsemigroups/word-range.hpp
+++ b/include/libsemigroups/word-range.hpp
@@ -1381,7 +1381,7 @@ namespace libsemigroups {
   };
 
   template <typename InputRange>
-  ToString::Range<InputRange>::~Range<InputRange>() = default;
+  ToString::Range<InputRange>::~Range() = default;
 
   //! \ingroup words_group
   //!


### PR DESCRIPTION
Fixed one more compiler warning (am patting myself on the back for that one). I also get the following warning still:
```
In file included from /home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/todd-coxeter.hpp:26,
                 from /home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/detail/tce.hpp:35,
                 from /home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/to-froidure-pin.hpp:34,
                 from tests/test-todd-coxeter.cpp:34:
In function ‘auto libsemigroups::todd_coxeter::class_of(libsemigroups::ToddCoxeter<Word>&, const char*) [with Word = std::vector<long unsigned int>]’,
    inlined from ‘void libsemigroups::CATCH2_INTERNAL_TEST_79()’ at tests/test-todd-coxeter.cpp:1686:5:
/home/rc234/Desktop/Source/libsemigroups/include/libsemigroups/todd-coxeter-helpers.hpp:758:45: warning: argument 1 null where non-null expected [-Wnonnull]
  758 |       return class_of(tc, w, w + std::strlen(w));
      |                                  ~~~~~~~~~~~^~~
In file included from /usr/include/c++/14/cstring:43,
                 from tests/catch_amalgamated.hpp:688,
                 from tests/test-todd-coxeter.cpp:23:
/usr/include/string.h: In function ‘void libsemigroups::CATCH2_INTERNAL_TEST_79()’:
/usr/include/string.h:407:15: note: in a call to function ‘size_t strlen(const char*)’ declared ‘nonnull’
  407 | extern size_t strlen (const char *__s)
      |               ^~~~~~
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-unused-command-line-argument’ may have been intended to silence earlier diagnostics
```
Looks like its tirggered by the following line in the test cases:
```cpp
    REQUIRE_THROWS_AS(class_of(tc, {}), LibsemigroupsException);
```
which is weird because the line just before it:
```cpp
    REQUIRE_THROWS_AS(class_of(tc, ""_w), LibsemigroupsException);
```
does not seem to trigger a warning.
It seems the implementation does check for nullpointer though:
```cpp
    template <typename Word>
    [[nodiscard]] auto class_of(ToddCoxeter<Word>& tc, char const* w) {
      detail::throw_if_nullptr(w, "2nd");
      return class_of(tc, w, w + std::strlen(w));
    }
```
hence the throw assertion in the test case. So methinks its a false positive. Any ideas how to suppress @james-d-mitchell @Joseph-Edwards ?