### PR TITLE
Remove `[[nodiscard]]` from all `.tpp` files

### DIFF
--- a/include/libsemigroups/transf.tpp
+++ b/include/libsemigroups/transf.tpp
@@ -172,7 +172,7 @@ namespace libsemigroups {
   }
 
   template <typename Return>
-  [[nodiscard]] std::enable_if_t<IsPPerm<Return>, Return>
+  std::enable_if_t<IsPPerm<Return>, Return>
   make(std::vector<typename Return::point_type> const& dom,
        std::vector<typename Return::point_type> const& ran,
        size_t const                                    M) {


### PR DESCRIPTION
This PR removes all instances of the attribute `[[nodiscard]]` from the `.tpp` files, of which there was only one.