### PR TITLE
V3 renumber test cases

### DIFF
--- a/etc/test-renumber-all.py
+++ b/etc/test-renumber-all.py
@@ -3,7 +3,7 @@
 
 The script should be run from the libsemigroups root directory. The numbering
 always starts from 0. Files are processed in lexicographic order. Within each
-file, test cases are numbered sequentially in order of occurence. Across test
+file, test cases are numbered sequentially in order of occurrence. Across test
 files, the test case family name (e.g. "Stephen" or "ToddCoxeter") is used to
 determine the number of the first test case.
 """

--- a/etc/test-renumber-all.py
+++ b/etc/test-renumber-all.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Renumber all tests in tests/test-*.cpp files in a duplicate free manner.
+
+The script should be run from the libsemigroups root directory. The numbering
+always starts from 0. Files are processed in lexicographic order. Within each
+file, test cases are numbered sequentially in order of occurence. Across test
+files, the test case family name (e.g. "Stephen" or "ToddCoxeter") is used to
+determine the number of the first test case.
+"""
+
+import re
+from collections import Counter
+from glob import glob
+
+
+if __name__ == "__main__":
+    test_file_names = glob("./tests/test-*.cpp")
+    test_file_names.sort()
+    test_case_only_regex = re.compile(
+        r"^\s*(LIBSEMIGROUPS_TEST_CASE|LIBSEMIGROUPS_TEMPLATE_TEST_CASE)",
+        flags=re.MULTILINE,
+    )
+    test_case_and_args_regex = re.compile(
+        r'^\s*(LIBSEMIGROUPS_TEST_CASE|LIBSEMIGROUPS_TEMPLATE_TEST_CASE)\s*\(\s*"(.*?)"\s*,\s*"(\w\w\w)"',
+        flags=re.MULTILINE,
+    )
+
+    smallest_free_number = Counter()
+    for test_file_name in test_file_names:
+        with open(test_file_name, "r") as test_file:
+            content = test_file.read()
+        new_content = []
+
+        names_seen = set()
+        last_end = 0
+        start = 0
+        # TODO(2): dry this out
+        while start is not None:
+            partial_match = test_case_only_regex.search(content, start)
+            match = test_case_and_args_regex.search(content, start)
+            if partial_match is None:
+                assert match is None, match
+                break
+
+            start = partial_match.start()
+            if match is None or match.start() != start:
+                count = content[:start].count("\n")
+                raise RuntimeError(
+                    f"Badly formed test case in file {test_file_name} line {count}!"
+                )
+
+            # TODO(2): figure out a better way of doing this
+            name = match.group(2).split("<")[0]
+            names_seen.add(name)
+
+            last_end = match.end(3)
+            start = last_end
+
+        current_free_number = 0
+        for name in names_seen:
+            current_free_number = max(smallest_free_number[name], current_free_number)
+
+        last_end = 0
+        start = 0
+        while start is not None:
+            match = test_case_and_args_regex.search(content, start)
+            if match is None:
+                break
+
+            if current_free_number > 999:
+                raise RuntimeError(f"Too many test cases in file {test_file_name}!")
+
+            new_content.append(content[last_end : match.start(3)])
+
+            new_content.append(str(current_free_number).zfill(3))
+            current_free_number += 1
+
+            last_end = match.end(3)
+            start = last_end
+
+        for name in names_seen:
+            smallest_free_number[name] = current_free_number
+
+        new_content.append(content[last_end:])
+
+        new_content = "".join(new_content)
+        assert len(content) == len(new_content), test_file_name
+        with open(test_file_name, "w") as test_file:
+            test_file.write(new_content)
+    print("Smallest free numbers for each test case name:")
+    for name, count in smallest_free_number.most_common():
+        print(f"{name}: {count}")

--- a/tests/test-action.cpp
+++ b/tests/test-action.cpp
@@ -46,7 +46,7 @@ namespace libsemigroups {
   using col_orb_type    = LeftAction<BMat8, BMat8, col_action_type>;
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "001",
+                          "000",
                           "row and column basis orbits for BMat8 x 1",
                           "[quick]") {
     auto         rg = ReportGuard(false);
@@ -69,7 +69,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "002",
+                          "001",
                           "row and column basis orbits for BMat8 x 2",
                           "[quick]") {
     using bmat8::col_space_basis;
@@ -129,7 +129,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "003",
+                          "002",
                           "add generators after enumeration",
                           "[quick]") {
     using bmat8::col_space_basis;
@@ -177,7 +177,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "004",
+                          "003",
                           "multipliers for BMat8 row and column orbits",
                           "[quick][no-valgrind]") {
     using bmat8::col_space_basis;
@@ -254,7 +254,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "005",
+                          "004",
                           "orbits for regular boolean mat monoid 5",
                           "[quick][no-valgrind]") {
     auto                     rg             = ReportGuard(false);
@@ -295,7 +295,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "006",
+                          "005",
                           "orbits for regular boolean mat monoid 6",
                           "[extreme]") {
     auto                     rg             = ReportGuard(true);
@@ -336,7 +336,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "007",
+                          "006",
                           "partial perm image orbit x 1",
                           "[quick]") {
     auto rg = ReportGuard(false);
@@ -361,7 +361,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "008",
+                          "007",
                           "partial perm image orbit x 2",
                           "[quick][no-valgrind]") {
     auto rg = ReportGuard(false);
@@ -388,7 +388,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "009",
+                          "008",
                           "partial perm image orbit x 3",
                           "[quick][no-valgrind]") {
     auto rg = ReportGuard(false);
@@ -416,7 +416,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "010",
+                          "009",
                           "partial perm image orbit x 4",
                           "[quick][no-valgrind]") {
     auto rg = ReportGuard(false);
@@ -443,7 +443,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "011",
+                          "010",
                           "permutation on integers",
                           "[quick]") {
     auto rg    = ReportGuard(false);
@@ -458,7 +458,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "012",
+                          "011",
                           "permutation on sets, arrays",
                           "[quick]") {
     auto rg    = ReportGuard(false);
@@ -476,7 +476,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "013",
+                          "012",
                           "permutation on tuples, arrays",
                           "[quick][no-valgrind]") {
     auto rg    = ReportGuard(false);
@@ -494,7 +494,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "014",
+                          "013",
                           "permutation on sets, vectors",
                           "[quick]") {
     auto rg    = ReportGuard(false);
@@ -508,7 +508,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "015",
+                          "014",
                           "permutation on tuples, vectors",
                           "[quick][no-valgrind]") {
     auto rg    = ReportGuard(false);
@@ -525,7 +525,7 @@ namespace libsemigroups {
     REQUIRE(oo.size() == 30'240);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Action", "016", "misc", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Action", "015", "misc", "[quick]") {
     auto rg    = ReportGuard(false);
     using Perm = LeastPerm<8>;
     RightAction<Perm, uint8_t, ImageRightAction<Perm, uint8_t>> o;
@@ -557,7 +557,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "017",
+                          "016",
                           "partial perm image orbit",
                           "[quick]") {
     auto rg = ReportGuard(false);
@@ -588,7 +588,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "018",
+                          "017",
                           "permutation on tuples, arrays (360360)",
                           "[quick][no-valgrind]") {
     auto rg    = ReportGuard(false);
@@ -606,7 +606,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "019",
+                          "018",
                           "orbits for regular BMat8 monoid 5 with stop/start",
                           "[quick][no-valgrind]") {
     auto                     rg             = ReportGuard(false);
@@ -655,7 +655,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Action",
-                                   "020",
+                                   "019",
                                    "regular boolean mat monoid 5",
                                    "[quick][no-valgrind]",
                                    BMat<>,
@@ -722,7 +722,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "021",
+                          "020",
                           "constructors",
                           "[quick][no-valgrind]") {
     auto rg    = ReportGuard(false);
@@ -768,7 +768,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Action",
-                          "022",
+                          "021",
                           "constructors",
                           "[quick][no-valgrind]") {
     row_orb_type o;

--- a/tests/test-bipart.cpp
+++ b/tests/test-bipart.cpp
@@ -50,7 +50,7 @@ namespace libsemigroups {
 
   }  // namespace
 
-  LIBSEMIGROUPS_TEST_CASE("Blocks", "001", "empty blocks", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Blocks", "000", "empty blocks", "[quick]") {
     Blocks b1 = make<Blocks>({});
     Blocks b2 = make<Blocks>({{4, 2}, {-1, -5}, {-3, -6}});
     REQUIRE(b2.lookup() == std::vector<bool>({true, false, true}));
@@ -67,7 +67,7 @@ namespace libsemigroups {
             == "Blocks({{-1, -5}, {2, 4}, {-3, -6}})");
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Blocks", "002", "non-empty blocks", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Blocks", "001", "non-empty blocks", "[quick]") {
     Blocks b = construct_blocks({0, 1, 2, 1, 0, 2}, {true, false, true});
     REQUIRE(b == b);
     REQUIRE_NOTHROW(b.block_no_checks(0, 0));
@@ -94,7 +94,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Blocks",
-                          "003",
+                          "002",
                           "left blocks of bipartition",
                           "[quick]") {
     Bipartition x = Bipartition(
@@ -116,7 +116,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Blocks",
-                          "004",
+                          "003",
                           "right blocks of bipartition",
                           "[quick]") {
     Bipartition x = Bipartition(
@@ -139,7 +139,7 @@ namespace libsemigroups {
     delete b;
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Blocks", "005", "copy [empty blocks]", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Blocks", "004", "copy [empty blocks]", "[quick]") {
     Blocks b = construct_blocks({}, {});
     Blocks c(b);
     REQUIRE(!IsBipartition<Blocks>);
@@ -154,7 +154,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Blocks",
-                          "006",
+                          "005",
                           "copy [non-empty blocks]",
                           "[quick]") {
     Blocks b = construct_blocks({0, 0, 1, 0, 2, 0, 1, 2, 2, 1, 0},
@@ -176,7 +176,7 @@ namespace libsemigroups {
     REQUIRE(c.rank() == 1);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Blocks", "007", "hash value", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Blocks", "006", "hash value", "[quick]") {
     Blocks b = construct_blocks({0, 0, 1, 0, 2, 0, 1, 2, 2, 1, 0},
                                 {false, true, false});
     Blocks c = construct_blocks({0, 0, 1, 0, 2, 0, 1, 2, 2, 1, 0},
@@ -191,7 +191,7 @@ namespace libsemigroups {
     REQUIRE(b.hash_value() == 0);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Blocks", "008", "operator<", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Blocks", "007", "operator<", "[quick]") {
     Blocks b = construct_blocks({0, 0, 1, 0, 2, 0, 1, 2, 2, 1, 0},
                                 {false, true, false});
     Blocks c = construct_blocks({0, 0, 1, 0, 2, 0, 1, 2, 2, 1, 0},
@@ -209,7 +209,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Bipartition",
-                          "009",
+                          "008",
                           "mem fns 1",
                           "[quick][bipartition]") {
     auto x = Bipartition(
@@ -269,7 +269,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Bipartition",
-                          "010",
+                          "009",
                           "hash",
                           "[quick][bipartition]") {
     Bipartition x({0, 1, 2, 1, 0, 2, 1, 0, 2, 2, 0, 0, 2, 0, 3, 4, 4, 1, 3, 0});
@@ -280,7 +280,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Bipartition",
-                          "011",
+                          "010",
                           "mem fns 2",
                           "[quick][bipartition]") {
     Bipartition x({0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 0, 0, 1, 2, 3, 3, 0, 4, 1, 1});
@@ -333,7 +333,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Bipartition",
-                          "012",
+                          "011",
                           "delete/copy",
                           "[quick][bipartition]") {
     Bipartition x({0, 0, 0, 0});
@@ -344,7 +344,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Bipartition",
-                          "013",
+                          "012",
                           "degree 0",
                           "[quick][bipartition]") {
     Bipartition x(std::vector<uint32_t>({}));
@@ -363,7 +363,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Bipartition",
-                          "014",
+                          "013",
                           "exceptions",
                           "[quick][bipartition]") {
     REQUIRE_NOTHROW(Bipartition(std::vector<uint32_t>()));
@@ -372,7 +372,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Bipartition",
-                          "015",
+                          "014",
                           "convenience constructor",
                           "[quick][bipartition]") {
     Bipartition xx(
@@ -531,7 +531,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Bipartition",
-                          "016",
+                          "015",
                           "force copy constructor over move constructor",
                           "[quick][bipartition]") {
     std::vector<uint32_t> xx(
@@ -579,12 +579,12 @@ namespace libsemigroups {
     REQUIRE(copy1 == copy2);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Bipartition", "017", "adapters", "[quick][bipart]") {
+  LIBSEMIGROUPS_TEST_CASE("Bipartition", "016", "adapters", "[quick][bipart]") {
     Bipartition x({0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 3, 3, 1, 2, 1});
     REQUIRE_NOTHROW(IncreaseDegree<Bipartition>()(x, 0));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Bipartition", "018", "bug", "[quick][bipart]") {
+  LIBSEMIGROUPS_TEST_CASE("Bipartition", "017", "bug", "[quick][bipart]") {
     Bipartition x({{1, -2, -3}, {-1}, {2, 3}});
     REQUIRE_NOTHROW(bipartition::validate(x));
   }

--- a/tests/test-cong.cpp
+++ b/tests/test-cong.cpp
@@ -121,7 +121,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "007",
+                          "002",
                           "2-sided congruence from presentation",
                           "[quick][cong]") {
     auto                    rg = ReportGuard(false);
@@ -146,7 +146,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "008",
+                          "003",
                           "2-sided congruence from presentation",
                           "[quick][cong]") {
     auto                    rg = ReportGuard(false);
@@ -177,7 +177,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "009",
+                          "004",
                           "infinite 2-sided congruence from presentation",
                           "[quick][cong]") {
     auto rg = ReportGuard(false);
@@ -222,7 +222,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "010",
+                          "005",
                           "2-sided congruence on finite semigroup",
                           "[quick][cong][no-valgrind]") {
     auto rg      = ReportGuard(false);
@@ -260,7 +260,7 @@ namespace libsemigroups {
   // threads blocks the others from stopping, extending the time
   // taken for this to run.
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "011",
+                          "006",
                           "congruence on full PBR monoid on 2 points",
                           "[extreme][cong]") {
     auto rg = ReportGuard(true);
@@ -308,7 +308,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "012",
+                          "007",
                           "2-sided congruence on finite semigroup",
                           "[quick][cong][no-valgrind]") {
     auto rg = ReportGuard(false);
@@ -333,7 +333,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "013",
+                          "008",
                           "trivial 2-sided congruence on bicyclic monoid",
                           "[quick][cong][no-valgrind]") {
     auto                    rg = ReportGuard(false);
@@ -350,7 +350,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "014",
+                          "009",
                           "non-trivial 2-sided congruence on bicyclic monoid",
                           "[quick][cong]") {
     auto rg = ReportGuard(false);
@@ -393,7 +393,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "015",
+                          "010",
                           "2-sided congruence on free abelian monoid",
                           "[quick][cong]") {
     auto                    rg = ReportGuard(false);
@@ -410,7 +410,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "016",
+                          "011",
                           "example where TC works but KB doesn't",
                           "[quick][cong]") {
     auto                      rg = ReportGuard(false);
@@ -430,7 +430,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "017",
+                          "012",
                           "2-sided congruence on finite semigroup",
                           "[quick][cong]") {
     auto rg      = ReportGuard(false);
@@ -458,7 +458,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "018",
+                          "013",
                           "infinite fp semigroup from GAP library",
                           "[quick][cong]") {
     auto                    rg = ReportGuard(false);
@@ -497,7 +497,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "Congruence",
-      "019",
+      "014",
       "2-sided cong. from presentation with infinite classes ",
       "[quick][cong]") {
     using words::operator+;
@@ -522,7 +522,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "020",
+                          "015",
                           "trivial cong. on an fp semigroup",
                           "[quick][cong][no-valgrind]") {
     auto                      rg = ReportGuard(false);
@@ -548,7 +548,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "021",
+                          "016",
                           "duplicate generators",
                           "[quick][cong]") {
     auto rg      = ReportGuard(false);
@@ -562,7 +562,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "022",
+                          "017",
                           "non-trivial classes",
                           "[quick][cong]") {
     auto rg = ReportGuard(false);
@@ -608,7 +608,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "023",
+                          "018",
                           "onesided congruence on finite semigroup",
                           "[quick][cong][no-valgrind]") {
     auto rg      = ReportGuard(false);
@@ -650,7 +650,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "024",
+                          "019",
                           "redundant generating pairs",
                           "[quick][cong]") {
     auto                    rg = ReportGuard(false);
@@ -663,7 +663,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "025",
+                          "020",
                           "2-sided cong. on free semigroup",
                           "[quick][cong]") {
     auto                      rg = ReportGuard(false);
@@ -676,7 +676,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "026",
+                          "021",
                           "is_obviously_(in)finite",
                           "[quick][cong]") {
     auto rg = ReportGuard(false);
@@ -777,7 +777,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "028",
+                          "022",
                           "2-sided congruences of BMat8 semigroup",
                           "[quick][cong][no-valgrind]") {
 #ifdef LIBSEMIGROUPS_HPCOMBI_ENABLED
@@ -845,7 +845,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "029",
+                          "023",
                           "left congruence on finite semigroup",
                           "[quick][cong]") {
     auto                  rg = ReportGuard(false);
@@ -878,7 +878,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "030",
+                          "024",
                           "onesided congruence on finite semigroup",
                           "[quick][cong]") {
     auto                  rg = ReportGuard(false);
@@ -907,7 +907,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "031",
+                          "025",
                           "onesided congruence on finite semigroup",
                           "[quick][cong]") {
     auto                  rg = ReportGuard(false);
@@ -940,7 +940,7 @@ namespace libsemigroups {
     REQUIRE(!congruence::contains(cong, w3, w5));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Congruence", "032", "contains", "[quick][cong]") {
+  LIBSEMIGROUPS_TEST_CASE("Congruence", "026", "contains", "[quick][cong]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -984,7 +984,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "033",
+                          "027",
                           "stellar_monoid S2",
                           "[quick][cong]") {
     auto                    rg = ReportGuard(false);
@@ -1013,7 +1013,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "034",
+                          "028",
                           "stellar_monoid S3",
                           "[quick][cong]") {
     auto                    rg = ReportGuard(false);
@@ -1058,7 +1058,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "035",
+                          "029",
                           "stellar_monoid S4",
                           "[quick][cong][no-valgrind]") {
     auto                    rg = ReportGuard(false);
@@ -1091,7 +1091,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "036",
+                          "030",
                           "stellar_monoid S5",
                           "[quick][cong][no-valgrind]") {
     auto                    rg = ReportGuard(false);
@@ -1125,7 +1125,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "037",
+                          "031",
                           "stellar_monoid S6",
                           "[quick][cong][no-valgrind]") {
     auto                    rg = ReportGuard(false);
@@ -1155,7 +1155,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "038",
+                          "032",
                           "stellar_monoid S7",
                           "[quick][cong][no-valgrind]") {
     auto                    rg = ReportGuard(false);
@@ -1185,7 +1185,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "039",
+                          "033",
                           "left cong. on an f.p. semigroup",
                           "[quick][cong]") {
     auto rg = ReportGuard(false);
@@ -1214,7 +1214,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "040",
+                          "034",
                           "2-sided cong. on infinite f.p. semigroup",
                           "[quick][cong]") {
     auto                    rg = ReportGuard(false);
@@ -1233,7 +1233,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "042",
+                          "035",
                           "const_contains",
                           "[quick][cong][no-valgrind]") {
     auto                    rg = ReportGuard(false);
@@ -1258,7 +1258,7 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Congruence", "043", "no winner", "[quick][cong]") {
+  LIBSEMIGROUPS_TEST_CASE("Congruence", "036", "no winner", "[quick][cong]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -1286,7 +1286,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "044",
+                          "037",
                           "congruence over smalloverlap",
                           "[quick][cong]") {
     auto                      rg = ReportGuard(false);
@@ -1328,7 +1328,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Congruence",
-                          "002",
+                          "038",
                           "python problem example",
                           "[quick][cong]") {
     Presentation<std::string> p;

--- a/tests/test-constants.cpp
+++ b/tests/test-constants.cpp
@@ -24,7 +24,7 @@
 namespace libsemigroups {
   // struct ForTesting {};
 
-  LIBSEMIGROUPS_TEST_CASE("Constants", "001", "Undefined", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Constants", "000", "Undefined", "[quick]") {
     // operator==
     REQUIRE(UNDEFINED == UNDEFINED);
     REQUIRE(!(UNDEFINED == POSITIVE_INFINITY));
@@ -76,7 +76,7 @@ namespace libsemigroups {
     // REQUIRE(UNDEFINED < ForTesting());
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Constants", "002", "PositiveInfinity", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Constants", "001", "PositiveInfinity", "[quick]") {
     // operator==
     REQUIRE(POSITIVE_INFINITY == POSITIVE_INFINITY);
     REQUIRE(!(POSITIVE_INFINITY == UNDEFINED));
@@ -124,7 +124,7 @@ namespace libsemigroups {
     // REQUIRE(ForTesting() < POSITIVE_INFINITY);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Constants", "003", "NegativeInfinity", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Constants", "002", "NegativeInfinity", "[quick]") {
     // operator==
     REQUIRE(NEGATIVE_INFINITY == NEGATIVE_INFINITY);
     REQUIRE(!(NEGATIVE_INFINITY == UNDEFINED));
@@ -172,7 +172,7 @@ namespace libsemigroups {
     // REQUIRE(!(NEGATIVE_INFINITY == size_t(0)));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Constants", "004", "LimitMax", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Constants", "003", "LimitMax", "[quick]") {
     // operator==
     REQUIRE(LIMIT_MAX == LIMIT_MAX);
     REQUIRE(!(LIMIT_MAX == UNDEFINED));

--- a/tests/test-containers.cpp
+++ b/tests/test-containers.cpp
@@ -33,7 +33,7 @@
 namespace libsemigroups {
   namespace detail {
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "001",
+                            "000",
                             "default constructor with 3 default args",
                             "[containers][quick]") {
       DynamicArray2<bool> rv = DynamicArray2<bool>();
@@ -43,7 +43,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "002",
+                            "001",
                             "default constructor with 2 default args",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(5);
@@ -53,7 +53,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "003",
+                            "002",
                             "default constructor with 1 default args",
                             "[containers][quick]") {
       DynamicArray2<bool> rv = DynamicArray2<bool>(5, 5);
@@ -65,7 +65,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "004",
+                            "003",
                             "default constructor with 0 default args",
                             "[containers][quick]") {
       DynamicArray2<bool> rv = DynamicArray2<bool>(2, 7, true);
@@ -77,7 +77,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "005",
+                            "004",
                             "copy constructor with 1 default args",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv   = DynamicArray2<size_t>(3, 7, 666);
@@ -90,7 +90,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "006",
+                            "005",
                             "copy constructor with 0 default args",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv   = DynamicArray2<size_t>(3, 7, 666);
@@ -112,7 +112,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "007",
+                            "006",
                             "add_rows",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(3, 7, 666);
@@ -137,7 +137,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "008",
+                            "007",
                             "add_rows",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(3, 7, 666);
@@ -156,7 +156,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "009",
+                            "008",
                             "add_cols",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(100, 2, 666);
@@ -175,7 +175,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "010",
+                            "009",
                             "set/get",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(100, 50, 666);
@@ -206,7 +206,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "011",
+                            "010",
                             "append 1/2",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(100, 50, 555);
@@ -241,7 +241,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "012",
+                            "011",
                             "append 2/2",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(10, 10, 555);
@@ -287,7 +287,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "013",
+                            "012",
                             "count",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(10, 10);
@@ -313,7 +313,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "014",
+                            "013",
                             "clear",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(10, 10);
@@ -327,7 +327,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "015",
+                            "014",
                             "begin_row and end_row",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(100, 2);
@@ -345,7 +345,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "016",
+                            "015",
                             "cbegin_row and cend_row",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(10, 10, 66);
@@ -357,7 +357,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "017",
+                            "016",
                             "iterator operator++ (postfix)",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(100, 2);  // cols, rows
@@ -418,7 +418,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "018",
+                            "017",
                             "iterator operator++ (prefix)",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(100, 2);  // cols, rows
@@ -529,7 +529,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "019",
+                            "018",
                             "iterator operator-- (postfix)",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(100, 2);  // cols, rows
@@ -568,7 +568,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "020",
+                            "019",
                             "iterator operator-- (prefix)",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(100, 2);  // cols, rows
@@ -607,7 +607,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "021",
+                            "020",
                             "operator=",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(10, 10, 3);
@@ -636,7 +636,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "022",
+                            "021",
                             "operator== and operator!=",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(10, 10, 3);
@@ -721,7 +721,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "023",
+                            "022",
                             "empty and clear",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(10, 10);
@@ -754,7 +754,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "024",
+                            "023",
                             "max_size",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(10, 10);
@@ -765,7 +765,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "025",
+                            "024",
                             "swap",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(10, 10, 3);
@@ -839,7 +839,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "026",
+                            "025",
                             "iterator arithmetic",
                             "[containers][quick]") {
       {
@@ -1022,7 +1022,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "027",
+                            "026",
                             "iterator comparison",
                             "[containers][quick]") {
       {
@@ -1052,7 +1052,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "028",
+                            "027",
                             "iterator operator=",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(10, 10, 1000);
@@ -1075,7 +1075,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "029",
+                            "028",
                             "iterator operator[]",
                             "[containers][quick]") {
       {
@@ -1131,7 +1131,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "030",
+                            "029",
                             "iterator operator->",
                             "[containers][quick][30]") {
       DynamicArray2<DynamicArray2<bool>> rv
@@ -1147,7 +1147,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "031",
+                            "030",
                             "const_iterator operator++/--",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(100, 2);  // cols, rows
@@ -1210,7 +1210,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "032",
+                            "031",
                             "const_iterator operator++/--",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(1, 1, 6);  // cols, rows
@@ -1223,7 +1223,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "033",
+                            "032",
                             "column iterators",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(3, 3);
@@ -1288,7 +1288,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "034",
+                            "033",
                             "column iterator arithmetic",
                             "[containers][quick][no-valgrind]") {
       {
@@ -1383,7 +1383,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "035",
+                            "034",
                             "iterator assignment constructor",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(100, 100);
@@ -1411,7 +1411,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "036",
+                            "035",
                             "reserve method",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(100, 100);
@@ -1421,7 +1421,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "037",
+                            "036",
                             "erase column",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(10, 10);
@@ -1440,7 +1440,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "038",
+                            "037",
                             "swap_rows",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(3, 10);
@@ -1462,7 +1462,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "039",
+                            "038",
                             "apply_row_permutation",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(3, 10);
@@ -1482,7 +1482,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "040",
+                            "039",
                             "swap",
                             "[containers][quick]") {
       DynamicArray2<size_t> da = DynamicArray2<size_t>({{0, 1}, {2, 3}});
@@ -1498,7 +1498,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "041",
+                            "040",
                             "shrink_rows_to",
                             "[containers][quick]") {
       DynamicArray2<size_t> da = DynamicArray2<size_t>({{0, 1}, {2, 3}});
@@ -1530,7 +1530,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "042",
+                            "041",
                             "shrink_rows_to - for range",
                             "[containers][quick]") {
       DynamicArray2<size_t> da = DynamicArray2<size_t>({{0, 1}, {2, 3}});
@@ -1566,7 +1566,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("StaticVector2",
-                            "043",
+                            "042",
                             "all",
                             "[containers][quick]") {
       StaticVector2<size_t, 3> sv;
@@ -1612,7 +1612,7 @@ namespace libsemigroups {
               == std::vector<size_t>({5}));
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Array2", "044", "all", "[containers][quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Array2", "043", "all", "[containers][quick]") {
       Array2<size_t, 3> rry;
       rry.fill(10);
       REQUIRE(std::vector<size_t>(rry.cbegin(0), rry.cend(0))
@@ -1647,7 +1647,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("StaticTriVector2",
-                            "045",
+                            "044",
                             "all",
                             "[containers][quick]") {
       StaticTriVector2<size_t, 3> stv;

--- a/tests/test-forest.cpp
+++ b/tests/test-forest.cpp
@@ -26,7 +26,7 @@
 namespace libsemigroups {
   struct LibsemigroupsException;
 
-  LIBSEMIGROUPS_TEST_CASE("Forest", "001", "test forest", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Forest", "000", "test forest", "[quick]") {
     Forest forest(100);
     REQUIRE(forest.number_of_nodes() == 100);
     for (size_t i = 1; i < 100; ++i) {

--- a/tests/test-freeband.cpp
+++ b/tests/test-freeband.cpp
@@ -31,7 +31,7 @@ namespace libsemigroups {
   // count_sort and radix_sort functions.
   /*
   LIBSEMIGROUPS_TEST_CASE("Test right and left",
-                          "001",
+                          "000",
                           "",
                           "[freeband][quick]") {
     word_type w = {0, 0, 0, 0, 1, 1, 0, 0, 2};
@@ -60,7 +60,7 @@ namespace libsemigroups {
             {4, 4, 5, 7, 8, 9, UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Test radix_sort", "002", "", "[freeband][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Test radix_sort", "001", "", "[freeband][quick]") {
     std::vector<word_type> level_edges = {{0, 0, 0, 0},
                                           {0, 1, 1, 0},
                                           {0, 2, 2, 0},
@@ -117,7 +117,7 @@ namespace libsemigroups {
   }
   */
 
-  LIBSEMIGROUPS_TEST_CASE("freeband_equal_to", "001", "", "[freeband][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("freeband_equal_to", "002", "", "[freeband][quick]") {
     REQUIRE(freeband_equal_to({}, {}));
     REQUIRE(!freeband_equal_to({0, 0}, {}));
     REQUIRE(!freeband_equal_to({}, {0}));

--- a/tests/test-froidure-pin-bmat.cpp
+++ b/tests/test-froidure-pin-bmat.cpp
@@ -91,7 +91,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "007",
+                                   "006",
                                    "regular bmat monoid 4",
                                    "[quick][froidure-pin][bmat][no-valgrind]",
                                    BMat<4>,
@@ -111,7 +111,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "009",
+                                   "007",
                                    "small example 2",
                                    "[quick][froidure-pin][bmat]",
                                    BMat<3>,
@@ -149,7 +149,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "011",
+                                   "008",
                                    "small example 3",
                                    "[quick][froidure-pin][bmat]",
                                    BMat<4>,
@@ -164,7 +164,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "013",
+                                   "009",
                                    "Clark generators",
                                    "[extreme][froidure-pin][bmat]",
                                    BMat<40>,

--- a/tests/test-froidure-pin-bmat8.cpp
+++ b/tests/test-froidure-pin-bmat8.cpp
@@ -39,7 +39,7 @@ namespace libsemigroups {
 #if (LIBSEMIGROUPS_SIZEOF_VOID_P == 8)
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin",
-                          "015",
+                          "010",
                           "regular boolean mat monoid 4 - BMat8",
                           "[quick][froidure-pin][bmat8][no-valgrind]") {
     auto               rg = ReportGuard(false);
@@ -234,7 +234,7 @@ namespace libsemigroups {
 #endif
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin",
-                          "016",
+                          "011",
                           "exception zero generators given - BMat8",
                           "[quick][froidure-pin][bmat8]") {
     std::vector<BMat8> gens;
@@ -243,7 +243,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin",
-                          "017",
+                          "012",
                           "exception to_element - BMat8",
                           "[quick][froidure-pin][bmat8]") {
     std::vector<BMat8> gens
@@ -262,7 +262,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin",
-                          "018",
+                          "013",
                           "exception prefix - BMat8",
                           "[quick][froidure-pin][bmat8][no-valgrind]") {
     std::vector<BMat8> gens
@@ -278,7 +278,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin",
-                          "020",
+                          "014",
                           "exception first_letter - BMat8",
                           "[quick][froidure-pin][bmat8][no-valgrind]") {
     std::vector<BMat8> gens
@@ -294,7 +294,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin",
-                          "022",
+                          "015",
                           "exception current_length - BMat8",
                           "[quick][froidure-pin][bmat8][no-valgrind]") {
     std::vector<BMat8> gens
@@ -310,7 +310,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin",
-                          "023",
+                          "016",
                           "exception product_by_reduction - BMat8",
                           "[quick][froidure-pin][bmat8][no-valgrind]") {
     std::vector<BMat8> gens
@@ -335,7 +335,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin",
-                          "024",
+                          "017",
                           "exception fast_product - BMat8",
                           "[quick][froidure-pin][bmat8][024]") {
     std::vector<BMat8> gens
@@ -357,7 +357,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin",
-                          "025",
+                          "018",
                           "exception is_idempotent - BMat8",
                           "[quick][froidure-pin][bmat8][no-valgrind]") {
     auto S = make<FroidurePin>(
@@ -392,7 +392,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin",
-                          "026",
+                          "019",
                           "copy constructor - BMat8",
                           "[quick][froidure-pin][bmat8][no-valgrind]") {
     auto rg = ReportGuard(false);
@@ -420,7 +420,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin",
-                          "027",
+                          "020",
                           "cbegin/end_rules - BMat8",
                           "[quick][froidure-pin][bmat8]") {
     FroidurePin<BMat8> S;

--- a/tests/test-froidure-pin-integers.cpp
+++ b/tests/test-froidure-pin-integers.cpp
@@ -78,7 +78,7 @@ namespace libsemigroups {
   };
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin",
-                          "031",
+                          "021",
                           "uint32_t/uint8_t",
                           "[quick][froidure-pin][integers]") {
     auto                  rg = ReportGuard(false);

--- a/tests/test-froidure-pin-intmat.cpp
+++ b/tests/test-froidure-pin-intmat.cpp
@@ -35,7 +35,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "FroidurePin",
-      "032",
+      "022",
       "Example 000",
       "[quick][froidure-pin][intmat][no-sanitize-undefined]",
       (IntMat<0, 0, int64_t>),
@@ -89,7 +89,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "034",
+                                   "023",
                                    "Example 001",
                                    "[quick][froidure-pin][intmat]",
                                    (IntMat<0, 0, int64_t>),
@@ -123,7 +123,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "036",
+                                   "024",
                                    "exception: current_position",
                                    "[quick][froidure-pin][element]",
                                    IntMat<2>,
@@ -146,7 +146,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "037",
+                                   "025",
                                    "exception: to_element",
                                    "[quick][froidure-pin][element]",
                                    IntMat<2>,
@@ -166,7 +166,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "FroidurePin",
-      "038",
+      "026",
       "exception: prefix, suffix, first_letter",
       "[quick][froidure-pin][element][no-valgrind]",
       IntMat<2>,

--- a/tests/test-froidure-pin-intpairs.cpp
+++ b/tests/test-froidure-pin-intpairs.cpp
@@ -109,7 +109,7 @@ namespace libsemigroups {
   static_assert(!std::is_trivial<IntPair>::value, "IntPair is not non-trivial");
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin",
-                          "039",
+                          "027",
                           "(pairs of integers) non-trivial user type",
                           "[quick][froidure-pin][intpairs][108]") {
     auto                 rg = ReportGuard(false);

--- a/tests/test-froidure-pin-matrix.cpp
+++ b/tests/test-froidure-pin-matrix.cpp
@@ -29,7 +29,7 @@ namespace libsemigroups {
   struct LibsemigroupsException;
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "040",
+                                   "028",
                                    "Example 000",
                                    "[quick][froidure-pin][matrix]",
                                    MaxPlusMat<2>,
@@ -71,7 +71,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "042",
+                                   "029",
                                    "Example 001",
                                    "[extreme][froidure-pin][matrix]",
                                    (NTPMat<0, 6, 3>),
@@ -95,7 +95,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "044",
+                                   "030",
                                    "Example 004",
                                    "[quick][froidure-pin][matrix]",
                                    MinPlusMat<>,
@@ -123,7 +123,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "046",
+                                   "031",
                                    "Example 005",
                                    "[quick][froidure-pin][matrix]",
                                    (MaxPlusTruncMat<33, 3>),
@@ -161,7 +161,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "049",
+                                   "032",
                                    "Example 006",
                                    "[quick][froidure-pin][matrix]",
                                    (MinPlusTruncMat<11, 3>),
@@ -197,7 +197,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "052",
+                                   "033",
                                    "Example 007",
                                    "[quick][froidure-pin][matrix]",
                                    (NTPMat<11, 3>),

--- a/tests/test-froidure-pin-maxplustrunc.cpp
+++ b/tests/test-froidure-pin-maxplustrunc.cpp
@@ -106,7 +106,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin",
-                          "055",
+                          "034",
                           "(tropical max-plus semiring matrices)",
                           "[quick][froidure-pin][tropmaxplus]") {
     auto rg = ReportGuard(false);

--- a/tests/test-froidure-pin-pbr.cpp
+++ b/tests/test-froidure-pin-pbr.cpp
@@ -32,7 +32,7 @@ namespace libsemigroups {
 namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<PBR>",
-                          "056",
+                          "035",
                           "example 1",
                           "[quick][froidure-pin][pbr]") {
     auto             rg   = ReportGuard(false);
@@ -125,7 +125,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<PBR>",
-                          "057",
+                          "036",
                           "example 2",
                           "[quick][froidure-pin][pbr]") {
     auto rg = ReportGuard(false);

--- a/tests/test-froidure-pin-pperm.cpp
+++ b/tests/test-froidure-pin-pperm.cpp
@@ -31,7 +31,7 @@ namespace libsemigroups {
   struct LibsemigroupsException;
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<PPerm<>>",
-                          "058",
+                          "037",
                           "",
                           "[quick][froidure-pin][pperm]") {
     auto rg = ReportGuard(false);
@@ -77,7 +77,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<PPerm<>>",
-                          "059",
+                          "038",
                           "",
                           "[quick][froidure-pin][pperm]") {
     auto                 rg = ReportGuard(false);
@@ -119,7 +119,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<PPerm<>>",
-                          "060",
+                          "039",
                           "exceptions: add_generator(s)",
                           "[quick][froidure-pin][pperm]") {
     FroidurePin<PPerm<>> S;

--- a/tests/test-froidure-pin-projmaxplus.cpp
+++ b/tests/test-froidure-pin-projmaxplus.cpp
@@ -29,7 +29,7 @@ namespace libsemigroups {
   struct LibsemigroupsException;
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "061",
+                                   "040",
                                    "example 1",
                                    "[quick][froidure-pin][projmaxplus]",
                                    ProjMaxPlusMat<3>,
@@ -75,7 +75,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("FroidurePin",
-                                   "062",
+                                   "041",
                                    "example 2",
                                    "[quick][froidure-pin][element]",
                                    ProjMaxPlusMat<3>,

--- a/tests/test-froidure-pin-transf.cpp
+++ b/tests/test-froidure-pin-transf.cpp
@@ -78,7 +78,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "FroidurePin",
-      "063",
+      "042",
       "JDM favourite",
       "[standard][froidure-pin][transformation][transf]",
       TRANSF_TYPES) {
@@ -130,7 +130,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "FroidurePin",
-      "065",
+      "043",
       "no exception zero generators given",
       "[quick][froidure-pin][transformation][transf]",
       Transf<>,
@@ -142,7 +142,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "FroidurePin",
-      "066",
+      "044",
       "exception generators of different degrees",
       "[quick][froidure-pin][transformation][transf]",
       Transf<>,
@@ -158,7 +158,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "067",
+                          "045",
                           "exception current_position",
                           "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(false);
@@ -176,7 +176,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "068",
+                          "046",
                           "exception to_element",
                           "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(false);
@@ -198,7 +198,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "069",
+                          "047",
                           "exception gens",
                           "[quick][froidure-pin][transformation][transf]") {
     auto rg = ReportGuard(false);
@@ -223,7 +223,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "070",
+                          "048",
                           "exception prefix",
                           "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(false);
@@ -239,7 +239,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "071",
+                          "049",
                           "exception suffix",
                           "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(false);
@@ -258,7 +258,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "072",
+                          "050",
                           "exception first_letter",
                           "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(false);
@@ -274,7 +274,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "073",
+                          "051",
                           "exception final_letter",
                           "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(false);
@@ -290,7 +290,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "074",
+                          "052",
                           "exception current_length",
                           "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(false);
@@ -306,7 +306,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "075",
+                          "053",
                           "exception product_by_reduction",
                           "[quick][froidure-pin][transformation][transf]") {
     auto                  rg = ReportGuard(false);
@@ -331,7 +331,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "076",
+                          "054",
                           "exception fast_product",
                           "[quick][froidure-pin][transformation][transf]") {
     auto                  rg = ReportGuard(false);
@@ -353,7 +353,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "077",
+                          "055",
                           "exception current_position",
                           "[quick][froidure-pin][transformation][transf]") {
     auto rg = ReportGuard(false);
@@ -378,7 +378,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "078",
+                          "056",
                           "exception is_idempotent",
                           "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(false);
@@ -398,7 +398,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "079",
+                          "057",
                           "exception add_generators",
                           "[quick][froidure-pin][transformation][transf]") {
     auto                  rg   = ReportGuard(false);
@@ -419,7 +419,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "080",
+                          "058",
                           "number_of_idempotents",
                           "[quick][froidure-pin][transformation][transf]") {
     auto                  rg = ReportGuard(false);
@@ -430,7 +430,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "081",
+                          "059",
                           "small semigroup",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -458,7 +458,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "082",
+                          "060",
                           "large semigroup",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto rg = ReportGuard(false);
@@ -479,7 +479,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "083",
+                          "061",
                           "at, position, current_*",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto rg = ReportGuard(false);
@@ -522,7 +522,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "084",
+                          "062",
                           "run",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -558,7 +558,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "085",
+                          "063",
                           "run [many stops and starts]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto rg = ReportGuard(false);
@@ -584,7 +584,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "086",
+                          "064",
                           "factorisation, length [1 element]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -614,7 +614,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "087",
+                          "065",
                           "factorisation, products [all elements]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -636,7 +636,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "088",
+                          "066",
                           "first/final letter, prefix, suffix, products",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -734,7 +734,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "089",
+                          "067",
                           "current_position [standard]",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -753,7 +753,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "090",
+                          "068",
                           "current_position [duplicate gens]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -807,7 +807,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "091",
+                          "069",
                           "current_position [after add_generators]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -856,7 +856,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "092",
+                          "070",
                           "cbegin_idempotents/cend [1 thread]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -876,7 +876,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "093",
+                          "071",
                           "idempotent_cend/cbegin [1 thread]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -897,7 +897,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "094",
+                          "072",
                           "is_idempotent [1 thread]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -919,7 +919,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "FroidurePin<Transf>",
-      "095",
+      "073",
       "cbegin_idempotents/cend, is_idempotent [2 threads]",
       "[standard][froidure-pin][transf][multithread][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -947,7 +947,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "096",
+                          "074",
                           "finished, started",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -972,7 +972,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "097",
+                          "075",
                           "current_position",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -1015,7 +1015,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "098",
+                          "076",
                           "sorted_position, sorted_at",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1069,7 +1069,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "099",
+                          "077",
                           "right/left Cayley graph",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1098,7 +1098,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "100",
+                          "078",
                           "iterator",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1158,7 +1158,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "101",
+                          "079",
                           "reverse iterator",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1226,7 +1226,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "102",
+                          "080",
                           "iterator arithmetic",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1279,7 +1279,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "103",
+                          "081",
                           "iterator sorted",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1330,7 +1330,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "104",
+                          "082",
                           "iterator sorted arithmetic",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1383,7 +1383,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "105",
+                          "083",
                           "copy [not enum.]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1424,7 +1424,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "106",
+                          "084",
                           "copy_closure [not enum.]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1486,7 +1486,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "107",
+                          "085",
                           "copy_add_generators [not enum.]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1547,7 +1547,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "108",
+                          "086",
                           "copy [partly enum.]",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -1588,7 +1588,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "109",
+                          "087",
                           "copy_closure [partly enum.]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1628,7 +1628,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "110",
+                          "088",
                           "copy_add_generators [partly enum.]",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -1667,7 +1667,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "111",
+                          "089",
                           "copy [fully enum.]",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -1697,7 +1697,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "112",
+                          "090",
                           "copy_closure [fully enum.]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1736,7 +1736,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "113",
+                          "091",
                           "copy_add_generators [fully enum.]",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -1774,7 +1774,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "114",
+                          "092",
                           "rules [duplicate gens]",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -1804,7 +1804,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "115",
+                          "093",
                           "rules",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1843,7 +1843,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "116",
+                          "094",
                           "rules [copy_closure, duplicate gens]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1878,7 +1878,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "117",
+                          "095",
                           "rules [copy_add_generators, duplicate gens]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1913,7 +1913,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "118",
+                          "096",
                           "rules [from copy, not enum.]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1936,7 +1936,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "119",
+                          "097",
                           "rules [from copy, partly enum.]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1963,7 +1963,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "120",
+                          "098",
                           "rules [from copy, fully enum.]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -1991,7 +1991,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "121",
+                          "099",
                           "rules [from copy_closure, not enum.]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -2019,7 +2019,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "122",
+                          "100",
                           "rules [from copy_add_generators, not enum.]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -2044,7 +2044,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "123",
+                          "101",
                           "rules [from copy_closure, partly enum.]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -2067,7 +2067,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "124",
+                          "102",
                           "rules [from copy_add_generators, partly enum.]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -2094,7 +2094,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "125",
+                          "103",
                           "rules [from copy_closure, fully enum.]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -2119,7 +2119,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "126",
+                          "104",
                           "rules [from copy_add_generators, fully enum.]",
                           "[quick][froidure-pin][transf][no-valgrind]") {
     auto                  rg = ReportGuard(false);
@@ -2144,7 +2144,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "127",
+                          "105",
                           "add_generators [duplicate generators]",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -2208,7 +2208,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "128",
+                          "106",
                           "add_generators [incremental 1]",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -2240,7 +2240,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "129",
+                          "107",
                           "add_generators [incremental 2]",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -2290,7 +2290,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "130",
+                          "108",
                           "closure [duplicate generators]",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -2335,7 +2335,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "131",
+                          "109",
                           "closure ",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -2359,7 +2359,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "132",
+                          "110",
                           "factorisation ",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -2371,7 +2371,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "133",
+                          "111",
                           "my favourite example with reserve",
                           "[standard][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -2390,7 +2390,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "134",
+                          "112",
                           "minimal_factorisation ",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -2411,7 +2411,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "135",
+                          "113",
                           "batch_size (for an extremely large value)",
                           "[quick][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -2426,7 +2426,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "136",
+                          "114",
                           "my favourite example without reserve",
                           "[standard][froidure-pin][transf]") {
     auto                  rg = ReportGuard(false);
@@ -2444,7 +2444,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "137",
+                          "115",
                           "exception: generators of different degrees",
                           "[quick][froidure-pin][transf]") {
     REQUIRE_THROWS_AS(make<FroidurePin>({Transf<>({0, 1, 2, 3, 4, 5}),
@@ -2453,7 +2453,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "138",
+                          "116",
                           "exception: current_position",
                           "[quick][froidure-pin][transf]") {
     FroidurePin<Transf<>> U;
@@ -2470,7 +2470,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "139",
+                          "117",
                           "exception: to_element",
                           "[quick][froidure-pin][transf]") {
     FroidurePin<Transf<>> U;
@@ -2489,7 +2489,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "140",
+                          "118",
                           "exception: gens, current_position",
                           "[quick][froidure-pin][transf]") {
     using point_type = typename Transf<>::point_type;
@@ -2514,7 +2514,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
-                          "141",
+                          "119",
                           "exception: add_generators",
                           "[quick][froidure-pin][transf]") {
     FroidurePin<Transf<>> S;

--- a/tests/test-gabow.cpp
+++ b/tests/test-gabow.cpp
@@ -238,7 +238,7 @@ namespace libsemigroups {
   // }
 
   LIBSEMIGROUPS_TEST_CASE("Gabow",
-                          "009",
+                          "007",
                           "large cycle",
                           "[quick][gabow][no-valgrind]") {
     WordGraph<size_t> wg;
@@ -257,7 +257,7 @@ namespace libsemigroups {
              | all_of([&scc](node_type i) { return scc.id(i) == 1; })));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Gabow", "010", "component", "[quick][gabow]") {
+  LIBSEMIGROUPS_TEST_CASE("Gabow", "008", "component", "[quick][gabow]") {
     using node_type = decltype(clique(1))::node_type;
 
     for (size_t n = 10; n < 512; n *= 4) {
@@ -310,7 +310,7 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Gabow", "011", "root of scc", "[quick][gabow]") {
+  LIBSEMIGROUPS_TEST_CASE("Gabow", "009", "root of scc", "[quick][gabow]") {
     auto wg = clique(10);
     for (size_t n = 0; n < 99; ++n) {
       add_clique(wg, 10);
@@ -333,7 +333,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Gabow",
-                          "012",
+                          "010",
                           "reverse_spanning_forest",
                           "[quick][gabow]") {
     auto wg = make<WordGraph<size_t>>(
@@ -345,7 +345,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Gabow",
-                          "013",
+                          "011",
                           "to_human_readable_repr",
                           "[quick][gabow]") {
     auto wg = make<WordGraph<size_t>>(

--- a/tests/test-iterator.cpp
+++ b/tests/test-iterator.cpp
@@ -40,7 +40,7 @@ namespace libsemigroups {
     using EqualTo = TestEqualTo;
   };
 
-  LIBSEMIGROUPS_TEST_CASE("ConstIteratorStateless", "001", "?", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ConstIteratorStateless", "000", "?", "[quick]") {
     std::vector<size_t> vec(10, 0);
 
     auto it1
@@ -55,7 +55,7 @@ namespace libsemigroups {
     REQUIRE(it3 != it2);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("ConstIteratorStateless", "002", "?", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("ConstIteratorStateless", "001", "?", "[quick]") {
     std::vector<size_t> vec(10, 0);
 
     auto it1 = detail::ConstIteratorStateless<IteratorTraitsCustomTypes1>(

--- a/tests/test-kambites.cpp
+++ b/tests/test-kambites.cpp
@@ -188,7 +188,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "002",
+                                   "001",
                                    "number_of_pieces",
                                    "[quick][kambites]",
                                    MultiStringView,
@@ -248,7 +248,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "004",
+                                   "002",
                                    "small_overlap_class",
                                    "[quick][kambites]",
                                    MultiStringView,
@@ -277,7 +277,7 @@ namespace libsemigroups {
 
   // TODO(1) split into multiple tests
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "006",
+                                   "003",
                                    "random",
                                    "[quick][kambites]",
                                    MultiStringView,
@@ -421,7 +421,7 @@ namespace libsemigroups {
   ////////////////////////////////////////////////////////////////////////
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "008",
+                                   "004",
                                    "KnuthBendix 055",
                                    "[quick][kambites][no-valgrind]",
                                    std::string,
@@ -476,7 +476,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "010",
+                                   "005",
                                    "smalloverlap/gap/test.gi:85",
                                    "[quick][kambites]",
                                    std::string,
@@ -508,7 +508,7 @@ namespace libsemigroups {
   ////////////////////////////////////////////////////////////////////////
 
   LIBSEMIGROUPS_TEST_CASE("Kambites",
-                          "012",
+                          "006",
                           "free semigroup",
                           "[quick][kambites]") {
     {
@@ -527,7 +527,7 @@ namespace libsemigroups {
   ////////////////////////////////////////////////////////////////////////
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "013",
+                                   "007",
                                    "smalloverlap/gap/test.gi:49",
                                    "[quick][kambites][no-valgrind]",
                                    std::string,
@@ -593,7 +593,7 @@ namespace libsemigroups {
   ////////////////////////////////////////////////////////////////////////
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "015",
+                                   "008",
                                    "smalloverlap/gap/test.gi:63",
                                    "[quick][kambites][no-valgrind]",
                                    std::string,
@@ -621,7 +621,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "017",
+                                   "009",
                                    "smalloverlap/gap/test.gi:70",
                                    "[quick][kambites][no-valgrind]",
                                    std::string,
@@ -651,7 +651,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "019",
+                                   "010",
                                    "smalloverlap/gap/test.gi:77",
                                    "[standard][kambites]",
                                    std::string,
@@ -705,7 +705,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "021",
+                                   "011",
                                    "code coverage",
                                    "[quick][kambites]",
                                    std::string,
@@ -723,7 +723,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "023",
+                                   "012",
                                    "Ex. 3.13 + 3.14 - prefix",
                                    "[quick][kambites]",
                                    std::string,
@@ -746,7 +746,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "025",
+                                   "013",
                                    "normal_form (Example 3.15)",
                                    "[quick][kambites]",
                                    std::string,
@@ -775,7 +775,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "027",
+                                   "014",
                                    "normal_form (Example 3.16) ",
                                    "[quick][kambites]",
                                    std::string,
@@ -797,7 +797,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "029",
+                                   "015",
                                    "normal_form (Example 3.16) more exhaustive",
                                    "[quick][kambites][no-valgrind]",
                                    std::string,
@@ -837,7 +837,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "031",
+                                   "016",
                                    "small presentation",
                                    "[quick][kambites]",
                                    std::string,
@@ -863,7 +863,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "033",
+                                   "017",
                                    "non-smalloverlap",
                                    "[quick][kambites]",
                                    std::string,
@@ -888,7 +888,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "035",
+                                   "018",
                                    "MT test 3",
                                    "[quick][kambites]",
                                    std::string,
@@ -931,7 +931,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "037",
+                                   "019",
                                    "MT test 5",
                                    "[quick][kambites]",
                                    std::string,
@@ -949,7 +949,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "039",
+                                   "020",
                                    "MT test 6",
                                    "[quick][kambites]",
                                    std::string,
@@ -969,7 +969,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "041",
+                                   "021",
                                    "MT test 10",
                                    "[quick][kambites]",
                                    std::string,
@@ -988,7 +988,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "043",
+                                   "022",
                                    "MT test 13",
                                    "[quick][kambites]",
                                    std::string,
@@ -1005,7 +1005,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "045",
+                                   "023",
                                    "MT test 14",
                                    "[quick][kambites]",
                                    std::string,
@@ -1022,7 +1022,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "047",
+                                   "024",
                                    "MT test 15",
                                    "[quick][kambites]",
                                    std::string,
@@ -1041,7 +1041,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "049",
+                                   "025",
                                    "MT test 16",
                                    "[quick][kambites]",
                                    std::string,
@@ -1059,7 +1059,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "051",
+                                   "026",
                                    "MT test 17",
                                    "[quick][kambites]",
                                    std::string,
@@ -1082,7 +1082,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "053",
+                                   "027",
                                    "weak C(4) not strong x 1",
                                    "[quick][kambites]",
                                    std::string,
@@ -1113,7 +1113,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "055",
+                                   "028",
                                    "weak C(4) not strong x 2",
                                    "[quick][kambites]",
                                    std::string,
@@ -1139,7 +1139,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "057",
+                                   "029",
                                    "weak C(4) not strong x 3",
                                    "[quick][kambites]",
                                    std::string,
@@ -1164,7 +1164,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "059",
+                                   "030",
                                    "weak C(4) not strong x 4",
                                    "[quick][kambites]",
                                    std::string,
@@ -1188,7 +1188,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "061",
+                                   "031",
                                    "weak C(4) not strong x 5",
                                    "[quick][kambites]",
                                    std::string,
@@ -1202,7 +1202,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "063",
+                                   "032",
                                    "weak C(4) not strong x 6",
                                    "[quick][kambites]",
                                    std::string,
@@ -1217,7 +1217,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "065",
+                                   "033",
                                    "Konovalov example",
                                    "[quick][kambites]",
                                    std::string,
@@ -1232,7 +1232,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "067",
+                                   "034",
                                    "long words",
                                    "[quick][kambites][no-valgrind]",
                                    std::string,
@@ -1289,7 +1289,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Kambites",
-                          "069",
+                          "035",
                           "almost all 2-generated 1-relation monoids are C(4)",
                           "[quick][kambites][no-valgrind]") {
     auto x = count_2_gen_1_rel<std::string>(1, 7);
@@ -1299,7 +1299,7 @@ namespace libsemigroups {
 
   // Takes approx 5s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Kambites",
-                                   "070",
+                                   "036",
                                    "almost all 2-gen. 1-rel. monoids are C(4)",
                                    "[extreme][kambites]",
                                    std::string,
@@ -1311,7 +1311,7 @@ namespace libsemigroups {
 
   // Takes approx. 21s
   LIBSEMIGROUPS_TEST_CASE("Kambites",
-                          "071",
+                          "037",
                           "almost all 2-gen. 1-rel. monoids are C(4)",
                           "[extreme][kambites]") {
     auto x = count_2_gen_1_rel<std::string>(1, 12);
@@ -1320,7 +1320,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Kambites",
-                          "072",
+                          "038",
                           "almost all 2-gen. 1-rel. monoids are C(4)",
                           "[fail][kambites]") {
     auto x = count_2_gen_1_rel<std::string>(1, 13);
@@ -1330,7 +1330,7 @@ namespace libsemigroups {
 
   // Takes about 1m45s
   LIBSEMIGROUPS_TEST_CASE("Kambites",
-                          "073",
+                          "039",
                           "almost all 2-gen. 1-relation monoids are C(4)",
                           "[extreme][kambites]") {
     std::cout.precision(10);
@@ -1359,7 +1359,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Kambites",
-                          "079",
+                          "040",
                           "normal form possible bug",
                           "[quick][kambites]") {
     // There was a bug in MultiStringView::append, that caused this
@@ -2119,7 +2119,7 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Kambites", "075", "example 1", "[quick][kambites]") {
+  LIBSEMIGROUPS_TEST_CASE("Kambites", "041", "example 1", "[quick][kambites]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
@@ -2134,7 +2134,7 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(contains(k, 00_w, 0_w), LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Kambites", "076", "example 2", "[quick][kambites]") {
+  LIBSEMIGROUPS_TEST_CASE("Kambites", "042", "example 2", "[quick][kambites]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(7);
@@ -2173,7 +2173,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Kambites",
-                          "077",
+                          "043",
                           "code coverage",
                           "[quick][kambites][no-valgrind]") {
     Presentation<word_type> p;
@@ -2200,7 +2200,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Kambites",
-                          "078",
+                          "044",
                           "large number of rules",
                           "[quick][kambites][no-valgrind]") {
     auto S = make<FroidurePin>({LeastTransf<6>({1, 2, 3, 4, 5, 0}),
@@ -2216,7 +2216,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Kambites",
-                          "074",
+                          "045",
                           "code coverage for constructors/init",
                           "[quick][kambites]") {
     Kambites k;
@@ -2284,7 +2284,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Kambites",
-                          "080",
+                          "046",
                           "to_human_readable_repr",
                           "[quick][kambites]") {
     Presentation<std::string> p;

--- a/tests/test-knuth-bendix-2.cpp
+++ b/tests/test-knuth-bendix-2.cpp
@@ -89,7 +89,7 @@ namespace libsemigroups {
   // Fibonacci group F(2,5) - monoid presentation - has order 12 (group
   // elements + empty word)
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "033",
+                                   "027",
                                    "kbmag/standalone/kb_data/f25monoid",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    REWRITER_TYPES) {
@@ -159,7 +159,7 @@ namespace libsemigroups {
   // trivial group - BHN presentation
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "KnuthBendix",
-      "034",
+      "028",
       "kbmag/standalone/kb_data/degen4a",
       "[quick][knuth-bendix][kbmag][shortlex][no-valgrind]",
       REWRITER_TYPES) {
@@ -199,7 +199,7 @@ namespace libsemigroups {
 
   // Torus group
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "035",
+                                   "029",
                                    "kbmag/standalone/kb_data/torus",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    REWRITER_TYPES) {
@@ -252,7 +252,7 @@ namespace libsemigroups {
   //  3-fold cover of A_6
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "KnuthBendix",
-      "036",
+      "030",
       "kbmag/standalone/kb_data/3a6",
       "[quick][knuth-bendix][kbmag][shortlex][no-valgrind]",
       REWRITER_TYPES) {
@@ -311,7 +311,7 @@ namespace libsemigroups {
 
   //  Free group on 2 generators
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "037",
+                                   "031",
                                    "kbmag/standalone/kb_data/f2",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    REWRITER_TYPES) {
@@ -356,7 +356,7 @@ namespace libsemigroups {
   // Symmetric group S_16
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "KnuthBendix",
-      "038",
+      "032",
       "kbmag/standalone/kb_data/s16",
       "[quick][knuth-bendix][kbmag][shortlex][no-valgrind]",
       REWRITER_TYPES) {
@@ -622,7 +622,7 @@ namespace libsemigroups {
   // Presentation of group A_4 regarded as monoid presentation - gives
   // infinite monoid.
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "039",
+                                   "033",
                                    "kbmag/standalone/kb_data/a4monoid",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    REWRITER_TYPES) {
@@ -659,7 +659,7 @@ namespace libsemigroups {
   // fairly clearly the trivial group
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "KnuthBendix",
-      "040",
+      "034",
       "kbmag/standalone/kb_data/degen3",
       "[quick][knuth-bendix][kbmag][shortlex][no-valgrind]",
       REWRITER_TYPES) {
@@ -690,7 +690,7 @@ namespace libsemigroups {
 
   // infinite cyclic group
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "041",
+                                   "035",
                                    "kbmag/standalone/kb_data/ab1",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    REWRITER_TYPES) {
@@ -712,7 +712,7 @@ namespace libsemigroups {
 
   // A generator, but trivial.
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "042",
+                                   "036",
                                    "kbmag/standalone/kb_data/degen2",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    REWRITER_TYPES) {
@@ -738,7 +738,7 @@ namespace libsemigroups {
 
   // Fibonacci group F(2,5)
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "043",
+                                   "037",
                                    "kbmag/standalone/kb_data/f25",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    REWRITER_TYPES) {
@@ -796,7 +796,7 @@ namespace libsemigroups {
 
   // Von Dyck (2,3,7) group - infinite hyperbolic
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "044",
+                                   "038",
                                    "kbmag/standalone/kb_data/237",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    REWRITER_TYPES) {
@@ -855,7 +855,7 @@ namespace libsemigroups {
 
   // Cyclic group of order 2.
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "045",
+                                   "039",
                                    "kbmag/standalone/kb_data/c2",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    REWRITER_TYPES) {
@@ -881,7 +881,7 @@ namespace libsemigroups {
   // The group is S_4, and the subgroup H of order 4. There are 30 reduced
   // words - 24 for the group elements, and 6 for the 6 cosets Hg.
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "046",
+                                   "040",
                                    "kbmag/standalone/kb_data/cosets",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    REWRITER_TYPES) {
@@ -937,7 +937,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "047",
+                                   "041",
                                    "Ex. 5.1 in Sims (KnuthBendix 09 again)",
                                    "[quick][knuth-bendix]",
                                    REWRITER_TYPES) {
@@ -962,7 +962,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "048",
+                                   "042",
                                    "kbmag/standalone/kb_data/nilp2",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    REWRITER_TYPES) {
@@ -982,7 +982,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "049",
+                                   "043",
                                    "Ex. 6.4 in Sims",
                                    "[quick][knuth-bendix][no-valgrind]",
                                    REWRITER_TYPES) {
@@ -1024,7 +1024,7 @@ namespace libsemigroups {
   // Von Dyck (2,3,7) group - infinite hyperbolic
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "KnuthBendix",
-      "050",
+      "044",
       "KnuthBendix 071 again",
       "[no-valgrind][quick][knuth-bendix][shortlex]",
       REWRITER_TYPES) {
@@ -1099,7 +1099,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "051",
+                                   "045",
                                    "Sims Ex. 5.4 - alt. overlap policy",
                                    "[quick][knuth-bendix]",
                                    REWRITER_TYPES) {
@@ -1142,7 +1142,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "052",
+                                   "046",
                                    "Sims - Ex. 5.4 - alt. overlap policy",
                                    "[quick][knuth-bendix]",
                                    REWRITER_TYPES) {
@@ -1172,7 +1172,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "053",
+                                   "047",
                                    "operator<<",
                                    "[quick][knuth-bendix]",
                                    REWRITER_TYPES) {
@@ -1198,7 +1198,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "054",
+                                   "048",
                                    "confluence_interval",
                                    "[quick][knuth-bendix]",
                                    REWRITER_TYPES) {
@@ -1215,7 +1215,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "055",
+                                   "049",
                                    "max_overlap",
                                    "[quick][knuth-bendix]",
                                    REWRITER_TYPES) {
@@ -1235,7 +1235,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "KnuthBendix",
-      "056",
+      "050",
       "kbmag/standalone/kb_data/d22",
       "[quick][knuth-bendix][fpsemi][kbmag][shortlex]",
       REWRITER_TYPES) {
@@ -1271,7 +1271,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "KnuthBendix",
-      "057",
+      "051",
       "kbmag/standalone/kb_data/d22",
       "[quick][knuth-bendix][fpsemi][kbmag][shortlex]",
       REWRITER_TYPES) {
@@ -1298,7 +1298,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "058",
+                                   "052",
                                    "small example",
                                    "[quick][knuth-bendix][shortlex]",
                                    REWRITER_TYPES) {
@@ -1318,7 +1318,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "059",
+                                   "053",
                                    "code coverage",
                                    "[quick]",
                                    REWRITER_TYPES) {
@@ -1334,7 +1334,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "060",
+                                   "054",
                                    "small overlap 1",
                                    "[quick]",
                                    REWRITER_TYPES) {
@@ -1369,7 +1369,7 @@ namespace libsemigroups {
 
   // Symmetric group S_9
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "061",
+                                   "055",
                                    "kbmag/standalone/kb_data/s9",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    REWRITER_TYPES) {
@@ -1419,7 +1419,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "062",
+                                   "056",
                                    "C(4) monoid",
                                    "[quick][knuth-bendix]",
                                    REWRITER_TYPES) {
@@ -1434,7 +1434,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "063",
+                                   "057",
                                    "1-relation hard case",
                                    "[fail][knuth-bendix]",
                                    REWRITER_TYPES) {
@@ -1452,7 +1452,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "064",
+                                   "058",
                                    "1-relation hard case x 2",
                                    "[quick][knuth-bendix][no-valgrind]",
                                    REWRITER_TYPES) {
@@ -1515,7 +1515,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "065",
+                                   "059",
                                    "search for a monoid that might not exist",
                                    "[quick][knuth-bendix]",
                                    REWRITER_TYPES) {
@@ -1553,7 +1553,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "066",
+                                   "060",
                                    "Chinese monoid",
                                    "[knuth-bendix][quick][no-valgrind]",
                                    REWRITER_TYPES) {
@@ -1575,7 +1575,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "067",
+                                   "061",
                                    "hypostylic",
                                    "[todd-coxeter][quick]",
                                    REWRITER_TYPES) {
@@ -1612,7 +1612,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "068",
+                                   "062",
                                    "Chinese id monoid",
                                    "[todd-coxeter][quick]",
                                    REWRITER_TYPES) {
@@ -1632,7 +1632,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "069",
+                                   "063",
                                    "sigma sylvester monoid",
                                    "[todd-coxeter][quick][no-valgrind]",
                                    REWRITER_TYPES) {
@@ -1769,7 +1769,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "070",
+                                   "064",
                                    "Reinis MFE",
                                    "[todd-coxeter][quick]",
                                    REWRITER_TYPES) {
@@ -1785,7 +1785,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "071",
+                                   "065",
                                    "sigma sylvester monoid x 2",
                                    "[todd-coxeter][quick]",
                                    REWRITER_TYPES) {

--- a/tests/test-knuth-bendix-3.cpp
+++ b/tests/test-knuth-bendix-3.cpp
@@ -82,7 +82,7 @@ namespace libsemigroups {
   }  // namespace
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "072",
+                                   "066",
                                    "Chap. 11, Lem. 1.8 (q = 6, r = 5) in NR",
                                    "[knuth-bendix][quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -131,7 +131,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "073",
+                                   "067",
                                    "NR Chap. 11, §2 (q=6, r=2, \u03B1=abaabba)",
                                    "[knuth-bendix][quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -157,7 +157,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "074",
+                                   "068",
                                    "Chap. 8, Thm. 4.2 in NR ",
                                    "[knuth-bendix][quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -197,7 +197,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "075",
+                                   "069",
                                    "equal_to fp semigroup",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -228,7 +228,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "076",
+                                   "070",
                                    "equal_to free semigroup",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -253,7 +253,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "077",
+                                   "071",
                                    "gap/smalloverlap/gap/test.gi",
                                    "[quick][knuth-bendix][smalloverlap]",
                                    KNUTH_BENDIX_TYPES) {
@@ -287,7 +287,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "078",
+                                   "072",
                                    "gap/smalloverlap/gap/test.gi:49",
                                    "[quick][knuth-bendix][smalloverlap]",
                                    KNUTH_BENDIX_TYPES) {
@@ -320,7 +320,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "079",
+                                   "073",
                                    "gap/smalloverlap/gap/test.gi:63",
                                    "[quick][knuth-bendix][smalloverlap]",
                                    KNUTH_BENDIX_TYPES) {
@@ -350,7 +350,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "080",
+                                   "074",
                                    "gap/smalloverlap/gap/test.gi:70",
                                    "[quick][knuth-bendix][smalloverlap]",
                                    KNUTH_BENDIX_TYPES) {
@@ -386,7 +386,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "KnuthBendix",
-      "081",
+      "075",
       "gap/smalloverlap/gap/test.gi:77",
       "[quick][knuth-bendix][smalloverlap][no-valgrind]",
       KNUTH_BENDIX_TYPES) {
@@ -420,7 +420,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "082",
+                                   "076",
                                    "gap/pkg/smalloverlap/gap/test.gi:85",
                                    "[quick][knuth-bendix][smalloverlap]",
                                    KNUTH_BENDIX_TYPES) {
@@ -447,7 +447,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "083",
+                                   "077",
                                    "Von Dyck (2,3,7) group",
                                    "[quick][knuth-bendix][kbmag]",
                                    KNUTH_BENDIX_TYPES) {
@@ -481,7 +481,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "084",
+                                   "078",
                                    "Von Dyck (2,3,7) group - alternate",
                                    "[no-valgrind][quick][knuth-bendix][kbmag]",
                                    KNUTH_BENDIX_TYPES) {
@@ -511,7 +511,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "085",
+                                   "079",
                                    "rewriting system from another test",
                                    "[quick][knuth-bendix][kbmag]",
                                    KNUTH_BENDIX_TYPES) {
@@ -566,7 +566,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "086",
+                                   "080",
                                    "rewriting system from Congruence 20",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -588,7 +588,7 @@ namespace libsemigroups {
   // 2-generator free abelian group (with this ordering KB terminates - but
   // no all)
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "087",
+                                   "081",
                                    "(from kbmag/standalone/kb_data/ab2)",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    KNUTH_BENDIX_TYPES) {
@@ -624,7 +624,7 @@ namespace libsemigroups {
   // with the commented out ordering, terminates almost immediately with the
   // uncommented order.
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "088",
+                                   "082",
                                    "kbmag/standalone/kb_data/d22",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    KNUTH_BENDIX_TYPES) {
@@ -700,7 +700,7 @@ namespace libsemigroups {
 
   // No generators - no anything!
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "089",
+                                   "083",
                                    "(from kbmag/standalone/kb_data/degen1)",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    KNUTH_BENDIX_TYPES) {
@@ -719,7 +719,7 @@ namespace libsemigroups {
 
   // Symmetric group S_4
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "090",
+                                   "084",
                                    "(from kbmag/standalone/kb_data/s4)",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    KNUTH_BENDIX_TYPES) {
@@ -755,7 +755,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "091",
+                                   "085",
                                    "fp semigroup",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -788,7 +788,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "092",
+                                   "086",
                                    "Chap. 11, Sec. 1 (q = 4, r = 3) in NR",
                                    "[knuth-bendix][quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -845,7 +845,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "093",
+                                   "087",
                                    "Chap. 11, Sec. 1 (q = 8, r = 5) in NR",
                                    "[no-valgrind][knuth-bendix][quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -898,7 +898,7 @@ namespace libsemigroups {
 
   // See KBFP 07 also.
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "094",
+                                   "088",
                                    "Chap. 7, Thm. 3.9 in NR",
                                    "[no-valgrind][knuth-bendix][quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -923,7 +923,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "095",
+                                   "089",
                                    "F(2, 5) - Chap. 9, Sec. 1 in NR",
                                    "[knuth-bendix][quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -952,7 +952,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "096",
+                                   "090",
                                    "F(2, 6) - Chap. 9, Sec. 1 in NR",
                                    "[knuth-bendix][quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -983,7 +983,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "097",
+                                   "091",
                                    "Chap. 10, Sec. 4 in NR",
                                    "[knuth-bendix][quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -1012,7 +1012,7 @@ namespace libsemigroups {
   // should be 2. With exponent 3, the presentation defines the trivial group,
   // with exponent of 2, it defines the symmetric group as desired.
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "098",
+                                   "092",
                                    "Sym(5) - Chap. 3, Prop. 1.1 in NR",
                                    "[no-valgrind][knuth-bendix][quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -1051,7 +1051,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "099",
+                                   "093",
                                    "SL(2, 7) - Chap. 3, Prop. 1.5 in NR",
                                    "[no-valgrind][quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -1089,7 +1089,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "100",
+                                   "094",
                                    "bicyclic monoid",
                                    "[knuth-bendix][quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -1117,7 +1117,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "101",
+                                   "095",
                                    "plactic monoid of degree 2",
                                    "[knuth-bendix][quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -1148,7 +1148,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "102",
+                                   "096",
                                    "before Chap. 7, Prop. 1.1 in NR",
                                    "[knuth-bendix][quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -1173,7 +1173,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "103",
+                                   "097",
                                    "Chap. 7, Thm. 3.6 in NR",
                                    "[knuth-bendix][quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -1212,7 +1212,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "104",
+                                   "098",
                                    "finite semigroup",
                                    "[knuth-bendix][quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -1252,7 +1252,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "KnuthBendix",
-      "105",
+      "099",
       "Giles Gardam in \"A counterexample to the unit conjecture for group "
       "rings\" (https://arxiv.org/abs/2102.11818)",
       "[fail]",

--- a/tests/test-knuth-bendix-4.cpp
+++ b/tests/test-knuth-bendix-4.cpp
@@ -78,7 +78,7 @@ namespace libsemigroups {
 
   // Takes approx. 2s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "106",
+                                   "100",
                                    "Sims Ex. 6.6 (limited overlap lengths)",
                                    "[standard][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -112,7 +112,7 @@ namespace libsemigroups {
 
   // Takes approx. 2s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "107",
+                                   "101",
                                    "kbmag/standalone/kb_data/funny3",
                                    "[standard][knuth-bendix][kbmag][shortlex]",
                                    KNUTH_BENDIX_TYPES) {
@@ -153,7 +153,7 @@ namespace libsemigroups {
   // Takes approx. 10s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "KnuthBendix",
-      "108",
+      "102",
       "kbmag/standalone/kb_data/f27) (finite) (2 / 2",
       "[extreme][knuth-bendix][kbmag][shortlex]",
       KNUTH_BENDIX_TYPES) {
@@ -185,7 +185,7 @@ namespace libsemigroups {
   // Mathieu group M_11
   // Takes approx. 58s (majority in checking confluence)
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "109",
+                                   "103",
                                    "kbmag/standalone/kb_data/m11",
                                    "[extreme][knuth-bendix][kbmag][shortlex]",
                                    KNUTH_BENDIX_TYPES) {
@@ -231,7 +231,7 @@ namespace libsemigroups {
   // Weyl group E8 (all gens involutory).
   // Takes approx. 5s for KnuthBendix
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "110",
+                                   "104",
                                    "kbmag/standalone/kb_data/e8",
                                    "[extreme][knuth-bendix][kbmag][shortlex]",
                                    KNUTH_BENDIX_TYPES) {
@@ -286,7 +286,7 @@ namespace libsemigroups {
   // Takes > 1m (knuth_bendix), didn't run to the end
   // Takes approx. 6s (knuth_bendix_by_overlap_length)
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "111",
+                                   "105",
                                    "kbmag/standalone/kb_data/degen4b",
                                    "[extreme][knuth-bendix][kbmag][shortlex]",
                                    KNUTH_BENDIX_TYPES) {
@@ -314,7 +314,7 @@ namespace libsemigroups {
   // Takes approx. 12s (knuth_bendix_by_overlap_length)
   // Takes > 19s (knuth_bendix), didn't run to the end
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "112",
+                                   "106",
                                    "kbmag/standalone/kb_data/f27_2gen",
                                    "[extreme][knuth-bendix][kbmag][shortlex]",
                                    KNUTH_BENDIX_TYPES) {
@@ -338,7 +338,7 @@ namespace libsemigroups {
 
   // Takes approx. 1m8s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "113",
+                                   "107",
                                    "Example 6.6 in Sims",
                                    "[extreme][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -366,7 +366,7 @@ namespace libsemigroups {
   // Takes approx. 13s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "KnuthBendix",
-      "114",
+      "108",
       "kbmag/standalone/kb_data/f27) (infinite) (1 / 2",
       "[extreme][knuth-bendix][kbmag][shortlex]",
       KNUTH_BENDIX_TYPES) {
@@ -396,7 +396,7 @@ namespace libsemigroups {
   // An extension of 2^6 be L32
   // Takes approx. 1m7s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "115",
+                                   "109",
                                    "kbmag/standalone/kb_data/l32ext",
                                    "[extreme][knuth-bendix][kbmag][shortlex]",
                                    KNUTH_BENDIX_TYPES) {
@@ -433,7 +433,7 @@ namespace libsemigroups {
   ////////////////////////////////////////////////////////////////////////
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "116",
+                                   "110",
                                    "Ceitin's undecidable word problem example",
                                    "[fail][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -455,7 +455,7 @@ namespace libsemigroups {
 
   // kbmag/standalone/kb_data/verifynilp
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "117",
+                                   "111",
                                    "kbmag/standalone/kb_data/verifynilp",
                                    "[fail][knuth-bendix][kbmag][shortlex]",
                                    KNUTH_BENDIX_TYPES) {
@@ -498,7 +498,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "118",
+                                   "112",
                                    "Sorouhesh",
                                    "[quick][knuth-bendix][kbmag][shortlex]",
                                    KNUTH_BENDIX_TYPES) {
@@ -627,7 +627,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "KnuthBendix",
-      "119",
+      "113",
       "all 2-generated 1-relation semigroups 1 to 10",
       "[fail][knuth-bendix][xxx]",
       KNUTH_BENDIX_TYPES) {
@@ -681,7 +681,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "120",
+                                   "114",
                                    "hard 2-generated 1-relation monoid",
                                    "[fail][knuth-bendix][xxx2]",
                                    KNUTH_BENDIX_TYPES) {
@@ -698,7 +698,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "121",
+                                   "115",
                                    "Konovalov",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -716,7 +716,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "KnuthBendix",
-      "122",
+      "116",
       "https://math.stackexchange.com/questions/2649807",
       "[knuth-bendix][fail]",
       KNUTH_BENDIX_TYPES) {
@@ -759,7 +759,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "123",
+                                   "117",
                                    "example with undecidable word problem",
                                    "[knuth-bendix][extreme]",
                                    KNUTH_BENDIX_TYPES) {
@@ -777,7 +777,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("KnuthBendix",
-                          "124",
+                          "118",
                           "partition_monoid(7)",
                           "[knuthbendix][extreme]") {
     auto        rg = ReportGuard(true);

--- a/tests/test-knuth-bendix-5.cpp
+++ b/tests/test-knuth-bendix-5.cpp
@@ -90,7 +90,7 @@ namespace libsemigroups {
   }  // namespace
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "125",
+                                   "119",
                                    "transformation semigroup (size 4)",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -110,7 +110,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "126",
+                                   "120",
                                    "transformation semigroup (size 9)",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -132,7 +132,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "127",
+                                   "121",
                                    "transformation semigroup (size 88)",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -154,7 +154,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "128",
+                                   "122",
                                    "internal_string_to_word",
                                    "[quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -172,7 +172,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "129",
+                                   "123",
                                    "internal_string_to_word x 2",
                                    "[quick]",
                                    KNUTH_BENDIX_TYPES) {
@@ -191,7 +191,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "130",
+                                   "124",
                                    "manual onesided congruence",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -289,7 +289,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "131",
+                                   "125",
                                    "onesided congruence!!!",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -384,7 +384,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "132",
+                                   "126",
                                    "manual left congruence!!!",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -448,7 +448,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "133",
+                                   "127",
                                    "automatic left congruence!!!",
                                    "[quick][knuth-bendix][no-valgrind]",
                                    KNUTH_BENDIX_TYPES) {
@@ -574,7 +574,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("KnuthBendix",
-                          "134",
+                          "128",
                           "left congruence on finite semigroup",
                           "[quick]") {
     auto                  rg = ReportGuard(false);

--- a/tests/test-knuth-bendix-6.cpp
+++ b/tests/test-knuth-bendix-6.cpp
@@ -61,7 +61,7 @@ namespace libsemigroups {
 #define KNUTH_BENDIX_TYPES RewriteTrie, RewriteFromLeft
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "135",
+                                   "129",
                                    "Presentation<word_type>",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -86,7 +86,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "136",
+                                   "130",
                                    "free semigroup congruence (6 classes)",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -119,7 +119,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "137",
+                                   "131",
                                    "free semigroup congruence (16 classes)",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -157,7 +157,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "138",
+                                   "132",
                                    "free semigroup congruence x 2",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -200,7 +200,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "139",
+                                   "133",
                                    "free semigroup congruence (240 classes)",
                                    "[no-valgrind][quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -218,7 +218,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "140",
+                                   "134",
                                    "free semigroup congruence x 2",
                                    "[no-valgrind][quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -236,7 +236,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "141",
+                                   "135",
                                    "constructors",
                                    "[quick][knuth-bendix][no-valgrind]",
                                    KNUTH_BENDIX_TYPES) {
@@ -259,7 +259,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "142",
+                                   "136",
                                    "number of classes when obv-inf",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -284,7 +284,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "143",
+                                   "137",
                                    "Chinese monoid x 2",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -300,7 +300,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "144",
+                                   "138",
                                    "partial_transformation_monoid(4)",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -320,7 +320,7 @@ namespace libsemigroups {
 
   // Takes about 1 minute
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "145",
+                                   "139",
                                    "partial_transformation_monoid5",
                                    "[extreme][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -336,7 +336,7 @@ namespace libsemigroups {
 
   // Takes about 5 seconds
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "146",
+                                   "140",
                                    "full_transformation_monoid Iwahori",
                                    "[extreme][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -352,7 +352,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "147",
+                                   "141",
                                    "constructors/init for finished x 2",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {
@@ -432,7 +432,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
-                                   "148",
+                                   "142",
                                    "close to or greater than 255 letters",
                                    "[quick][knuth-bendix]",
                                    KNUTH_BENDIX_TYPES) {

--- a/tests/test-konieczny-bmat.cpp
+++ b/tests/test-konieczny-bmat.cpp
@@ -44,7 +44,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Konieczny",
-                                   "002",
+                                   "001",
                                    "4x4 boolean matrix semigroup (size 415)",
                                    "[quick][bmat][no-valgrind]",
                                    BMat<>,
@@ -63,7 +63,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
       "Konieczny",
-      "004",
+      "002",
       "40x40 boolean matrix semigroup (size 248'017)",
       "[extreme][bmat]",
       BMat<40>,
@@ -78,7 +78,7 @@ namespace libsemigroups {
     REQUIRE(S.size() == 248'017);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Konieczny", "006", "exceptions", "[quick][bmat]") {
+  LIBSEMIGROUPS_TEST_CASE("Konieczny", "003", "exceptions", "[quick][bmat]") {
     auto rg = ReportGuard(false);
     REQUIRE_THROWS_AS(
         Konieczny<BMat<>>(
@@ -89,7 +89,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Konieczny",
-                                   "007",
+                                   "004",
                                    "5x5 boolean matrix semigroup (size 513)",
                                    "[quick][bmat][no-valgrind]",
                                    BMat<>,

--- a/tests/test-konieczny-bmat8-1.cpp
+++ b/tests/test-konieczny-bmat8-1.cpp
@@ -28,7 +28,7 @@
 namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "009",
+                          "005",
                           "regular elements and idempotents",
                           "[quick][no-valgrind][bmat8]") {
 #ifdef LIBSEMIGROUPS_HPCOMBI_ENABLED
@@ -76,7 +76,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "010",
+                          "006",
                           "regular D-class 01",
                           "[quick][bmat8]") {
     auto                     rg   = ReportGuard(false);
@@ -96,7 +96,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "011",
+                          "007",
                           "regular D-class 02",
                           "[quick][bmat8][no-valgrind]") {
     auto                     rg = ReportGuard(false);
@@ -118,7 +118,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "012",
+                          "008",
                           "regular D-class 04: contains",
                           "[quick][no-valgrind][bmat8]") {
     auto                     rg = ReportGuard(false);
@@ -144,7 +144,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "013",
+                          "009",
                           "non-regular D-classes 01",
                           "[quick][bmat8]") {
     auto                     rg    = ReportGuard(false);
@@ -245,7 +245,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "014",
+                          "010",
                           "RegularDClass",
                           "[quick][bmat8]") {
     auto                     rg = ReportGuard(false);
@@ -267,7 +267,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "015",
+                          "011",
                           "full bmat monoid 4",
                           "[quick][no-valgrind][bmat8]") {
     auto                     rg = ReportGuard(false);

--- a/tests/test-konieczny-bmat8-2.cpp
+++ b/tests/test-konieczny-bmat8-2.cpp
@@ -34,7 +34,7 @@ namespace libsemigroups {
   struct LibsemigroupsException;
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "016",
+                          "012",
                           "full bmat monoid 5",
                           "[extreme][bmat8]") {
 #ifdef LIBSEMIGROUPS_HPCOMBI_ENABLED
@@ -124,7 +124,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "017",
+                          "013",
                           "regular generated bmat monoid 4 idempotents",
                           "[quick][no-valgrind][bmat8]") {
     auto                     rg = ReportGuard(false);
@@ -171,7 +171,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "018",
+                          "014",
                           "regular generated bmat monoid 5",
                           "[extreme][bmat8]") {
 #ifdef LIBSEMIGROUPS_HPCOMBI_ENABLED
@@ -231,7 +231,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "019",
+                          "015",
                           "my favourite example",
                           "[quick][finite][no-valgrind][bmat8]") {
     auto                     rg   = ReportGuard(false);
@@ -305,7 +305,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "020",
+                          "016",
                           "another large example",
                           "[quick][no-valgrind][bmat8]") {
 #ifdef LIBSEMIGROUPS_HPCOMBI_ENABLED
@@ -388,7 +388,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "021",
+                          "017",
                           "my favourite example transposed",
                           "[quick][no-valgrind][bmat8]") {
     auto                     rg   = ReportGuard(false);
@@ -462,7 +462,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "022",
+                          "018",
                           "full bmat monoid 5 with stop in Action",
                           "[extreme][bmat8]") {
 #ifdef LIBSEMIGROUPS_HPCOMBI_ENABLED
@@ -559,7 +559,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "023",
+                          "019",
                           "regular generated bmat monoid 5 with stops",
                           "[extreme][bmat8]") {
     auto                     rg             = ReportGuard(true);
@@ -595,7 +595,7 @@ namespace libsemigroups {
     REQUIRE(T.number_of_idempotents() == 73023);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Konieczny", "024", "exceptions", "[quick][bmat8]") {
+  LIBSEMIGROUPS_TEST_CASE("Konieczny", "020", "exceptions", "[quick][bmat8]") {
     auto                     rg    = ReportGuard(false);
     const std::vector<BMat8> gens  = {BMat8({{0, 1, 0}, {0, 0, 1}, {1, 0, 0}}),
                                       BMat8({{0, 1, 0}, {1, 0, 0}, {0, 0, 1}}),
@@ -636,7 +636,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "025",
+                          "021",
                           "0-parameter constructor",
                           "[quick][no-valgrind][bmat8]") {
     auto                     rg   = ReportGuard(false);

--- a/tests/test-konieczny-bmat8-3.cpp
+++ b/tests/test-konieczny-bmat8-3.cpp
@@ -40,7 +40,7 @@ namespace libsemigroups {
   }  // namespace
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "026",
+                          "022",
                           "non-regular D-classes 02",
                           "[quick][bmat8][no-valgrind]") {
     auto                     rg = ReportGuard(false);
@@ -159,7 +159,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "027",
+                          "023",
                           "Hall monoid 5",
                           "[extreme][bmat8]") {
 #ifdef LIBSEMIGROUPS_HPCOMBI_ENABLED

--- a/tests/test-konieczny-pperm.cpp
+++ b/tests/test-konieczny-pperm.cpp
@@ -25,7 +25,7 @@
 namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "028",
+                          "024",
                           "partial perm",
                           "[quick][pperm][no-valgrind]") {
     auto                             rg = ReportGuard(false);
@@ -50,7 +50,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "029",
+                          "025",
                           "symmetric inverse monoid n = 8",
                           "[quick][pperm][no-valgrind]") {
     auto                     rg = ReportGuard(false);
@@ -65,7 +65,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "030",
+                          "026",
                           "exceptions",
                           "[quick][pperm][no-valgrind]") {
     auto rg          = ReportGuard(false);

--- a/tests/test-konieczny-transf.cpp
+++ b/tests/test-konieczny-transf.cpp
@@ -26,7 +26,7 @@
 namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "031",
+                          "027",
                           "transformations",
                           "[quick][transf]") {
     using Transf         = LeastTransf<5>;
@@ -53,7 +53,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "032",
+                          "028",
                           "transformations - JDM favourite example",
                           "[quick][no-valgrind][transf]") {
     using Transf         = LeastTransf<8>;
@@ -79,7 +79,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "033",
+                          "029",
                           "transformations - large example",
                           "[quick][no-valgrind][transf]") {
     auto                        rg   = ReportGuard(false);
@@ -108,7 +108,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "034",
+                          "030",
                           "transformations - large example with stop",
                           "[quick][no-valgrind][transf]") {
     auto                rg = ReportGuard(false);
@@ -122,7 +122,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "035",
+                          "031",
                           "transformations - large example with run_until",
                           "[quick][no-valgrind][transf]") {
     auto                rg = ReportGuard(false);
@@ -145,7 +145,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "036",
+                          "032",
                           "transformations - large example with stop in Action",
                           "[quick][no-valgrind][transf]") {
     auto                rg = ReportGuard(false);
@@ -165,7 +165,7 @@ namespace libsemigroups {
     REQUIRE(S.size() == 232511);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Konieczny", "037", "exceptions", "[quick][transf]") {
+  LIBSEMIGROUPS_TEST_CASE("Konieczny", "033", "exceptions", "[quick][transf]") {
     auto rg          = ReportGuard(false);
     using point_type = typename Transf<>::point_type;
     std::vector<point_type> v(65, 0);
@@ -175,7 +175,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "038",
+                          "034",
                           "transformations: contains",
                           "[quick][transf]") {
     auto                rg = ReportGuard(false);
@@ -214,7 +214,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "039",
+                          "035",
                           "transformations Hall monoid 5",
                           "[extreme][transf]") {
     auto rg      = ReportGuard();
@@ -254,7 +254,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "040",
+                          "036",
                           "transformations - destructor coverage",
                           "[quick][transf][no-valgrind]") {
     auto rg      = ReportGuard(false);
@@ -275,7 +275,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "041",
+                          "037",
                           "current_number_D_classes",
                           "[quick][transf][no-valgrind]") {
     auto rg      = ReportGuard(false);
@@ -297,7 +297,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "042",
+                          "038",
                           "add_generator",
                           "[quick][transf][no-valgrind]") {
     auto rg      = ReportGuard(false);
@@ -315,7 +315,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
-                          "043",
+                          "039",
                           "add_generator",
                           "[quick][transf][no-valgrind]") {
     auto rg      = ReportGuard(false);

--- a/tests/test-matrix.cpp
+++ b/tests/test-matrix.cpp
@@ -281,7 +281,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "002",
+                                   "001",
                                    "boolean matrix - test 2",
                                    "[quick]",
                                    BMat<3>,
@@ -298,7 +298,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "003",
+                                   "002",
                                    "boolean matrix - test 3",
                                    "[quick]",
                                    BMat<2>,
@@ -315,7 +315,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "004",
+                                   "003",
                                    "boolean matrix - test 4",
                                    "[quick]",
                                    BMat<3>,
@@ -338,7 +338,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "006",
+                                   "004",
                                    "boolean matrix - row_basis",
                                    "[quick]",
                                    BMat<3>,
@@ -369,7 +369,7 @@ namespace libsemigroups {
   ////////////////////////////////////////////////////////////////////////
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "008",
+                                   "005",
                                    "integer matrix - test 1",
                                    "[quick]",
                                    IntMat<3>,
@@ -421,7 +421,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Matrix",
-                          "010",
+                          "006",
                           "integer matrix - code cov",
                           "[quick]") {
     IntMat<>* A = new IntMat<>();
@@ -448,7 +448,7 @@ namespace libsemigroups {
   ////////////////////////////////////////////////////////////////////////
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "011",
+                                   "007",
                                    "max-plus matrix - test 1",
                                    "[quick]",
                                    MaxPlusMat<>,
@@ -478,7 +478,7 @@ namespace libsemigroups {
     REQUIRE(Hash<TestType>()(y) != 0);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "013", "MaxPlusMat code cov", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Matrix", "008", "MaxPlusMat code cov", "[quick]") {
     MaxPlusMat<3>* B = new MaxPlusMat<3>();
     delete B;
     MaxPlusMat<3>::Row* C = new MaxPlusMat<3>::Row();
@@ -490,7 +490,7 @@ namespace libsemigroups {
   ////////////////////////////////////////////////////////////////////////
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "014",
+                                   "009",
                                    "min-plus matrix - test 1",
                                    "[quick]",
                                    MinPlusMat<3>,
@@ -545,7 +545,7 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "016", "MinPlusMat code cov", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Matrix", "010", "MinPlusMat code cov", "[quick]") {
     MinPlusMat<3>* B = new MinPlusMat<3>();
     delete B;
     MinPlusMat<3>::Row* C = new MinPlusMat<3>::Row();
@@ -557,7 +557,7 @@ namespace libsemigroups {
   ////////////////////////////////////////////////////////////////////////
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "017",
+                                   "011",
                                    "max-plus trunc. matrix - test 1",
                                    "[quick]",
                                    (MaxPlusTruncMat<5, 2>),
@@ -615,7 +615,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "020",
+                                   "012",
                                    "max-plus trunc. matrix - test 2",
                                    "[quick]",
                                    (MaxPlusTruncMat<5, 4>),
@@ -670,7 +670,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "023",
+                                   "013",
                                    "max-plus trunc. matrix - test 3",
                                    "[quick]",
                                    (MaxPlusTruncMat<33, 3>),
@@ -706,7 +706,7 @@ namespace libsemigroups {
     delete sr;
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "026", "MaxPlusMat code cov", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Matrix", "014", "MaxPlusMat code cov", "[quick]") {
     MaxPlusTruncMat<33, 3>* B = new MaxPlusTruncMat<33, 3>();
     delete B;
     MaxPlusTruncMat<5, 2>::Row* C = new MaxPlusTruncMat<5, 2>::Row();
@@ -726,7 +726,7 @@ namespace libsemigroups {
   ////////////////////////////////////////////////////////////////////////
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "027",
+                                   "015",
                                    "min-plus trunc. matrix - test 1",
                                    "[quick]",
                                    (MinPlusTruncMat<33, 3>),
@@ -772,7 +772,7 @@ namespace libsemigroups {
   ////////////////////////////////////////////////////////////////////////
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "030",
+                                   "016",
                                    "3x3 matrix, t = 0, p = 3",
                                    "[quick]",
                                    (NTPMat<0, 3, 3, 3>),
@@ -805,7 +805,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "034",
+                                   "017",
                                    "4x4 matrix, t = 0, p = 10",
                                    "[quick]",
                                    (NTPMat<0, 10>),
@@ -875,7 +875,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "036",
+                                   "018",
                                    "4x4 matrix, t = 0, p = 10",
                                    "[quick]",
                                    (NTPMat<0, 10, 4, 4>),
@@ -918,7 +918,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "038",
+                                   "019",
                                    "3x3 matrix, t = 33, p = 2",
                                    "[quick]",
                                    (NTPMat<33, 2>),
@@ -955,7 +955,7 @@ namespace libsemigroups {
   ////////////////////////////////////////////////////////////////////////
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
-                                   "042",
+                                   "020",
                                    "3x3 matrix",
                                    "[quick]",
                                    (ProjMaxPlusMat<3, 3>),
@@ -1040,7 +1040,7 @@ namespace libsemigroups {
     REQUIRE(matrix::pow(x, 0) == TestType::one(3));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "044", "exceptions", "[quick][element]") {
+  LIBSEMIGROUPS_TEST_CASE("Matrix", "021", "exceptions", "[quick][element]") {
     using Mat               = NTPMat<>;
     using scalar_type       = typename Mat::scalar_type;
     NTPSemiring<> const* sr = new NTPSemiring<>(23, 1);
@@ -1055,7 +1055,7 @@ namespace libsemigroups {
     delete sr;
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Matrix", "045", "code coverage", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Matrix", "022", "code coverage", "[quick]") {
     {
       BMat<> x(0, 0);
       x.transpose();
@@ -1113,14 +1113,14 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("BMatFastest",
-                          "046",
+                          "023",
                           "check no throw",
                           "[quick][matrix]") {
     REQUIRE_NOTHROW(BMatFastest<3>({{0, 1}, {0, 1}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("Matrix",
-                          "047",
+                          "024",
                           "to_human_readable_repr",
                           "[quick][matrix]") {
     BMat<3> x({{0, 1, 0}, {0, 1, 0}, {0, 0, 0}});

--- a/tests/test-obvinf.cpp
+++ b/tests/test-obvinf.cpp
@@ -41,7 +41,7 @@ namespace libsemigroups {
   using namespace literals;
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "001",
+                          "000",
                           "Multiple rule additions",
                           "[quick]") {
     IsObviouslyInfinite      ioi(3);
@@ -73,7 +73,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "002",
+                          "001",
                           "b^n does not occur on its own in any relation",
                           "[quick]") {
     IsObviouslyInfinite      ioi(2);
@@ -83,7 +83,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "003",
+                          "002",
                           "Preserves occurrences of the generator 'a'",
                           "[quick]") {
     IsObviouslyInfinite      ioi(2);
@@ -93,7 +93,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "004",
+                          "003",
                           "Less relations than generators",
                           "[quick]") {
     IsObviouslyInfinite      ioi(3);
@@ -103,7 +103,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "005",
+                          "004",
                           "Relations preserve length",
                           "[quick]") {
     IsObviouslyInfinite      ioi(3);
@@ -114,7 +114,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "006",
+                          "005",
                           "Matrix has non empty kernel",
                           "[quick]") {
     IsObviouslyInfinite    ioi(2);
@@ -131,7 +131,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "007",
+                          "006",
                           "Free product of trivial semigroups",
                           "[quick]") {
     IsObviouslyInfinite      ioi(2);
@@ -141,7 +141,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "008",
+                          "007",
                           "Another free product",
                           "[quick]") {
     IsObviouslyInfinite      ioi(5);
@@ -152,7 +152,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "009",
+                          "008",
                           "Infinite but not obviously so",
                           "[quick]") {
     IsObviouslyInfinite      ioi(2);
@@ -164,7 +164,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "010",
+                          "009",
                           "Finite semigroup",
                           "[quick]") {
     IsObviouslyInfinite      ioi(3);
@@ -177,7 +177,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "011",
+                          "010",
                           "Multiple rule additions",
                           "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(3);
@@ -207,7 +207,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "012",
+                          "011",
                           "b^n does not occur on its own in any relation",
                           "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(2);
@@ -217,7 +217,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "013",
+                          "012",
                           "Preserves occurrences of the generator 'a'",
                           "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(2);
@@ -227,7 +227,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "014",
+                          "013",
                           "Less relations than generators",
                           "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(3);
@@ -237,7 +237,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "015",
+                          "014",
                           "Relations preserve length",
                           "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(3);
@@ -248,7 +248,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "016",
+                          "015",
                           "Matrix has non empty kernel",
                           "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(2);
@@ -258,7 +258,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "017",
+                          "016",
                           "Free product of trivial semigroups",
                           "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(2);
@@ -268,7 +268,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "018",
+                          "017",
                           "Another free product",
                           "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(5);
@@ -279,7 +279,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "019",
+                          "018",
                           "Infinite but not obviously so",
                           "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(2);
@@ -291,7 +291,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "020",
+                          "019",
                           "Finite semigroup",
                           "[quick][integer-alphabet]") {
     IsObviouslyInfinite    ioi(3);
@@ -304,7 +304,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "021",
+                          "020",
                           "from presentation",
                           "[quick][integer-alphabet]") {
     Presentation<word_type> p;
@@ -313,7 +313,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ObviouslyInfinite",
-                          "022",
+                          "021",
                           "from ToddCoxeter",
                           "[quick][integer-alphabet]") {
     ToddCoxeter<word_type> tc(congruence_kind::twosided,

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -1601,7 +1601,7 @@ namespace libsemigroups {
   // }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "030",
+                          "029",
                           "helpers remove_trivial_rules",
                           "[quick][presentation]") {
     auto rg = ReportGuard(false);
@@ -1611,7 +1611,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "031",
+                          "030",
                           "helpers replace_subword (existing, replacement)",
                           "[quick][presentation]") {
     auto rg = ReportGuard(false);
@@ -1621,7 +1621,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "032",
+                          "031",
                           "helpers replace_subword (std::string)",
                           "[quick][presentation]") {
     auto                      rg = ReportGuard(false);
@@ -1632,7 +1632,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "033",
+                          "032",
                           "helpers replace_word",
                           "[quick][presentation]") {
     auto rg = ReportGuard(false);
@@ -1642,7 +1642,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "034",
+                          "033",
                           "helpers longest_rule",
                           "[quick][presentation]") {
     auto rg = ReportGuard(false);
@@ -1652,7 +1652,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "035",
+                          "034",
                           "helpers longest_rule_length",
                           "[quick][presentation]") {
     auto rg = ReportGuard(false);
@@ -1662,7 +1662,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "036",
+                          "035",
                           "helpers remove_redundant_generators",
                           "[quick][presentation]") {
     auto rg = ReportGuard(false);
@@ -1672,7 +1672,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "037",
+                          "036",
                           "helpers remove_redundant_generators",
                           "[quick][presentation]") {
     auto                      rg = ReportGuard(false);
@@ -1695,7 +1695,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "038",
+                          "037",
                           "helpers reverse",
                           "[quick][presentation]") {
     auto rg = ReportGuard(false);
@@ -1705,7 +1705,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "039",
+                          "038",
                           "in_alphabet",
                           "[quick][presentation]") {
     auto rg = ReportGuard(false);
@@ -1715,7 +1715,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "040",
+                          "039",
                           "replace_subword with empty word",
                           "[quick][presentation]") {
     auto                      rg = ReportGuard(false);
@@ -1729,7 +1729,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "041",
+                          "040",
                           "clear",
                           "[quick][presentation]") {
     auto                      rg = ReportGuard(false);
@@ -1744,7 +1744,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "042",
+                          "041",
                           "change_alphabet",
                           "[quick][presentation]") {
     Presentation<std::string> p;
@@ -1776,7 +1776,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "043",
+                          "042",
                           "letter",
                           "[quick][presentation]") {
     using words::human_readable_letter;
@@ -1796,7 +1796,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "044",
+                          "043",
                           "normalize_alphabet",
                           "[quick][presentation]") {
     Presentation<std::string> p;
@@ -1810,7 +1810,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "045",
+                          "044",
                           "first_unused_letter/letter",
                           "[quick][presentation]") {
     using words::human_readable_letter;
@@ -1847,7 +1847,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "046",
+                          "045",
                           "longest_subword_reducing_length issue",
                           "[quick][presentation]") {
     Presentation<std::string> p;
@@ -1899,7 +1899,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "047",
+                          "046",
                           "make_semigroup",
                           "[quick][presentation]") {
     check_make_semigroup<word_type>();
@@ -1908,7 +1908,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "048",
+                          "047",
                           "greedy_reduce_length",
                           "[quick][presentation]") {
     Presentation<std::string> p;
@@ -1935,7 +1935,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "049",
+                          "048",
                           "greedy_reduce_length_and_number_of_gens",
                           "[quick][presentation]") {
     Presentation<std::string> p1;
@@ -1972,7 +1972,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "050",
+                          "049",
                           "aaaaaaaab = aaaaaaaaab strong compression",
                           "[quick][presentation]") {
     Presentation<std::string> p;
@@ -1998,7 +1998,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "051",
+                          "050",
                           "case where strong compression doesn't work",
                           "[quick][presentation]") {
     Presentation<std::string> p;
@@ -2017,7 +2017,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "052",
+                          "051",
                           "proof that",
                           "[quick][presentation]") {
     Presentation<std::string> p;
@@ -2054,7 +2054,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "053",
+                          "052",
                           "decompression",
                           "[quick][presentation]") {
     Presentation<std::string> p;
@@ -2069,7 +2069,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "054",
+                          "053",
                           "sort_rules bug",
                           "[quick][presentation]") {
     std::string prefix1 = "dabd", suffix1 = "cbb", prefix2 = "abbaba",
@@ -2634,7 +2634,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "055",
+                          "054",
                           "meaningful exception messages",
                           "[quick][presentation]") {
     using literals::operator""_w;
@@ -2716,7 +2716,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "056",
+                          "055",
                           "add_generator (std::string)",
                           "[quick][presentation]") {
     auto            rg = ReportGuard(false);
@@ -2750,7 +2750,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "057",
+                          "056",
                           "add_generator (word_type)",
                           "[quick][presentation]") {
     auto rg = ReportGuard(false);
@@ -2782,7 +2782,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "058",
+                          "057",
                           "remove_generator",
                           "[quick][presentation]") {
     auto rg = ReportGuard(false);
@@ -2792,7 +2792,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "059",
+                          "058",
                           "to_human_readble_repr",
                           "[quick][presentation]") {
     auto rg = ReportGuard(false);
@@ -2848,7 +2848,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "060",
+                          "059",
                           "to_word",
                           "[quick][presentation]") {
     auto                      rg = ReportGuard(false);
@@ -2864,7 +2864,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "061",
+                          "060",
                           "to_string",
                           "[quick][presentation]") {
     auto                      rg = ReportGuard(false);
@@ -2880,7 +2880,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "062",
+                          "061",
                           "to_gap_string",
                           "[quick][presentation]") {
     auto                      rg = ReportGuard(false);
@@ -2921,7 +2921,7 @@ namespace libsemigroups {
                "my_var := F / R;\n");
   }
   LIBSEMIGROUPS_TEST_CASE("InversePresentation",
-                          "063",
+                          "062",
                           "constructors (word_type)",
                           "[quick][presentation]") {
     auto                           rg = ReportGuard(false);
@@ -2938,7 +2938,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("InversePresentation",
-                          "064",
+                          "063",
                           "constructors (StaticVector1)",
                           "[quick][presentation]") {
     auto                                             rg = ReportGuard(false);
@@ -2955,7 +2955,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("InversePresentation",
-                          "065",
+                          "064",
                           "constructors (std::string)",
                           "[quick][presentation]") {
     auto                             rg = ReportGuard(false);
@@ -2972,7 +2972,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("InversePresentation",
-                          "066",
+                          "065",
                           "construct from presnetation",
                           "[quick][presentation]") {
     auto rg = ReportGuard(false);
@@ -2982,7 +2982,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("InversePresentation",
-                          "067",
+                          "066",
                           "inverses",
                           "[quick][presentation]") {
     auto rg = ReportGuard(false);
@@ -2992,7 +2992,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "029",
+                          "067",
                           "longest_subword_reducing_length #01",
                           "[quick][presentation]") {
     using literals::        operator""_w;

--- a/tests/test-race.cpp
+++ b/tests/test-race.cpp
@@ -65,7 +65,7 @@ namespace libsemigroups {
       }
     };
 
-    LIBSEMIGROUPS_TEST_CASE("Race", "001", "run_for", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Race", "000", "run_for", "[quick]") {
       auto rg = ReportGuard(false);
       Race rc;
       rc.max_threads(1);
@@ -76,7 +76,7 @@ namespace libsemigroups {
       REQUIRE(rc.winner() != nullptr);
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Race", "002", "run_until", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Race", "001", "run_until", "[quick]") {
       auto rg = ReportGuard(false);
       Race rc;
       rc.add_runner(std::make_shared<TestRunner1>());
@@ -86,7 +86,7 @@ namespace libsemigroups {
       REQUIRE(rc.winner() != nullptr);
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Race", "003", "exceptions", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Race", "002", "exceptions", "[quick]") {
       auto rg = ReportGuard(false);
       Race rc;
       REQUIRE_THROWS_AS(rc.run_for(std::chrono::milliseconds(10)),
@@ -102,7 +102,7 @@ namespace libsemigroups {
       REQUIRE_THROWS_AS(rc.add_runner(tr), LibsemigroupsException);
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Race", "004", "iterators", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Race", "003", "iterators", "[quick]") {
       auto rg = ReportGuard(false);
       Race rc;
       rc.max_threads(2);
@@ -113,7 +113,7 @@ namespace libsemigroups {
       REQUIRE(2 == rc.number_of_runners());
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Race", "005", "find_runner", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Race", "004", "find_runner", "[quick]") {
       auto rg = ReportGuard(false);
       Race rc;
       rc.max_threads(2);
@@ -123,7 +123,7 @@ namespace libsemigroups {
       REQUIRE(rc.find_runner<TestRunner2>() == nullptr);
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Race", "006", "run_func", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Race", "005", "run_func", "[quick]") {
       auto rg = ReportGuard(false);
       Race rc;
       rc.max_threads(2);
@@ -133,7 +133,7 @@ namespace libsemigroups {
       REQUIRE(rc.winner() != nullptr);
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Race", "007", "run_func", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Race", "006", "run_func", "[quick]") {
       auto rg = ReportGuard(false);
       Race rc;
       rc.max_threads(2);
@@ -145,7 +145,7 @@ namespace libsemigroups {
       REQUIRE(rc.winner() != nullptr);
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Race", "008", "run_func", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Race", "007", "run_func", "[quick]") {
       auto rg = ReportGuard(false);
       Race rc;
       rc.max_threads(4);

--- a/tests/test-runner.cpp
+++ b/tests/test-runner.cpp
@@ -84,7 +84,7 @@ namespace libsemigroups {
       }
     };
 
-    LIBSEMIGROUPS_TEST_CASE("Reporter", "010", "Code coverage", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Reporter", "000", "Code coverage", "[quick]") {
       Reporter r;
       REQUIRE(!r.report());
       REQUIRE(r.report_every() == std::chrono::seconds(1));
@@ -119,7 +119,7 @@ namespace libsemigroups {
       REQUIRE(t.report_every() == std::chrono::seconds(1));
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Runner", "000", "run_for", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Runner", "001", "run_for", "[quick]") {
       auto        rg = ReportGuard(false);
       TestRunner1 tr;
       tr.run_for(std::chrono::milliseconds(10));
@@ -130,7 +130,7 @@ namespace libsemigroups {
       tr.run_for(std::chrono::nanoseconds(1000000));
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Runner", "001", "run_for", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Runner", "002", "run_for", "[quick]") {
       auto        rg = ReportGuard(false);
       TestRunner1 tr;
       tr.run_for(std::chrono::nanoseconds(1000000));
@@ -139,7 +139,7 @@ namespace libsemigroups {
       REQUIRE(!tr.dead());
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Runner", "002", "run_for", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Runner", "003", "run_for", "[quick]") {
       auto        rg = ReportGuard(false);
       TestRunner2 tr;
       tr.run_for(std::chrono::milliseconds(50));
@@ -169,7 +169,7 @@ namespace libsemigroups {
       REQUIRE(tr.stopped_by_predicate());
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Runner", "003", "run_for", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Runner", "004", "run_for", "[quick]") {
       auto        rg = ReportGuard(false);
       TestRunner3 tr;
       tr.run_for(FOREVER);
@@ -182,7 +182,7 @@ namespace libsemigroups {
       REQUIRE_NOTHROW(tr.report_why_we_stopped());
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Runner", "004", "started", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Runner", "005", "started", "[quick]") {
       auto        rg = ReportGuard(false);
       TestRunner1 tr;
       REQUIRE(!tr.started());
@@ -194,7 +194,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("Runner",
-                            "005",
+                            "006",
                             "run_until",
                             "[quick][no-valgrind]") {
       auto        rg = ReportGuard(false);
@@ -209,7 +209,7 @@ namespace libsemigroups {
       REQUIRE(!tr.dead());
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Runner", "006", "kill", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Runner", "007", "kill", "[quick]") {
       auto        rg = ReportGuard(false);
       TestRunner1 tr;
       tr.kill();
@@ -219,7 +219,7 @@ namespace libsemigroups {
       REQUIRE_NOTHROW(tr.report_why_we_stopped());
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Runner", "007", "copy constructor", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Runner", "008", "copy constructor", "[quick]") {
       auto        rg = ReportGuard(false);
       TestRunner1 tr1;
       tr1.run_for(std::chrono::milliseconds(10));
@@ -234,7 +234,7 @@ namespace libsemigroups {
       REQUIRE(!tr2.dead());
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Runner", "008", "report", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Runner", "009", "report", "[quick]") {
       auto        rg = ReportGuard(false);
       TestRunner1 tr;
       REQUIRE(!tr.report());
@@ -256,7 +256,7 @@ namespace libsemigroups {
     }  // namespace
 
     LIBSEMIGROUPS_TEST_CASE("Runner",
-                            "009",
+                            "010",
                             "run_until with function pointer",
                             "[quick][no-valgrind]") {
       auto        rg = ReportGuard(false);

--- a/tests/test-schreier-sims.cpp
+++ b/tests/test-schreier-sims.cpp
@@ -2985,7 +2985,7 @@ namespace libsemigroups {
   //     }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "036",
+                          "033",
                           "symmetric perm. group (degree 5)",
                           "[quick][schreier-sims]") {
     auto rg    = ReportGuard(false);
@@ -2997,7 +2997,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "037",
+                          "034",
                           "alternating perm. group (degree 17)",
                           "[quick][schreier-sims][no-valgrind]") {
     auto             rg = ReportGuard(false);
@@ -3063,7 +3063,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "038",
+                          "035",
                           "exceptions",
                           "[quick][schreier-sims]") {
     auto rg    = ReportGuard(false);
@@ -3093,7 +3093,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "039",
+                          "036",
                           "exceptions",
                           "[quick][schreier-sims]") {
     auto rg    = ReportGuard(false);
@@ -3110,7 +3110,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "040",
+                          "037",
                           "trivial group",
                           "[quick][schreier-sims]") {
     auto            rg = ReportGuard(false);
@@ -3126,7 +3126,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "041",
+                          "038",
                           "A17 bug",
                           "[quick][schreier-sims]") {
     auto             rg = ReportGuard(false);
@@ -3180,7 +3180,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "042",
+                          "039",
                           "orbit_lookup test",
                           "[quick][schreier-sims]") {
     auto             rg = ReportGuard(false);
@@ -3289,7 +3289,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "SchreierSims",
-      "043",
+      "040",
       "transversal_element and inverse_transversal_element test",
       "[quick][schreier-sims][no-valgrind]") {
     auto             rg = ReportGuard(false);
@@ -3346,7 +3346,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "044",
+                          "041",
                           "trivial perm. group intersection (degree 1)",
                           "[quick][schreier-sims][intersection]") {
     auto            rg = ReportGuard(false);
@@ -3360,7 +3360,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "045",
+                          "042",
                           "trivial perm. group intersection (degree 2)",
                           "[quick][schreier-sims][intersection]") {
     auto            rg = ReportGuard(false);
@@ -3376,7 +3376,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "046",
+                          "043",
                           "cyclic group intersection (degree 13)",
                           "[quick][schreier-sims][intersection]") {
     auto             rg = ReportGuard(false);
@@ -3395,7 +3395,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "047",
+                          "044",
                           "D10 and Z5 intersection",
                           "[quick][schreier-sims][intersection]") {
     auto             rg = ReportGuard(false);
@@ -3414,7 +3414,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "048",
+                          "045",
                           "D8 and Q8 intersection",
                           "[quick][schreier-sims][intersection]") {
     auto            rg = ReportGuard(false);
@@ -3432,7 +3432,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "049",
+                          "046",
                           "primitive on 8 points intersection",
                           "[quick][schreier-sims][intersection]") {
     auto            rg = ReportGuard(false);
@@ -3449,7 +3449,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "050",
+                          "047",
                           "primitive on 8 points intersection (swap order)",
                           "[quick][schreier-sims][intersection]") {
     auto            rg = ReportGuard(false);
@@ -3466,7 +3466,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "051",
+                          "048",
                           "A13 and PGL(2, 11) intersection",
                           "[quick][schreier-sims][intersection]") {
     auto             rg = ReportGuard(false);
@@ -3485,7 +3485,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "052",
+                          "049",
                           "A13 and PGL(2, 11) intersection (swap order)",
                           "[quick][schreier-sims][intersection]") {
     auto             rg = ReportGuard(false);
@@ -3505,7 +3505,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "SchreierSims",
-      "053",
+      "050",
       "S17 and A39 intersection",
       "[standard][schreier-sims][no-valgrind][intersection]") {
     auto             rg = ReportGuard(false);
@@ -3541,7 +3541,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "SchreierSims",
-      "054",
+      "051",
       "A50 and PGL(2, 49) intersection",
       "[extreme][schreier-sims][no-valgrind][intersection]") {
     auto             rg = ReportGuard(false);
@@ -3592,7 +3592,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "055",
+                          "052",
                           "3^3:13 and 3^3.2.A(4) intersection",
                           "[quick][schreier-sims][intersection]") {
     auto             rg = ReportGuard(false);
@@ -3629,7 +3629,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "SchreierSims",
-      "056",
+      "053",
       "PGamma(2, 9) wreath Sym(2) and Alt(6)^2.D_8 intersection",
       "[standard][schreier-sims][no-valgrind][intersection]") {
     auto              rg = ReportGuard(false);
@@ -3683,7 +3683,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "SchreierSims",
-      "057",
+      "054",
       "Alt(6)^2.2^2:4 and Alt(6)^2.4 intersection",
       "[standard][schreier-sims][no-valgrind][intersection]") {
     auto              rg = ReportGuard(false);
@@ -3729,7 +3729,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "058",
+                          "055",
                           "3^3(S(4) x 2) and ASL(3, 3) intersection",
                           "[quick][schreier-sims][intersection]") {
     auto             rg = ReportGuard(false);
@@ -3765,7 +3765,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "059",
+                          "056",
                           "7^2:3 x Q(8) and 7^2:D(2*6) intersection",
                           "[quick][schreier-sims][intersection]") {
     auto             rg = ReportGuard(false);
@@ -3820,7 +3820,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "060",
+                          "057",
                           "D(2*53) and 53:13 intersection",
                           "[quick][schreier-sims][intersection]") {
     auto             rg = ReportGuard(false);
@@ -3851,7 +3851,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "061",
+                          "058",
                           "2^6:(7 x D_14) and PSL(2, 6)^2.4 intersection",
                           "[quick][schreier-sims][intersection]") {
     auto             rg = ReportGuard(false);
@@ -3907,7 +3907,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "062",
+                          "059",
                           "2^6:(S_3 x GL(3, 2)) and 2.6:Alt(7) intersection",
                           "[quick][schreier-sims][intersection][no-valgrind]") {
     auto             rg = ReportGuard(false);
@@ -3979,7 +3979,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "SchreierSims",
-      "063",
+      "060",
       "AGL(7, 2) and PGL(2, 127) intersection",
       "[extreme][schreier-sims][no-valgrind][intersection]") {
     auto              rg = ReportGuard(false);
@@ -4066,7 +4066,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "064",
+                          "061",
                           "PSL(2, 127) and AGL(1, 2^7) intersection",
                           "[quick][schreier-sims][intersection][no-valgrind]") {
     auto              rg = ReportGuard(false);
@@ -4151,7 +4151,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "SchreierSims",
-      "065",
+      "062",
       "PSL(3, 4).2 and PSL(3, 4).2 (nontrivial) intersection",
       "[quick][schreier-sims][intersection]") {
     auto              rg = ReportGuard(false);
@@ -4252,7 +4252,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "066",
+                          "063",
                           "PSL(3, 4).Sym(3) and PSL(3, 4).2 intersection",
                           "[quick][schreier-sims][intersection]") {
     auto              rg = ReportGuard(false);
@@ -4359,7 +4359,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "067",
+                          "064",
                           "3^4:5:4 and D_16:4 intersection",
                           "[quick][schreier-sims][intersection]") {
     auto             rg = ReportGuard(false);
@@ -4436,7 +4436,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("SchreierSims",
-                          "068",
+                          "065",
                           "uint8_t Perm",
                           "[quick][schreier-sims][copy constructor]") {
     auto rg    = ReportGuard(false);

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -3311,7 +3311,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims1",
-                          "087",
+                          "086",
                           "2-sylvester monoid",
                           "[fail][sims1]") {
     Presentation<word_type> p;
@@ -3343,7 +3343,7 @@ namespace libsemigroups {
             == 0);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Sims1", "088", "Brauer monoid", "[fail][sims1]") {
+  LIBSEMIGROUPS_TEST_CASE("Sims1", "087", "Brauer monoid", "[fail][sims1]") {
     // This doesn't fail it's just very extreme
     auto          p = presentation::examples::brauer_monoid(5);
     MinimalRepOrc orc;
@@ -3365,7 +3365,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims1",
-                          "089",
+                          "088",
                           "partial Brauer monoid",
                           "[fail][sims1]") {
     // This doesn't fail it's just very extreme
@@ -3390,7 +3390,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims1",
-                          "090",
+                          "089",
                           "possible full transf. monoid 8",
                           "[extreme][sims1]") {
     auto                    rg = ReportGuard(true);
@@ -3432,7 +3432,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims1",
-                          "091",
+                          "090",
                           "free semilattice n = 8",
                           "[fail][sims1]") {
     Presentation<std::string> p;
@@ -3468,7 +3468,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "092",
+                          "091",
                           "temperley_lieb_monoid(4) from presentation",
                           "[quick][sims2][low-index]") {
     auto  rg = ReportGuard(false);
@@ -3490,7 +3490,7 @@ namespace libsemigroups {
 
   // Takes approx. 13.5s in debug mode.
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "093",
+                          "092",
                           "2-sided T_4",
                           "[quick][sims2][no-valgrind][no-coverage]") {
     auto  rg = ReportGuard(false);
@@ -3501,7 +3501,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "094",
+                          "093",
                           "2-sided T_4 Iwahori presentation",
                           "[quick][sims2][low-index][no-valgrind]") {
     auto  rg = ReportGuard(false);
@@ -3512,7 +3512,7 @@ namespace libsemigroups {
   // Not sure if the next test case runs to completion or not, JDM ran this
   // for 2m30s and it didn't terminate.
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "095",
+                          "094",
                           "2-sided T_4 Aizenstat presentation",
                           "[fail][sims2][low-index]") {
     auto  rg = ReportGuard(true);
@@ -3525,7 +3525,7 @@ namespace libsemigroups {
   // Not sure if the next test case runs to completion or not, JDM ran this
   // for 2m30s and it didn't terminate.
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "096",
+                          "095",
                           "2-sided S_6 Burnside+Miller presentation",
                           "[fail][sims2][low-index]") {
     auto  rg = ReportGuard(true);
@@ -3535,7 +3535,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "097",
+                          "096",
                           "2-sided CI_4 Fernandes presentation",
                           "[standard][sims2][low-index]") {
     auto  rg = ReportGuard(false);
@@ -3546,7 +3546,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "098",
+                          "097",
                           "2-sided CI_4 Froidure-Pin presentation",
                           "[standard][sims2][low-index]") {
     auto                  rg = ReportGuard(false);
@@ -3565,7 +3565,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "099",
+                          "098",
                           "2-sided (2,3,7) triangle group",
                           "[quick][sims2][low-index][no-valgrind]") {
     auto                      rg = ReportGuard(false);
@@ -3583,7 +3583,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "100",
+                          "099",
                           "2-sided Heineken group",
                           "[extreme][sims2][low-index]") {
     auto                      rg = ReportGuard(true);
@@ -3604,7 +3604,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "101",
+                          "100",
                           "2-sided Catalan monoid n=4",
                           "[quick][sims2][low-index][no-valgrind]") {
     auto                   rg = ReportGuard(false);
@@ -3624,7 +3624,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "102",
+                          "101",
                           "2-sided Heineken monoid",
                           "[extreme][sims2][low-index]") {
     auto                      rg = ReportGuard(true);
@@ -3650,7 +3650,7 @@ namespace libsemigroups {
 
   // Takes approx. 1 minute
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "103",
+                          "102",
                           "2-sided Fibonacci(2, 9)",
                           "[extreme][sims2][low-index]") {
     auto                      rg = ReportGuard(true);
@@ -3684,7 +3684,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "104",
+                          "103",
                           "2-sided one-relation baaabaaa=aba",
                           "[standard][sims2][low-index][no-coverage]") {
     auto                      rg = ReportGuard(false);
@@ -3743,7 +3743,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "Sims2",
-      "105",
+      "104",
       "2-sided one-relation baabbaa=a",
       "[extreme][sims2][low-index][no-valgrind][no-coverage]") {
     auto                      rg = ReportGuard(true);
@@ -3795,7 +3795,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "106",
+                          "105",
                           "2-sided full transformation monoid 2",
                           "[quick][sims2]") {
     auto                    rg = ReportGuard(false);
@@ -3858,7 +3858,7 @@ namespace libsemigroups {
         == std::vector<relation_type>({{100_w, 1_w}}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Sims2", "107", "2-sided example", "[quick][sims1]") {
+  LIBSEMIGROUPS_TEST_CASE("Sims2", "106", "2-sided example", "[quick][sims1]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.contains_empty_word(true);
@@ -3881,7 +3881,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "108",
+                          "107",
                           "2-sided full transf. monoid 3",
                           "[quick][sims2]") {
     auto                      rg = ReportGuard(false);
@@ -3960,7 +3960,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "109",
+                          "108",
                           "2-sided 2-generated free monoid",
                           "[standard][sims2][no-coverage]") {
     auto                      rg = ReportGuard(false);
@@ -3985,7 +3985,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "110",
+                          "109",
                           "symmetric inverse monoid (Gay)",
                           "[standard][sims2]") {
     auto rg = ReportGuard(false);
@@ -3999,7 +3999,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "111",
+                          "110",
                           "2-sided congruence-free monoid n=3",
                           "[quick][sims2][no-valgrind]") {
     auto rg = ReportGuard(false);
@@ -4032,7 +4032,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "112",
+                          "111",
                           "2-sided congruence-free monoid n=8",
                           "[quick][sims2][no-valgrind]") {
     auto rg = ReportGuard(false);
@@ -4070,7 +4070,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "113",
+                          "112",
                           "2-sided bicyclic monoid",
                           "[quick][sims2][no-valgrind]") {
     auto                      rg = ReportGuard(false);
@@ -4086,7 +4086,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "114",
+                          "113",
                           "2-sided 2-generated free commutative monoid",
                           "[quick][sims2][no-valgrind]") {
     auto                      rg = ReportGuard(false);
@@ -4117,7 +4117,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "115",
+                          "114",
                           "free semilattice n = 8",
                           "[standard][sims1][no-coverage]") {
     auto rg = ReportGuard(false);
@@ -4137,7 +4137,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "116",
+                          "115",
                           "2-sided 2-generated free semigroup",
                           "[quick][sims2]") {
     auto                      rg = ReportGuard(false);
@@ -4169,7 +4169,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "117",
+                          "116",
                           "1-sided ideals 2-generated free semigroup",
                           "[quick][sims1]") {
     auto                      rg = ReportGuard(false);
@@ -4197,7 +4197,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims1",
-                          "118",
+                          "117",
                           "1-sided ideals partition monoid, n = 2",
                           "[quick][sims1]") {
     auto                    rg = ReportGuard(false);
@@ -4237,7 +4237,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "119",
+                          "118",
                           "2-sided ideals Jura's example",
                           "[quick][sims1][no-valgrind]") {
     auto                      rg = ReportGuard(false);
@@ -4275,7 +4275,7 @@ namespace libsemigroups {
 
   // about 2 seconds
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "120",
+                          "119",
                           "order_preserving_monoid(5)",
                           "[standard][sims1][no-coverage]") {
     auto rg = ReportGuard(false);
@@ -4335,7 +4335,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "121",
+                          "120",
                           "order_preserving_monoid(6)",
                           "[fail][sims1]") {
     auto rg = ReportGuard(false);
@@ -4362,7 +4362,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "122",
+                          "121",
                           "partition_monoid(2)",
                           "[quick][sims1]") {
     auto                    rg = ReportGuard(false);
@@ -4400,7 +4400,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "123",
+                          "122",
                           "Adding and removing pruners",
                           "[quick][low-index]") {
     auto                      rg = ReportGuard(false);
@@ -4421,7 +4421,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims1",
-                          "124",
+                          "123",
                           "onesided congruence checking",
                           "[quick][low-index]") {
     auto                    rg = ReportGuard(false);
@@ -4473,7 +4473,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "125",
+                          "124",
                           "Two-sided congruence checking",
                           "[quick][low-index]") {
     auto                    rg = ReportGuard(false);
@@ -4516,7 +4516,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims1",
-                          "126",
+                          "125",
                           "to_human_readable_repr test",
                           "[quick][low-index]") {
     auto                    rg = ReportGuard(false);
@@ -4819,7 +4819,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims1",
-                          "127",
+                          "126",
                           "symmetric_inverse_monoid(3)",
                           "[quick][low-index]") {
     auto rg = ReportGuard(false);
@@ -4860,7 +4860,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims1",
-                          "128",
+                          "127",
                           "SimsRefinerFaithful test",
                           "[quick][low-index]") {
     auto                    rg = ReportGuard(false);
@@ -4908,7 +4908,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims1",
-                          "129",
+                          "128",
                           "Threading tests",
                           "[quick][low-index]") {
     auto                    rg = ReportGuard(false);
@@ -4934,7 +4934,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims1",
-                          "130",
+                          "129",
                           "MinimalRepOrc test",
                           "[quick][low-index]") {
     auto                    rg = ReportGuard(false);
@@ -4990,7 +4990,7 @@ namespace libsemigroups {
   // }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "256",
+                          "130",
                           "Partition monoid mfrc",
                           "[fail][low-index]") {
     // This doesn't fail it's just very extreme
@@ -5039,7 +5039,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "257",
+                          "131",
                           "Temperley-Lieb monoid mfrc",
                           "[fail][low-index]") {
     // This doesn't fail it's just very extreme
@@ -5105,7 +5105,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "258",
+                          "132",
                           "Partial Brauer monoid mfrc",
                           "[fail][low-index]") {
     // This doesn't fail it's just very extreme
@@ -5151,7 +5151,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "259",
+                          "133",
                           "Motzkin monoid mfrc",
                           "[fail][low-index]") {
     // This doesn't fail it's just very extreme
@@ -5200,7 +5200,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "260",
+                          "134",
                           "Brauer monoid mfrc",
                           "[fail][low-index]") {
     // This doesn't fail it's just very extreme
@@ -5251,7 +5251,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Sims2",
-                          "086",
+                          "135",
                           "Non-contiguous alphabet",
                           "[quick][low-index]") {
     auto                    rg = ReportGuard(false);

--- a/tests/test-stephen.cpp
+++ b/tests/test-stephen.cpp
@@ -1040,7 +1040,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "034",
+                          "032",
                           "(inverse) "
                           "step_hen test_schutzenbergergraph 001 "
                           "(string)",
@@ -1069,7 +1069,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "035",
+                          "033",
                           "(inverse) "
                           "step_hen test_schutzenbergergraph 001",
                           "[stephen][quick]") {
@@ -1097,7 +1097,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "036",
+                          "034",
                           "(inverse) "
                           "step_hen test_schutzenbergergraph 002",
                           "[stephen][quick]") {
@@ -1116,7 +1116,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "037",
+                          "035",
                           "(inverse) "
                           "step_hen test_schutzenbergergraph 003",
                           "[stephen][quick]") {
@@ -1136,7 +1136,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "038",
+                          "036",
                           "(inverse) "
                           "step_hen test_schutzenbergergraph 004",
                           "[stephen][quick]") {
@@ -1175,7 +1175,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "039",
+                          "037",
                           "(inverse) "
                           "step_hen test_schutzenbergergraph 005",
                           "[stephen][quick]") {
@@ -1196,7 +1196,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "040",
+                          "038",
                           "(inverse) "
                           "step_hen test_schutzenbergergraph 006",
                           "[stephen][quick]") {
@@ -1225,7 +1225,7 @@ namespace libsemigroups {
                  {UNDEFINED, UNDEFINED, UNDEFINED, 5, UNDEFINED, 4}}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Stephen", "041", "corner case", "[stephen][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Stephen", "039", "corner case", "[stephen][quick]") {
     ReportGuard rg(false);
     ToWord      to_word("x");
 
@@ -1243,7 +1243,7 @@ namespace libsemigroups {
     REQUIRE(!stephen::accepts(S, to_word("x")));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Stephen", "042", "empty word", "[stephen][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Stephen", "040", "empty word", "[stephen][quick]") {
     ReportGuard rg(false);
     auto        p = presentation::examples::symmetric_inverse_monoid(4);
     REQUIRE(p.contains_empty_word());
@@ -1262,7 +1262,7 @@ namespace libsemigroups {
     REQUIRE(s.word_graph().number_of_nodes() == 48);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Stephen", "043", "shared_ptr", "[stephen][quick]") {
+  LIBSEMIGROUPS_TEST_CASE("Stephen", "041", "shared_ptr", "[stephen][quick]") {
     ReportGuard                    rg(false);
     ToWord                         to_word("abcABC");
     InversePresentation<word_type> p;
@@ -1290,7 +1290,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "044",
+                          "042",
                           "inverse presentation -- operator==",
                           "[stephen][quick][no-valgrind]") {
     ReportGuard            rg(false);
@@ -1344,7 +1344,7 @@ namespace libsemigroups {
   }  // namespace
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "045",
+                          "043",
                           "inverse presentation",
                           "[stephen][standard]") {
     using words::                  operator+;
@@ -1376,7 +1376,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "046",
+                          "044",
                           "non-inverse presentation -- operator==",
                           "[stephen][quick][no-valgrind]") {
     ReportGuard rg(false);
@@ -1404,7 +1404,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "032",
+                          "045",
                           "Plactic monoid",
                           "[stephen][quick]") {
     auto rg = ReportGuard(false);
@@ -1416,7 +1416,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "033",
+                          "046",
                           "Whyte's 4-relation full transf monoid 8",
                           "[stephen][standard]") {
     auto                    rg = ReportGuard(false);
@@ -1508,7 +1508,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "047",
+                          "048",
                           "bicyclic monoid",
                           "[stephen][fail]") {
     ReportGuard                    rg(true);
@@ -1528,7 +1528,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "048",
+                          "049",
                           "chinese monoid",
                           "[stephen][quick]") {
     ReportGuard rg(false);
@@ -1542,7 +1542,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "049",
+                          "050",
                           "to_human_readable_repr",
                           "[stephen][quick]") {
     ReportGuard             rg(false);
@@ -1633,7 +1633,7 @@ namespace libsemigroups {
 
   // The following uses up about 7GB memory to run
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "050",
+                          "051",
                           "shared_ptr memory check",
                           "[stephen][extreme][no-valgrind]") {
     ReportGuard                    rg(true);
@@ -1691,7 +1691,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Stephen",
-                          "051",
+                          "052",
                           "Incomplete Munn tree products",
                           "[stephen][quick]") {
     ReportGuard rg(false);

--- a/tests/test-timer.cpp
+++ b/tests/test-timer.cpp
@@ -28,7 +28,7 @@
 namespace libsemigroups {
   namespace detail {
     LIBSEMIGROUPS_TEST_CASE("Timer",
-                            "001",
+                            "000",
                             "string method (1 argument)",
                             "[quick]") {
       Timer                    t;
@@ -71,7 +71,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("Timer",
-                            "002",
+                            "001",
                             "string method (0 arguments)",
                             "[quick]") {
       Timer t;
@@ -84,7 +84,7 @@ namespace libsemigroups {
 // with expansion:
 //  0 > 0
 #ifndef __CYGWIN__
-    LIBSEMIGROUPS_TEST_CASE("Timer", "003", "reset/elapsed method", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Timer", "002", "reset/elapsed method", "[quick]") {
       Timer t;
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
       auto e
@@ -99,7 +99,7 @@ namespace libsemigroups {
     }
 #endif
 
-    LIBSEMIGROUPS_TEST_CASE("Timer", "004", "operator<<", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Timer", "003", "operator<<", "[quick]") {
       std::ostringstream os;
       Timer              t;
       os << t;

--- a/tests/test-to-knuth-bendix.cpp
+++ b/tests/test-to-knuth-bendix.cpp
@@ -44,7 +44,7 @@ namespace libsemigroups {
   using RewriteTrie_word       = std::pair<RewriteTrie, word_type>;
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("to<KnuthBendix>",
-                                   "001",
+                                   "010",
                                    "from FroidurePin",
                                    "[quick][to_knuth_bendix]",
                                    RewriteFromLeft_string,
@@ -65,7 +65,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("to<KnuthBendix>",
-                                   "002",
+                                   "011",
                                    "from ToddCoxeter",
                                    "[quick][to_knuth_bendix]",
                                    std::string,
@@ -107,7 +107,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("to<KnuthBendix>",
-                                   "003",
+                                   "012",
                                    "from ToddCoxeter",
                                    "[quick][to_knuth_bendix]",
                                    RewriteFromLeft_string,

--- a/tests/test-to-presentation.cpp
+++ b/tests/test-to-presentation.cpp
@@ -54,7 +54,7 @@ namespace libsemigroups {
   using detail::StaticVector1;
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("to<Presentation>",
-                                   "000",
+                                   "013",
                                    "from FroidurePin",
                                    "[quick][to_presentation]",
                                    word_type,
@@ -83,7 +83,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("to<Presentation>",
-                          "001",
+                          "014",
                           "from FroidurePin and alphabet",
                           "[quick][to_presentation]") {
     FroidurePin<Bipartition> S;
@@ -125,7 +125,7 @@ namespace libsemigroups {
       = std::pair<StaticVector1<uint8_t, 3>, StaticVector1<uint8_t, 3>>;
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("to<Presentation>",
-                                   "002",
+                                   "015",
                                    "from present.",
                                    "[quick][to_presentation]",
                                    string_string,
@@ -180,7 +180,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("to<Presentation>",
-                                   "003",
+                                   "016",
                                    "from present. + func.",
                                    "[quick][to_presentation]",
                                    string_string,
@@ -229,7 +229,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("to<Presentation>",
-                          "004",
+                          "017",
                           "from present. and alphabet",
                           "[quick][to_presentation]") {
     Presentation<word_type> p;
@@ -254,7 +254,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("to<Presentation>",
-                          "005",
+                          "018",
                           "use human readable alphabet for to<Presentation>",
                           "[quick][presentation]") {
     Presentation<word_type> p;
@@ -272,7 +272,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("to<InversePresentation>",
-                                   "006",
+                                   "019",
                                    "from inv. present.",
                                    "[quick][to_presentation]",
                                    string_string,
@@ -342,7 +342,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("to<InversePresentation>",
-                                   "007",
+                                   "020",
                                    "from present.",
                                    "[quick][to_presentation][no-valgrind]",
                                    std::string,

--- a/tests/test-to-todd-coxeter.cpp
+++ b/tests/test-to-todd-coxeter.cpp
@@ -31,7 +31,7 @@ namespace libsemigroups {
   congruence_kind constexpr onesided = congruence_kind::onesided;
 
   LIBSEMIGROUPS_TEST_CASE("to<ToddCoxeter<word_type>>",
-                          "000",
+                          "021",
                           "from WordGraph",
                           "[quick]") {
     auto rg = ReportGuard(false);
@@ -76,7 +76,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("to<ToddCoxeter<std::string>>",
-                          "001",
+                          "022",
                           "from WordGraph",
                           "[quick]") {
     auto rg = ReportGuard(false);
@@ -122,7 +122,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("to<ToddCoxeter<word_type>>",
-                          "002",
+                          "023",
                           "from WordGraph",
                           "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
@@ -184,7 +184,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("to<ToddCoxeter>",
-                          "003",
+                          "024",
                           "from KnuthBendix",
                           "[quick]") {
     auto rg = ReportGuard(false);

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -588,7 +588,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "005",
+                          "004",
                           "non-trivial two-sided from relations",
                           "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
@@ -621,7 +621,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "006",
+                          "005",
                           "small onesided cong. on free semigroup",
                           "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
@@ -646,7 +646,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "007",
+                          "006",
                           "left cong. on free semigroup",
                           "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
@@ -683,7 +683,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "008",
+                          "007",
                           "for small fp semigroup",
                           "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
@@ -750,7 +750,7 @@ namespace libsemigroups {
   }  // namespace
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "010",
+                          "008",
                           "left congruence on transformation semigroup",
                           "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
@@ -799,7 +799,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "011",
+                          "009",
                           "onesided cong. trans. semigroup",
                           "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
@@ -865,7 +865,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "012",
+                          "010",
                           "trans. semigroup (size 88)",
                           "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
@@ -904,7 +904,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "015",
+                          "011",
                           "finite fp-semigroup, dihedral group of order 6 ",
                           "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
@@ -932,7 +932,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "016",
+                          "012",
                           "finite fp-semigroup, size 16",
                           "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
@@ -974,7 +974,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "017",
+                          "013",
                           "finite fp-semigroup, size 16 x 2",
                           "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
@@ -1051,7 +1051,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "018",
+                          "014",
                           "test lookahead",
                           "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
@@ -1090,7 +1090,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "020",
+                          "015",
                           "2-sided cong. on free semigroup",
                           "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
@@ -1110,7 +1110,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "021",
+                          "016",
                           "calling run when obviously infinite",
                           "[todd-coxeter][quick]") {
     Presentation<word_type> p;
@@ -1128,7 +1128,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "022",
+                          "017",
                           "stellar_monoid S3",
                           "[todd-coxeter][quick][hivert]") {
     auto rg = ReportGuard(false);
@@ -1194,7 +1194,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "023",
+                          "018",
                           "finite semigroup (size 5)",
                           "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
@@ -1217,7 +1217,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "024",
+                          "019",
                           "exceptions",
                           "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
@@ -1263,7 +1263,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "025",
+                          "020",
                           "obviously infinite",
                           "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
@@ -1286,7 +1286,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "026",
+                          "021",
                           "exceptions x 2",
                           "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
@@ -1330,7 +1330,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "028",
+                          "022",
                           "quotient ToddCoxeter",
                           "[todd-coxeter][quick]") {
     auto                      rg = ReportGuard(false);
@@ -1357,7 +1357,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "029",
+                          "023",
                           "from KnuthBendix",
                           "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
@@ -1406,7 +1406,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "032",
+                          "024",
                           "from WordGraph",
                           "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
@@ -1418,7 +1418,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "033",
+                          "025",
                           "congruence of ToddCoxeter",
                           "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
@@ -1442,7 +1442,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "034",
+                          "026",
                           "congruence of ToddCoxeter x 2",
                           "[todd-coxeter][quick]") {
     auto rg      = ReportGuard(false);
@@ -1466,7 +1466,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "035",
+                          "027",
                           "congruence over fp semigroup",
                           "[todd-coxeter][quick]") {
     auto                      rg = ReportGuard(false);
@@ -1532,7 +1532,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "037",
+                          "028",
                           "copy constructor",
                           "[todd-coxeter][quick]") {
     auto                    rg = ReportGuard(false);
@@ -1581,7 +1581,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "ToddCoxeter",
-      "039",
+      "029",
       "stylic_monoid",
       "[todd-coxeter][standard][no-coverage][no-valgrind]") {
     auto rg = ReportGuard(false);
@@ -1615,7 +1615,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "040",
+                          "030",
                           "fibonacci_semigroup(4, 6)",
                           "[todd-coxeter][fail]") {
     auto        rg = ReportGuard();
@@ -1625,7 +1625,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "041",
+                          "031",
                           "some finite classes",
                           "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
@@ -1715,7 +1715,7 @@ namespace libsemigroups {
 
   // Takes about 1.8s
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "042",
+                          "032",
                           "symmetric_group(9) Moore_b",
                           "[todd-coxeter][extreme]") {
     auto rg = ReportGuard(true);
@@ -1745,7 +1745,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "043",
+                          "033",
                           "symmetric_group(7) Moore_a",
                           "[todd-coxeter][quick][no-valgrind]") {
     auto rg = ReportGuard(false);
@@ -1772,7 +1772,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "116",
+                          "034",
                           "symmetric_group(7) Burnside",
                           "[todd-coxeter][quick][no-valgrind]") {
     auto rg = ReportGuard(false);
@@ -1792,7 +1792,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "046",
+                          "035",
                           "Easdown-East-FitzGerald DualSymInv(5)",
                           "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     auto       rg = ReportGuard(false);
@@ -1812,7 +1812,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "047",
+                          "036",
                           "uniform_block_bijection_monoid(3) (FitzGerald) ",
                           "[todd-coxeter][quick][no-valgrind]") {
     // 16, 131, 1496, 22482, 426833, 9934563, 9934563
@@ -1833,7 +1833,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "048",
+                          "037",
                           "stellar_monoid(7) (Gay-Hivert)",
                           "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     auto         rg = ReportGuard(false);
@@ -1853,7 +1853,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "049",
+                          "038",
                           "partition_monoid(4) (East)",
                           "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     auto rg = ReportGuard(false);
@@ -1874,7 +1874,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "050",
+                          "039",
                           "singular_brauer_monoid(6) (Maltcev + Mazorchuk)",
                           "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     auto         rg = ReportGuard(false);
@@ -1895,7 +1895,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "051",
+                          "040",
                           "orientation_preserving_monoid(6) (Ruskuc + Arthur)",
                           "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     auto         rg = ReportGuard(false);
@@ -1916,7 +1916,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "052",
+                          "041",
                           "POPR(5) (Ruskuc + Arthur)",
                           "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     auto         rg = ReportGuard(false);
@@ -1937,7 +1937,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "053",
+                          "042",
                           "temperley_lieb_monoid(10) (East)",
                           "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     auto         rg = ReportGuard(false);
@@ -1964,7 +1964,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "ToddCoxeter",
-      "054",
+      "043",
       "Generate GAP benchmarks for stellar_monoid(n) (Gay-Hivert)",
       "[todd-coxeter][fail]") {
     auto rg = ReportGuard(true);
@@ -1977,7 +1977,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "ToddCoxeter",
-      "055",
+      "044",
       "Generate GAP benchmarks for partition_monoid(n) (East)",
       "[todd-coxeter][fail]") {
     auto rg = ReportGuard(true);
@@ -1991,7 +1991,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "056",
+                          "045",
                           "Generate GAP benchmarks for dual symmetric inverse "
                           "monoid (Easdown + East + FitzGerald)",
                           "[todd-coxeter][fail]") {
@@ -2005,7 +2005,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "057",
+                          "046",
                           "Generate GAP benchmarks for "
                           "uniform_block_bijection_monoid (FitzGerald)",
                           "[todd-coxeter][fail]") {
@@ -2020,7 +2020,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "058",
+                          "047",
                           "Generate GAP benchmarks for stylic monoids",
                           "[todd-coxeter][fail]") {
     auto rg = ReportGuard(true);
@@ -2032,7 +2032,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "059",
+                          "048",
                           "Generate GAP benchmarks for OP_n",
                           "[todd-coxeter][fail]") {
     auto rg = ReportGuard(true);
@@ -2044,7 +2044,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "060",
+                          "049",
                           "Generate GAP benchmarks for OR_n",
                           "[todd-coxeter][fail]") {
     auto rg = ReportGuard(true);
@@ -2059,7 +2059,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "ToddCoxeter",
-      "061",
+      "050",
       "Generate GAP benchmarks for temperley_lieb_monoid(n)",
       "[todd-coxeter][fail]") {
     auto rg = ReportGuard(true);
@@ -2073,7 +2073,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "ToddCoxeter",
-      "062",
+      "051",
       "Generate GAP benchmarks for singular_brauer_monoid(n)",
       "[todd-coxeter][fail]") {
     auto rg = ReportGuard(true);
@@ -2086,7 +2086,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "111",
+                          "052",
                           "partition_monoid(2)",
                           "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
@@ -2103,7 +2103,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "112",
+                          "053",
                           "brauer_monoid(4) (Kudryavtseva + Mazorchuk)",
                           "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     auto         rg = ReportGuard(false);
@@ -2122,7 +2122,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "113",
+                          "054",
                           "symmetric_inverse_monoid(5) Shutov",
                           "[todd-coxeter][quick][no-valgrind]") {
     auto rg = ReportGuard(false);
@@ -2139,7 +2139,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "114",
+                          "055",
                           "partial_transformation_monoid(5) Shutov",
                           "[todd-coxeter][extreme]") {
     auto   rg = ReportGuard(true);
@@ -2158,7 +2158,7 @@ namespace libsemigroups {
 
   // stop_early in lookahead really helps in this example
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "115",
+                          "056",
                           "full_transformation_monoid(7) Iwahori",
                           "[todd-coxeter][extreme]") {
     auto   rg = ReportGuard(true);
@@ -2186,7 +2186,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "063",
+                          "057",
                           "add_rule",
                           "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
@@ -2283,7 +2283,7 @@ namespace libsemigroups {
 
   // KnuthBendix methods fail for this one
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "064",
+                          "058",
                           "from kbmag/standalone/kb_data/s4",
                           "[todd-coxeter][quick][kbmag]") {
     auto rg = ReportGuard(false);
@@ -2321,7 +2321,7 @@ namespace libsemigroups {
   // Second of BHN's series of increasingly complicated presentations
   // of 1. Doesn't terminate
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "065",
+                          "059",
                           "(from kbmag/standalone/kb_data/degen4b) "
                           "(KnuthBendix 065)",
                           "[fail][todd-coxeter][kbmag][shortlex]") {
@@ -2361,7 +2361,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "067",
+                          "060",
                           "Repeated construction from same FroidurePin",
                           "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
@@ -2414,7 +2414,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "068",
+                          "061",
                           "Sym(5) from Chapter 3, Proposition 1.1 in NR",
                           "[todd-coxeter][quick]") {
     auto rg = ReportGuard(false);
@@ -2463,7 +2463,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "069",
+                          "062",
                           "Chapter 7, Theorem 3.6 in NR (size 243)",
                           "[no-valgrind][todd-coxeter][quick]") {
     auto                      rg = ReportGuard(false);
@@ -2486,7 +2486,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "070",
+                          "063",
                           "finite semigroup (size 99)",
                           "[todd-coxeter][quick]") {
     auto                      rg = ReportGuard(false);
@@ -2513,7 +2513,7 @@ namespace libsemigroups {
   // The following 8 examples are from Trevor Walker's Thesis: Semigroup
   // enumeration - computer implementation and applications, p41.
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "071",
+                          "064",
                           "Walker 1",
                           "[todd-coxeter][standard][no-valgrind]") {
     auto                      rg = ReportGuard(false);
@@ -2592,7 +2592,7 @@ namespace libsemigroups {
   // The following example is a good one for using the lookahead.
   // This is no longer extreme with the preprocessing
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "072",
+                          "065",
                           "Walker 2",
                           "[todd-coxeter][quick][no-coverage][no-valgrind]") {
     auto                      rg = ReportGuard(false);
@@ -2654,7 +2654,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "073",
+                          "066",
                           "Walker 3",
                           "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
@@ -2683,7 +2683,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "074",
+                          "067",
                           "Walker 4",
                           "[todd-coxeter][extreme]") {
     auto                      rg = ReportGuard();
@@ -2734,7 +2734,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "075",
+                          "068",
                           "Walker 5",
                           "[todd-coxeter][extreme]") {
     auto                      rg = ReportGuard(true);
@@ -2778,7 +2778,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "076",
+                          "069",
                           "not Walker 6",
                           "[todd-coxeter][extreme]") {
     auto                      rg = ReportGuard();
@@ -2824,7 +2824,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "077",
+                          "070",
                           "Walker 6",
                           "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
@@ -2873,7 +2873,7 @@ namespace libsemigroups {
 
   // Felsch is faster here too!
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "078",
+                          "071",
                           "Walker 7",
                           "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
@@ -2916,7 +2916,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "079",
+                          "072",
                           "Walker 8",
                           "[todd-coxeter][standard]") {
     auto rg = ReportGuard(false);
@@ -2958,7 +2958,7 @@ namespace libsemigroups {
 
   // This is a good example of why large collapse is required
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "080",
+                          "073",
                           "KnuthBendix 098",
                           "[todd-coxeter][quick][no-valgrind][no-coverage]") {
     auto                      rg = ReportGuard(false);
@@ -2987,7 +2987,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "081",
+                          "074",
                           "Holt 2 - SL(2, p)",
                           "[todd-coxeter][extreme]") {
     auto                        rg     = ReportGuard();
@@ -3008,7 +3008,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "082",
+                          "075",
                           "Holt 3",
                           "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
@@ -3036,7 +3036,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "083",
+                          "076",
                           "Holt 3 x 2",
                           "[todd-coxeter][fail]") {
     auto                      rg = ReportGuard();
@@ -3064,7 +3064,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "084",
+                          "077",
                           "Campbell-Reza 1",
                           "[todd-coxeter][quick]") {
     auto                      rg = ReportGuard(false);
@@ -3107,7 +3107,7 @@ namespace libsemigroups {
 
   // The next example demonstrates why we require deferred standardization
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "085",
+                          "078",
                           "Renner monoid type D4 (Gay-Hivert), q = 1",
                           "[no-valgrind][quick][todd-coxeter][no-coverage]") {
     auto rg = ReportGuard(false);
@@ -3140,7 +3140,7 @@ namespace libsemigroups {
 
   // Felsch very slow here
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "086",
+                          "079",
                           "trivial semigroup",
                           "[no-valgrind][todd-coxeter][quick][no-coverage]") {
     auto rg = ReportGuard(false);
@@ -3167,7 +3167,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "087",
+                          "080",
                           "ACE --- 2p17-2p14 - HLT",
                           "[todd-coxeter][standard][ace]") {
     auto                      rg = ReportGuard(false);
@@ -3202,7 +3202,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "088",
+                          "081",
                           "ACE --- 2p17-2p3 - HLT",
                           "[todd-coxeter][standard][ace]") {
     auto                      rg = ReportGuard(false);
@@ -3233,7 +3233,7 @@ namespace libsemigroups {
   // In this example large_collapse makes a huge difference to the run time,
   // 73ms versus 1173ms for the save case.
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "089",
+                          "082",
                           "ACE --- 2p17-1a - HLT",
                           "[todd-coxeter][standard][ace]") {
     auto rg = ReportGuard(false);
@@ -3264,7 +3264,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "090",
+                          "083",
                           "ACE --- F27",
                           "[todd-coxeter][standard][ace]") {
     auto                      rg = ReportGuard(false);
@@ -3293,7 +3293,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "091",
+                          "084",
                           "ACE --- SL219 - HLT",
                           "[todd-coxeter][standard][ace]") {
     auto                      rg = ReportGuard(false);
@@ -3342,7 +3342,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "092",
+                          "085",
                           "ACE --- perf602p5",
                           "[no-valgrind][todd-coxeter][quick][ace]") {
     auto                      rg = ReportGuard(false);
@@ -3393,7 +3393,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "093",
+                          "086",
                           "ACE --- M12",
                           "[todd-coxeter][standard][ace]") {
     auto                      rg = ReportGuard(false);
@@ -3427,7 +3427,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "094",
+                          "087",
                           "ACE --- C5",
                           "[todd-coxeter][quick][ace]") {
     auto                      rg = ReportGuard(false);
@@ -3452,7 +3452,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "095",
+                          "088",
                           "ACE --- A5-C5",
                           "[todd-coxeter][quick][ace]") {
     auto                      rg = ReportGuard(false);
@@ -3480,7 +3480,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "096",
+                          "089",
                           "ACE --- A5",
                           "[todd-coxeter][quick][ace]") {
     auto                      rg = ReportGuard(false);
@@ -3510,7 +3510,7 @@ namespace libsemigroups {
   // 1.5s or so.
   // Seems to have gotten worse still since the comment about up to 1.8s
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "097",
+                          "090",
                           "relation ordering",
                           "[todd-coxeter][extreme]") {
     auto rg = ReportGuard(true);
@@ -3530,7 +3530,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "098",
+                          "091",
                           "relation ordering x 2",
                           "[todd-coxeter][quick]") {
     Presentation<word_type> p;
@@ -3639,7 +3639,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "099",
+                          "092",
                           "short circuit size in obviously infinite",
                           "[todd-coxeter][quick]") {
     auto                      rg = ReportGuard(false);
@@ -3651,7 +3651,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "100",
+                          "093",
                           "http://brauer.maths.qmul.ac.uk/Atlas/misc/24A8",
                           "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
@@ -3683,7 +3683,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "101",
+                          "094",
                           "http://brauer.maths.qmul.ac.uk/Atlas/spor/M11/",
                           "[todd-coxeter][quick][no-coverage][no-valgrind]") {
     auto                      rg = ReportGuard(false);
@@ -3725,7 +3725,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "102",
+                          "095",
                           "http://brauer.maths.qmul.ac.uk/Atlas/spor/M12/",
                           "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
@@ -3752,7 +3752,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "103",
+                          "096",
                           "http://brauer.maths.qmul.ac.uk/Atlas/spor/M22",
                           "[todd-coxeter][extreme]") {
     ReportGuard               rg(true);
@@ -3778,7 +3778,7 @@ namespace libsemigroups {
   // Takes about 4 minutes (2021 - MacBook Air M1 - 8GB RAM)
   // with Felsch (3.5mins or 2.5mins with lowerbound) or HLT (4.5mins)
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "104",
+                          "097",
                           "http://brauer.maths.qmul.ac.uk/Atlas/spor/M23",
                           "[todd-coxeter][extreme]") {
     Presentation<std::string> p;
@@ -3819,7 +3819,7 @@ namespace libsemigroups {
 
   // Takes about 3 minutes (with HLT)
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "105",
+                          "098",
                           "http://brauer.maths.qmul.ac.uk/Atlas/clas/S62",
                           "[todd-coxeter][extreme]") {
     Presentation<std::string> p;
@@ -3861,7 +3861,7 @@ namespace libsemigroups {
 
   // Approx. 32 minutes (2021 - MacBook Air M1 - 8GB RAM)
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "106",
+                          "099",
                           "http://brauer.maths.qmul.ac.uk/Atlas/spor/HS",
                           "[todd-coxeter][extreme]") {
     auto rg = ReportGuard();
@@ -3899,7 +3899,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "107",
+                          "100",
                           "http://brauer.maths.qmul.ac.uk/Atlas/spor/J1",
                           "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
@@ -3921,7 +3921,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "108",
+                          "101",
                           "http://brauer.maths.qmul.ac.uk/Atlas/lin/L34/",
                           "[todd-coxeter][quick][no-coverage][no-valgrind]") {
     auto                      rg = ReportGuard(false);
@@ -3951,7 +3951,7 @@ namespace libsemigroups {
 
   // Takes about 10 seconds (2021 - MacBook Air M1 - 8GB RAM)
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "109",
+                          "102",
                           "http://brauer.maths.qmul.ac.uk/Atlas/clas/S62 x 2",
                           "[todd-coxeter][extreme]") {
     Presentation<std::string> p;
@@ -3976,7 +3976,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "013",
+                          "103",
                           "redundant rule x1",
                           "[todd-coxeter][quick]") {
     auto                      rg = ReportGuard(false);
@@ -4004,7 +4004,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "120",
+                          "104",
                           "redundant rule x2",
                           "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
@@ -4025,7 +4025,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "014",
+                          "105",
                           "hypo plactic id monoid",
                           "[todd-coxeter][extreme]") {
     std::array<uint64_t, 11> const num
@@ -4058,7 +4058,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "019",
+                          "106",
                           "Chinese id monoid",
                           "[todd-coxeter][extreme]") {
     std::array<uint64_t, 11> const num = {
@@ -4100,7 +4100,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "030",
+                          "107",
                           "Chinese id monoid x 2",
                           "[todd-coxeter][extreme]") {
     auto n = 5;
@@ -4202,7 +4202,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "027",
+                          "108",
                           "plactic (n, 1)-id monoid",
                           "[todd-coxeter][extreme]") {
     // auto                          r = 3, s = 2;
@@ -4362,7 +4362,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "036",
+                          "109",
                           "plactic (n, 1)-id monoid x 2",
                           "[todd-coxeter][extreme]") {
     using words::pow;
@@ -4404,7 +4404,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "038",
+                          "110",
                           "sigma-plactic monoid",
                           "[todd-coxeter][extreme]") {
     auto p = presentation::examples::sigma_plactic_monoid({2, 2, 2});
@@ -4434,7 +4434,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "044",
+                          "111",
                           "2-sylvester monoid",
                           "[todd-coxeter][extreme]") {
     using words::pow;
@@ -4465,7 +4465,7 @@ namespace libsemigroups {
 
   // Takes nearly 13 hours to complete
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "045",
+                          "112",
                           "Whyte's 8-generator 4-relation full transf monoid 8",
                           "[todd-coxeter][fail]") {
     auto                    rg = ReportGuard(true);
@@ -4567,7 +4567,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "066",
+                          "113",
                           "Whyte's 2-generator 4-relation full transf monoid 8",
                           "[todd-coxeter][extreme]") {
     auto                    rg = ReportGuard(true);
@@ -4618,7 +4618,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE(
       "ToddCoxeter",
-      "110",
+      "114",
       "minimal E-disjunctive idempotent pure onesided congruence",
       "[todd-coxeter][quick]") {
     auto rg     = ReportGuard(false);
@@ -4650,7 +4650,7 @@ namespace libsemigroups {
 
   // Takes about 2 minutes
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "10X",
+                          "115",
                           "https://brauer.maths.qmul.ac.uk/Atlas/exc/TF42",
                           "[todd-coxeter][extreme]") {
     Presentation<std::string> p;
@@ -4676,7 +4676,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "10Y",
+                          "116",
                           "cyclic groups",
                           "[todd-coxeter][quick]") {
     Presentation<std::string> p;
@@ -4831,7 +4831,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
-                          "121",
+                          "120",
                           "check full enum not triggered",
                           "[todd-coxeter][extreme]") {
     Presentation<std::string> p;

--- a/tests/test-types.cpp
+++ b/tests/test-types.cpp
@@ -23,7 +23,7 @@
 #include "libsemigroups/types.hpp"   // for SmallestInteger, Smalle...
 
 namespace libsemigroups {
-  LIBSEMIGROUPS_TEST_CASE("SmallestInteger", "001", "", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("SmallestInteger", "000", "", "[quick]") {
     REQUIRE(sizeof(SmallestInteger<0>::type) == 1);
     REQUIRE(sizeof(SmallestInteger<255>::type) == 1);
     REQUIRE(sizeof(SmallestInteger<256>::type) == 2);

--- a/tests/test-uf.cpp
+++ b/tests/test-uf.cpp
@@ -30,7 +30,7 @@
 
 namespace libsemigroups {
   namespace detail {
-    LIBSEMIGROUPS_TEST_CASE("UF", "001", "constructor by size", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("UF", "000", "constructor by size", "[quick]") {
       {
         Duf<> uf(7);
         REQUIRE(uf.size() == 7);
@@ -51,7 +51,7 @@ namespace libsemigroups {
       }
     }
 
-    LIBSEMIGROUPS_TEST_CASE("UF", "002", "copy constructor", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("UF", "001", "copy constructor", "[quick]") {
       {
         Duf<> uf(11);
         uf.unite(0, 10);
@@ -105,7 +105,7 @@ namespace libsemigroups {
       }
     }
 
-    LIBSEMIGROUPS_TEST_CASE("UF", "003", "find", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("UF", "002", "find", "[quick]") {
       {
         Duf<> uf(11);
         uf.unite(0, 10);
@@ -150,7 +150,7 @@ namespace libsemigroups {
       }
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Duf", "004", "unite", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Duf", "003", "unite", "[quick]") {
       Duf<> uf(12);
       uf.unite(0, 1);
       uf.unite(4, 2);
@@ -207,7 +207,7 @@ namespace libsemigroups {
           uf.cbegin(), uf.cend(), [&uf](size_t i) { return uf.find(i) == i; }));
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Suf", "005", "unite", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Suf", "004", "unite", "[quick]") {
       Suf<12> uf;
       uf.unite(0, 1);
       uf.unite(4, 2);
@@ -264,7 +264,7 @@ namespace libsemigroups {
           uf.cbegin(), uf.cend(), [&uf](size_t i) { return uf.find(i) == i; }));
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Duf", "006", "compress", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Duf", "005", "compress", "[quick]") {
       {
         Duf<> uf(12);
         uf.unite(0, 1);
@@ -294,7 +294,7 @@ namespace libsemigroups {
       }
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Suf", "007", "compress", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Suf", "006", "compress", "[quick]") {
       {
         Suf<12> uf;
         uf.unite(0, 1);
@@ -321,7 +321,7 @@ namespace libsemigroups {
       }
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Duf", "008", "resize", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Duf", "007", "resize", "[quick]") {
       Duf<> uf(0);
       for (size_t i = 0; i < 10; ++i) {
         uf.resize(i);
@@ -358,7 +358,7 @@ namespace libsemigroups {
       REQUIRE(uf.number_of_blocks() == 23);
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Duf", "009", "resize", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Duf", "008", "resize", "[quick]") {
       Duf<> uf({0, 0, 2, 3, 3, 5});
       REQUIRE(uf.size() == 6);
       uf.resize(7);
@@ -374,7 +374,7 @@ namespace libsemigroups {
               == std::vector<size_t>({2, 3, 5, 6, 7}));
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Duf", "010", "big chain", "[no-valgrind][quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Duf", "009", "big chain", "[no-valgrind][quick]") {
       std::vector<size_t> tab;
       tab.push_back(0);
       for (size_t i = 0; i < 100000; i++) {
@@ -392,7 +392,7 @@ namespace libsemigroups {
       }
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Suf", "011", "big chain", "[no-valgrind][quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Suf", "010", "big chain", "[no-valgrind][quick]") {
       std::array<uint32_t, 100001> tab;
       std::iota(tab.begin() + 1, tab.end(), 0);
       Suf<100001> uf(std::move(tab));
@@ -407,7 +407,7 @@ namespace libsemigroups {
       }
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Duf", "012", "empty table", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Duf", "011", "empty table", "[quick]") {
       Duf<> uf(0);
       REQUIRE(uf.number_of_blocks() == 0);
       uf.resize(1);
@@ -415,12 +415,12 @@ namespace libsemigroups {
       REQUIRE(uf.number_of_blocks() == 1);
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Suf", "013", "empty table", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Suf", "012", "empty table", "[quick]") {
       Suf<0> uf;
       REQUIRE(uf.number_of_blocks() == 0);
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Duf", "014", "join", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Duf", "013", "join", "[quick]") {
       Duf<> uf1(10);
       uf1.unite(2, 4);
       uf1.unite(4, 9);
@@ -445,7 +445,7 @@ namespace libsemigroups {
               == std::vector<size_t>({4, 5, 6, 8}));
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Suf", "015", "join", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Suf", "014", "join", "[quick]") {
       Suf<10> uf1;
       uf1.unite(2, 4);
       uf1.unite(4, 9);
@@ -470,7 +470,7 @@ namespace libsemigroups {
               == std::vector<size_t>({4, 5, 6, 8}));
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Duf", "016", "contains", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Duf", "015", "contains", "[quick]") {
       Duf<> uf1(10);
       uf1.unite(2, 4);
       uf1.unite(4, 9);
@@ -510,7 +510,7 @@ namespace libsemigroups {
       REQUIRE(uf1 != uf2);
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Suf", "017", "contains", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Suf", "016", "contains", "[quick]") {
       Suf<10> uf1;
       uf1.unite(2, 4);
       uf1.unite(4, 9);
@@ -550,7 +550,7 @@ namespace libsemigroups {
       REQUIRE(uf1 != uf2);
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Duf", "018", "swap", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Duf", "017", "swap", "[quick]") {
       Duf<> uf1(10);
       uf1.unite(2, 4);
       uf1.unite(4, 9);
@@ -581,7 +581,7 @@ namespace libsemigroups {
       REQUIRE(uf2 == uf1);
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Suf", "019", "swap", "[quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Suf", "018", "swap", "[quick]") {
       Suf<10> uf1;
       uf1.unite(2, 4);
       uf1.unite(4, 9);

--- a/tests/test-ukkonen.cpp
+++ b/tests/test-ukkonen.cpp
@@ -492,7 +492,7 @@ namespace libsemigroups {
     REQUIRE(ukkonen::number_of_pieces(t, "xxx") == POSITIVE_INFINITY);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Ukkonen", "018", "pieces", "[quick][ukkonen]") {
+  LIBSEMIGROUPS_TEST_CASE("Ukkonen", "008", "pieces", "[quick][ukkonen]") {
     Ukkonen t;
     ToWord  string_to_word("ab");
     ukkonen::add_word(t, string_to_word("baabbaaaa"));
@@ -518,7 +518,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Ukkonen",
-                          "019",
+                          "009",
                           "code coverage",
                           "[quick][ukkonen]") {
     Ukkonen u;
@@ -623,7 +623,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Ukkonen",
-                          "020",
+                          "010",
                           "code coverage",
                           "[quick][ukkonen]") {
     Ukkonen u;

--- a/tests/test-word-graph-with-sources.cpp
+++ b/tests/test-word-graph-with-sources.cpp
@@ -35,7 +35,7 @@ namespace libsemigroups {
   namespace detail {
 
     LIBSEMIGROUPS_TEST_CASE("WordGraphWithSources",
-                            "044",
+                            "000",
                             "constructor with 1  default arg",
                             "[quick][digraph]") {
       WordGraphWithSources<size_t> g;
@@ -44,7 +44,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("WordGraphWithSources",
-                            "045",
+                            "001",
                             "constructor with 0 default args",
                             "[quick][digraph]") {
       for (size_t j = 0; j < 100; ++j) {
@@ -55,7 +55,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("WordGraphWithSources",
-                            "046",
+                            "002",
                             "add nodes",
                             "[quick][digraph]") {
       WordGraphWithSources<size_t> g(3);
@@ -69,7 +69,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("WordGraphWithSources",
-                            "047",
+                            "003",
                             "add edges",
                             "[quick][digraph]") {
       WordGraph<size_t> g(17, 31);
@@ -104,7 +104,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("WordGraphWithSources",
-                            "048",
+                            "004",
                             "exceptions",
                             "[quick][digraph]") {
       WordGraphWithSources<size_t> graph(10, 5);
@@ -120,7 +120,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("WordGraphWithSources",
-                            "049",
+                            "005",
                             "reserve",
                             "[quick][digraph]") {
       WordGraphWithSources<size_t> graph;
@@ -135,7 +135,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("WordGraphWithSources",
-                            "050",
+                            "006",
                             "default constructors",
                             "[quick][digraph]") {
       auto g1 = WordGraphWithSources<size_t>();
@@ -159,7 +159,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("WordGraphWithSources",
-                            "051",
+                            "007",
                             "target_no_checks",
                             "[quick]") {
       size_t                       number_of_levels = 10;
@@ -181,7 +181,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("WordGraphWithSources",
-                            "052",
+                            "008",
                             "operator<<",
                             "[quick]") {
       WordGraphWithSources<uint32_t> ad;
@@ -199,7 +199,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("WordGraphWithSources",
-                            "053",
+                            "009",
                             "quotient",
                             "[quick]") {
       WordGraphWithSources<size_t> dws1(0, 0);
@@ -209,7 +209,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("WordGraphWithSources",
-                            "054",
+                            "010",
                             "hopcroft_karp_quotient",
                             "[quick]") {
       WordGraphWithSources<size_t> d1(3, 3);


### PR DESCRIPTION
This PR adds a (very ~~hacky~~ excellent) script for renumbering all test cases and applies it to the existing test cases.