### PR TITLE
Update copyright years

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 #
 # libsemigroups - C++ library for semigroups and monoids
-# Copyright (C) 2019 James D. Mitchell
+# Copyright (C) 2019-2025 James D. Mitchell
 #
 # This file is part of the build system of libsemigroups.
 # Requires GNU autoconf, GNU automake and GNU libtool.

--- a/benchmarks/bench-action.cpp
+++ b/benchmarks/bench-action.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/benchmarks/bench-bmat.cpp
+++ b/benchmarks/bench-bmat.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/benchmarks/bench-freeband.cpp
+++ b/benchmarks/bench-freeband.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021 James D. Mitchell
+// Copyright (C) 2021-2025 James D. Mitchell
 //                    Reinis Cirpons
 //
 // This program is free software: you can redistribute it and/or modify

--- a/benchmarks/bench-kambites.cpp
+++ b/benchmarks/bench-kambites.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021-2022 James D. Mitchell + Maria Tsalakou
+// Copyright (C) 2021-2025 James D. Mitchell + Maria Tsalakou
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/benchmarks/bench-konieczny.cpp
+++ b/benchmarks/bench-konieczny.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/benchmarks/bench-multi-string-view.cpp
+++ b/benchmarks/bench-multi-string-view.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/benchmarks/bench-sims1.cpp
+++ b/benchmarks/bench-sims1.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/benchmarks/bench-string-range.cpp
+++ b/benchmarks/bench-string-range.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/benchmarks/bench-todd-coxeter.cpp
+++ b/benchmarks/bench-todd-coxeter.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020-24 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/benchmarks/bench-uf.cpp
+++ b/benchmarks/bench-uf.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/benchmarks/bench-wilo.cpp
+++ b/benchmarks/bench-wilo.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/benchmarks/bench-wislo.cpp
+++ b/benchmarks/bench-wislo.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/benchmarks/bench-word-graph.cpp
+++ b/benchmarks/bench-word-graph.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/benchmarks/uf-old.cpp
+++ b/benchmarks/uf-old.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 Michael Young
+// Copyright (C) 2019-2025 Michael Young
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/benchmarks/uf-old.hpp
+++ b/benchmarks/uf-old.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 Michael Young
+// Copyright (C) 2019-2025 Michael Young
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/etc/update-copyright.py
+++ b/etc/update-copyright.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Update all copyright years.
+
+The script should be run from the libsemigroups root directory. Once run, all of
+the copyright information in the files listed below will either have the form
+
+Copyright (C) CREATION_YEAR-CURRENT_YEAR Author 1 (+ Author 2 ...)
+
+for files not created this year, or
+
+Copyright (C) CURRENT_YEAR Author 1 (+ Author 2 ...)
+
+for files created this year.
+
+The files edit by this script are:
+    * autogen.sh
+    * benchmarks/**
+    * include/libsemigroups/**
+    * src/**
+    * tests/**
+"""
+
+import re
+from datetime import date
+from glob import glob
+from os.path import isfile
+
+BOLD_TEXT = "\033[1m"
+END_BOLD_TEXT = "\033[0m"
+
+
+year = date.today().year
+
+# Match copyright for the date ranges 20XX-20YY, unless 20YY is the same as the
+# current year
+copyright_info_old_file = re.compile(
+    rf"(copyright \(c\) 20\d\d)-(?!{year})(20\d\d|\d\d\b)", re.IGNORECASE
+)
+
+# Match copyright for the date 20XX, unless 20XX is the current year
+copyright_info_new_file = re.compile(
+    rf"(copyright \(c\) (?!{year})20\d\d)(?!-)", re.IGNORECASE
+)
+
+# Match any copyright and capture the author
+copyright_author = re.compile(r"copyright \(c\).*20\d\d (.*)", re.IGNORECASE)
+
+pathnames = [
+    "autogen.sh",
+    "benchmarks/**",
+    "include/libsemigroups/**",
+    "src/**",
+    "tests/**",
+]
+
+authors = set()
+
+
+def process_line(line):
+    """Update the copyright information in a given line, and add the author to
+    the list of authors if any changes are made.
+    """
+    new_line = line
+    new_line = copyright_info_old_file.sub(rf"\1-{year}", new_line)
+    new_line = copyright_info_new_file.sub(rf"\1-{year}", new_line)
+    changed = line != new_line
+    if changed:
+        author_matches = copyright_author.search(new_line)
+        authors.add(author_matches[1])
+    return new_line, changed
+
+
+def process_file(filename):
+    """Update the copyright information in a file, and report any changes"""
+    with open(filename, "r") as f:
+        content = f.readlines()
+    changed = False
+    for line_number, line in enumerate(content):
+        new_line, changed = process_line(line)
+        if changed:
+            content[line_number] = new_line
+            break
+
+    print(f"{filename + ' . . .':64}", end="")
+    if changed:
+        with open(filename, "w") as f:
+            f.writelines(content)
+        print(f"{'Changed':>16}")
+    else:
+        print(f"{'Already correct':>16}")
+
+
+def process_path(pathname):
+    """Update the copyright information of all files in a specified path."""
+    print(
+        BOLD_TEXT
+        + f"Checking for Copyright year changes in {pathname} . . ."
+        + END_BOLD_TEXT
+    )
+    filenames = glob(pathname, recursive=True, include_hidden=True)
+    for filename in filter(isfile, filenames):
+        process_file(filename)
+
+
+if __name__ == "__main__":
+    for pathname in pathnames:
+        process_path(pathname)
+    if authors:
+        print(
+            "\nThe following contributors' Copyright years have been updated:"
+        )
+        for author in sorted(authors):
+            print(f" * {author}")
+        print(
+            "Please check that these are all libsemigroups contributors. If "
+            "they are not, then the script has updated an incorrect Copyright "
+            "and this should be reverted."
+        )

--- a/include/libsemigroups/action.hpp
+++ b/include/libsemigroups/action.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/action.tpp
+++ b/include/libsemigroups/action.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/adapters.hpp
+++ b/include/libsemigroups/adapters.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2023 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/aho-corasick.hpp
+++ b/include/libsemigroups/aho-corasick.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023-2024 Joseph Edwards + James D. Mitchell
+// Copyright (C) 2023-2025 Joseph Edwards + James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/aho-corasick.tpp
+++ b/include/libsemigroups/aho-corasick.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell + Joseph Edwards
+// Copyright (C) 2019-2025 James D. Mitchell + Joseph Edwards
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/bipart.hpp
+++ b/include/libsemigroups/bipart.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021-2024 James D. Mitchell
+// Copyright (C) 2021-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/bitset.hpp
+++ b/include/libsemigroups/bitset.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020-2023 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/bmat-adapters.hpp
+++ b/include/libsemigroups/bmat-adapters.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020-2024 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/bmat-fastest.hpp
+++ b/include/libsemigroups/bmat-fastest.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021 James D. Mitchell
+// Copyright (C) 2021-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/bmat8.hpp
+++ b/include/libsemigroups/bmat8.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-24 Finn Smith
+// Copyright (C) 2019-2025 Finn Smith
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/cong-class.tpp
+++ b/include/libsemigroups/cong-class.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/cong-common-helpers.hpp
+++ b/include/libsemigroups/cong-common-helpers.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/cong-common-helpers.tpp
+++ b/include/libsemigroups/cong-common-helpers.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/cong-helpers.hpp
+++ b/include/libsemigroups/cong-helpers.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/cong-helpers.tpp
+++ b/include/libsemigroups/cong-helpers.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/cong.hpp
+++ b/include/libsemigroups/cong.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/constants.hpp
+++ b/include/libsemigroups/constants.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/debug.hpp
+++ b/include/libsemigroups/debug.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/deprecated.hpp
+++ b/include/libsemigroups/deprecated.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/bruidhinn-traits.hpp
+++ b/include/libsemigroups/detail/bruidhinn-traits.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2023 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/cong-common-class.hpp
+++ b/include/libsemigroups/detail/cong-common-class.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2023 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/cong-common-class.tpp
+++ b/include/libsemigroups/detail/cong-common-class.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/containers.hpp
+++ b/include/libsemigroups/detail/containers.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/eigen.hpp
+++ b/include/libsemigroups/detail/eigen.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/felsch-graph.hpp
+++ b/include/libsemigroups/detail/felsch-graph.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022-23 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/felsch-graph.tpp
+++ b/include/libsemigroups/detail/felsch-graph.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022-23 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/felsch-tree.hpp
+++ b/include/libsemigroups/detail/felsch-tree.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/fmt.hpp
+++ b/include/libsemigroups/detail/fmt.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/formatters.hpp
+++ b/include/libsemigroups/detail/formatters.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/function-ref.hpp
+++ b/include/libsemigroups/detail/function-ref.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/int-range.hpp
+++ b/include/libsemigroups/detail/int-range.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/iterator.hpp
+++ b/include/libsemigroups/detail/iterator.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/kambites-nf.hpp
+++ b/include/libsemigroups/detail/kambites-nf.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/kbe.hpp
+++ b/include/libsemigroups/detail/kbe.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2023 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/kbe.tpp
+++ b/include/libsemigroups/detail/kbe.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/ke.hpp
+++ b/include/libsemigroups/detail/ke.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/knuth-bendix-impl.hpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell + Joseph Edwards
+// Copyright (C) 2019-2025 James D. Mitchell + Joseph Edwards
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/knuth-bendix-impl.tpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/knuth-bendix-nf.hpp
+++ b/include/libsemigroups/detail/knuth-bendix-nf.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/multi-string-view.hpp
+++ b/include/libsemigroups/detail/multi-string-view.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021 James D. Mitchell + Maria Tsalakou
+// Copyright (C) 2021-2025 James D. Mitchell + Maria Tsalakou
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/node-managed-graph.hpp
+++ b/include/libsemigroups/detail/node-managed-graph.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/node-managed-graph.tpp
+++ b/include/libsemigroups/detail/node-managed-graph.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022-2023 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/node-manager.hpp
+++ b/include/libsemigroups/detail/node-manager.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2022 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/node-manager.tpp
+++ b/include/libsemigroups/detail/node-manager.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/path-iterators.hpp
+++ b/include/libsemigroups/detail/path-iterators.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/path-iterators.tpp
+++ b/include/libsemigroups/detail/path-iterators.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/pool.hpp
+++ b/include/libsemigroups/detail/pool.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/race.hpp
+++ b/include/libsemigroups/detail/race.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/report.hpp
+++ b/include/libsemigroups/detail/report.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/report.tpp
+++ b/include/libsemigroups/detail/report.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/rewriters.hpp
+++ b/include/libsemigroups/detail/rewriters.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023-2024 Joseph Edwards + James D. Mitchell
+// Copyright (C) 2023-2025 Joseph Edwards + James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/stl.hpp
+++ b/include/libsemigroups/detail/stl.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/string.hpp
+++ b/include/libsemigroups/detail/string.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/tce.hpp
+++ b/include/libsemigroups/detail/tce.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2023 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/timer.hpp
+++ b/include/libsemigroups/detail/timer.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/todd-coxeter-impl.hpp
+++ b/include/libsemigroups/detail/todd-coxeter-impl.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-23 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/todd-coxeter-impl.tpp
+++ b/include/libsemigroups/detail/todd-coxeter-impl.tpp
@@ -1,7 +1,7 @@
 
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/uf.hpp
+++ b/include/libsemigroups/detail/uf.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/word-graph-with-sources.hpp
+++ b/include/libsemigroups/detail/word-graph-with-sources.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022-23 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/word-graph-with-sources.tpp
+++ b/include/libsemigroups/detail/word-graph-with-sources.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/detail/word-iterators.hpp
+++ b/include/libsemigroups/detail/word-iterators.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 Joseph Edwards
+// Copyright (C) 2024-2025 Joseph Edwards
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/dot.hpp
+++ b/include/libsemigroups/dot.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023-2024 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/exception.hpp
+++ b/include/libsemigroups/exception.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/forest.hpp
+++ b/include/libsemigroups/forest.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 Finn Smith + James Mitchell
+// Copyright (C) 2019-2025 Finn Smith + James Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/freeband.hpp
+++ b/include/libsemigroups/freeband.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021 James D. Mitchell
+// Copyright (C) 2021-2025 James D. Mitchell
 //                    Tom D. Conti-Leslie
 //                    Murray T. Whyte
 //                    Reinis Cirpons

--- a/include/libsemigroups/froidure-pin-base.hpp
+++ b/include/libsemigroups/froidure-pin-base.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/froidure-pin.hpp
+++ b/include/libsemigroups/froidure-pin.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2023 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/froidure-pin.tpp
+++ b/include/libsemigroups/froidure-pin.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2023 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/gabow.hpp
+++ b/include/libsemigroups/gabow.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/gabow.tpp
+++ b/include/libsemigroups/gabow.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/hpcombi.hpp
+++ b/include/libsemigroups/hpcombi.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/kambites-class.hpp
+++ b/include/libsemigroups/kambites-class.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021-2023 James D. Mitchell + Maria Tsalakou
+// Copyright (C) 2021-2025 James D. Mitchell + Maria Tsalakou
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/kambites-class.tpp
+++ b/include/libsemigroups/kambites-class.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/kambites-helpers.hpp
+++ b/include/libsemigroups/kambites-helpers.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell + Maria Tsalakou
+// Copyright (C) 2024-2025 James D. Mitchell + Maria Tsalakou
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/kambites.hpp
+++ b/include/libsemigroups/kambites.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/knuth-bendix-helpers.hpp
+++ b/include/libsemigroups/knuth-bendix-helpers.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell + Maria Tsalakou
+// Copyright (C) 2024-2025 James D. Mitchell + Maria Tsalakou
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/knuth-bendix-helpers.tpp
+++ b/include/libsemigroups/knuth-bendix-helpers.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/knuth-bendix.hpp
+++ b/include/libsemigroups/knuth-bendix.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/konieczny.hpp
+++ b/include/libsemigroups/konieczny.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-20 Finn Smith
+// Copyright (C) 2019-2025 Finn Smith
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/konieczny.tpp
+++ b/include/libsemigroups/konieczny.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-24 Finn Smith
+// Copyright (C) 2019-2025 Finn Smith
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/matrix.hpp
+++ b/include/libsemigroups/matrix.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/obvinf.hpp
+++ b/include/libsemigroups/obvinf.hpp
@@ -1,7 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
-// Copyright (C) 2020 Reinis Cirpons
+// Copyright (C) 2020-2025 James D. Mitchell + Reinis Cirpons
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/paths.hpp
+++ b/include/libsemigroups/paths.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/paths.tpp
+++ b/include/libsemigroups/paths.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/pbr.hpp
+++ b/include/libsemigroups/pbr.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/presentation-examples.hpp
+++ b/include/libsemigroups/presentation-examples.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 Murray T. Whyte
+// Copyright (C) 2022-2025 Murray T. Whyte
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022-2024 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/presentation.tpp
+++ b/include/libsemigroups/presentation.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022-2023 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/ranges.hpp
+++ b/include/libsemigroups/ranges.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/ranges.tpp
+++ b/include/libsemigroups/ranges.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/runner.hpp
+++ b/include/libsemigroups/runner.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/runner.tpp
+++ b/include/libsemigroups/runner.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/schreier-sims.hpp
+++ b/include/libsemigroups/schreier-sims.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/schreier-sims.tpp
+++ b/include/libsemigroups/schreier-sims.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/sims.hpp
+++ b/include/libsemigroups/sims.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022-24 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/sims.tpp
+++ b/include/libsemigroups/sims.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 Reinis Cirpons
+// Copyright (C) 2024-2025 Reinis Cirpons
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/stephen.hpp
+++ b/include/libsemigroups/stephen.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022-2023 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/stephen.tpp
+++ b/include/libsemigroups/stephen.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022-2023 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/to-froidure-pin.hpp
+++ b/include/libsemigroups/to-froidure-pin.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/to-froidure-pin.tpp
+++ b/include/libsemigroups/to-froidure-pin.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/to-presentation.hpp
+++ b/include/libsemigroups/to-presentation.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023-2024 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/to-presentation.tpp
+++ b/include/libsemigroups/to-presentation.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 Joseph Edwards
+// Copyright (C) 2024-2025 Joseph Edwards
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/to-todd-coxeter.hpp
+++ b/include/libsemigroups/to-todd-coxeter.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/todd-coxeter-helpers.tpp
+++ b/include/libsemigroups/todd-coxeter-helpers.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021-24 James D. Mitchell
+// Copyright (C) 2021-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/transf.tpp
+++ b/include/libsemigroups/transf.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/types.hpp
+++ b/include/libsemigroups/types.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/ukkonen.hpp
+++ b/include/libsemigroups/ukkonen.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021-2024 James D. Mitchell + Maria Tsalakou
+// Copyright (C) 2021-2025 James D. Mitchell + Maria Tsalakou
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/ukkonen.tpp
+++ b/include/libsemigroups/ukkonen.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021-23 James D. Mitchell + Maria Tsalakou
+// Copyright (C) 2021-2025 James D. Mitchell + Maria Tsalakou
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/word-graph.hpp
+++ b/include/libsemigroups/word-graph.hpp
@@ -1,7 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 Finn Smith
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 Finn Smith + James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/word-graph.tpp
+++ b/include/libsemigroups/word-graph.tpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/include/libsemigroups/word-range.hpp
+++ b/include/libsemigroups/word-range.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020-2023 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/aho-corasick.cpp
+++ b/src/aho-corasick.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023-2024 Joseph Edwards + James D. Mitchell
+// Copyright (C) 2023-2025 Joseph Edwards + James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/bipart.cpp
+++ b/src/bipart.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021-2024 James D. Mitchell
+// Copyright (C) 2021-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/bmat8.cpp
+++ b/src/bmat8.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-24 Finn Smith
+// Copyright (C) 2019-2025 Finn Smith
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/cong-helpers.cpp
+++ b/src/cong-helpers.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/detail/cong-common-class.cpp
+++ b/src/detail/cong-common-class.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/detail/felsch-tree.cpp
+++ b/src/detail/felsch-tree.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/detail/ke.cpp
+++ b/src/detail/ke.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021 James D. Mitchell + Maria Tsalakou
+// Copyright (C) 2021-2025 James D. Mitchell + Maria Tsalakou
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/detail/race.cpp
+++ b/src/detail/race.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/detail/report.cpp
+++ b/src/detail/report.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2023 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/detail/rewriters.cpp
+++ b/src/detail/rewriters.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023-2024 Joseph Edwards + James D. Mitchell
+// Copyright (C) 2023-2025 Joseph Edwards + James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/detail/string.cpp
+++ b/src/detail/string.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021 James D. Mitchell + Maria Tsalakou
+// Copyright (C) 2021-2025 James D. Mitchell + Maria Tsalakou
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/detail/timer.cpp
+++ b/src/detail/timer.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/detail/todd-coxeter-impl.cpp
+++ b/src/detail/todd-coxeter-impl.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/detail/word-iterators.cpp
+++ b/src/detail/word-iterators.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 Joseph Edwards
+// Copyright (C) 2024-2025 Joseph Edwards
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/forest.cpp
+++ b/src/forest.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/freeband.cpp
+++ b/src/freeband.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021 James D. Mitchell
+// Copyright (C) 2021-2025 James D. Mitchell
 //                    Tom D. Conti-Leslie
 //                    Murray T. Whyte
 //                    Reinis Cirpons

--- a/src/froidure-pin-base.cpp
+++ b/src/froidure-pin-base.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/obvinf.cpp
+++ b/src/obvinf.cpp
@@ -1,7 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
-// Copyright (C) 2020 Reinis Cirpons
+// Copyright (C) 2020-2025 James D. Mitchell + Reinis Cirpons
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/pbr.cpp
+++ b/src/pbr.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/presentation-examples.cpp
+++ b/src/presentation-examples.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 Murray T. Whyte
+// Copyright (C) 2022-2025 Murray T. Whyte
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/presentation.cpp
+++ b/src/presentation.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 Murray T. Whyte
+// Copyright (C) 2023-2025 Murray T. Whyte
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/sims.cpp
+++ b/src/sims.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/todd-coxeter-helpers.cpp
+++ b/src/todd-coxeter-helpers.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2024 James D. Mitchell
+// Copyright (C) 2024-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ukkonen.cpp
+++ b/src/ukkonen.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021-2024 James D. Mitchell + Maria Tsalakou
+// Copyright (C) 2021-2025 James D. Mitchell + Maria Tsalakou
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/word-range.cpp
+++ b/src/word-range.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2023 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/bmat-data.cpp
+++ b/tests/bmat-data.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/bmat-data.cpp
+++ b/tests/bmat-data.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020-2025-2025 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/bmat-data.hpp
+++ b/tests/bmat-data.hpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 Finn Smith
+// Copyright (C) 2020-2025 Finn Smith
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-action.cpp
+++ b/tests/test-action.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 Finn Smith
+// Copyright (C) 2019-2025 Finn Smith
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-aho-corasick.cpp
+++ b/tests/test-aho-corasick.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 Joseph Edwards + James D. Mitchell
+// Copyright (C) 2023-2025 Joseph Edwards + James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-bipart.cpp
+++ b/tests/test-bipart.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021 James D. Mitchell
+// Copyright (C) 2021-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-bitset.cpp
+++ b/tests/test-bitset.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-bmat8.cpp
+++ b/tests/test-bmat8.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-24 Finn Smith
+// Copyright (C) 2019-2025 Finn Smith
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-cong-common.cpp
+++ b/tests/test-cong-common.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-cong.cpp
+++ b/tests/test-cong.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-constants.cpp
+++ b/tests/test-constants.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-containers.cpp
+++ b/tests/test-containers.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-felsch-tree.cpp
+++ b/tests/test-felsch-tree.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-forest.cpp
+++ b/tests/test-forest.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 Finn Smith
+// Copyright (C) 2019-2025 Finn Smith
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-freeband.cpp
+++ b/tests/test-freeband.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021-2024 Reinis Cirpons + James Mitchell
+// Copyright (C) 2021-2025 Reinis Cirpons + James Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-froidure-pin-bipart.cpp
+++ b/tests/test-froidure-pin-bipart.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-froidure-pin-bmat.cpp
+++ b/tests/test-froidure-pin-bmat.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-froidure-pin-bmat8.cpp
+++ b/tests/test-froidure-pin-bmat8.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-froidure-pin-integers.cpp
+++ b/tests/test-froidure-pin-integers.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-froidure-pin-intmat.cpp
+++ b/tests/test-froidure-pin-intmat.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-froidure-pin-intpairs.cpp
+++ b/tests/test-froidure-pin-intpairs.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-froidure-pin-matrix.cpp
+++ b/tests/test-froidure-pin-matrix.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-froidure-pin-maxplustrunc.cpp
+++ b/tests/test-froidure-pin-maxplustrunc.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-froidure-pin-pbr.cpp
+++ b/tests/test-froidure-pin-pbr.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-froidure-pin-pperm.cpp
+++ b/tests/test-froidure-pin-pperm.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-froidure-pin-projmaxplus.cpp
+++ b/tests/test-froidure-pin-projmaxplus.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-froidure-pin-transf.cpp
+++ b/tests/test-froidure-pin-transf.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-froidure-pin-transf.cpp
+++ b/tests/test-froidure-pin-transf.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2025-2025 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-gabow.cpp
+++ b/tests/test-gabow.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James Mitchell
+// Copyright (C) 2023-2025 James Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-hpcombi.cpp
+++ b/tests/test-hpcombi.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-iterator.cpp
+++ b/tests/test-iterator.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-kambites.cpp
+++ b/tests/test-kambites.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021 James D. Mitchell + Maria Tsalakou
+// Copyright (C) 2021-2025 James D. Mitchell + Maria Tsalakou
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-kbe.cpp
+++ b/tests/test-kbe.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-knuth-bendix-1.cpp
+++ b/tests/test-knuth-bendix-1.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2023 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-knuth-bendix-2.cpp
+++ b/tests/test-knuth-bendix-2.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020-2023 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-knuth-bendix-3.cpp
+++ b/tests/test-knuth-bendix-3.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020-2023 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-knuth-bendix-4.cpp
+++ b/tests/test-knuth-bendix-4.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020-2023 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-knuth-bendix-5.cpp
+++ b/tests/test-knuth-bendix-5.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020-2023 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-knuth-bendix-6.cpp
+++ b/tests/test-knuth-bendix-6.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020-2023 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-konieczny-bmat.cpp
+++ b/tests/test-konieczny-bmat.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 Finn Smith
+// Copyright (C) 2020-2025 Finn Smith
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-konieczny-bmat8-1.cpp
+++ b/tests/test-konieczny-bmat8-1.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 Finn Smith
+// Copyright (C) 2020-2025 Finn Smith
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-konieczny-bmat8-2.cpp
+++ b/tests/test-konieczny-bmat8-2.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 Finn Smith
+// Copyright (C) 2020-2025 Finn Smith
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-konieczny-bmat8-3.cpp
+++ b/tests/test-konieczny-bmat8-3.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 Finn Smith
+// Copyright (C) 2020-2025 Finn Smith
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-konieczny-pperm.cpp
+++ b/tests/test-konieczny-pperm.cpp
@@ -1,6 +1,6 @@
 
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 Finn Smith
+// Copyright (C) 2020-2025 Finn Smith
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-konieczny-transf.cpp
+++ b/tests/test-konieczny-transf.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 Finn Smith
+// Copyright (C) 2020-2025 Finn Smith
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-main.cpp
+++ b/tests/test-main.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-main.hpp
+++ b/tests/test-main.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-matrix.cpp
+++ b/tests/test-matrix.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-multi-string-view.cpp
+++ b/tests/test-multi-string-view.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021 James D. Mitchell + Maria Tsalakou
+// Copyright (C) 2021-2025 James D. Mitchell + Maria Tsalakou
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-obvinf.cpp
+++ b/tests/test-obvinf.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 Reinis Cirpons
+// Copyright (C) 2020-2025 Reinis Cirpons
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-paths.cpp
+++ b/tests/test-paths.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 J. D. Mitchell
+// Copyright (C) 2023-2025 J. D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-pbr.cpp
+++ b/tests/test-pbr.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-21 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-pool.cpp
+++ b/tests/test-pool.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-presentation-examples-1.cpp
+++ b/tests/test-presentation-examples-1.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 Murray T. Whyte
+// Copyright (C) 2022-2025 Murray T. Whyte
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-presentation-examples-2.cpp
+++ b/tests/test-presentation-examples-2.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 Murray T. Whyte
+// Copyright (C) 2022-2025 Murray T. Whyte
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-presentation-examples-3.cpp
+++ b/tests/test-presentation-examples-3.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 Murray T. Whyte
+// Copyright (C) 2022-2025 Murray T. Whyte
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022-2023 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-race.cpp
+++ b/tests/test-race.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-ranges.cpp
+++ b/tests/test-ranges.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-rewriters.cpp
+++ b/tests/test-rewriters.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2023 Joseph Edwards
+// Copyright (C) 2019-2025 Joseph Edwards
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-runner.cpp
+++ b/tests/test-runner.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-schreier-sims.cpp
+++ b/tests/test-schreier-sims.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2024 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022-24 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-stephen.cpp
+++ b/tests/test-stephen.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022-2023 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-string.cpp
+++ b/tests/test-string.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021 James D. Mitchell + Maria Tsalakou
+// Copyright (C) 2021-2025 James D. Mitchell + Maria Tsalakou
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-timer.cpp
+++ b/tests/test-timer.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-to-froidure-pin.cpp
+++ b/tests/test-to-froidure-pin.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-to-presentation.cpp
+++ b/tests/test-to-presentation.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2022 James D. Mitchell
+// Copyright (C) 2022-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2023 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-transf.cpp
+++ b/tests/test-transf.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-types.cpp
+++ b/tests/test-types.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-21 James D. Mitchell
+// Copyright (C) 2019-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-uf.cpp
+++ b/tests/test-uf.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C/C++ library for semigroups and monoids
-// Copyright (C) 2020 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-ukkonen.cpp
+++ b/tests/test-ukkonen.cpp
@@ -1,5 +1,5 @@
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2021-2023 James D. Mitchell + Maria Tsalakou
+// Copyright (C) 2021-2025 James D. Mitchell + Maria Tsalakou
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2019-2023 Finn Smith
+// Copyright (C) 2019-2025 Finn Smith
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/test-word-range.cpp
+++ b/tests/test-word-range.cpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2020-2023 James D. Mitchell
+// Copyright (C) 2020-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/word-graph-test-common.hpp
+++ b/tests/word-graph-test-common.hpp
@@ -1,6 +1,6 @@
 //
 // libsemigroups - C++ library for semigroups and monoids
-// Copyright (C) 2023 James D. Mitchell
+// Copyright (C) 2023-2025 James D. Mitchell
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This PR bumps the copyright years of our files. Now, every copyright has the form
```
Copyright (C) 20XX-2025 Author 1 (+ Author 2 ...)
```
or
```
Copyright (C) 2025 Author 1 (+ Author 2 ...)
```
for files created this year.