### PR TITLE
perf: improve perf of is_acyclic

### DIFF
--- a/include/libsemigroups/bipart.hpp
+++ b/include/libsemigroups/bipart.hpp
@@ -368,6 +368,7 @@ namespace libsemigroups {
     //! valid.
     //!
     //! \complexity Linear in the sum of the sizes of the vectors in \p blocks.
+    // TODO(0) this should be a make function not a constructor
     explicit Blocks(std::vector<std::vector<int32_t>> const& blocks);
 
     //! \brief Default copy assignment operator.

--- a/include/libsemigroups/detail/path-iterators.hpp
+++ b/include/libsemigroups/detail/path-iterators.hpp
@@ -230,6 +230,8 @@ namespace libsemigroups {
       using iterator_category = std::forward_iterator_tag;
 
      private:
+      // TODO(1) maybe try replacing _can_reach_target with std::unordered_set,
+      // then we can use the output of ancestors_of directly
       std::vector<bool>      _can_reach_target;
       value_type             _edges;
       WordGraph<Node> const* _word_graph;

--- a/include/libsemigroups/detail/path-iterators.tpp
+++ b/include/libsemigroups/detail/path-iterators.tpp
@@ -301,37 +301,12 @@ namespace libsemigroups {
     template <typename Node>
     void const_pstilo_iterator<Node>::init_can_reach_target() {
       if (_can_reach_target.empty()) {
-        std::vector<std::vector<node_type>> in_neighbours(
-            _word_graph->number_of_nodes(), std::vector<node_type>({}));
-        for (auto n = _word_graph->cbegin_nodes();
-             n != _word_graph->cend_nodes();
-             ++n) {
-          for (auto e = _word_graph->cbegin_targets(*n);
-               e != _word_graph->cend_targets(*n);
-               ++e) {
-            if (*e != UNDEFINED) {
-              in_neighbours[*e].push_back(*n);
-            }
-          }
-        }
-
         _can_reach_target.resize(_word_graph->number_of_nodes(), false);
-        _can_reach_target[_target]   = true;
-        std::vector<node_type>& todo = in_neighbours[_target];
-        std::vector<node_type>  next;
-
-        while (!todo.empty()) {
-          for (auto& m : todo) {
-            if (_can_reach_target[m] == 0) {
-              _can_reach_target[m] = true;
-              next.insert(next.end(),
-                          in_neighbours[m].cbegin(),
-                          in_neighbours[m].cend());
-            }
-          }
-          std::swap(next, todo);
-          next.clear();
-        }
+        auto ancestors
+            = word_graph::ancestors_of_no_checks(*_word_graph, _target);
+        std::for_each(ancestors.begin(), ancestors.end(), [this](auto n) {
+          _can_reach_target[n] = true;
+        });
       }
     }
 

--- a/include/libsemigroups/word-graph.hpp
+++ b/include/libsemigroups/word-graph.hpp
@@ -2832,7 +2832,7 @@ namespace libsemigroups {
         // always have an odd number of arguments, so we check that it's even
         // here (the argument x and an odd number of further arguments).
         WordGraph<Node> xy;
-        operator()(xy, x, std::forward<Args>(args)...);
+                        operator()(xy, x, std::forward<Args>(args)...);
         return xy;
       }
 
@@ -2867,7 +2867,7 @@ namespace libsemigroups {
         return is_subrelation(x, static_cast<Node>(0), y, static_cast<Node>(0));
       }
     };  // JoinerMeeterCommon
-  }  // namespace detail
+  }     // namespace detail
 
   //! \ingroup word_graph_group
   //! \brief Class for taking joins of word graphs.

--- a/include/libsemigroups/word-graph.hpp
+++ b/include/libsemigroups/word-graph.hpp
@@ -2200,6 +2200,10 @@ namespace libsemigroups {
     [[nodiscard]] std::unordered_set<Node1>
     nodes_reachable_from(WordGraph<Node1> const& wg, Node2 source);
 
+    template <typename Node1, typename Node2>
+    [[nodiscard]] std::unordered_set<Node1>
+    ancestors_of(WordGraph<Node1> const& wg, Node2 source);
+
     //! \brief Returns the std::unordered_set of nodes reachable from a given
     //! node in a word graph.
     //!
@@ -2224,6 +2228,10 @@ namespace libsemigroups {
     template <typename Node1, typename Node2>
     [[nodiscard]] std::unordered_set<Node1>
     nodes_reachable_from_no_checks(WordGraph<Node1> const& wg, Node2 source);
+
+    template <typename Node1, typename Node2>
+    [[nodiscard]] std::unordered_set<Node1>
+    ancestors_of_no_checks(WordGraph<Node1> const& wg, Node2 source);
 
     //! \brief Returns the number of nodes reachable from a given node in a
     //! word graph.
@@ -2824,7 +2832,7 @@ namespace libsemigroups {
         // always have an odd number of arguments, so we check that it's even
         // here (the argument x and an odd number of further arguments).
         WordGraph<Node> xy;
-                        operator()(xy, x, std::forward<Args>(args)...);
+        operator()(xy, x, std::forward<Args>(args)...);
         return xy;
       }
 
@@ -2859,7 +2867,7 @@ namespace libsemigroups {
         return is_subrelation(x, static_cast<Node>(0), y, static_cast<Node>(0));
       }
     };  // JoinerMeeterCommon
-  }     // namespace detail
+  }  // namespace detail
 
   //! \ingroup word_graph_group
   //! \brief Class for taking joins of word graphs.

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -22,6 +22,7 @@
 
 #include "Catch2-3.8.0/catch_amalgamated.hpp"  // for TEST_CASE
 #include "libsemigroups/constants.hpp"
+#include "libsemigroups/word-graph.hpp"
 #include "test-main.hpp"  // for LIBSEMIGROUPS_TEST_CASE
 
 #include "libsemigroups/bmat8.hpp"
@@ -928,6 +929,16 @@ namespace libsemigroups {
 
     REQUIRE(tc.number_of_classes() == 6);
     REQUIRE(index_of(tc, {1}) == index_of(tc, {2}));
+    REQUIRE(tc.word_graph().number_of_nodes() == 7);
+    REQUIRE(tc.word_graph().target(0, 0) == 1);
+    auto        pred = word_graph::ancestors_of_no_checks(tc.word_graph(), 1);
+    std::vector result(pred.begin(), pred.end());
+    std::sort(result.begin(), result.end());
+    REQUIRE(result == std::vector<uint32_t>({0, 1, 2, 3, 4, 5, 6}));
+    auto desc = word_graph::nodes_reachable_from(tc.word_graph(), 1);
+    result.assign(desc.begin(), desc.end());
+    std::sort(result.begin(), result.end());
+    REQUIRE(result == std::vector<uint32_t>({1, 2, 3, 4, 5, 6}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
@@ -3190,6 +3201,11 @@ namespace libsemigroups {
     H.lookahead_next(1'000'000);
 
     REQUIRE(H.number_of_classes() == 16'384);
+
+    REQUIRE(word_graph::is_reachable(H.word_graph(), 0, 0));
+    REQUIRE(word_graph::ancestors_of_no_checks(H.word_graph(), 0).size()
+            == 16'384);
+    REQUIRE(!word_graph::is_acyclic(H.word_graph(), 0, 0));
 
     // The following no longer works
     // REQUIRE(class_of(H, "").size_hint() == POSITIVE_INFINITY);


### PR DESCRIPTION
The previous code for computing `is_acyclic(WordGraph, node, node)` had a quadratic step, which this PR replaces with a linear step. This manifested itself in ToddCoxeter test case 080, which took over 4s. This was not apparent before: b47de7b2696cf7892e4d89e0a4048be8dee79668 because in that commit we added a step which computes the number of paths from a source to a target in pstislo. 