### PR TITLE
Reclassify tests

### DIFF
--- a/tests/test-cong.cpp
+++ b/tests/test-cong.cpp
@@ -1165,7 +1165,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Congruence",
                           "032",
                           "stellar_monoid S7",
-                          "[quick][cong][no-valgrind]") {
+                          "[standard][cong]") {
     auto                    rg = ReportGuard(false);
     Presentation<word_type> p  = presentation::examples::zero_rook_monoid(7);
 

--- a/tests/test-froidure-pin-transf.cpp
+++ b/tests/test-froidure-pin-transf.cpp
@@ -892,11 +892,10 @@ namespace libsemigroups {
     REQUIRE(nr == S.number_of_idempotents());
   }
 
-  LIBSEMIGROUPS_TEST_CASE(
-      "FroidurePin<Transf>",
-      "073",
-      "cbegin_idempotents/cend, is_idempotent",
-      "[standard][froidure-pin][transf][multithread][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "073",
+                          "cbegin_idempotents/cend, is_idempotent",
+                          "[standard][froidure-pin][transf][multithread]") {
     auto                  rg = ReportGuard(false);
     FroidurePin<Transf<>> S;
     S.add_generator(make<Transf<>>({1, 2, 3, 4, 5, 6, 0}));

--- a/tests/test-hpcombi.cpp
+++ b/tests/test-hpcombi.cpp
@@ -298,7 +298,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("HPCombi", "012", "Renner0", "[standard][hpcombi]") {
-    auto rg = ReportGuard(true);
+    auto rg = ReportGuard(false);
     auto S  = make<FroidurePin>(
         {Renner0Element({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}),
           Renner0Element(

--- a/tests/test-hpcombi.cpp
+++ b/tests/test-hpcombi.cpp
@@ -297,7 +297,7 @@ namespace libsemigroups {
     REQUIRE(S.size() == 597369);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("HPCombi", "012", "Renner0", "[extreme][hpcombi]") {
+  LIBSEMIGROUPS_TEST_CASE("HPCombi", "012", "Renner0", "[standard][hpcombi]") {
     auto rg = ReportGuard(true);
     auto S  = make<FroidurePin>(
         {Renner0Element({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}),

--- a/tests/test-knuth-bendix-4.cpp
+++ b/tests/test-knuth-bendix-4.cpp
@@ -776,14 +776,4 @@ namespace libsemigroups {
     REQUIRE(!k.finished());
   }
 
-  LIBSEMIGROUPS_TEST_CASE("KnuthBendix",
-                          "118",
-                          "partition_monoid(7)",
-                          "[knuthbendix][extreme]") {
-    auto        rg = ReportGuard(true);
-    auto        p  = presentation::examples::partition_monoid(7);
-    KnuthBendix k(twosided, p);
-    REQUIRE(k.number_of_classes() == 0);
-  }
-
 }  // namespace libsemigroups

--- a/tests/test-konieczny-bmat8-2.cpp
+++ b/tests/test-konieczny-bmat8-2.cpp
@@ -36,9 +36,9 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
                           "012",
                           "full bmat monoid 5",
-                          "[extreme][bmat8]") {
+                          "[standard][bmat8]") {
     using BMat = BMatFastest<5>;
-    auto rg    = ReportGuard(true);
+    auto rg    = ReportGuard(false);
 
     Konieczny T = make<Konieczny>({BMat({{1, 0, 0, 0, 0},
                                          {0, 1, 0, 0, 0},
@@ -162,9 +162,9 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
                           "014",
                           "regular generated bmat monoid 5",
-                          "[extreme][bmat8]") {
+                          "[standard][bmat8]") {
     using BMat = BMatFastest<5>;
-    auto rg    = ReportGuard(true);
+    auto rg    = ReportGuard(false);
 
     Konieczny T = make<Konieczny>({BMat({{0, 1, 0, 0, 0},
                                          {1, 0, 0, 0, 0},
@@ -434,9 +434,9 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
                           "018",
                           "full bmat monoid 5 with stop in Action",
-                          "[extreme][bmat8]") {
+                          "[standard][bmat8]") {
     using BMat = BMatFastest<5>;
-    auto rg    = ReportGuard(true);
+    auto rg    = ReportGuard(false);
 
     Konieczny T = make<Konieczny>({BMat({{1, 0, 0, 0, 0},
                                          {0, 1, 0, 0, 0},
@@ -522,8 +522,8 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Konieczny",
                           "019",
                           "regular generated bmat monoid 5 with stops",
-                          "[extreme][bmat8]") {
-    auto rg = ReportGuard(true);
+                          "[standard][bmat8]") {
+    auto rg = ReportGuard(false);
 
     Konieczny T = make<Konieczny>({BMat8({{0, 1, 0, 0, 0},
                                           {1, 0, 0, 0, 0},

--- a/tests/test-presentation-examples-1.cpp
+++ b/tests/test-presentation-examples-1.cpp
@@ -653,7 +653,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Example",
                           "043",
                           "partial_transformation_monoid(5) Shutov",
-                          "[pres-examples][quick][no-valgrind]") {
+                          "[pres-examples][standard]") {
     auto        rg = ReportGuard(false);
     size_t      n  = 5;
     ToddCoxeter tc(congruence_kind::twosided,
@@ -1021,8 +1021,8 @@ namespace libsemigroups {
       "Example",
       "073",
       "renner_type_B_monoid(5, 1) (Gay-Hivert presentation)",
-      "[extreme][pres-examples][hivert]") {
-    auto        rg = ReportGuard(true);
+      "[standard][pres-examples][hivert]") {
+    auto        rg = ReportGuard(false);
     ToddCoxeter tc(congruence_kind::twosided, renner_type_B_monoid(5, 1));
     REQUIRE(tc.presentation().rules.size() == 272);
     REQUIRE(!is_obviously_infinite(tc));
@@ -1047,8 +1047,8 @@ namespace libsemigroups {
       "Example",
       "074",
       "renner_type_B_monoid(5, 0) (Gay-Hivert presentation)",
-      "[extreme][pres-examples][hivert]") {
-    auto        rg = ReportGuard(true);
+      "[standard][pres-examples][hivert]") {
+    auto        rg = ReportGuard(false);
     ToddCoxeter tc(congruence_kind::twosided, renner_type_B_monoid(5, 0));
     tc.strategy(decltype(tc)::options::strategy::felsch);
 
@@ -1142,8 +1142,8 @@ namespace libsemigroups {
       "Example",
       "081",
       "renner_type_D_monoid(5, 1) (Gay-Hivert presentation)",
-      "[extreme][pres-examples][hivert]") {
-    auto        rg = ReportGuard(true);
+      "[standard][pres-examples][hivert]") {
+    auto        rg = ReportGuard(false);
     ToddCoxeter tc(congruence_kind::twosided, renner_type_D_monoid(5, 1));
     tc.strategy(decltype(tc)::options::strategy::felsch);
 
@@ -1157,8 +1157,8 @@ namespace libsemigroups {
       "Example",
       "082",
       "renner_type_D_monoid(5, 0) (Gay-Hivert presentation)",
-      "[extreme][pres-examples][hivert]") {
-    auto        rg = ReportGuard(true);
+      "[standard][pres-examples][hivert]") {
+    auto        rg = ReportGuard(false);
     ToddCoxeter tc(congruence_kind::twosided, renner_type_D_monoid(5, 0));
     tc.strategy(decltype(tc)::options::strategy::felsch);
 

--- a/tests/test-schreier-sims.cpp
+++ b/tests/test-schreier-sims.cpp
@@ -3508,11 +3508,10 @@ namespace libsemigroups {
     REQUIRE(U.contains(make<Perm>({11, 10, 5, 7, 8, 2, 9, 3, 4, 6, 1, 0, 12})));
   }
 
-  LIBSEMIGROUPS_TEST_CASE(
-      "SchreierSims",
-      "050",
-      "S17 and A39 intersection",
-      "[standard][schreier-sims][no-valgrind][intersection]") {
+  LIBSEMIGROUPS_TEST_CASE("SchreierSims",
+                          "050",
+                          "S17 and A39 intersection",
+                          "[quick][schreier-sims][no-valgrind][intersection]") {
     auto             rg = ReportGuard(false);
     SchreierSims<50> S, T, U;
     using Perm = SchreierSims<50>::element_type;
@@ -3544,11 +3543,10 @@ namespace libsemigroups {
          34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49})));
   }
 
-  LIBSEMIGROUPS_TEST_CASE(
-      "SchreierSims",
-      "051",
-      "A50 and PGL(2, 49) intersection",
-      "[extreme][schreier-sims][no-valgrind][intersection]") {
+  LIBSEMIGROUPS_TEST_CASE("SchreierSims",
+                          "051",
+                          "A50 and PGL(2, 49) intersection",
+                          "[standard][schreier-sims][intersection]") {
     auto             rg = ReportGuard(false);
     SchreierSims<50> S, T, U;
     using Perm = SchreierSims<50>::element_type;
@@ -3638,7 +3636,7 @@ namespace libsemigroups {
       "SchreierSims",
       "053",
       "PGamma(2, 9) wreath Sym(2) and Alt(6)^2.D_8 intersection",
-      "[standard][schreier-sims][no-valgrind][intersection]") {
+      "[quick][schreier-sims][no-valgrind][intersection]") {
     auto              rg = ReportGuard(false);
     SchreierSims<100> S, T, U;
     using Perm = SchreierSims<100>::element_type;
@@ -3688,11 +3686,10 @@ namespace libsemigroups {
          63, 53, 43, 33, 23, 12, 2,  92, 82, 72, 62, 52, 42, 32, 22})));
   }
 
-  LIBSEMIGROUPS_TEST_CASE(
-      "SchreierSims",
-      "054",
-      "Alt(6)^2.2^2:4 and Alt(6)^2.4 intersection",
-      "[standard][schreier-sims][no-valgrind][intersection]") {
+  LIBSEMIGROUPS_TEST_CASE("SchreierSims",
+                          "054",
+                          "Alt(6)^2.2^2:4 and Alt(6)^2.4 intersection",
+                          "[quick][schreier-sims][no-valgrind][intersection]") {
     auto              rg = ReportGuard(false);
     SchreierSims<100> S, T, U;
     using Perm = SchreierSims<100>::element_type;
@@ -3989,11 +3986,10 @@ namespace libsemigroups {
          16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31})));
   }
 
-  LIBSEMIGROUPS_TEST_CASE(
-      "SchreierSims",
-      "060",
-      "AGL(7, 2) and PGL(2, 127) intersection",
-      "[extreme][schreier-sims][no-valgrind][intersection]") {
+  LIBSEMIGROUPS_TEST_CASE("SchreierSims",
+                          "060",
+                          "AGL(7, 2) and PGL(2, 127) intersection",
+                          "[standard][schreier-sims][intersection]") {
     auto              rg = ReportGuard(false);
     SchreierSims<128> S, T, U;
     using Perm = SchreierSims<128>::element_type;

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -2266,10 +2266,11 @@ namespace libsemigroups {
     }
   }
 
+  // Not terminated after 5 hours on JDE's PC
   LIBSEMIGROUPS_TEST_CASE("Sims1",
                           "053",
                           "partial_transformation_monoid(3)",
-                          "[extreme][low-index]") {
+                          "[fail][low-index]") {
     auto  rg = ReportGuard(true);
     auto  p  = presentation::examples::partial_transformation_monoid_MW24(3);
     Sims1 S;
@@ -3390,10 +3391,12 @@ namespace libsemigroups {
     }
   }
 
+  // This took 4h31min21s to run on JDE's PC. 4h2min42s of which were spent
+  // computing the 7-classes.
   LIBSEMIGROUPS_TEST_CASE("Sims1",
                           "089",
                           "possible full transf. monoid 8",
-                          "[extreme][sims1]") {
+                          "[fail][sims1]") {
     auto                    rg = ReportGuard(true);
     Presentation<word_type> p;
     p.rules = std::vector<word_type>(

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -893,7 +893,7 @@ namespace libsemigroups {
                           "022",
                           "singular_brauer_monoid(4) (Maltcev-Mazorchuk)",
                           "[extreme][sims1][no-coverage]") {
-    auto                     rg = ReportGuard(false);
+    auto                     rg = ReportGuard(true);
     FroidurePin<Bipartition> S;
     S.add_generator(make<Bipartition>({{1, 2}, {3, -1}, {4, -2}, {-3, -4}}));
     S.add_generator(make<Bipartition>({{1, 2}, {3, -1}, {4, -4}, {-2, -3}}));
@@ -1070,8 +1070,8 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Sims1",
                           "024",
                           "brauer_monoid(4) (Kudryavtseva-Mazorchuk)",
-                          "[extreme][sims1]") {
-    auto rg = ReportGuard(true);
+                          "[standard][sims1]") {
+    auto rg = ReportGuard(false);
     auto p  = presentation::examples::brauer_monoid_KM07(4);
     REQUIRE(p.alphabet().size() == 6);
     REQUIRE(presentation::length(p) == 140);
@@ -1229,8 +1229,8 @@ namespace libsemigroups {
       "Sims1",
       "026",
       "uniform_block_bijection_monoid_Fit03(4) (Fitzgerald)",
-      "[extreme][sims1]") {
-    auto rg = ReportGuard(true);
+      "[standard][sims1]") {
+    auto rg = ReportGuard(false);
     auto p  = presentation::examples::uniform_block_bijection_monoid_Fit03(4);
     presentation::remove_duplicate_rules(p);
     presentation::reduce_complements(p);
@@ -1282,9 +1282,8 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Sims1",
                           "029",
                           "fibonacci_semigroup(4, 6)",
-                          "[standard][sims1][no-valgrind]") {
-    std::cout << "\n";            // So that the reporting looks good
-    auto rg = ReportGuard(true);  // for code coverage
+                          "[standard][sims1]") {
+    auto rg = ReportGuard(false);
     auto p  = presentation::examples::fibonacci_semigroup(4, 6);
     presentation::remove_duplicate_rules(p);
     presentation::sort_each_rule(p);
@@ -1690,8 +1689,8 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Sims1",
                           "037",
                           "rectangular_band(9, 2)",
-                          "[extreme][sims1]") {
-    auto rg = ReportGuard(true);
+                          "[standard][sims1]") {
+    auto rg = ReportGuard(false);
     auto p  = presentation::examples::rectangular_band(9, 2);
     presentation::remove_duplicate_rules(p);
     presentation::sort_each_rule(p);
@@ -1720,7 +1719,7 @@ namespace libsemigroups {
                           "038",
                           "partition_monoid(3) - minimal o.r.c. rep",
                           "[standard][sims1]") {
-    auto rg = ReportGuard(true);
+    auto rg = ReportGuard(false);
     auto p  = presentation::examples::partition_monoid_HR05(3);
     REQUIRE(p.contains_empty_word());
     REQUIRE(p.alphabet() == 0123456_w);
@@ -1779,7 +1778,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Sims1",
                           "039",
                           "temperley_lieb_monoid(n) - n = 3 .. 6, minimal rep",
-                          "[standard][sims1]") {
+                          "[quick][sims1]") {
     auto rg = ReportGuard(false);
 
     std::array<uint64_t, 11> const sizes
@@ -2404,11 +2403,11 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Sims1",
                           "059",
                           "Plactic semigroup 7 up to index 3",
-                          "[extreme][low-index][plactic]") {
+                          "[standard][low-index][plactic]") {
     std::array<uint64_t, 5> const num = {0, 1, 621, 408'024, 281'600'130};
     // The last value took approx. 12m34s to run and is omitted from the
     // extreme test.
-    auto rg = ReportGuard(true);
+    auto rg = ReportGuard(false);
     auto p  = presentation::examples::plactic_monoid(7);
     p.contains_empty_word(false);
     for (size_t n = 2; n < 4; ++n) {
@@ -2514,10 +2513,10 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Sims1",
                           "065",
                           "Chinese semigroup 7 up to index 4",
-                          "[extreme][low-index][chinese]") {
+                          "[standard][low-index][chinese]") {
     std::array<uint64_t, 5> const num = {0, 1, 1'023, 786'949, 988'827'143};
     // Last value took about 50m to compute
-    auto rg = ReportGuard(true);
+    auto rg = ReportGuard(false);
     auto p  = presentation::examples::chinese_monoid(7);
     p.contains_empty_word(false);
     for (size_t n = 2; n < 4; ++n) {
@@ -3062,7 +3061,7 @@ namespace libsemigroups {
                           "078",
                           "order_preserving_monoid(5)",
                           "[standard][sims1]") {
-    auto rg = ReportGuard(true);
+    auto rg = ReportGuard(false);
     auto p  = presentation::examples::order_preserving_monoid(5);
 
     REQUIRE(p.rules.size() == 50);
@@ -3194,7 +3193,7 @@ namespace libsemigroups {
             == 1);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Sims1", "083", "M11 x 1", "[extreme][sims1]") {
+  LIBSEMIGROUPS_TEST_CASE("Sims1", "083", "M11 x 1", "[standard][sims1]") {
     using words::pow;
     Presentation<std::string> p;
     p.alphabet("abcABC");
@@ -3251,10 +3250,7 @@ namespace libsemigroups {
             == 24);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Sims1",
-                          "085",
-                          "JonesMonoid(4)",
-                          "[extreme][sims1]") {
+  LIBSEMIGROUPS_TEST_CASE("Sims1", "085", "JonesMonoid(4)", "[quick][sims1]") {
     using words::pow;
     Presentation<std::string> p = to<Presentation<std::string>>(
         presentation::examples::temperley_lieb_monoid(4));
@@ -3746,11 +3742,10 @@ namespace libsemigroups {
     REQUIRE(S.number_of_threads(8).number_of_congruences(13) == 330'328);
   }
 
-  LIBSEMIGROUPS_TEST_CASE(
-      "Sims2",
-      "104",
-      "2-sided one-relation baabbaa=a",
-      "[extreme][sims2][low-index][no-valgrind][no-coverage]") {
+  LIBSEMIGROUPS_TEST_CASE("Sims2",
+                          "104",
+                          "2-sided one-relation baabbaa=a",
+                          "[extreme][sims2][low-index][no-coverage]") {
     auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -4093,7 +4088,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Sims2",
                           "113",
                           "2-sided 2-generated free commutative monoid",
-                          "[quick][sims2][no-valgrind]") {
+                          "[standard][sims2]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -1719,11 +1719,11 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Sims1",
                           "038",
                           "partition_monoid(3) - minimal o.r.c. rep",
-                          "[extreme][sims1]") {
+                          "[standard][sims1]") {
     auto rg = ReportGuard(true);
-    auto p  = presentation::examples::partition_monoid(3);
-    REQUIRE(!p.contains_empty_word());
-    REQUIRE(p.alphabet() == 01234_w);
+    auto p  = presentation::examples::partition_monoid_HR05(3);
+    REQUIRE(p.contains_empty_word());
+    REQUIRE(p.alphabet() == 0123456_w);
 
     auto d = RepOrc()
                  .presentation(p)
@@ -1760,7 +1760,7 @@ namespace libsemigroups {
     std::vector<WordGraph<uint32_t>> all;
 
     auto hook = [&](WordGraph<uint32_t> const& x) {
-      auto first = 1;
+      auto first = 0;
       auto SS    = to<FroidurePin<Transf<0, node_type>>>(
           x, first, x.number_of_active_nodes());
       SuppressReportFor supp("FroidurePin");
@@ -3061,11 +3061,12 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Sims1",
                           "078",
                           "order_preserving_monoid(5)",
-                          "[extreme][sims1]") {
+                          "[standard][sims1]") {
     auto rg = ReportGuard(true);
     auto p  = presentation::examples::order_preserving_monoid(5);
 
     REQUIRE(p.rules.size() == 50);
+    presentation::normalize_alphabet(p);
     presentation::sort_each_rule(p);
     presentation::sort_rules(p);
     presentation::remove_duplicate_rules(p);

--- a/tests/test-stephen.cpp
+++ b/tests/test-stephen.cpp
@@ -22,7 +22,6 @@
 #include <cctype>         // for isupper
 #include <cstddef>        // for size_t
 #include <cstdint>        // for uint32_t
-#include <iostream>       // for operator<<
 #include <memory>         // for make_shared
 #include <string>         // for basic_st...
 #include <tuple>          // for tie
@@ -1346,9 +1345,9 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Stephen",
                           "043",
                           "inverse presentation",
-                          "[stephen][standard]") {
+                          "[stephen][extreme]") {
     using words::                  operator+;
-    ReportGuard                    rg(false);
+    ReportGuard                    rg(true);
     ToWord                         to_word("abcABC");
     InversePresentation<word_type> p;
     p.alphabet(to_word("abcABC"));
@@ -1418,8 +1417,8 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Stephen",
                           "046",
                           "Whyte's 4-relation full transf monoid 8",
-                          "[stephen][standard]") {
-    auto                    rg = ReportGuard(false);
+                          "[stephen][extreme]") {
+    auto                    rg = ReportGuard(true);
     Presentation<word_type> p;
     p.rules = {00_w,       ""_w,       11_w,         ""_w,         22_w,
                ""_w,       33_w,       ""_w,         44_w,         ""_w,
@@ -1635,8 +1634,8 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("Stephen",
                           "051",
                           "shared_ptr memory check",
-                          "[stephen][extreme][no-valgrind]") {
-    ReportGuard                    rg(true);
+                          "[stephen][standard]") {
+    ReportGuard                    rg(false);
     ToWord                         to_word("abcABC");
     InversePresentation<word_type> p;
     p.alphabet(to_word("abcABC"));
@@ -1651,9 +1650,7 @@ namespace libsemigroups {
     size_t                                               n = 12;
     std::vector<Stephen<InversePresentation<word_type>>> stephens(n);
     // Uses no extra memory with shared pointer
-    std::cout << "Shared pointer - no extra memory\n";
     for (size_t i = 0; i < n; ++i) {
-      std::cout << i << "\n";
       stephens[i].init(ptr);
       if (i % 2 == 0) {
         stephen::set_word(stephens[i], to_word("a"));
@@ -1671,9 +1668,7 @@ namespace libsemigroups {
 
     std::vector<Stephen<InversePresentation<word_type>>> bad_stephens(n);
     // Uses 6GB extra memory without shared pointer
-    std::cout << "No shared pointer - about 6GB peak memory usage\n";
     for (size_t i = 0; i < n; ++i) {
-      std::cout << i << "\n";
       bad_stephens[i].init(p);
       if (i % 2 == 0) {
         stephen::set_word(bad_stephens[i], to_word("a"));

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -2747,7 +2747,7 @@ namespace libsemigroups {
   }
 
   // This test seems to segfault, including on debug mode, and it causes JDE's
-  // terminal to crash making it tought to figure out what's going wrong.
+  // terminal to crash making it tough to figure out what's going wrong.
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "068",
                           "Walker 5",
@@ -2793,7 +2793,7 @@ namespace libsemigroups {
   }
 
   // This test seems to segfault, including on debug mode, and it causes JDE's
-  // terminal to crash making it tought to figure out what's going wrong.
+  // terminal to crash making it tough to figure out what's going wrong.
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "069",
                           "not Walker 6",
@@ -3774,7 +3774,7 @@ namespace libsemigroups {
   }
 
   // This test seems to segfault, including on debug mode, and it causes JDE's
-  // terminal to crash making it tought to figure out what's going wrong.
+  // terminal to crash making it tough to figure out what's going wrong.
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "096",
                           "http://brauer.maths.qmul.ac.uk/Atlas/spor/M22",
@@ -3843,7 +3843,7 @@ namespace libsemigroups {
   }
 
   // This test seems to segfault, including on debug mode, and it causes JDE's
-  // terminal to crash making it tought to figure out what's going wrong.
+  // terminal to crash making it tough to figure out what's going wrong.
   // Takes about 3 minutes (with HLT)
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "098",
@@ -4581,7 +4581,7 @@ namespace libsemigroups {
   }
 
   // This test seems to segfault, including on debug mode, and it causes JDE's
-  // terminal to crash making it tought to figure out what's going wrong.
+  // terminal to crash making it tough to figure out what's going wrong.
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "113",
                           "Whyte's 2-generator 4-relation full transf monoid 8",

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -3535,13 +3535,13 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "090",
                           "relation ordering",
-                          "[todd-coxeter][extreme]") {
-    auto rg = ReportGuard(true);
+                          "[todd-coxeter][standard]") {
+    auto rg = ReportGuard(false);
     // Sorting the rules makes this twice as slow...
     auto p = presentation::examples::renner_type_D_monoid(5, 1);
     presentation::sort_each_rule(p);
     presentation::sort_rules(p);
-    REQUIRE(p.rules.size() == 308);
+    REQUIRE(p.rules.size() == 302);
     presentation::remove_duplicate_rules(p);
     presentation::reduce_complements(p);
     REQUIRE(p.rules.size() == 230);
@@ -4054,40 +4054,29 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "105",
                           "hypo plactic id monoid",
-                          "[todd-coxeter][extreme]") {
+                          "[todd-coxeter][standard]") {
     std::array<uint64_t, 11> const num
         = {0, 0, 4, 13, 40, 121, 364, 1'093, 3'280, 9'841, 29'524};
     // A003462
-    auto rg = ReportGuard(true);
+    auto rg = ReportGuard(false);
     for (size_t n = 4; n < 11; ++n) {
       auto p = presentation::examples::hypo_plactic_monoid(n);
       p.contains_empty_word(true);
       presentation::add_idempotent_rules_no_checks(
           p, (seq<size_t>() | take(n) | to_vector()));
-      REQUIRE(p.rules == std::vector<word_type>());
       ToddCoxeter tc(twosided, p);
       REQUIRE(tc.number_of_classes() == num[n] + 1);
       auto  fp = to<FroidurePin>(tc);
       Gabow scc(fp.right_cayley_graph());
       REQUIRE(scc.number_of_components() == num[n]);
       REQUIRE(fp.number_of_idempotents() == std::pow(2, n) - 1);
-      if (n < 3)
-        continue;
-      presentation::sort_each_rule(p);
-      presentation::sort_rules(p);
-      auto q = to<Presentation<std::string>>(p);
-      presentation::change_alphabet(q, "abc");
-      REQUIRE(q.rules == std::vector<std::string>());
-      // REQUIRE((normal_forms(tc) | to_vector())
-      //
-      //         == std::vector({{}, {0}, {1}, {0, 1}, {1, 0}}));
     }
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "106",
                           "Chinese id monoid",
-                          "[todd-coxeter][extreme]") {
+                          "[todd-coxeter][standard]") {
     std::array<uint64_t, 11> const num = {
         0, 0, 4, 14, 50, 187, 730, 2'949, 12'234, 51'821, 223'190};  // A007317
     std::vector<std::vector<uint64_t>> tri
@@ -4431,37 +4420,36 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "110",
                           "sigma-plactic monoid",
-                          "[todd-coxeter][extreme]") {
+                          "[todd-coxeter][quick]") {
     auto p = presentation::examples::sigma_plactic_monoid({2, 2, 2});
     p.contains_empty_word(true);
     ToddCoxeter tc(twosided, p);
 
     REQUIRE(tc.number_of_classes() == 15);
 
-    std::vector nf = {""_w,
-                      0_w,
-                      101_w,
-                      212012_w,
-                      12012_w,
-                      202_w,
-                      01_w,
-                      2012_w,
-                      012_w,
-                      02_w,
-                      1012_w,
-                      1_w,
-                      212_w,
-                      12_w,
-                      2_w};
-    std::for_each(nf.begin(), nf.end(), [&tc](auto& w) { w = reduce(tc, w); });
-    REQUIRE(nf == std::vector<word_type>());
-    REQUIRE((normal_forms(tc) | to_vector()) == std::vector<word_type>());
+    REQUIRE((normal_forms(tc) | to_vector())
+            == std::vector<word_type>({""_w,
+                                       0_w,
+                                       1_w,
+                                       2_w,
+                                       01_w,
+                                       02_w,
+                                       10_w,
+                                       12_w,
+                                       20_w,
+                                       21_w,
+                                       012_w,
+                                       021_w,
+                                       102_w,
+                                       210_w,
+                                       1021_w}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "111",
                           "2-sylvester monoid",
                           "[todd-coxeter][extreme]") {
+    auto rg = ReportGuard(true);
     using words::pow;
     size_t                  n = 4;
     Presentation<word_type> p;

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -432,8 +432,8 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "002",
                           "Example 6.6 in Sims (see also KnuthBendix 013)",
-                          "[todd-coxeter][standard]") {
-    auto rg = ReportGuard(false);
+                          "[todd-coxeter][extreme]") {
+    auto rg = ReportGuard(true);
 
     Presentation<word_type> p;
     p.alphabet(4);
@@ -503,7 +503,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "003",
                           "constructed from FroidurePin",
-                          "[no-valgrind][todd-coxeter][quick][no-coverage]") {
+                          "[todd-coxeter][standard][no-coverage]") {
     auto rg = ReportGuard(false);
 
     FroidurePin S = make<FroidurePin>(
@@ -1589,11 +1589,10 @@ namespace libsemigroups {
     REQUIRE(tc.current_word_graph() == copy.current_word_graph());
   }
 
-  LIBSEMIGROUPS_TEST_CASE(
-      "ToddCoxeter",
-      "029",
-      "stylic_monoid",
-      "[todd-coxeter][standard][no-coverage][no-valgrind]") {
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "029",
+                          "stylic_monoid",
+                          "[todd-coxeter][extreme][no-coverage]") {
     auto rg = ReportGuard(false);
 
     auto p = presentation::examples::stylic_monoid(9);
@@ -1727,8 +1726,8 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "032",
                           "symmetric_group(9) Moore_b",
-                          "[todd-coxeter][extreme]") {
-    auto rg = ReportGuard(true);
+                          "[todd-coxeter][standard]") {
+    auto rg = ReportGuard(false);
 
     auto p = presentation::examples::symmetric_group_Moo97_b(9);
     presentation::reduce_complements(p);
@@ -1784,7 +1783,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "034",
                           "symmetric_group(7) Burnside",
-                          "[todd-coxeter][quick][no-valgrind]") {
+                          "[todd-coxeter][standard]") {
     auto rg = ReportGuard(false);
 
     size_t n = 7;
@@ -1804,7 +1803,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "035",
                           "Easdown-East-FitzGerald DualSymInv(5)",
-                          "[todd-coxeter][quick][no-valgrind][no-coverage]") {
+                          "[todd-coxeter][standard][no-coverage]") {
     auto       rg = ReportGuard(false);
     auto const n  = 5;
     auto p = presentation::examples::dual_symmetric_inverse_monoid_EEF07(n);
@@ -1845,7 +1844,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "037",
                           "stellar_monoid(7) (Gay-Hivert)",
-                          "[todd-coxeter][quick][no-valgrind][no-coverage]") {
+                          "[todd-coxeter][standard][no-coverage]") {
     auto         rg = ReportGuard(false);
     size_t const n  = 7;
     auto         p  = presentation::examples::stellar_monoid_GH19(n);
@@ -1949,7 +1948,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "042",
                           "temperley_lieb_monoid(10) (East)",
-                          "[todd-coxeter][quick][no-valgrind][no-coverage]") {
+                          "[todd-coxeter][standard][no-coverage]") {
     auto         rg = ReportGuard(false);
     size_t const n  = 10;
     auto         p  = presentation::examples::temperley_lieb_monoid_Eas21(n);
@@ -2529,7 +2528,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "064",
                           "Walker 1",
-                          "[todd-coxeter][standard][no-valgrind]") {
+                          "[todd-coxeter][standard]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcABCDEFGHIXYZ");
@@ -2608,7 +2607,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "065",
                           "Walker 2",
-                          "[todd-coxeter][quick][no-coverage][no-valgrind]") {
+                          "[todd-coxeter][standard][no-coverage]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -2699,8 +2698,8 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "067",
                           "Walker 4",
-                          "[todd-coxeter][extreme]") {
-    auto                      rg = ReportGuard();
+                          "[todd-coxeter][standard]") {
+    auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab");
     presentation::add_rule(p, "aaa", "a");
@@ -2893,8 +2892,8 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "071",
                           "Walker 7",
-                          "[todd-coxeter][standard]") {
-    auto                      rg = ReportGuard(false);
+                          "[todd-coxeter][extreme]") {
+    auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.alphabet("abcde");
     presentation::add_rule(p, "aaa", "a");
@@ -2936,8 +2935,8 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "072",
                           "Walker 8",
-                          "[todd-coxeter][standard]") {
-    auto rg = ReportGuard(false);
+                          "[todd-coxeter][extreme]") {
+    auto rg = ReportGuard(true);
 
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -2978,7 +2977,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "073",
                           "KnuthBendix 098",
-                          "[todd-coxeter][quick][no-valgrind][no-coverage]") {
+                          "[todd-coxeter][standard][no-coverage]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("aAbBcCdDyYfFgGe");
@@ -3008,7 +3007,7 @@ namespace libsemigroups {
                           "074",
                           "Holt 2 - SL(2, p)",
                           "[todd-coxeter][extreme]") {
-    auto                        rg     = ReportGuard();
+    auto                        rg     = ReportGuard(true);
     std::array<size_t, 4> const sizes  = {24, 120, 336, 1'320};
     std::array<size_t, 4> const primes = {3, 5, 7, 11};
 
@@ -3127,7 +3126,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "078",
                           "Renner monoid type D4 (Gay-Hivert), q = 1",
-                          "[no-valgrind][quick][todd-coxeter][no-coverage]") {
+                          "[standard][todd-coxeter][no-coverage]") {
     auto rg = ReportGuard(false);
     auto p  = presentation::examples::renner_type_D_monoid(4, 1);
     presentation::normalize_alphabet(p);
@@ -3318,8 +3317,8 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "084",
                           "ACE --- SL219 - HLT",
-                          "[todd-coxeter][standard][ace]") {
-    auto                      rg = ReportGuard(false);
+                          "[todd-coxeter][extreme][ace]") {
+    auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.alphabet("abAB");
     p.contains_empty_word(true);
@@ -3418,8 +3417,8 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "086",
                           "ACE --- M12",
-                          "[todd-coxeter][standard][ace]") {
-    auto                      rg = ReportGuard(false);
+                          "[todd-coxeter][extreme][ace]") {
+    auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.alphabet("abcABC");
     p.contains_empty_word(true);
@@ -3708,7 +3707,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "094",
                           "http://brauer.maths.qmul.ac.uk/Atlas/spor/M11/",
-                          "[todd-coxeter][quick][no-coverage][no-valgrind]") {
+                          "[todd-coxeter][standard][no-coverage]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("xyXY");
@@ -3750,8 +3749,8 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "095",
                           "http://brauer.maths.qmul.ac.uk/Atlas/spor/M12/",
-                          "[todd-coxeter][standard]") {
-    auto                      rg = ReportGuard(false);
+                          "[todd-coxeter][extreme]") {
+    auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.alphabet("xyXY");
     p.contains_empty_word(true);
@@ -3806,6 +3805,7 @@ namespace libsemigroups {
                           "097",
                           "http://brauer.maths.qmul.ac.uk/Atlas/spor/M23",
                           "[todd-coxeter][extreme]") {
+    auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.alphabet("xyXY");
     p.contains_empty_word(true);
@@ -3887,11 +3887,12 @@ namespace libsemigroups {
   }
 
   // Approx. 32 minutes (2021 - MacBook Air M1 - 8GB RAM)
+  // Approx. 17.5 minutes (2025 - intel i7-13700H - 64GB RAM)
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "099",
                           "http://brauer.maths.qmul.ac.uk/Atlas/spor/HS",
                           "[todd-coxeter][extreme]") {
-    auto rg = ReportGuard();
+    auto rg = ReportGuard(true);
 
     Presentation<std::string> p;
     p.alphabet("xyXY");
@@ -3950,7 +3951,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "101",
                           "http://brauer.maths.qmul.ac.uk/Atlas/lin/L34/",
-                          "[todd-coxeter][quick][no-coverage][no-valgrind]") {
+                          "[todd-coxeter][standard][no-coverage]") {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("xyXY");
@@ -3981,6 +3982,7 @@ namespace libsemigroups {
                           "102",
                           "http://brauer.maths.qmul.ac.uk/Atlas/clas/S62 x 2",
                           "[todd-coxeter][extreme]") {
+    auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.alphabet("xyXY");
     p.contains_empty_word(true);
@@ -4087,13 +4089,12 @@ namespace libsemigroups {
            {1, 4, 12, 16, 13, 4, 1},
            {1, 5, 20, 40, 55, 41, 20, 5, 1},
            {1, 6, 30, 80, 155, 186, 156, 80, 30, 6, 1}};
-    auto rg = ReportGuard(true);
+    auto rg = ReportGuard(false);
     for (size_t n = 2; n < 11; ++n) {
       auto p = presentation::examples::chinese_monoid(n);
       p.contains_empty_word(true);
       presentation::add_idempotent_rules_no_checks(
           p, (seq<size_t>() | take(n) | to_vector()));
-      // REQUIRE(p.rules == std::vector<word_type>());
       ToddCoxeter tc(twosided, p);
       REQUIRE(tc.number_of_classes() == num[n] + 1);
       auto  fp = to<FroidurePin>(tc);
@@ -4218,7 +4219,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "108",
                           "plactic (n, 1)-id monoid",
-                          "[todd-coxeter][extreme]") {
+                          "[todd-coxeter][quick]") {
     // auto                          r = 3, s = 2;
     // std::array<uint64_t, 7> const size = {1, 3, 14, 95, 885, 10'858,
     // 170'209};
@@ -4668,6 +4669,7 @@ namespace libsemigroups {
                           "115",
                           "https://brauer.maths.qmul.ac.uk/Atlas/exc/TF42",
                           "[todd-coxeter][extreme]") {
+    auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.contains_empty_word(true).alphabet("xyXY");
     presentation::add_inverse_rules(p, "XYxy");
@@ -4745,8 +4747,8 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "118",
                           "alternating group 8",
-                          "[todd-coxeter][extreme]") {
-    auto                      rg = ReportGuard(true);
+                          "[todd-coxeter][standard]") {
+    auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("abcABC").contains_empty_word(true);
     presentation::add_inverse_rules(p, "ABCabc");
@@ -4848,7 +4850,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "120",
                           "check full enum not triggered",
-                          "[todd-coxeter][extreme]") {
+                          "[todd-coxeter][standard]") {
     Presentation<std::string> p;
     p.alphabet("abcd");
     presentation::add_rule(p, "aa", "a");

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -2747,10 +2747,12 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 36'412);
   }
 
+  // This test seems to segfault, including on debug mode, and it causes JDE's
+  // terminal to crash making it tought to figure out what's going wrong.
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "068",
                           "Walker 5",
-                          "[todd-coxeter][extreme]") {
+                          "[todd-coxeter][fail]") {
     auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -2791,10 +2793,12 @@ namespace libsemigroups {
     check_complete_compatible(tc);
   }
 
+  // This test seems to segfault, including on debug mode, and it causes JDE's
+  // terminal to crash making it tought to figure out what's going wrong.
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "069",
                           "not Walker 6",
-                          "[todd-coxeter][extreme]") {
+                          "[todd-coxeter][fail]") {
     auto                      rg = ReportGuard();
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -3770,10 +3774,12 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 95'040);
   }
 
+  // This test seems to segfault, including on debug mode, and it causes JDE's
+  // terminal to crash making it tought to figure out what's going wrong.
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "096",
                           "http://brauer.maths.qmul.ac.uk/Atlas/spor/M22",
-                          "[todd-coxeter][extreme]") {
+                          "[todd-coxeter][fail]") {
     ReportGuard               rg(true);
     Presentation<std::string> p;
     p.alphabet("xyXY");
@@ -3836,11 +3842,13 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 10'200'960);
   }
 
+  // This test seems to segfault, including on debug mode, and it causes JDE's
+  // terminal to crash making it tought to figure out what's going wrong.
   // Takes about 3 minutes (with HLT)
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "098",
                           "http://brauer.maths.qmul.ac.uk/Atlas/clas/S62",
-                          "[todd-coxeter][extreme]") {
+                          "[todd-coxeter][fail]") {
     Presentation<std::string> p;
     p.alphabet("xyXY");
     p.contains_empty_word(true);
@@ -4104,30 +4112,28 @@ namespace libsemigroups {
       REQUIRE(scc.number_of_components() == num[n]);
       REQUIRE(fp.number_of_idempotents() == std::pow(2, n) - 1);
 
-      std::vector<uint64_t> length = {};
-      for (auto&& nf : normal_forms(tc)) {
-        while (nf.size() >= length.size()) {
-          length.push_back(0);
+      if (n <= 6) {
+        std::vector<uint64_t> length = {};
+        for (auto&& nf : normal_forms(tc)) {
+          while (nf.size() >= length.size()) {
+            length.push_back(0);
+          }
+          length[nf.size()]++;
         }
-        length[nf.size()]++;
+        REQUIRE(length == tri[n]);
       }
-      REQUIRE(length == tri[n]);
-
-      if (n < 3)
-        continue;
     }
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "107",
                           "Chinese id monoid x 2",
-                          "[todd-coxeter][extreme]") {
+                          "[todd-coxeter][fail]") {
     auto n = 5;
     auto p = presentation::examples::chinese_monoid(n);
     p.contains_empty_word(true);
     presentation::add_idempotent_rules_no_checks(
         p, (seq<size_t>() | take(n) | to_vector()));
-    // REQUIRE(p.rules == std::vector<word_type>());
     ToddCoxeter tc(twosided, p);
     tc.run();
 
@@ -4383,7 +4389,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "109",
                           "plactic (n, 1)-id monoid x 2",
-                          "[todd-coxeter][extreme]") {
+                          "[todd-coxeter][fail]") {
     using words::pow;
     using words::operator+;
     // #include "Plact4-1_3_last.txt"
@@ -4585,10 +4591,12 @@ namespace libsemigroups {
     }
   }
 
+  // This test seems to segfault, including on debug mode, and it causes JDE's
+  // terminal to crash making it tought to figure out what's going wrong.
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
                           "113",
                           "Whyte's 2-generator 4-relation full transf monoid 8",
-                          "[todd-coxeter][extreme]") {
+                          "[todd-coxeter][fail]") {
     auto                    rg = ReportGuard(true);
     Presentation<word_type> p;
     p.rules = {00_w,

--- a/tests/test-word-range.cpp
+++ b/tests/test-word-range.cpp
@@ -192,7 +192,7 @@ namespace libsemigroups {
   LIBSEMIGROUPS_TEST_CASE("WordRange",
                           "007",
                           "lex + sort",
-                          "[wislo][quick][no-valgrind][no-coverage]") {
+                          "[wislo][standard][no-coverage]") {
     word_type first = {};
     word_type last(13, 2);
     auto      w = std::vector(cbegin_wilo(3, 13, first, last),


### PR DESCRIPTION
This PR reclassifies the tests so that we conform with the table specified in [CONTRIBUTING.rst](https://github.com/libsemigroups/libsemigroups/blob/36f00facebb5ce4235af2ab6bc1fae1fab7f5ae9/CONTRIBUTING.rst), and makes minor changes to make the test more consistent.

Specifically:
 - [X] The time-related tag of each test case conforms with: 
   - "quick" < 200ms;
   - 200ms < "standard" < 3s;
   - 3s < "extreme".
 - [X] Reporting is enabled for every "extreme" test;
 - [X] reporting is disabled for every "quick" and "standard" test;
 - [X] "fail" is marked for old "extreme tests" that hadn't finished after several hours; and
 - [X] "fail" is marked for any test that does not pass.

I tried my best to fix any failing tests but, in several of them, it wasn't clear to me what was actually being tested, so these have been marked fail. I welcome any suggestions on if/how these should be fixed. 

With these changes, using an Intel i7-13700H cpu with 64 GB of RAM and configuring using `./configure CXX="ccache g++" CXXFLAGS="-g -O2"`, the:
 - "quick" tests run in ~8 seconds;
 - "standard" tests run in ~1 minute 20 seconds; and
 - "extreme" tests run in ~1 hour 10 minutes.

The output generated by the extreme tests can be found below for reference:
[extreme.log.zip](https://github.com/user-attachments/files/19277450/extreme.log.zip)