### PR TITLE
Add test analysis

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           mkdir -p m4
           ./autogen.sh 
-          ./configure CXX="$CXX" --disable-hpcombi
+          ./configure CXX="$CXX"
       - name: Build libsemigroups . . .
         run: make -j4
       - name: Build test_all . . .

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           mkdir -p m4
           ./autogen.sh
-          ./configure CXX="$CXX" CXXFLAGS="$CXXFLAGS" --disable-hpcombi --disable-backward
+          ./configure CXX="$CXX" CXXFLAGS="$CXXFLAGS" --disable-backward
       - name: Build libsemigroups . . .
         run: make -j4
       - name: Build test_all . . .

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -34,7 +34,14 @@ jobs:
       - name: Build test_all . . .
         run: make test_all -j4
       - name: Run the quick and standard tests . . .
-        run: ./test_all "[quick],[standard]"
+        run: ./test_all --reporter junit::out=junit.xml "[quick],[standard]"
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && matrix.compiler == 'g++' }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          verbose: true
   benchmarks:
     name: Benchmarks compile
     timeout-minutes: 10

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           mkdir -p m4
           ./autogen.sh 
-          ./configure CXX="$CXX" CXXFLAGS="$CXXFLAGS" --disable-hpcombi
+          ./configure CXX="$CXX" CXXFLAGS="$CXXFLAGS"
       - name: Build libsemigroups . . .
         run: make -j4
       - name: Build test_all . . .


### PR DESCRIPTION
This PR adjusts the output of the `Quick tests/g++` job so that the results can be uploaded to Codecov. Moving forward, this will allow us to track the runtime of individual tests, and see if there are tests that fail more often than others. This should only introduce a small overhead, since these tests are getting run anyway; now we just keep hold of the output. 

This PR also removes the `--disable-hpcombi` flag from several otherwise default configurations, since I couldn't really see what it was included. If there was a good reason for this, I'm happy to revert this change.