### PR TITLE
Patch readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ monoids. The main algorithms implemented in `libsemigroups` are:
   for permutation groups in the class template [`libsemigroups::SchreierSims`][];
 - a version of Stephen's procedure from
   ["Applications of automata theory to presentations of monoids and inverse monoids"][]
-  for finitely presented inverse semigroups and monoids (for a given word \\(w\\) this
-  procedure is for determining words equivalent to \\(w\\) or that are
-  left divisors of \\(w\\)) in the class template [`libsemigroups::Stephen`][];
+  for finitely presented inverse semigroups and monoids (for a given word `w` this
+  procedure is for determining words equivalent to `w` or that are
+  left divisors of `w`) in the class template [`libsemigroups::Stephen`][];
 - the [Todd-Coxeter algorithm][] for finitely presented semigroups and monoids;
   in the class template [`libsemigroups::ToddCoxeter`][]; see also
   ["The Todd–Coxeter algorithm for semigroups and monoids"][].

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ monoids. The main algorithms implemented in `libsemigroups` are:
 [Jean-Eric Pin]: https://www.irif.fr/~jep/
 
 `libsemigroups` is used in the [Semigroups package for
-GAP](https://semigroups.github.io/Semigroups) (see \cite Mitchell2025aa), and it
+GAP](https://semigroups.github.io/Semigroups), and it
 is possible to use `libsemigroups` directly in Python 3 via the package
 [libsemigroups_pybind11](https://libsemigroups.github.io/libsemigroups_pybind11/).
 The development version of `libsemigroups` is available on
@@ -137,7 +137,7 @@ tracker](https://github.com/libsemigroups/libsemigroups/issues).
 `libsemigroups` uses:
 
 - [Catch2](https://github.com/catchorg/Catch2) for tests and benchmarks;
-- [eigen](http://eigen.tuxfamily.org/) for some linear algebra computations \cite Guennebaud2010aa;
+- [eigen](http://eigen.tuxfamily.org/) for some linear algebra computations;
 - [fmt](https://github.com/fmtlib/fmt) for string formatting;
 - [HPCombi](https://github.com/libsemigroups/HPCombi) which uses the SSE and AVX
   instruction sets for very fast manipulation of transformations, partial

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ See the documentation <https://libsemigroups.github.io/libsemigroups/>.
 
 ## Installation
 
-See [the installation page](install.md) for more info.
+See [the installation page](docs/install.md) for more info.
 
 ## Issues
 

--- a/include/libsemigroups/kambites-class.hpp
+++ b/include/libsemigroups/kambites-class.hpp
@@ -65,7 +65,7 @@ namespace libsemigroups {
   //! On this page there are links to the documentation for the algorithms in
   //! `libsemigroups` for small overlap monoids by Mark %Kambites and the
   //! authors of `libsemigroups`; see \cite Kambites2009aa,
-  //! \cite Kambites2009ab, and \cite Mitchell2021aa.
+  //! \cite Kambites2009ab, and \cite Mitchell2023aa.
   //!
   //! Helper functions for the class template \ref_kambites can be found in the
   //! namespace \ref cong_common_helpers_group "congruence_common" and

--- a/include/libsemigroups/obvinf.hpp
+++ b/include/libsemigroups/obvinf.hpp
@@ -70,6 +70,10 @@ namespace libsemigroups {
   //! This page collects the documentation for the functionality in
   //! `libsemigroups` for checking if a finitely presented semigroup or monoid
   //! is obviously infinite.
+  //!
+  //! If `libsemigroups` is compiled with the flag `--enable-eigen`, then the
+  //! functions and classes documented on this page may make use of the Eigen
+  //! library for linear algebra (see \cite Guennebaud2010aa).
 
   //! \ingroup obvinf_group
   //!

--- a/include/libsemigroups/paths.hpp
+++ b/include/libsemigroups/paths.hpp
@@ -392,6 +392,10 @@ namespace libsemigroups {
   //! At worst \f$O(nm)\f$ where \f$n\f$ is the number of nodes and \f$m\f$
   //! is the out-degree of the word graph.
   //!
+  //! \note If `libsemigroups` is compiled with the flag `--enable-eigen`, then
+  //! this function makes use of the Eigen library for linear algebra (see
+  //! \cite Guennebaud2010aa).
+  //!
   //! \warning If the number of paths exceeds 2 ^ 64, then return value of
   //! this function will not be correct.
   template <typename Node1, typename Node2>
@@ -463,6 +467,10 @@ namespace libsemigroups {
   //! * paths::algorithm::automatic: attempts to select the fastest algorithm of
   //! the
   //!   preceding algorithms and then applies that.
+  //!
+  //! \note If `libsemigroups` is compiled with the flag `--enable-eigen`, then
+  //! this function makes use of the Eigen library for linear algebra (see
+  //! \cite Guennebaud2010aa).
   //!
   //! \warning If \p lgrthm is paths::algorithm::automatic, then it is not
   //! always the case that the fastest algorithm is used.
@@ -543,6 +551,10 @@ namespace libsemigroups {
   //! * paths::algorithm::trivial: constant (only valid in some circumstances)
   //! * paths::algorithm::automatic: attempts to select the fastest algorithm of
   //!   the preceding algorithms and then applies that.
+  //!
+  //! \note If `libsemigroups` is compiled with the flag `--enable-eigen`, then
+  //! this function makes use of the Eigen library for linear algebra (see
+  //! \cite Guennebaud2010aa).
   //!
   //! \warning If \p lgrthm is paths::algorithm::automatic, then it is not
   //! always the case that the fastest algorithm is used.


### PR DESCRIPTION
This PR updates the documentation such that:
* the README doesn't contain any doxygen specific markdown;
* there are no citations in the README; and
* the link to `install.md` is correct.