### PR TITLE
Move `Paths` helper functions to the `paths` namespace

### DIFF
--- a/include/libsemigroups/detail/knuth-bendix-impl.hpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.hpp
@@ -48,6 +48,7 @@
 #include "libsemigroups/debug.hpp"         // for LIBSEMIGROUPS_...
 #include "libsemigroups/obvinf.hpp"        // for is_obviously_infinite
 #include "libsemigroups/order.hpp"         // for ShortLexCompare
+#include "libsemigroups/paths.hpp"         // for paths
 #include "libsemigroups/presentation.hpp"  // for operator!=
 #include "libsemigroups/ranges.hpp"        // for count, iterato...
 #include "libsemigroups/types.hpp"         // for congruence_kind

--- a/include/libsemigroups/detail/knuth-bendix-impl.tpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.tpp
@@ -292,7 +292,7 @@ namespace libsemigroups {
       if (internal_presentation().alphabet().empty()) {
         return 1 + modifier;
       } else {
-        uint64_t result = number_of_paths(gilman_graph(), 0);
+        uint64_t result = paths::number_of_paths(gilman_graph(), 0);
         return result == POSITIVE_INFINITY ? result : result + modifier;
       }
     }

--- a/include/libsemigroups/detail/path-iterators.hpp
+++ b/include/libsemigroups/detail/path-iterators.hpp
@@ -191,7 +191,8 @@ namespace libsemigroups {
       }
 
       [[nodiscard]] node_type target() const noexcept {
-        if (_it == cend_pilo(_it.word_graph()) && _length == UNDEFINED) {
+        if (_it == const_pilo_iterator<Node>(&_it.word_graph(), 0, 0, 0)
+            && _length == UNDEFINED) {
           return UNDEFINED;
         }
         return _it.target();
@@ -337,10 +338,11 @@ namespace libsemigroups {
                              size_type                   max)
           : _count(source == UNDEFINED
                        ? 0
-                       : number_of_paths(*ptr, source, target, min, max)),
+                       //  : number_of_paths(*ptr, source, target, min, max)),
+                       : 0),
             _it(ptr, source, min, max),
             _target(target),
-            _end(cend_pislo(*ptr)) {
+            _end(const_pislo_iterator<Node>(ptr, UNDEFINED, 0, 0)) {
         operator++();
       }
 

--- a/include/libsemigroups/detail/path-iterators.tpp
+++ b/include/libsemigroups/detail/path-iterators.tpp
@@ -155,20 +155,21 @@ namespace libsemigroups {
           _max(max),
           _source(source) {
       if (_length != UNDEFINED) {
-        _it = cbegin_pilo(*ptr, source, _length, _length + 1);
+        _it = const_pilo_iterator<Node>(ptr, source, _length, _length + 1);
       } else {
-        _it = cend_pilo(*ptr);
+        _it = const_pilo_iterator<Node>(ptr, 0, 0, 0);
       }
     }
 
     template <typename Node>
     const_pislo_iterator<Node> const& const_pislo_iterator<Node>::operator++() {
       ++_it;
-      if (_it == cend_pilo(_it.word_graph())) {
+      if (_it == const_pilo_iterator<Node>(&_it.word_graph(), 0, 0, 0)) {
         if (_length < _max - 1) {
           ++_length;
-          _it = cbegin_pilo(_it.word_graph(), _source, _length, _length + 1);
-          if (_it == cend_pilo(_it.word_graph())) {
+          _it = const_pilo_iterator<Node>(
+              &_it.word_graph(), _source, _length, _length + 1);
+          if (_it == const_pilo_iterator<Node>(&_it.word_graph(), 0, 0, 0)) {
             _length = UNDEFINED;
           }
         } else {

--- a/include/libsemigroups/paths.hpp
+++ b/include/libsemigroups/paths.hpp
@@ -68,496 +68,506 @@ namespace libsemigroups {
       //! best.
       automatic
     };
-  }  // namespace paths
 
-  //! \relates Paths
-  //!
-  //! \brief Returns an iterator for pilo (Path And Node In Lex Order).
-  //!
-  //! Returns a forward iterator pointing to a pair consisting of the edge
-  //! labels of the first path (in lexicographical order) starting at
-  //! \p source with length in the range \f$[min, max)\f$ and the last node
-  //! of that path.
-  //!
-  //! If incremented, the iterator will point to the next least edge
-  //! labelling of a path (in lexicographical order), and its last node, with
-  //! length in the range \f$[min, max)\f$.  Iterators of the type returned
-  //! by this function are equal whenever they point to equal objects.
-  //!
-  //! \param wg the WordGraph.
-  //! \param source the source node.
-  //! \param min the minimum length of a path to enumerate (defaults to \c 0).
-  //! \param max the maximum length of a path to enumerate (defaults to
-  //!        \ref POSITIVE_INFINITY).
-  //!
-  //! \returns
-  //! An iterator \c it of type \c const_pilo_iterator pointing to a `std::pair`
-  //! where:
-  //! * \c it->first is a \ref word_type consisting of the edge
-  //! labels of the first path (in lexicographical order) from \p source of
-  //! length in the range \f$[min, max)\f$; and
-  //! * \c it->second is the last node on the path from \p source labelled by
-  //! \c it->first, a value of \ref WordGraph::node_type.
-  //!
-  //! \throws LibsemigroupsException if \p source is not a node in the
-  //! word graph.
-  //!
-  //! \warning
-  //! Copying iterators of this type is expensive.  As a consequence, prefix
-  //! incrementing \c ++it the returned  iterator \c it significantly cheaper
-  //! than postfix incrementing \c it++.
-  //!
-  //! \warning
-  //! If the word graph represented by \c this contains a cycle that is
-  //! reachable from \p source, then there are infinitely many paths starting
-  //! at \p source, and so \p max should be chosen with some care.
-  //!
-  //! \sa
-  //! cend_pilo
-  // not noexcept because constructors of const_pilo_iterator aren't
-  template <typename Node1, typename Node2>
-  [[nodiscard]] auto cbegin_pilo(WordGraph<Node1> const& wg,
-                                 Node2                   source,
-                                 size_t                  min = 0,
-                                 size_t max = POSITIVE_INFINITY) {
-    word_graph::throw_if_node_out_of_bounds(wg, static_cast<Node1>(source));
-    return detail::const_pilo_iterator<Node1>(&wg, source, min, max);
-  }
-
-  //! \relates Paths
-  //! Returns an iterator for pilo (Path And Node In Lex Order).
-  //!
-  //! Returns a forward iterator pointing to one after the last path from any
-  //! node in the word graph.
-  //!
-  //! The iterator returned by this function may still dereferenceable and
-  //! incrementable, but may not point to a path in the correct range.
-  //!
-  //! \sa cbegin_pilo
-  // not noexcept because constructors of const_pilo_iterator aren't
-  template <typename Node>
-  [[nodiscard]] auto cend_pilo(WordGraph<Node> const& wg) {
-    return detail::const_pilo_iterator<Node>(&wg, 0, 0, 0);
-  }
-
-  //! \relates Paths
-  //!
-  //! Returns an iterator for pislo (Path And Node In Short Lex Order).
-  //!
-  //! Returns a forward iterator pointing to a pair consisting of the edge
-  //! labels of the first path (in short-lex order) starting at \p source
-  //! with length in the range \f$[min, max)\f$ and the last node of that
-  //! path.
-  //!
-  //! If incremented, the iterator will point to the next least edge
-  //! labelling of a path (in short-lex order), and its last node, with
-  //! length in the range \f$[min, max)\f$.  Iterators of the type returned
-  //! by this function are equal whenever they point to equal objects.
-  //!
-  //! \param wg the WordGraph.
-  //! \param source the source node.
-  //! \param min the minimum length of a path to enumerate (defaults to \c 0).
-  //! \param max the maximum length of a path to enumerate (defaults to
-  //!        \ref POSITIVE_INFINITY).
-  //!
-  //! \returns
-  //! An iterator \c it of type \c detail::const_pislo_iterator pointing to a
-  //! `std::pair` where:
-  //! * \c it->first is a \ref word_type consisting of the edge
-  //! labels of the first path (in short-lex order) from \p source of
-  //! length in the range \f$[min, max)\f$; and
-  //! * \c it->second is the last node on the path from \p source labelled by
-  //! \c it->first, a value of \ref WordGraph::node_type.
-  //!
-  //! \throws LibsemigroupsException if \p source is not a node in the
-  //! word graph.
-  //!
-  //! \warning
-  //! Copying iterators of this type is expensive.  As a consequence, prefix
-  //! incrementing \c ++it the returned  iterator \c it significantly cheaper
-  //! than postfix incrementing \c it++.
-  //!
-  //! \warning
-  //! If the word graph represented by \c this contains a cycle that is
-  //! reachable from \p source, then there are infinitely many paths starting
-  //! at \p source, and so \p max should be chosen with some care.
-  //!
-  //! \sa
-  //! cend_pislo
-  // TODO(2) example and what is the complexity?
-  // not noexcept because detail::const_pislo_iterator constructors aren't
-  template <typename Node1, typename Node2>
-  [[nodiscard]] auto cbegin_pislo(WordGraph<Node1> const& wg,
-                                  Node2                   source,
-                                  size_t                  min = 0,
-                                  size_t max = POSITIVE_INFINITY) {
-    word_graph::throw_if_node_out_of_bounds(wg, static_cast<Node1>(source));
-    return detail::const_pislo_iterator<Node1>(&wg, source, min, max);
-  }
-
-  //! \relates Paths
-  //! Returns an iterator for pislo (Path And Node In Short Lex Order).
-  //!
-  //! Returns a forward iterator pointing to one after the last path from any
-  //! node in the word graph.
-  //!
-  //! The iterator returned by this function may still dereferenceable and
-  //! incrementable, but may not point to a path in the correct range.
-  //!
-  //! \sa cbegin_pislo
-  // not noexcept because detail::const_pislo_iterator constructors aren't
-  template <typename Node>
-  [[nodiscard]] auto cend_pislo(WordGraph<Node> const& wg) {
-    return detail::const_pislo_iterator<Node>(&wg, UNDEFINED, 0, 0);
-  }
-
-  //! \relates Paths
-  //! Returns an iterator for PSTILO (Path Source Target In Lex Order).
-  //!
-  //! Returns a forward iterator pointing to the edge labels of the first
-  //! path (in lexicographical order) starting at the node \p source and
-  //! ending at the node \p target with length in the range \f$[min, max)\f$.
-  //!
-  //! If incremented, the iterator will point to the next least edge
-  //! labelling of a path (in lexicographical order).  Iterators of the type
-  //! returned by this function are equal whenever they point to equal
-  //! objects.
-  //!
-  //! \param wg the WordGraph.
-  //! \param source the first node.
-  //! \param target the last node.
-  //! \param min the minimum length of a path to enumerate (defaults to \c 0).
-  //! \param max the maximum length of a path to enumerate (defaults to
-  //!        \ref POSITIVE_INFINITY).
-  //!
-  //! \returns
-  //! An iterator \c it of type \c detail::const_pstilo_iterator pointing to a
-  //! \ref word_type consisting of the edge labels of the first
-  //! path (in lexicographical order) from the node \p source to the node
-  //! \p target with length in the range \f$[min, max)\f$ (if any).
-  //!
-  //! \throws LibsemigroupsException if \p target or \p source is not a node
-  //! in the word graph.
-  //!
-  //! \warning
-  //! Copying iterators of this type is expensive.  As a consequence, prefix
-  //! incrementing \c ++it the returned  iterator \c it significantly cheaper
-  //! than postfix incrementing \c it++.
-  //!
-  //! \warning
-  //! If the word graph represented by \c this contains a cycle that is
-  //! reachable from \p source, then there may be infinitely many paths
-  //! starting at \p source, and so \p max should be chosen with some care.
-  //!
-  //! \sa
-  //! cend_pstilo
-  // not noexcept because detail::const_pstilo_iterator constructors aren't
-  template <typename Node1, typename Node2>
-  [[nodiscard]] auto cbegin_pstilo(WordGraph<Node1> const& wg,
+    //! \brief Returns an iterator for pilo (Path And Node In Lex Order).
+    //!
+    //! This function returns a forward iterator pointing to a pair consisting
+    //! of the edge labels of the first path (in lexicographical order) starting
+    //! at \p source with length in the range \f$[min, max)\f$ and the last node
+    //! of that path.
+    //!
+    //! If incremented, the iterator will point to the next least edge
+    //! labelling of a path (in lexicographical order), and its last node, with
+    //! length in the range \f$[min, max)\f$.  Iterators of the type returned
+    //! by this function are equal whenever they point to equal objects.
+    //!
+    //! \param wg the WordGraph.
+    //! \param source the source node.
+    //! \param min the minimum length of a path to enumerate (defaults to \c 0).
+    //! \param max the maximum length of a path to enumerate (defaults to
+    //!        \ref POSITIVE_INFINITY).
+    //!
+    //! \returns
+    //! An iterator \c it of type \c const_pilo_iterator pointing to a
+    //! `std::pair` where:
+    //! * \c it->first is a \ref word_type consisting of the edge
+    //! labels of the first path (in lexicographical order) from \p source of
+    //! length in the range \f$[min, max)\f$; and
+    //! * \c it->second is the last node on the path from \p source labelled by
+    //! \c it->first, a value of \ref WordGraph::node_type.
+    //!
+    //! \throws LibsemigroupsException if \p source is not a node in the
+    //! word graph.
+    //!
+    //! \warning
+    //! Copying iterators of this type is expensive.  As a consequence, prefix
+    //! incrementing \c ++it the returned  iterator \c it significantly cheaper
+    //! than postfix incrementing \c it++.
+    //!
+    //! \warning
+    //! If the word graph represented by \c this contains a cycle that is
+    //! reachable from \p source, then there are infinitely many paths starting
+    //! at \p source, and so \p max should be chosen with some care.
+    //!
+    //! \sa
+    //! cend_pilo
+    // not noexcept because constructors of const_pilo_iterator aren't
+    template <typename Node1, typename Node2>
+    [[nodiscard]] auto cbegin_pilo(WordGraph<Node1> const& wg,
                                    Node2                   source,
-                                   Node2                   target,
                                    size_t                  min = 0,
                                    size_t max = POSITIVE_INFINITY) {
-    // source & target are validated in is_reachable.
-    if (!word_graph::is_reachable(wg, source, target)) {
-      return cend_pstilo(wg);
+      word_graph::throw_if_node_out_of_bounds(wg, static_cast<Node1>(source));
+      return detail::const_pilo_iterator<Node1>(&wg, source, min, max);
     }
-    return detail::const_pstilo_iterator<Node1>(&wg, source, target, min, max);
-  }
 
-  //! \relates Paths
-  //! Returns an iterator for PSTILO (Path Source Target In Lex Order).
-  //!
-  //! Returns a forward iterator pointing to one after the last path from any
-  //! node in the word graph.
-  //!
-  //! The iterator returned by this function may still dereferenceable and
-  //! incrementable, but may not point to a path in the correct range.
-  //!
-  //! \sa cbegin_pstilo
-  // not noexcept because detail::const_pstilo_iterator constructors aren't
-  template <typename Node>
-  [[nodiscard]] auto cend_pstilo(WordGraph<Node> const& wg) {
-    return detail::const_pstilo_iterator<Node>(&wg, 0, 0, 0, 0);
-  }
+    //! \brief Returns an iterator for pilo (Path And Node In Lex Order).
+    //!
+    //! This function returns a forward iterator pointing to one after the last
+    //! path from any node in the word graph.
+    //!
+    //! The iterator returned by this function may still dereferenceable and
+    //! incrementable, but may not point to a path in the correct range.
+    //!
+    //! \sa cbegin_pilo
+    // not noexcept because constructors of const_pilo_iterator aren't
+    template <typename Node>
+    [[nodiscard]] auto cend_pilo(WordGraph<Node> const& wg) {
+      return detail::const_pilo_iterator<Node>(&wg, 0, 0, 0);
+    }
 
-  //! \relates Paths
-  //!
-  //! Returns an iterator for PSTISLO (Path Source Target In Short Lex
-  //! Order).
-  //!
-  //! Returns a forward iterator pointing to the edge labels of the first
-  //! path (in short-lex order) starting at the node \p source and ending
-  //! at the node \p target with length in the range \f$[min, max)\f$.
-  //!
-  //! If incremented, the iterator will point to the next least edge
-  //! labelling of a path (in short-lex order).  Iterators of the type
-  //! returned by this function are equal whenever they point to equal
-  //! objects.
-  //!
-  //! \param wg the WordGraph.
-  //! \param source the first node.
-  //! \param target the last node.
-  //! \param min the minimum length of a path to enumerate (defaults to \c 0).
-  //! \param max the maximum length of a path to enumerate (defaults to
-  //!        \ref POSITIVE_INFINITY).
-  //!
-  //! \returns
-  //! An iterator \c it of type \c detail::const_pstislo_iterator pointing to a
-  //! \ref word_type consisting of the edge labels of the first
-  //! path (in short-lex order) from the node \p source to the node \p target
-  //! with length in the range \f$[min, max)\f$ (if any).
-  //!
-  //! \throws LibsemigroupsException if \p target or \p source is not a node
-  //! in the word graph.
-  //!
-  //! \warning
-  //! Copying iterators of this type is expensive.  As a consequence, prefix
-  //! incrementing \c ++it the returned  iterator \c it significantly cheaper
-  //! than postfix incrementing \c it++.
-  //!
-  //! \warning
-  //! If the word graph represented by \c this contains a cycle that is
-  //! reachable from \p source, then there may be infinitely many paths
-  //! starting at \p source, and so \p max should be chosen with some care.
-  //!
-  //! \sa
-  //! cend_pstislo
-  // not noexcept because cbegin_pislo isn't
-  template <typename Node1, typename Node2>
-  [[nodiscard]] auto cbegin_pstislo(WordGraph<Node1> const& wg,
+    //! \brief Returns an iterator for pislo (Path And Node In Short Lex Order).
+    //!
+    //! This function returns a forward iterator pointing to a pair consisting
+    //! of the edge labels of the first path (in short-lex order) starting at \p
+    //! source with length in the range \f$[min, max)\f$ and the last node of
+    //! that path.
+    //!
+    //! If incremented, the iterator will point to the next least edge
+    //! labelling of a path (in short-lex order), and its last node, with
+    //! length in the range \f$[min, max)\f$.  Iterators of the type returned
+    //! by this function are equal whenever they point to equal objects.
+    //!
+    //! \param wg the WordGraph.
+    //! \param source the source node.
+    //! \param min the minimum length of a path to enumerate (defaults to \c 0).
+    //! \param max the maximum length of a path to enumerate (defaults to
+    //!        \ref POSITIVE_INFINITY).
+    //!
+    //! \returns
+    //! An iterator \c it of type \c detail::const_pislo_iterator pointing to a
+    //! `std::pair` where:
+    //! * \c it->first is a \ref word_type consisting of the edge
+    //! labels of the first path (in short-lex order) from \p source of
+    //! length in the range \f$[min, max)\f$; and
+    //! * \c it->second is the last node on the path from \p source labelled by
+    //! \c it->first, a value of \ref WordGraph::node_type.
+    //!
+    //! \throws LibsemigroupsException if \p source is not a node in the
+    //! word graph.
+    //!
+    //! \warning
+    //! Copying iterators of this type is expensive.  As a consequence, prefix
+    //! incrementing \c ++it the returned  iterator \c it significantly cheaper
+    //! than postfix incrementing \c it++.
+    //!
+    //! \warning
+    //! If the word graph represented by \c this contains a cycle that is
+    //! reachable from \p source, then there are infinitely many paths starting
+    //! at \p source, and so \p max should be chosen with some care.
+    //!
+    //! \sa
+    //! cend_pislo
+    // TODO(2) example and what is the complexity?
+    // not noexcept because detail::const_pislo_iterator constructors aren't
+    template <typename Node1, typename Node2>
+    [[nodiscard]] auto cbegin_pislo(WordGraph<Node1> const& wg,
                                     Node2                   source,
-                                    Node2                   target,
                                     size_t                  min = 0,
                                     size_t max = POSITIVE_INFINITY) {
-    // source & target are validated in is_reachable.
-    if (!word_graph::is_reachable(wg, source, target)) {
-      return cend_pstislo(wg);
+      word_graph::throw_if_node_out_of_bounds(wg, static_cast<Node1>(source));
+      return detail::const_pislo_iterator<Node1>(&wg, source, min, max);
     }
-    return detail::const_pstislo_iterator<Node1>(&wg, source, target, min, max);
-  }
 
-  //! \relates Paths
-  //!
-  //! Returns an iterator for PSTISLO (Path Source Target In Short Lex
-  //! Order).
-  //!
-  //! Returns a forward iterator pointing to one after the last path from any
-  //! node in the word graph.
-  //!
-  //! The iterator returned by this function may still dereferenceable and
-  //! incrementable, but may not point to a path in the correct range.
-  //!
-  //! \sa cbegin_pstislo
-  // not noexcept because cend_pislo isn't
-  template <typename Node>
-  [[nodiscard]] auto cend_pstislo(WordGraph<Node> const& wg) {
-    return detail::const_pstislo_iterator<Node>(
-        &wg, UNDEFINED, UNDEFINED, 0, 0);
-  }
+    //! \brief Returns an iterator for pislo (Path And Node In Short Lex Order).
+    //!
+    //! This function returns a forward iterator pointing to one after the last
+    //! path from any node in the word graph.
+    //!
+    //! The iterator returned by this function may still dereferenceable and
+    //! incrementable, but may not point to a path in the correct range.
+    //!
+    //! \sa cbegin_pislo
+    // not noexcept because detail::const_pislo_iterator constructors aren't
+    template <typename Node>
+    [[nodiscard]] auto cend_pislo(WordGraph<Node> const& wg) {
+      return detail::const_pislo_iterator<Node>(&wg, UNDEFINED, 0, 0);
+    }
 
-  //! \relates Paths
-  //! Returns the paths::algorithm used by number_of_paths().
-  //!
-  //! \param wg the WordGraph.
-  //! \param source the source node.
-  //!
-  //! \returns A value of type paths::algorithm.
-  //!
-  //! \exceptions
-  //! \noexcept
-  //!
-  //! \complexity
-  //! Constant
-  template <typename Node1, typename Node2>
-  [[nodiscard]] paths::algorithm
-  number_of_paths_algorithm(WordGraph<Node1> const& wg, Node2 source) noexcept {
-    (void) wg;
-    (void) source;
-    return paths::algorithm::acyclic;
-  }
+    //! \brief Returns an iterator for PSTILO (Path Source Target In Lex Order).
+    //!
+    //! This function returns a forward iterator pointing to one after the last
+    //! path from any node in the word graph.
+    //!
+    //! The iterator returned by this function may still dereferenceable and
+    //! incrementable, but may not point to a path in the correct range.
+    //!
+    //! \sa cbegin_pstilo
+    // not noexcept because detail::const_pstilo_iterator constructors aren't
+    template <typename Node>
+    [[nodiscard]] auto cend_pstilo(WordGraph<Node> const& wg) {
+      return detail::const_pstilo_iterator<Node>(&wg, 0, 0, 0, 0);
+    }
 
-  //! \relates Paths
-  //! Returns the number of paths from a source node.
-  //!
-  //! \param wg the WordGraph.
-  //! \param source the source node.
-  //!
-  //! \returns A value of type `uint64_t`.
-  //!
-  //! \throws LibsemigroupsException if \p source is not a node in the
-  //! word graph.
-  //!
-  //! \complexity
-  //! At worst \f$O(nm)\f$ where \f$n\f$ is the number of nodes and \f$m\f$
-  //! is the out-degree of the word graph.
-  //!
-  //! \warning If the number of paths exceeds 2 ^ 64, then return value of
-  //! this function will not be correct.
-  template <typename Node1, typename Node2>
-  [[nodiscard]] uint64_t number_of_paths(WordGraph<Node1> const& wg,
-                                         Node2                   source);
+    //! \brief Returns an iterator for PSTILO (Path Source Target In Lex Order).
+    //!
+    //! This function returns a forward iterator pointing to the edge labels of
+    //! the first path (in lexicographical order) starting at the node \p source
+    //! and ending at the node \p target with length in the range \f$[min,
+    //! max)\f$.
+    //!
+    //! If incremented, the iterator will point to the next least edge
+    //! labelling of a path (in lexicographical order).  Iterators of the type
+    //! returned by this function are equal whenever they point to equal
+    //! objects.
+    //!
+    //! \param wg the WordGraph.
+    //! \param source the first node.
+    //! \param target the last node.
+    //! \param min the minimum length of a path to enumerate (defaults to \c 0).
+    //! \param max the maximum length of a path to enumerate (defaults to
+    //!        \ref POSITIVE_INFINITY).
+    //!
+    //! \returns
+    //! An iterator \c it of type \c detail::const_pstilo_iterator pointing to a
+    //! \ref word_type consisting of the edge labels of the first
+    //! path (in lexicographical order) from the node \p source to the node
+    //! \p target with length in the range \f$[min, max)\f$ (if any).
+    //!
+    //! \throws LibsemigroupsException if \p target or \p source is not a node
+    //! in the word graph.
+    //!
+    //! \warning
+    //! Copying iterators of this type is expensive.  As a consequence, prefix
+    //! incrementing \c ++it the returned  iterator \c it significantly cheaper
+    //! than postfix incrementing \c it++.
+    //!
+    //! \warning
+    //! If the word graph represented by \c this contains a cycle that is
+    //! reachable from \p source, then there may be infinitely many paths
+    //! starting at \p source, and so \p max should be chosen with some care.
+    //!
+    //! \sa
+    //! cend_pstilo
+    // not noexcept because detail::const_pstilo_iterator constructors aren't
+    template <typename Node1, typename Node2>
+    [[nodiscard]] auto cbegin_pstilo(WordGraph<Node1> const& wg,
+                                     Node2                   source,
+                                     Node2                   target,
+                                     size_t                  min = 0,
+                                     size_t max = POSITIVE_INFINITY) {
+      // source & target are validated in is_reachable.
+      if (!word_graph::is_reachable(wg, source, target)) {
+        return cend_pstilo(wg);
+      }
+      return detail::const_pstilo_iterator<Node1>(
+          &wg, source, target, min, max);
+    }
 
-  //! \relates Paths
-  //! Returns the paths::algorithm used by number_of_paths().
-  //!
-  //! Returns the algorithm used by number_of_paths() to compute the number
-  //! of paths originating at the given source node with length in the range
-  //! \f$[min, max)\f$.
-  //!
-  //! \param wg the WordGraph.
-  //! \param source the source node.
-  //! \param min the minimum length of paths to count.
-  //! \param max the maximum length of paths to count.
-  //!
-  //! \returns A value of type paths::algorithm.
-  //!
-  //! \exceptions
-  //! \no_libsemigroups_except
-  //!
-  //! \complexity
-  //! At worst \f$O(nm)\f$ where \f$n\f$ is the number of nodes and \f$m\f$
-  //! is the out-degree of the word graph.
-  // Not noexcept because word_graph::topological_sort is not.
-  template <typename Node1, typename Node2>
-  [[nodiscard]] paths::algorithm
-  number_of_paths_algorithm(WordGraph<Node1> const& wg,
-                            Node2                   source,
-                            size_t                  min,
-                            size_t                  max);
+    //! \brief Returns an iterator for PSTISLO (Path Source Target In Short Lex
+    //! Order).
+    //!
+    //! This function returns a forward iterator pointing to one after the last
+    //! path from any node in the word graph.
+    //!
+    //! The iterator returned by this function may still dereferenceable and
+    //! incrementable, but may not point to a path in the correct range.
+    //!
+    //! \sa cbegin_pstislo
+    // not noexcept because cend_pislo isn't
+    template <typename Node>
+    [[nodiscard]] auto cend_pstislo(WordGraph<Node> const& wg) {
+      return detail::const_pstislo_iterator<Node>(
+          &wg, UNDEFINED, UNDEFINED, 0, 0);
+    }
 
-  //! \relates Paths
-  //! Returns the number of paths starting at a given node with length in a
-  //! given range.
-  //!
-  //! \param wg the WordGraph.
-  //! \param source the first node.
-  //! \param min the minimum length of a path.
-  //! \param max the maximum length of a path.
-  //! \param lgrthm the algorithm to use (defaults to:
-  //! paths::algorithm::automatic).
-  //!
-  //! \returns
-  //! A value of type \c uint64_t.
-  //!
-  //! \throws LibsemigroupsException if:
-  //! * \p source is not a node in the word graph.
-  //! * the algorithm specified by \p lgrthm is not applicable.
-  //!
-  //! \complexity
-  //! The complexity depends on the value of \p lgrthm as follows:
-  //! * paths::algorithm::dfs: \f$O(r)\f$ where \f$r\f$ is the number of paths
-  //! in
-  //!   the word graph starting at \p source
-  //! * paths::algorithm::matrix: at worst \f$O(n ^ 3 k)\f$ where \f$n\f$ is the
-  //!   number of nodes and \f$k\f$ equals \p max.
-  //! * paths::algorithm::acyclic: at worst \f$O(nm)\f$ where \f$n\f$ is the
-  //! number
-  //!   of nodes and \f$m\f$ is the out-degree of the word graph (only valid if
-  //!   the subgraph induced by the nodes reachable from \p source is
-  //!   acyclic)
-  //! * paths::algorithm::trivial: at worst \f$O(nm)\f$ where \f$n\f$ is the
-  //! number
-  //!   of nodes and \f$m\f$ is the out-degree of the word graph (only valid in
-  //!   some circumstances)
-  //! * paths::algorithm::automatic: attempts to select the fastest algorithm of
-  //! the
-  //!   preceding algorithms and then applies that.
-  //!
-  //! \warning If \p lgrthm is paths::algorithm::automatic, then it is not
-  //! always the case that the fastest algorithm is used.
-  //!
-  //! \warning If the number of paths exceeds 2 ^ 64, then return value of
-  //! this function will not be correct.
-  // not noexcept for example detail::number_of_paths_trivial can throw
-  template <typename Node1, typename Node2>
-  [[nodiscard]] uint64_t number_of_paths(WordGraph<Node1> const& wg,
-                                         Node2                   source,
-                                         size_t                  min,
-                                         size_t                  max,
-                                         paths::algorithm        lgrthm
-                                         = paths::algorithm::automatic);
+    //! \brief Returns an iterator for PSTISLO (Path Source Target In Short Lex
+    //! Order).
+    //!
+    //! This function returns a forward iterator pointing to the edge labels of
+    //! the first path (in short-lex order) starting at the node \p source and
+    //! ending at the node \p target with length in the range \f$[min, max)\f$.
+    //!
+    //! If incremented, the iterator will point to the next least edge
+    //! labelling of a path (in short-lex order).  Iterators of the type
+    //! returned by this function are equal whenever they point to equal
+    //! objects.
+    //!
+    //! \param wg the WordGraph.
+    //! \param source the first node.
+    //! \param target the last node.
+    //! \param min the minimum length of a path to enumerate (defaults to \c 0).
+    //! \param max the maximum length of a path to enumerate (defaults to
+    //!        \ref POSITIVE_INFINITY).
+    //!
+    //! \returns
+    //! An iterator \c it of type \c detail::const_pstislo_iterator pointing to
+    //! a \ref word_type consisting of the edge labels of the first path (in
+    //! short-lex order) from the node \p source to the node \p target with
+    //! length in the range \f$[min, max)\f$ (if any).
+    //!
+    //! \throws LibsemigroupsException if \p target or \p source is not a node
+    //! in the word graph.
+    //!
+    //! \warning
+    //! Copying iterators of this type is expensive.  As a consequence, prefix
+    //! incrementing \c ++it the returned  iterator \c it significantly cheaper
+    //! than postfix incrementing \c it++.
+    //!
+    //! \warning
+    //! If the word graph represented by \c this contains a cycle that is
+    //! reachable from \p source, then there may be infinitely many paths
+    //! starting at \p source, and so \p max should be chosen with some care.
+    //!
+    //! \sa
+    //! cend_pstislo
+    // not noexcept because cbegin_pislo isn't
+    template <typename Node1, typename Node2>
+    [[nodiscard]] auto cbegin_pstislo(WordGraph<Node1> const& wg,
+                                      Node2                   source,
+                                      Node2                   target,
+                                      size_t                  min = 0,
+                                      size_t max = POSITIVE_INFINITY) {
+      // source & target are validated in is_reachable.
+      if (!word_graph::is_reachable(wg, source, target)) {
+        return cend_pstislo(wg);
+      }
+      return detail::const_pstislo_iterator<Node1>(
+          &wg, source, target, min, max);
+    }
 
-  //! \relates Paths
-  //!
-  //! Returns the \ref paths::algorithm used by number_of_paths().
-  //!
-  //! Returns the \ref paths::algorithm used by number_of_paths() to compute
-  //! the number of paths originating at the given source node and ending at
-  //! the given target node with length in the range \f$[min, max)\f$.
-  //!
-  //! \param wg the WordGraph.
-  //! \param source the source node.
-  //! \param target the target node.
-  //! \param min the minimum length of paths to count.
-  //! \param max the maximum length of paths to count.
-  //!
-  //! \returns A value of type \ref paths::algorithm.
-  //!
-  //! \exceptions
-  //! \no_libsemigroups_except
-  //!
-  //! \complexity
-  //! At worst \f$O(nm)\f$ where \f$n\f$ is the number of nodes and \f$m\f$
-  //! is the out-degree of the word graph.
-  // Not noexcept because word_graph::topological_sort isn't
-  template <typename Node1, typename Node2>
-  [[nodiscard]] paths::algorithm
-  number_of_paths_algorithm(WordGraph<Node1> const& wg,
-                            Node2                   source,
-                            Node2                   target,
-                            size_t                  min,
-                            size_t                  max);
+    //! \brief Returns the paths::algorithm used by number_of_paths().
+    //!
+    //! This function returns the paths::algorithm used by number_of_paths().
+    //!
+    //! \param wg the WordGraph.
+    //! \param source the source node.
+    //!
+    //! \returns A value of type paths::algorithm.
+    //!
+    //! \exceptions
+    //! \noexcept
+    //!
+    //! \complexity
+    //! Constant
+    template <typename Node1, typename Node2>
+    [[nodiscard]] paths::algorithm
+    number_of_paths_algorithm(WordGraph<Node1> const& wg,
+                              Node2                   source) noexcept {
+      (void) wg;
+      (void) source;
+      return paths::algorithm::acyclic;
+    }
 
-  //! \relates Paths
-  //!
-  //! Returns the number of paths between a pair of nodes with length in a
-  //! given range.
-  //!
-  //! \param wg the WordGraph.
-  //! \param source the first node.
-  //! \param target the last node.
-  //! \param min the minimum length of a path.
-  //! \param max the maximum length of a path.
-  //! \param lgrthm the algorithm to use (defaults to:
-  //! paths::algorithm::automatic).
-  //!
-  //! \returns
-  //! A value of type `uint64_t`.
-  //!
-  //! \throws LibsemigroupsException if:
-  //! * \p source is not a node in the word graph.
-  //! * \p target is not a node in the word graph.
-  //! * the algorithm specified by \p lgrthm is not applicable.
-  //!
-  //! \complexity
-  //! The complexity depends on the value of \p lgrthm as follows:
-  //! * paths::algorithm::dfs: \f$O(r)\f$ where \f$r\f$ is the number of paths
-  //!   in the word graph starting at \p source
-  //! * paths::algorithm::matrix: at worst \f$O(n ^ 3 k)\f$ where \f$n\f$ is the
-  //!   number of nodes and \f$k\f$ equals \p max.
-  //! * paths::algorithm::acyclic: at worst \f$O(nm)\f$ where \f$n\f$ is the
-  //!   number of nodes and \f$m\f$ is the out-degree of the word graph (only
-  //!   valid if the subgraph induced by the nodes reachable from \p source is
-  //!   acyclic)
-  //! * paths::algorithm::trivial: constant (only valid in some circumstances)
-  //! * paths::algorithm::automatic: attempts to select the fastest algorithm of
-  //!   the preceding algorithms and then applies that.
-  //!
-  //! \warning If \p lgrthm is paths::algorithm::automatic, then it is not
-  //! always the case that the fastest algorithm is used.
-  //!
-  //! \warning If the number of paths exceeds 2 ^ 64, then return value of
-  //! this function will not be correct.
-  // not noexcept because cbegin_pstilo isn't
-  template <typename Node1, typename Node2>
-  [[nodiscard]] uint64_t number_of_paths(WordGraph<Node1> const& wg,
-                                         Node2                   source,
-                                         Node2                   target,
-                                         size_t                  min,
-                                         size_t                  max,
-                                         paths::algorithm        lgrthm
-                                         = paths::algorithm::automatic);
+    //! \brief Returns the number of paths from a source node.
+    //!
+    //! This function returns the number of paths from a source node.
+    //!
+    //! \param wg the WordGraph.
+    //! \param source the source node.
+    //!
+    //! \returns A value of type `uint64_t`.
+    //!
+    //! \throws LibsemigroupsException if \p source is not a node in the
+    //! word graph.
+    //!
+    //! \complexity
+    //! At worst \f$O(nm)\f$ where \f$n\f$ is the number of nodes and \f$m\f$
+    //! is the out-degree of the word graph.
+    //!
+    //! \note If `libsemigroups` is compiled with the flag `--enable-eigen`,
+    //! then this function makes use of the Eigen library for linear algebra
+    //! (see \cite Guennebaud2010aa).
+    //!
+    //! \warning If the number of paths exceeds 2 ^ 64, then return value of
+    //! this function will not be correct.
+    template <typename Node1, typename Node2>
+    [[nodiscard]] uint64_t number_of_paths(WordGraph<Node1> const& wg,
+                                           Node2                   source);
+
+    //! \brief Returns the paths::algorithm used by number_of_paths().
+    //!
+    //! This function returns the algorithm used by number_of_paths() to compute
+    //! the number of paths originating at the given source node with length in
+    //! the range \f$[min, max)\f$.
+    //!
+    //! \param wg the WordGraph.
+    //! \param source the source node.
+    //! \param min the minimum length of paths to count.
+    //! \param max the maximum length of paths to count.
+    //!
+    //! \returns A value of type paths::algorithm.
+    //!
+    //! \exceptions
+    //! \no_libsemigroups_except
+    //!
+    //! \complexity
+    //! At worst \f$O(nm)\f$ where \f$n\f$ is the number of nodes and \f$m\f$
+    //! is the out-degree of the word graph.
+    // Not noexcept because word_graph::topological_sort is not.
+    template <typename Node1, typename Node2>
+    [[nodiscard]] paths::algorithm
+    number_of_paths_algorithm(WordGraph<Node1> const& wg,
+                              Node2                   source,
+                              size_t                  min,
+                              size_t                  max);
+
+    //! \brief Returns the number of paths starting at a given node with length
+    //! in a given range.
+    //!
+    //! This function returns the number of paths starting at a given node with
+    //! length in a given range.
+    //!
+    //! \param wg the WordGraph.
+    //! \param source the first node.
+    //! \param min the minimum length of a path.
+    //! \param max the maximum length of a path.
+    //! \param lgrthm the algorithm to use (defaults to:
+    //! paths::algorithm::automatic).
+    //!
+    //! \returns
+    //! A value of type \c uint64_t.
+    //!
+    //! \throws LibsemigroupsException if:
+    //! * \p source is not a node in the word graph.
+    //! * the algorithm specified by \p lgrthm is not applicable.
+    //!
+    //! \complexity
+    //! The complexity depends on the value of \p lgrthm as follows:
+    //! * paths::algorithm::dfs: \f$O(r)\f$ where \f$r\f$ is the number of paths
+    //! in
+    //!   the word graph starting at \p source
+    //! * paths::algorithm::matrix: at worst \f$O(n ^ 3 k)\f$ where \f$n\f$ is
+    //! the
+    //!   number of nodes and \f$k\f$ equals \p max.
+    //! * paths::algorithm::acyclic: at worst \f$O(nm)\f$ where \f$n\f$ is the
+    //! number
+    //!   of nodes and \f$m\f$ is the out-degree of the word graph (only valid
+    //!   if the subgraph induced by the nodes reachable from \p source is
+    //!   acyclic)
+    //! * paths::algorithm::trivial: at worst \f$O(nm)\f$ where \f$n\f$ is the
+    //! number
+    //!   of nodes and \f$m\f$ is the out-degree of the word graph (only valid
+    //!   in some circumstances)
+    //! * paths::algorithm::automatic: attempts to select the fastest algorithm
+    //! of the
+    //!   preceding algorithms and then applies that.
+    //!
+    //! \note If `libsemigroups` is compiled with the flag `--enable-eigen`,
+    //! then this function makes use of the Eigen library for linear algebra
+    //! (see \cite Guennebaud2010aa).
+    //!
+    //! \warning If \p lgrthm is paths::algorithm::automatic, then it is not
+    //! always the case that the fastest algorithm is used.
+    //!
+    //! \warning If the number of paths exceeds 2 ^ 64, then return value of
+    //! this function will not be correct.
+    // not noexcept for example detail::number_of_paths_trivial can throw
+    template <typename Node1, typename Node2>
+    [[nodiscard]] uint64_t number_of_paths(WordGraph<Node1> const& wg,
+                                           Node2                   source,
+                                           size_t                  min,
+                                           size_t                  max,
+                                           paths::algorithm        lgrthm
+                                           = paths::algorithm::automatic);
+
+    //! \brief Returns the \ref paths::algorithm used by number_of_paths().
+    //!
+    //! This function returns the \ref paths::algorithm used by
+    //! number_of_paths() to compute the number of paths originating at the
+    //! given source node and ending at the given target node with length in the
+    //! range \f$[min, max)\f$.
+    //!
+    //! \param wg the WordGraph.
+    //! \param source the source node.
+    //! \param target the target node.
+    //! \param min the minimum length of paths to count.
+    //! \param max the maximum length of paths to count.
+    //!
+    //! \returns A value of type \ref paths::algorithm.
+    //!
+    //! \exceptions
+    //! \no_libsemigroups_except
+    //!
+    //! \complexity
+    //! At worst \f$O(nm)\f$ where \f$n\f$ is the number of nodes and \f$m\f$
+    //! is the out-degree of the word graph.
+    // Not noexcept because word_graph::topological_sort isn't
+    template <typename Node1, typename Node2>
+    [[nodiscard]] paths::algorithm
+    number_of_paths_algorithm(WordGraph<Node1> const& wg,
+                              Node2                   source,
+                              Node2                   target,
+                              size_t                  min,
+                              size_t                  max);
+
+    //! \brief Returns the number of paths between a pair of nodes with length
+    //! in a given range.
+    //!
+    //! This function the number of paths between a pair of nodes with length in
+    //! a given range.
+    //!
+    //! \param wg the WordGraph.
+    //! \param source the first node.
+    //! \param target the last node.
+    //! \param min the minimum length of a path.
+    //! \param max the maximum length of a path.
+    //! \param lgrthm the algorithm to use (defaults to:
+    //! paths::algorithm::automatic).
+    //!
+    //! \returns
+    //! A value of type `uint64_t`.
+    //!
+    //! \throws LibsemigroupsException if:
+    //! * \p source is not a node in the word graph.
+    //! * \p target is not a node in the word graph.
+    //! * the algorithm specified by \p lgrthm is not applicable.
+    //!
+    //! \complexity
+    //! The complexity depends on the value of \p lgrthm as follows:
+    //! * paths::algorithm::dfs: \f$O(r)\f$ where \f$r\f$ is the number of paths
+    //!   in the word graph starting at \p source
+    //! * paths::algorithm::matrix: at worst \f$O(n ^ 3 k)\f$ where \f$n\f$ is
+    //! the
+    //!   number of nodes and \f$k\f$ equals \p max.
+    //! * paths::algorithm::acyclic: at worst \f$O(nm)\f$ where \f$n\f$ is the
+    //!   number of nodes and \f$m\f$ is the out-degree of the word graph (only
+    //!   valid if the subgraph induced by the nodes reachable from \p source is
+    //!   acyclic)
+    //! * paths::algorithm::trivial: constant (only valid in some circumstances)
+    //! * paths::algorithm::automatic: attempts to select the fastest algorithm
+    //! of
+    //!   the preceding algorithms and then applies that.
+    //!
+    //! \note If `libsemigroups` is compiled with the flag `--enable-eigen`,
+    //! then this function makes use of the Eigen library for linear algebra
+    //! (see \cite Guennebaud2010aa).
+    //!
+    //! \warning If \p lgrthm is paths::algorithm::automatic, then it is not
+    //! always the case that the fastest algorithm is used.
+    //!
+    //! \warning If the number of paths exceeds 2 ^ 64, then return value of
+    //! this function will not be correct.
+    // not noexcept because cbegin_pstilo isn't
+    template <typename Node1, typename Node2>
+    [[nodiscard]] uint64_t number_of_paths(WordGraph<Node1> const& wg,
+                                           Node2                   source,
+                                           Node2                   target,
+                                           size_t                  min,
+                                           size_t                  max,
+                                           paths::algorithm        lgrthm
+                                           = paths::algorithm::automatic);
+  }  // namespace paths
 
   //! \ingroup word_graph_group
   //!
@@ -1092,7 +1102,7 @@ namespace libsemigroups {
   //!
   //! \brief Return a human readable representation of a Paths object.
   //!
-  //! Return a human readable representation of a Paths object.
+  //! This function returns a human readable representation of a Paths object.
   //!
   //! \tparam Node the type of the nodes in the underlying WordGraph.
   //!

--- a/include/libsemigroups/paths.tpp
+++ b/include/libsemigroups/paths.tpp
@@ -312,7 +312,7 @@ namespace libsemigroups {
   }  // namespace detail
 
   template <typename Node1, typename Node2>
-  uint64_t number_of_paths(WordGraph<Node1> const& wg, Node2 source) {
+  uint64_t paths::number_of_paths(WordGraph<Node1> const& wg, Node2 source) {
     // Don't allow selecting the algorithm because we check
     // acyclicity anyway.
     // TODO(2): could use algorithm::dfs in some cases.
@@ -345,10 +345,10 @@ namespace libsemigroups {
   }
 
   template <typename Node1, typename Node2>
-  paths::algorithm number_of_paths_algorithm(WordGraph<Node1> const& wg,
-                                             Node2                   source,
-                                             size_t                  min,
-                                             size_t                  max) {
+  paths::algorithm paths::number_of_paths_algorithm(WordGraph<Node1> const& wg,
+                                                    Node2  source,
+                                                    size_t min,
+                                                    size_t max) {
     if (min >= max || word_graph::is_complete(wg)) {
       return paths::algorithm::trivial;
     }
@@ -373,16 +373,17 @@ namespace libsemigroups {
   }
 
   template <typename Node1, typename Node2>
-  uint64_t number_of_paths(WordGraph<Node1> const& wg,
-                           Node2                   source,
-                           size_t                  min,
-                           size_t                  max,
-                           paths::algorithm        lgrthm) {
+  uint64_t paths::number_of_paths(WordGraph<Node1> const& wg,
+                                  Node2                   source,
+                                  size_t                  min,
+                                  size_t                  max,
+                                  paths::algorithm        lgrthm) {
     word_graph::throw_if_node_out_of_bounds(wg, static_cast<Node1>(source));
 
     switch (lgrthm) {
       case paths::algorithm::dfs:
-        return std::distance(cbegin_pilo(wg, source, min, max), cend_pilo(wg));
+        return std::distance(paths::cbegin_pilo(wg, source, min, max),
+                             paths::cend_pilo(wg));
       case paths::algorithm::matrix:
         return detail::number_of_paths_matrix(wg, source, min, max);
       case paths::algorithm::acyclic:
@@ -392,20 +393,21 @@ namespace libsemigroups {
       case paths::algorithm::automatic:
         // intentional fall through
       default:
-        return number_of_paths(wg,
-                               source,
-                               min,
-                               max,
-                               number_of_paths_algorithm(wg, source, min, max));
+        return paths::number_of_paths(
+            wg,
+            source,
+            min,
+            max,
+            paths::number_of_paths_algorithm(wg, source, min, max));
     }
   }
 
   template <typename Node1, typename Node2>
-  paths::algorithm number_of_paths_algorithm(WordGraph<Node1> const& wg,
-                                             Node2                   source,
-                                             Node2                   target,
-                                             size_t                  min,
-                                             size_t                  max) {
+  paths::algorithm paths::number_of_paths_algorithm(WordGraph<Node1> const& wg,
+                                                    Node2  source,
+                                                    Node2  target,
+                                                    size_t min,
+                                                    size_t max) {
     bool acyclic = word_graph::is_acyclic(wg, source, target);
     if (min >= max || !word_graph::is_reachable(wg, source, target)
         || (!acyclic && max == POSITIVE_INFINITY)) {
@@ -421,12 +423,12 @@ namespace libsemigroups {
   }
 
   template <typename Node1, typename Node2>
-  uint64_t number_of_paths(WordGraph<Node1> const& wg,
-                           Node2                   source,
-                           Node2                   target,
-                           size_t                  min,
-                           size_t                  max,
-                           paths::algorithm        lgrthm) {
+  uint64_t paths::number_of_paths(WordGraph<Node1> const& wg,
+                                  Node2                   source,
+                                  Node2                   target,
+                                  size_t                  min,
+                                  size_t                  max,
+                                  paths::algorithm        lgrthm) {
     word_graph::throw_if_node_out_of_bounds(wg, static_cast<Node1>(source));
     word_graph::throw_if_node_out_of_bounds(wg, static_cast<Node1>(target));
 
@@ -435,8 +437,8 @@ namespace libsemigroups {
         if (detail::number_of_paths_special(wg, source, target, min, max)) {
           return POSITIVE_INFINITY;
         }
-        return std::distance(cbegin_pstilo(wg, source, target, min, max),
-                             cend_pstilo(wg));
+        return std::distance(paths::cbegin_pstilo(wg, source, target, min, max),
+                             paths::cend_pstilo(wg));
       case paths::algorithm::matrix:
         return detail::number_of_paths_matrix(wg, source, target, min, max);
       case paths::algorithm::acyclic:
@@ -446,13 +448,13 @@ namespace libsemigroups {
       case paths::algorithm::automatic:
         // intentional fall through
       default:
-        return number_of_paths(
+        return paths::number_of_paths(
             wg,
             source,
             target,
             min,
             max,
-            number_of_paths_algorithm(wg, source, target, min, max));
+            paths::number_of_paths_algorithm(wg, source, target, min, max));
     }
   }
 
@@ -488,19 +490,21 @@ namespace libsemigroups {
       _position      = 0;
       if (_order == Order::shortlex && _source != UNDEFINED) {
         if (_target != UNDEFINED) {
-          _current = cbegin_pstislo(*_word_graph, _source, _target, _min, _max);
-          _end     = cend_pstislo(*_word_graph);
+          _current = paths::cbegin_pstislo(
+              *_word_graph, _source, _target, _min, _max);
+          _end = paths::cend_pstislo(*_word_graph);
         } else {
-          _current = cbegin_pislo(*_word_graph, _source, _min, _max);
-          _end     = cend_pislo(*_word_graph);
+          _current = paths::cbegin_pislo(*_word_graph, _source, _min, _max);
+          _end     = paths::cend_pislo(*_word_graph);
         }
       } else if (_order == Order::lex && _source != UNDEFINED) {
         if (_target != UNDEFINED) {
-          _current = cbegin_pstilo(*_word_graph, _source, _target, _min, _max);
-          _end     = cend_pstilo(*_word_graph);
+          _current = paths::cbegin_pstilo(
+              *_word_graph, _source, _target, _min, _max);
+          _end = paths::cend_pstilo(*_word_graph);
         } else {
-          _current = cbegin_pilo(*_word_graph, _source, _min, _max);
-          _end     = cend_pilo(*_word_graph);
+          _current = paths::cbegin_pilo(*_word_graph, _source, _min, _max);
+          _end     = paths::cend_pilo(*_word_graph);
         }
       }
       return true;
@@ -514,9 +518,10 @@ namespace libsemigroups {
     if (_word_graph->number_of_nodes() == 0) {
       return num_paths;
     } else if (_target != UNDEFINED) {
-      num_paths = number_of_paths(*_word_graph, _source, _target, _min, _max);
+      num_paths
+          = paths::number_of_paths(*_word_graph, _source, _target, _min, _max);
     } else {
-      num_paths = number_of_paths(*_word_graph, _source, _min, _max);
+      num_paths = paths::number_of_paths(*_word_graph, _source, _min, _max);
     }
 
     if (_current_valid && num_paths != POSITIVE_INFINITY) {

--- a/include/libsemigroups/stephen.hpp
+++ b/include/libsemigroups/stephen.hpp
@@ -722,7 +722,7 @@ namespace libsemigroups {
                                       size_t max = POSITIVE_INFINITY) {
       s.run();
       using node_type = typename Stephen<PresentationType>::node_type;
-      return number_of_paths(
+      return paths::number_of_paths(
           s.word_graph(), node_type(0), s.accept_state(), min, max);
     }
 
@@ -758,7 +758,7 @@ namespace libsemigroups {
                                     size_t                     min = 0,
                                     size_t max = POSITIVE_INFINITY) {
       s.run();
-      return number_of_paths(s.word_graph(), 0, min, max);
+      return paths::number_of_paths(s.word_graph(), 0, min, max);
     }
 
     //! \brief Returns a \ref Dot object representing the Stephen word graph.

--- a/tests/test-knuth-bendix-4.cpp
+++ b/tests/test-knuth-bendix-4.cpp
@@ -425,7 +425,7 @@ namespace libsemigroups {
     REQUIRE(ad.number_of_nodes() == 6'021);
     REQUIRE(ad.number_of_edges() == 7'435);
     REQUIRE(word_graph::is_acyclic(ad));
-    REQUIRE(number_of_paths(ad, 0, 0, 100) == 10'752);
+    REQUIRE(paths::number_of_paths(ad, 0, 0, 100) == 10'752);
   }
 
   ////////////////////////////////////////////////////////////////////////

--- a/tests/test-paths.cpp
+++ b/tests/test-paths.cpp
@@ -336,11 +336,12 @@ namespace libsemigroups {
     p.target(UNDEFINED);
     REQUIRE((p | count()) == 262'143);
 
-    REQUIRE(number_of_paths(wg, 0, 4, 0, N) == 131'062);
-    REQUIRE(number_of_paths(wg, 0, 4, 10, N) == 130'556);
-    REQUIRE(number_of_paths(wg, 4, 1, 0, N) == 0);
-    REQUIRE(number_of_paths(wg, 0, 0, POSITIVE_INFINITY) == POSITIVE_INFINITY);
-    REQUIRE(number_of_paths(wg, 0, 0, 10) == 1'023);
+    REQUIRE(paths::number_of_paths(wg, 0, 4, 0, N) == 131'062);
+    REQUIRE(paths::number_of_paths(wg, 0, 4, 10, N) == 130'556);
+    REQUIRE(paths::number_of_paths(wg, 4, 1, 0, N) == 0);
+    REQUIRE(paths::number_of_paths(wg, 0, 0, POSITIVE_INFINITY)
+            == POSITIVE_INFINITY);
+    REQUIRE(paths::number_of_paths(wg, 0, 0, 10) == 1'023);
   }
 
   LIBSEMIGROUPS_TEST_CASE("Paths", "005", "#4", "[quick]") {
@@ -553,33 +554,33 @@ namespace libsemigroups {
                                        {UNDEFINED, 5},
                                        {3}});
 
-    REQUIRE_THROWS_AS(cbegin_pstilo(wg, 1, 6), LibsemigroupsException);
-    REQUIRE_THROWS_AS(cbegin_pstilo(wg, 6, 1), LibsemigroupsException);
-    REQUIRE(cbegin_pstilo(wg, 2, 1) == cend_pstilo(wg));
-    REQUIRE(cbegin_pstilo(wg, 0, 3, 10, 1) == cend_pstilo(wg));
+    REQUIRE_THROWS_AS(paths::cbegin_pstilo(wg, 1, 6), LibsemigroupsException);
+    REQUIRE_THROWS_AS(paths::cbegin_pstilo(wg, 6, 1), LibsemigroupsException);
+    REQUIRE(paths::cbegin_pstilo(wg, 2, 1) == paths::cend_pstilo(wg));
+    REQUIRE(paths::cbegin_pstilo(wg, 0, 3, 10, 1) == paths::cend_pstilo(wg));
 
-    REQUIRE_THROWS_AS(cbegin_pstislo(wg, 1, 6), LibsemigroupsException);
-    REQUIRE_THROWS_AS(cbegin_pstislo(wg, 6, 1), LibsemigroupsException);
-    REQUIRE(cbegin_pstislo(wg, 2, 1) == cend_pstislo(wg));
-    REQUIRE(cbegin_pstislo(wg, 0, 3, 10, 1) == cend_pstislo(wg));
+    REQUIRE_THROWS_AS(paths::cbegin_pstislo(wg, 1, 6), LibsemigroupsException);
+    REQUIRE_THROWS_AS(paths::cbegin_pstislo(wg, 6, 1), LibsemigroupsException);
+    REQUIRE(paths::cbegin_pstislo(wg, 2, 1) == paths::cend_pstislo(wg));
+    REQUIRE(paths::cbegin_pstislo(wg, 0, 3, 10, 1) == paths::cend_pstislo(wg));
 
-    REQUIRE_THROWS_AS(cbegin_pilo(wg, 6), LibsemigroupsException);
-    REQUIRE(cbegin_pilo(wg, 0, 1, 1) == cend_pilo(wg));
-    REQUIRE_THROWS_AS(cbegin_pislo(wg, 6), LibsemigroupsException);
-    REQUIRE(cbegin_pislo(wg, 0, 1, 1) == cend_pislo(wg));
+    REQUIRE_THROWS_AS(paths::cbegin_pilo(wg, 6), LibsemigroupsException);
+    REQUIRE(paths::cbegin_pilo(wg, 0, 1, 1) == paths::cend_pilo(wg));
+    REQUIRE_THROWS_AS(paths::cbegin_pislo(wg, 6), LibsemigroupsException);
+    REQUIRE(paths::cbegin_pislo(wg, 0, 1, 1) == paths::cend_pislo(wg));
 
-    REQUIRE_THROWS_AS(cbegin_pilo(wg, 6), LibsemigroupsException);
-    REQUIRE(cbegin_pilo(wg, 0, 1, 1) == cend_pilo(wg));
+    REQUIRE_THROWS_AS(paths::cbegin_pilo(wg, 6), LibsemigroupsException);
+    REQUIRE(paths::cbegin_pilo(wg, 0, 1, 1) == paths::cend_pilo(wg));
 
-    REQUIRE_THROWS_AS(cbegin_pislo(wg, 6), LibsemigroupsException);
-    REQUIRE(cbegin_pislo(wg, 0, 1, 1) == cend_pislo(wg));
+    REQUIRE_THROWS_AS(paths::cbegin_pislo(wg, 6), LibsemigroupsException);
+    REQUIRE(paths::cbegin_pislo(wg, 0, 1, 1) == paths::cend_pislo(wg));
 
-    verify_forward_iterator_requirements(cbegin_pilo(wg, 0));
-    verify_forward_iterator_requirements(cbegin_pislo(wg, 0));
-    verify_forward_iterator_requirements(cbegin_pilo(wg, 0));
-    verify_forward_iterator_requirements(cbegin_pislo(wg, 0));
-    verify_forward_iterator_requirements(cbegin_pstilo(wg, 0, 1));
-    verify_forward_iterator_requirements(cbegin_pstislo(wg, 0, 1));
+    verify_forward_iterator_requirements(paths::cbegin_pilo(wg, 0));
+    verify_forward_iterator_requirements(paths::cbegin_pislo(wg, 0));
+    verify_forward_iterator_requirements(paths::cbegin_pilo(wg, 0));
+    verify_forward_iterator_requirements(paths::cbegin_pislo(wg, 0));
+    verify_forward_iterator_requirements(paths::cbegin_pstilo(wg, 0, 1));
+    verify_forward_iterator_requirements(paths::cbegin_pstislo(wg, 0, 1));
   }
 
   LIBSEMIGROUPS_TEST_CASE("Paths", "009", "pstilo corner case", "[quick]") {
@@ -625,23 +626,23 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Paths",
-                          "010",
+                          "number_of_paths",
                           "number_of_paths corner cases",
                           "[quick]") {
     WordGraph<size_t> wg;
-    REQUIRE_THROWS_AS(number_of_paths(wg, 0, 0, POSITIVE_INFINITY),
+    REQUIRE_THROWS_AS(paths::number_of_paths(wg, 0, 0, POSITIVE_INFINITY),
                       LibsemigroupsException);
     size_t const n = 20;
     wg.add_to_out_degree(1);
     word_graph::add_cycle(wg, n);
-    REQUIRE(number_of_paths(wg, 10) == POSITIVE_INFINITY);
-    REQUIRE(number_of_paths_algorithm(wg, 10, 10, 0, POSITIVE_INFINITY)
+    REQUIRE(paths::number_of_paths(wg, 10) == POSITIVE_INFINITY);
+    REQUIRE(paths::number_of_paths_algorithm(wg, 10, 10, 0, POSITIVE_INFINITY)
             == paths::algorithm::trivial);
-    REQUIRE(number_of_paths(wg, 10, 10, 0, POSITIVE_INFINITY)
+    REQUIRE(paths::number_of_paths(wg, 10, 10, 0, POSITIVE_INFINITY)
             == POSITIVE_INFINITY);
     wg = chain(n);
-    REQUIRE(number_of_paths(wg, 10) == 10);
-    REQUIRE(number_of_paths(wg, 19) == 1);
+    REQUIRE(paths::number_of_paths(wg, 10) == 10);
+    REQUIRE(paths::number_of_paths(wg, 19) == 1);
   }
 
   LIBSEMIGROUPS_TEST_CASE("Paths",
@@ -733,7 +734,8 @@ namespace libsemigroups {
     for (auto s = wg.cbegin_nodes(); s != wg.cend_nodes(); ++s) {
       for (size_t min = 0; min < wg.number_of_nodes(); ++min) {
         for (size_t max = 0; max < wg.number_of_nodes(); ++max) {
-          REQUIRE(number_of_paths(wg, *s, min, max) == expected[*s][min][max]);
+          REQUIRE(paths::number_of_paths(wg, *s, min, max)
+                  == expected[*s][min][max]);
           p.source(*s).min(min).max(max);
           REQUIRE(p.count() == expected[*s][min][max]);
         }
@@ -744,7 +746,7 @@ namespace libsemigroups {
     p.source(0).target(3).min(0).max(2);
     REQUIRE((p | to_vector()) == std::vector({0_w, 2_w}));
 
-    REQUIRE(number_of_paths(wg, 0, 3, 0, 2, paths::algorithm::acyclic)
+    REQUIRE(paths::number_of_paths(wg, 0, 3, 0, 2, paths::algorithm::acyclic)
             == (p | count()));
 
     for (auto s = wg.cbegin_nodes(); s != wg.cend_nodes(); ++s) {
@@ -752,15 +754,16 @@ namespace libsemigroups {
         for (size_t min = 0; min < N; ++min) {
           for (size_t max = min; max < N; ++max) {
             p.source(*s).target(*t).min(min).max(max);
-            REQUIRE(number_of_paths(wg, *s, *t, min, max) == (p | count()));
+            REQUIRE(paths::number_of_paths(wg, *s, *t, min, max)
+                    == (p | count()));
           }
         }
       }
     }
   }
 
-  // This test is marginally slower using Paths rather than cbegin_pstilo etc,
-  // seemily because of the use of std::variant in Paths (according to
+  // This test is marginally slower using Paths rather than paths::cbegin_pstilo
+  // etc, seemily because of the use of std::variant in Paths (according to
   // Instruments)
   LIBSEMIGROUPS_TEST_CASE("Paths",
                           "012",
@@ -772,7 +775,7 @@ namespace libsemigroups {
     REQUIRE(wg.number_of_nodes() == std::pow(2, n) - 1);
     REQUIRE(wg.number_of_edges() == std::pow(2, n) - 2);
     REQUIRE(word_graph::is_acyclic(wg));
-    REQUIRE(number_of_paths(wg, 0) == std::pow(2, n) - 1);
+    REQUIRE(paths::number_of_paths(wg, 0) == std::pow(2, n) - 1);
 
     Paths p(wg);
     p.order(Order::lex);
@@ -781,15 +784,15 @@ namespace libsemigroups {
       for (node_type min = 0; min < n; ++min) {
         for (size_t max = min; max < n; ++max) {
           p.source(*s).min(min).max(max);
-          REQUIRE(number_of_paths(wg, *s, min, max) == (p | count()));
+          REQUIRE(paths::number_of_paths(wg, *s, min, max) == (p | count()));
         }
       }
     }
-    REQUIRE(number_of_paths_algorithm(wg, 0, 1, 0, 1)
+    REQUIRE(paths::number_of_paths_algorithm(wg, 0, 1, 0, 1)
             == paths::algorithm::acyclic);
 
     p.source(0).target(1).min(0).max(1);
-    REQUIRE(number_of_paths(wg, 0, 1, 0, 1) == (p | count()));
+    REQUIRE(paths::number_of_paths(wg, 0, 1, 0, 1) == (p | count()));
     REQUIRE(p.count() == (p | count()));
 
     for (auto s = wg.cbegin_nodes(); s != wg.cend_nodes(); ++s) {
@@ -797,7 +800,8 @@ namespace libsemigroups {
         for (node_type min = 0; min < n; ++min) {
           for (size_t max = min; max < n; ++max) {
             p.source(*s).target(*t).min(min).max(max);
-            REQUIRE(number_of_paths(wg, *s, *t, min, max) == (p | count()));
+            REQUIRE(paths::number_of_paths(wg, *s, *t, min, max)
+                    == (p | count()));
           }
         }
       }
@@ -813,16 +817,17 @@ namespace libsemigroups {
     REQUIRE(wg.number_of_nodes() == std::pow(2, n) - 1);
     REQUIRE(wg.number_of_edges() == std::pow(2, n) - 2);
     REQUIRE(word_graph::is_acyclic(wg));
-    REQUIRE(number_of_paths_algorithm(wg, 0) == paths::algorithm::acyclic);
-    REQUIRE(number_of_paths(wg, 0) == std::pow(2, n) - 1);
+    REQUIRE(paths::number_of_paths_algorithm(wg, 0)
+            == paths::algorithm::acyclic);
+    REQUIRE(paths::number_of_paths(wg, 0) == std::pow(2, n) - 1);
 
     // The following tests for code coverage
     wg.target(19, 0, 0);
-    REQUIRE(
-        number_of_paths(wg, 0, 0, 0, POSITIVE_INFINITY, paths::algorithm::dfs)
-        == POSITIVE_INFINITY);
+    REQUIRE(paths::number_of_paths(
+                wg, 0, 0, 0, POSITIVE_INFINITY, paths::algorithm::dfs)
+            == POSITIVE_INFINITY);
     // 0 not reachable from 10
-    REQUIRE(number_of_paths(
+    REQUIRE(paths::number_of_paths(
                 wg, 10, 0, 0, POSITIVE_INFINITY, paths::algorithm::matrix)
             == 0);
   }
@@ -838,7 +843,7 @@ namespace libsemigroups {
     REQUIRE(word_graph::is_reachable(wg, 1, 0));
     REQUIRE(word_graph::is_reachable(wg, 0, 1));
     REQUIRE(word_graph::is_reachable(wg, 0, 0));
-    REQUIRE(number_of_paths(wg, 0, 0, 401) != 0);
+    REQUIRE(paths::number_of_paths(wg, 0, 0, 401) != 0);
   }
 
   LIBSEMIGROUPS_TEST_CASE("Paths",
@@ -867,12 +872,15 @@ namespace libsemigroups {
     REQUIRE(word_graph::is_acyclic(wg));
     REQUIRE(!word_graph::is_complete(wg));
 
-    REQUIRE(number_of_paths_algorithm(wg, 0, 0, 16)
+    REQUIRE(paths::number_of_paths_algorithm(wg, 0, 0, 16)
             == paths::algorithm::acyclic);
-    REQUIRE(number_of_paths(wg, 0, 0, 30) == 9);
-    REQUIRE(number_of_paths(wg, 1, 0, 10, paths::algorithm::acyclic) == 6);
-    REQUIRE(number_of_paths(wg, 1, 0, 10, paths::algorithm::matrix) == 6);
-    REQUIRE(number_of_paths(wg, 1, 9, 0, 10, paths::algorithm::matrix) == 3);
+    REQUIRE(paths::number_of_paths(wg, 0, 0, 30) == 9);
+    REQUIRE(paths::number_of_paths(wg, 1, 0, 10, paths::algorithm::acyclic)
+            == 6);
+    REQUIRE(paths::number_of_paths(wg, 1, 0, 10, paths::algorithm::matrix)
+            == 6);
+    REQUIRE(paths::number_of_paths(wg, 1, 9, 0, 10, paths::algorithm::matrix)
+            == 3);
   }
 
   LIBSEMIGROUPS_TEST_CASE("Paths",
@@ -898,26 +906,29 @@ namespace libsemigroups {
     REQUIRE(!word_graph::is_acyclic(wg));
     REQUIRE(word_graph::is_complete(wg));
 
-    REQUIRE(number_of_paths_algorithm(wg, 0) == paths::algorithm::acyclic);
-    REQUIRE(number_of_paths(wg, 0) == POSITIVE_INFINITY);
-    REQUIRE_THROWS_AS(number_of_paths(wg, 0, 0, 10, paths::algorithm::acyclic),
-                      LibsemigroupsException);
+    REQUIRE(paths::number_of_paths_algorithm(wg, 0)
+            == paths::algorithm::acyclic);
+    REQUIRE(paths::number_of_paths(wg, 0) == POSITIVE_INFINITY);
     REQUIRE_THROWS_AS(
-        number_of_paths(wg, 1, 9, 0, 10, paths::algorithm::acyclic),
+        paths::number_of_paths(wg, 0, 0, 10, paths::algorithm::acyclic),
+        LibsemigroupsException);
+    REQUIRE_THROWS_AS(
+        paths::number_of_paths(wg, 1, 9, 0, 10, paths::algorithm::acyclic),
         LibsemigroupsException);
 
     wg = binary_tree(n);
-    REQUIRE(number_of_paths_algorithm(wg, 0) == paths::algorithm::acyclic);
-    REQUIRE(number_of_paths(wg, 0) == 1023);
+    REQUIRE(paths::number_of_paths_algorithm(wg, 0)
+            == paths::algorithm::acyclic);
+    REQUIRE(paths::number_of_paths(wg, 0) == 1023);
 
     word_graph::add_cycle(wg, n);
     wg.target(0, 0, n + 1);
     REQUIRE(!word_graph::is_acyclic(wg));
     REQUIRE(!word_graph::is_complete(wg));
-    REQUIRE(number_of_paths(wg, 1) == 511);
-    REQUIRE(number_of_paths_algorithm(wg, 1, 0, POSITIVE_INFINITY)
+    REQUIRE(paths::number_of_paths(wg, 1) == 511);
+    REQUIRE(paths::number_of_paths_algorithm(wg, 1, 0, POSITIVE_INFINITY)
             == paths::algorithm::acyclic);
-    REQUIRE(number_of_paths(wg, 1, 0, POSITIVE_INFINITY) == 511);
+    REQUIRE(paths::number_of_paths(wg, 1, 0, POSITIVE_INFINITY) == 511);
     REQUIRE(word_graph::topological_sort(wg).empty());
     REQUIRE(*std::find_if(wg.cbegin_nodes(), wg.cend_nodes(), [&wg](size_t m) {
       return word_graph::topological_sort(wg, m).empty();
@@ -944,14 +955,15 @@ namespace libsemigroups {
     Paths p(wg);
     p.order(Order::lex).source(0).min(0).max(10);
     REQUIRE((p | count()) == 6'858);
-    REQUIRE(number_of_paths_algorithm(wg, 0, 0, 10)
+    REQUIRE(paths::number_of_paths_algorithm(wg, 0, 0, 10)
             == paths::algorithm::matrix);
-    REQUIRE(number_of_paths(wg, 0, 0, 10) == 6'858);
-    REQUIRE_THROWS_AS(number_of_paths(wg, 1, 0, 10, paths::algorithm::trivial),
-                      LibsemigroupsException);
-    REQUIRE(number_of_paths_algorithm(wg, 0, 10, 12)
+    REQUIRE(paths::number_of_paths(wg, 0, 0, 10) == 6'858);
+    REQUIRE_THROWS_AS(
+        paths::number_of_paths(wg, 1, 0, 10, paths::algorithm::trivial),
+        LibsemigroupsException);
+    REQUIRE(paths::number_of_paths_algorithm(wg, 0, 10, 12)
             == paths::algorithm::matrix);
-    REQUIRE(number_of_paths(wg, 0, 10, 12) == 35300);
+    REQUIRE(paths::number_of_paths(wg, 0, 10, 12) == 35300);
 
     auto checker1 = [&wg](word_type const& w) {
       return 10 <= w.size() && w.size() < 12
@@ -969,19 +981,19 @@ namespace libsemigroups {
     REQUIRE(distinct_words.size() == 35'300);
     REQUIRE((p | count()) == 35'300);
 
-    REQUIRE(number_of_paths_algorithm(wg, 1, 5, 0, 10)
+    REQUIRE(paths::number_of_paths_algorithm(wg, 1, 5, 0, 10)
             == paths::algorithm::trivial);
-    REQUIRE(number_of_paths(wg, 1, 5, 0, 10) == 0);
+    REQUIRE(paths::number_of_paths(wg, 1, 5, 0, 10) == 0);
 
     p.source(1).target(5).min(0).max(10);
     REQUIRE(0 == (p | count()));
-    REQUIRE(number_of_paths(wg, 1, 1, 0, 10) == 1404);
+    REQUIRE(paths::number_of_paths(wg, 1, 1, 0, 10) == 1404);
     REQUIRE_THROWS_AS(
-        number_of_paths(wg, 1, 1, 0, 10, paths::algorithm::trivial),
+        paths::number_of_paths(wg, 1, 1, 0, 10, paths::algorithm::trivial),
         LibsemigroupsException);
 
     p.source(1).target(1).min(0).max(10);
-    REQUIRE(number_of_paths(wg, 1, 1, 0, 10)
+    REQUIRE(paths::number_of_paths(wg, 1, 1, 0, 10)
             == static_cast<uint64_t>((p | count())));
 
     auto checker2 = [&wg](word_type const& w) {
@@ -1000,10 +1012,11 @@ namespace libsemigroups {
     wg.target(0, 0, 1);
     wg.target(1, 0, 0);
 
-    REQUIRE(number_of_paths(
+    REQUIRE(paths::number_of_paths(
                 wg, 0, 1, 0, POSITIVE_INFINITY, paths::algorithm::matrix)
             == POSITIVE_INFINITY);
-    REQUIRE(number_of_paths(wg, 0, 1, 0, 10, paths::algorithm::matrix) == 5);
+    REQUIRE(paths::number_of_paths(wg, 0, 1, 0, 10, paths::algorithm::matrix)
+            == 5);
   }
 
   LIBSEMIGROUPS_TEST_CASE("Paths",

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -555,7 +555,8 @@ namespace libsemigroups {
                           "follow_path | 20 node chain",
                           "[quick]") {
     WordGraph<size_t> wg = chain(20);
-    for (auto it = cbegin_pilo(wg, 0); it != cend_pilo(wg); ++it) {
+    for (auto it = paths::cbegin_pilo(wg, 0); it != paths::cend_pilo(wg);
+         ++it) {
       REQUIRE(word_graph::follow_path(wg, 0, *it) == it.target());
       REQUIRE(word_graph::follow_path_no_checks(wg, 0, *it) == it.target());
     }


### PR DESCRIPTION
This PR moves the `Paths` helper functions to the `paths` namespace.