### PR TITLE
Fix transf corner cases

### DIFF
--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -2407,6 +2407,154 @@ namespace libsemigroups {
   template <size_t N>
   using LeastPerm = typename detail::LeastPermHelper<N>::type;
 
+  //! \ingroup transf_group
+  //!
+  //! \brief Return a string that can be used to recreate a transformation.
+  //!
+  //! This function returns a std::string containing the input required to
+  //! construct a copy of the argument \p x.
+  //!
+  //! \tparam N the degree.
+  //! \tparam Scalar an unsigned integer type (the type of the image values).
+  //!
+  //! \param x the transformation.
+  //! \param prefix a prefix for the returned string (defaults to `Transf<N,
+  //! Scalar>` with \p N and \p Scalar replaced by their values).
+  //! \param braces the braces to use in the string (defaults to `"{}"`).
+  //!
+  //! \returns A string containing the input required to recreate \p x.
+  //!
+  //! \throws LibsemigroupsException if the argument \p braces is not of length
+  //! \c 2.
+  template <size_t N, typename Scalar>
+  [[nodiscard]] std::string to_input_string(Transf<N, Scalar> const& x,
+                                            std::string_view prefix = "",
+                                            std::string_view braces = "{}");
+
+  //! \ingroup transf_group
+  //!
+  //! \brief Return a string that can be used to recreate a permutation.
+  //!
+  //! This function returns a std::string containing the input required to
+  //! construct a copy of the argument \p x.
+  //!
+  //! \tparam N the degree.
+  //! \tparam Scalar an unsigned integer type (the type of the image values).
+  //!
+  //! \param x the permutation.
+  //! \param prefix a prefix for the returned string (defaults to `Perm<N,
+  //! Scalar>` with \p N and \p Scalar replaced by their values).
+  //! \param braces the braces to use in the string (defaults to `"{}"`).
+  //!
+  //! \returns A string containing the input required to recreate \p x.
+  //!
+  //! \throws LibsemigroupsException if the argument \p braces is not of length
+  //! \c 2.
+  template <size_t N, typename Scalar>
+  [[nodiscard]] std::string to_input_string(Perm<N, Scalar> const& x,
+                                            std::string_view       prefix = "",
+                                            std::string_view braces = "{}");
+
+  //! \ingroup transf_group
+  //!
+  //! \brief Return a string that can be used to recreate a partial permutation.
+  //!
+  //! This function returns a std::string containing the input required to
+  //! construct a copy of the argument \p x.
+  //!
+  //! \tparam N the degree.
+  //! \tparam Scalar an unsigned integer type (the type of the image values).
+  //!
+  //! \param x the partial permutation.
+  //! \param prefix a prefix for the returned string (defaults to `PPerm<N,
+  //! Scalar>` with \p N and \p Scalar replaced by their values).
+  //! \param braces the braces to use in the string (defaults to `"{}"`).
+  //!
+  //! \returns A string containing the input required to recreate \p x.
+  //!
+  //! \throws LibsemigroupsException if the argument \p braces is not of length
+  //! \c 2.
+  template <size_t N, typename Scalar>
+  [[nodiscard]] std::string to_input_string(PPerm<N, Scalar> const& x,
+                                            std::string_view        prefix = "",
+                                            std::string_view braces = "{}");
+
+  //! \ingroup transf_group
+  //!
+  //! \brief Return a human readable representation of a Transf object.
+  //!
+  //! This function returns a human readable representation of a Transf object.
+  //! The returned std::string is either the same as \ref to_input_string if the
+  //! width of the returned string is less than the parameter \p max_width, or
+  //! a std::string of the form \c "<transformation of degree X and rank Y>" if
+  //! not.
+  //!
+  //! \param x the Transf.
+  //! \param prefix a prefix for the returned string (defaults to `Transf<N,
+  //! Scalar>` with \p N and \p Scalar replaced by their values).
+  //! \param braces the braces to use in the string (defaults to `"{}"`).
+  //! \param max_width the maximum width of the returned string (defaults to \c
+  //! 72).
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <size_t N, typename Scalar>
+  [[nodiscard]] std::string to_human_readable_repr(Transf<N, Scalar> const& x,
+                                                   std::string_view prefix = "",
+                                                   std::string_view braces
+                                                   = "{}",
+                                                   size_t max_width = 72);
+
+  //! \ingroup transf_group
+  //!
+  //! \brief Return a human readable representation of a Perm object.
+  //!
+  //! This function returns a human readable representation of a Perm object.
+  //! The returned std::string is either the same as \ref to_input_string if the
+  //! width of the returned string is less than the parameter \p max_width, or
+  //! a std::string of the form \c "<permutation of degree X>" if not.
+  //!
+  //! \param x the Perm.
+  //! \param prefix a prefix for the returned string (defaults to `Perm<N,
+  //! Scalar>` with \p N and \p Scalar replaced by their values).
+  //! \param braces the braces to use in the string (defaults to `"{}"`).
+  //! \param max_width the maximum width of the returned string (defaults to \c
+  //! 72).
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <size_t N, typename Scalar>
+  [[nodiscard]] std::string to_human_readable_repr(Perm<N, Scalar> const& x,
+                                                   std::string_view prefix = "",
+                                                   std::string_view braces
+                                                   = "{}",
+                                                   size_t max_width = 72);
+
+  //! \ingroup transf_group
+  //!
+  //! \brief Return a human readable representation of a PPerm object.
+  //!
+  //! This function returns a human readable representation of a PPerm object.
+  //! The returned std::string is either the same as \ref to_input_string if the
+  //! width of the returned string is less than the parameter \p max_width, or
+  //! a std::string of the form \c "<partial permutation of degree X and rank
+  //! Y>" if not.
+  //!
+  //! \param x the PPerm.
+  //! \param prefix a prefix for the returned string (defaults to `PPerm<N,
+  //! Scalar>` with \p N and \p Scalar replaced by their values).
+  //! \param braces the braces to use in the string (defaults to `"{}"`).
+  //! \param max_width the maximum width of the returned string (defaults to \c
+  //! 72).
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <size_t N, typename Scalar>
+  [[nodiscard]] std::string to_human_readable_repr(PPerm<N, Scalar> const& x,
+                                                   std::string_view prefix = "",
+                                                   std::string_view braces
+                                                   = "{}",
+                                                   size_t max_width = 72);
 }  // namespace libsemigroups
 
 #include "transf.tpp"

--- a/include/libsemigroups/transf.hpp
+++ b/include/libsemigroups/transf.hpp
@@ -2414,12 +2414,17 @@ namespace libsemigroups {
   //! This function returns a std::string containing the input required to
   //! construct a copy of the argument \p x.
   //!
+  //! If neither \p prefix nor \p braces is specified, then the returned string
+  //! will have the form `"Transf<N, Scalar>({...})"` where \p N and \p Scalar
+  //! are replaced by their values, and `...` is replaced by the contents of \p
+  //! x. If \p prefix is a non-empty string, its value will replace the prefix
+  //! `"Transf<N, Scalar>"` in the returned string.
+  //!
   //! \tparam N the degree.
   //! \tparam Scalar an unsigned integer type (the type of the image values).
   //!
   //! \param x the transformation.
-  //! \param prefix a prefix for the returned string (defaults to `Transf<N,
-  //! Scalar>` with \p N and \p Scalar replaced by their values).
+  //! \param prefix a prefix for the returned string (defaults to `""`).
   //! \param braces the braces to use in the string (defaults to `"{}"`).
   //!
   //! \returns A string containing the input required to recreate \p x.
@@ -2438,12 +2443,17 @@ namespace libsemigroups {
   //! This function returns a std::string containing the input required to
   //! construct a copy of the argument \p x.
   //!
+  //! If neither \p prefix nor \p braces is specified, then the returned string
+  //! will have the form `"Perm<N, Scalar>({...})"` where \p N and \p Scalar are
+  //! replaced by their values, and `...` is replaced by the contents of \p x.
+  //! If \p prefix is a non-empty string, its value will replace the prefix
+  //! `"Perm<N, Scalar>"` in the returned string.
+  //!
   //! \tparam N the degree.
   //! \tparam Scalar an unsigned integer type (the type of the image values).
   //!
   //! \param x the permutation.
-  //! \param prefix a prefix for the returned string (defaults to `Perm<N,
-  //! Scalar>` with \p N and \p Scalar replaced by their values).
+  //! \param prefix a prefix for the returned string (defaults to `""`).
   //! \param braces the braces to use in the string (defaults to `"{}"`).
   //!
   //! \returns A string containing the input required to recreate \p x.
@@ -2462,12 +2472,18 @@ namespace libsemigroups {
   //! This function returns a std::string containing the input required to
   //! construct a copy of the argument \p x.
   //!
+  //! If neither \p prefix nor \p braces is specified, the returned string will
+  //! have the form `"PPerm<N, Scalar>({dom}, {im}, {deg})"` where \p N and \p
+  //! Scalar are replaced by their values, and `dom`, `im`, and `degree` are
+  //! replaced by the domain, image, and degree of \p x, respectively. If \p
+  //! prefix is a non-empty string, its value will replace the prefix "PPerm<N,
+  //! Scalar>" in the returned string.
+  //!
   //! \tparam N the degree.
   //! \tparam Scalar an unsigned integer type (the type of the image values).
   //!
   //! \param x the partial permutation.
-  //! \param prefix a prefix for the returned string (defaults to `PPerm<N,
-  //! Scalar>` with \p N and \p Scalar replaced by their values).
+  //! \param prefix a prefix for the returned string (defaults to `""`).
   //! \param braces the braces to use in the string (defaults to `"{}"`).
   //!
   //! \returns A string containing the input required to recreate \p x.
@@ -2489,9 +2505,19 @@ namespace libsemigroups {
   //! a std::string of the form \c "<transformation of degree X and rank Y>" if
   //! not.
   //!
+  //! If the returned value of \ref to_input_string has length less than \p
+  //! max_width, then the following applies. If neither \p prefix nor \p braces
+  //! is specified, then the returned string will have the form `"Transf<N,
+  //! Scalar>({...})"` where \p N and \p Scalar are replaced by their values,
+  //! and `...` is replaced by the contents of \p x. If \p prefix is a non-empty
+  //! string, its value will replace the prefix `"Transf<N, Scalar>"` in the
+  //! returned string.
+  //!
+  //! \tparam N the degree of the transformation \p x.
+  //! \tparam Scalar the type of the image values.
+  //!
   //! \param x the Transf.
-  //! \param prefix a prefix for the returned string (defaults to `Transf<N,
-  //! Scalar>` with \p N and \p Scalar replaced by their values).
+  //! \param prefix a prefix for the returned string (defaults to `""`).
   //! \param braces the braces to use in the string (defaults to `"{}"`).
   //! \param max_width the maximum width of the returned string (defaults to \c
   //! 72).
@@ -2514,12 +2540,22 @@ namespace libsemigroups {
   //! width of the returned string is less than the parameter \p max_width, or
   //! a std::string of the form \c "<permutation of degree X>" if not.
   //!
+  //! If the returned value of \ref to_input_string has length less than \p
+  //! max_width, then the following applies. If neither \p prefix nor \p braces
+  //! is specified, then the returned string
+  //! will have the form `"Perm<N, Scalar>({...})"` where \p N and \p Scalar are
+  //! replaced by their values, and `...` is replaced by the contents of \p x.
+  //! If \p prefix is a non-empty string, its value will replace the prefix
+  //! `"Perm<N, Scalar>"` in the returned string.
+  //!
+  //! \tparam N the degree of the permutation \p x.
+  //! \tparam Scalar the type of the image values.
+  //!
   //! \param x the Perm.
-  //! \param prefix a prefix for the returned string (defaults to `Perm<N,
-  //! Scalar>` with \p N and \p Scalar replaced by their values).
+  //! \param prefix a prefix for the returned string (defaults to `""`).
   //! \param braces the braces to use in the string (defaults to `"{}"`).
-  //! \param max_width the maximum width of the returned string (defaults to \c
-  //! 72).
+  //! \param max_width the maximum width of the returned string (defaults to
+  //! \c 72).
   //!
   //! \exceptions
   //! \no_libsemigroups_except
@@ -2540,9 +2576,20 @@ namespace libsemigroups {
   //! a std::string of the form \c "<partial permutation of degree X and rank
   //! Y>" if not.
   //!
+  //! If the returned value of \ref to_input_string has length less than \p
+  //! max_width, then the following applies. If neither \p prefix nor \p braces
+  //! is specified, the returned string will
+  //! have the form `"PPerm<N, Scalar>({dom}, {im}, {deg})"` where \p N and \p
+  //! Scalar are replaced by their values, and `dom`, `im`, and `degree` are
+  //! replaced by the domain, image, and degree of \p x, respectively. If \p
+  //! prefix is a non-empty string, its value will replace the prefix "PPerm<N,
+  //! Scalar>" in the returned string.
+  //!
+  //! \tparam N the degree of the partial permutation \p x.
+  //! \tparam Scalar the type of the image values.
+  //!
   //! \param x the PPerm.
-  //! \param prefix a prefix for the returned string (defaults to `PPerm<N,
-  //! Scalar>` with \p N and \p Scalar replaced by their values).
+  //! \param prefix a prefix for the returned string (defaults to `""`).
   //! \param braces the braces to use in the string (defaults to `"{}"`).
   //! \param max_width the maximum width of the returned string (defaults to \c
   //! 72).

--- a/include/libsemigroups/transf.tpp
+++ b/include/libsemigroups/transf.tpp
@@ -483,4 +483,122 @@ namespace libsemigroups {
     inverse(x, xx);
     Lambda<PPerm<N, Scalar>, BitSet<M>>()(res, xx);
   }
+
+  namespace detail {
+    template <typename Thing>
+    std::string transf_to_input_string(Thing const&     x,
+                                       std::string_view prefix,
+                                       std::string_view braces = "{}") {
+      if (braces.size() != 2) {
+        LIBSEMIGROUPS_EXCEPTION("the 2nd argument (braces) must have length 2, "
+                                "but found {} of length {}",
+                                braces,
+                                braces.size());
+      }
+      return fmt::format("{}({}{}{})",
+                         prefix,
+                         braces[0],
+                         fmt::join(x.begin(), x.end(), ", "),
+                         braces[1]);
+    }
+  }  // namespace detail
+
+  template <size_t N, typename Scalar>
+  std::string to_input_string(Transf<N, Scalar> const& x,
+                              std::string_view         prefix,
+                              std::string_view         braces) {
+    std::string actual_prefix;
+    if (prefix.empty()) {
+      // Yes this looks weird, but the point is to keep the string that prefix
+      // views alive until after the end of the function call.
+      actual_prefix
+          = fmt::format("Transf<{}, uint{}_t>", N, sizeof(Scalar) * 8);
+      prefix = actual_prefix;
+    }
+    return detail::transf_to_input_string(x, prefix, braces);
+  }
+
+  template <size_t N, typename Scalar>
+  std::string to_input_string(Perm<N, Scalar> const& x,
+                              std::string_view       prefix,
+                              std::string_view       braces) {
+    std::string actual_prefix;
+    if (prefix.empty()) {
+      // Yes this looks weird, but the point is to keep the string that prefix
+      // views alive until after the end of the function call.
+      actual_prefix = fmt::format("Perm<{}, uint{}_t>", N, sizeof(Scalar) * 8);
+      prefix        = actual_prefix;
+    }
+    return detail::transf_to_input_string(x, prefix, braces);
+  }
+
+  template <size_t N, typename Scalar>
+  std::string to_input_string(PPerm<N, Scalar> const& x,
+                              std::string_view        prefix,
+                              std::string_view        braces) {
+    if (braces.size() != 2) {
+      LIBSEMIGROUPS_EXCEPTION("the 2nd argument (braces) must have length 2, "
+                              "but found {} of length {}",
+                              braces,
+                              braces.size());
+    }
+    std::string actual_prefix;
+    if (prefix.empty()) {
+      // Yes this looks weird, but the point is to keep the string that prefix
+      // views alive until after the end of the function call.
+      actual_prefix = fmt::format("PPerm<{}, uint{}_t>", N, sizeof(Scalar) * 8);
+      prefix        = actual_prefix;
+    }
+    auto dom = domain(x);
+    auto im  = dom;
+    std::for_each(im.begin(), im.end(), [&x](auto& val) { val = x[val]; });
+
+    return fmt::format("{}({}{}{}, {}{}{}, {})",
+                       prefix,
+                       braces[0],
+                       fmt::join(dom.begin(), dom.end(), ", "),
+                       braces[1],
+                       braces[0],
+                       fmt::join(im.begin(), im.end(), ", "),
+                       braces[1],
+                       x.degree());
+  }
+
+  template <size_t N, typename Scalar>
+  std::string to_human_readable_repr(Transf<N, Scalar> const& x,
+                                     std::string_view         prefix,
+                                     std::string_view         braces,
+                                     size_t                   max_width) {
+    auto result = to_input_string(x, prefix, braces);
+    if (result.size() <= max_width) {
+      return result;
+    }
+    return fmt::format(
+        "<transformation of degree {} and rank {}>", x.degree(), x.rank());
+  }
+
+  template <size_t N, typename Scalar>
+  std::string to_human_readable_repr(Perm<N, Scalar> const& x,
+                                     std::string_view       prefix,
+                                     std::string_view       braces,
+                                     size_t                 max_width) {
+    auto result = to_input_string(x, prefix, braces);
+    if (result.size() <= max_width) {
+      return result;
+    }
+    return fmt::format("<permutation of degree {}>", x.degree());
+  }
+
+  template <size_t N, typename Scalar>
+  std::string to_human_readable_repr(PPerm<N, Scalar> const& x,
+                                     std::string_view        prefix,
+                                     std::string_view        braces,
+                                     size_t                  max_width) {
+    auto result = to_input_string(x, prefix, braces);
+    if (result.size() <= max_width) {
+      return result;
+    }
+    return fmt::format(
+        "<partial permutation of degree {} and rank {}>", x.degree(), x.rank());
+  }
 }  // namespace libsemigroups

--- a/include/libsemigroups/transf.tpp
+++ b/include/libsemigroups/transf.tpp
@@ -166,7 +166,10 @@ namespace libsemigroups {
     LIBSEMIGROUPS_ASSERT(x.degree() == degree());
     LIBSEMIGROUPS_ASSERT(&x != this && &y != this);
     size_t const n = degree();
-    for (point_type i = 0; i < n; ++i) {
+    // Use size_t for the loop variable <i> below because if, for example,
+    // n = 256 and point_type = uint8_t, then the i < n is always true in the
+    // next line.
+    for (size_t i = 0; i < n; ++i) {
       (*this)[i] = (x[i] == UNDEFINED ? UNDEFINED : y[x[i]]);
     }
   }
@@ -177,7 +180,7 @@ namespace libsemigroups {
                                  size_t                     deg) {
     if (N != 0 && deg != N) {
       // Sanity check that the final argument is compatible with the
-      // template param N, if we have a dynamic pperm
+      // template param N, if we have a static pperm
       LIBSEMIGROUPS_EXCEPTION(
           "the 3rd argument is not valid, expected {}, found {}", N, deg);
     } else if (dom.size() != ran.size()) {
@@ -198,6 +201,25 @@ namespace libsemigroups {
     std::unordered_map<Scalar, size_t> seen;
     detail::throw_if_duplicates(dom.cbegin(), dom.cend(), seen);
     detail::throw_if_duplicates(ran.cbegin(), ran.cend(), seen);
+
+    auto it = std::find(dom.cbegin(), dom.cend(), UNDEFINED);
+    if (it != dom.cend()) {
+      LIBSEMIGROUPS_EXCEPTION(
+          "the 1st argument (domain) must not contain UNDEFINED, but found "
+          "UNDEFINED (= {}) in position {}",
+          static_cast<Scalar>(UNDEFINED),
+          std::distance(dom.cbegin(), it));
+    }
+    it = std::find(ran.cbegin(), ran.cend(), UNDEFINED);
+    if (it != ran.cend()) {
+      LIBSEMIGROUPS_EXCEPTION(
+          "the 2nd argument (range) must not contain UNDEFINED, but found "
+          "UNDEFINED (= {}) in position {}",
+          static_cast<Scalar>(UNDEFINED),
+          std::distance(ran.cbegin(), it));
+    }
+    // NOTE: it is ok if deg >= max. value of Scalar, but then necessary that
+    // the values in <dom> and <ran> are less than (max. value of Scalar) - 1.
   }
 
   template <typename Return>

--- a/tests/test-transf.cpp
+++ b/tests/test-transf.cpp
@@ -350,4 +350,44 @@ namespace libsemigroups {
     REQUIRE_NOTHROW(LeastPPerm<3>({0, 1, 2}));
     REQUIRE_NOTHROW(LeastPerm<3>({0, 1, 2}));
   }
+
+  LIBSEMIGROUPS_TEST_CASE("Transf",
+                          "011",
+                          "to_human_readable_repr",
+                          "[quick]") {
+    auto x = make<Transf<3>>({0, 1, 2});
+    REQUIRE(to_human_readable_repr(x) == "Transf<3, uint8_t>({0, 1, 2})");
+    REQUIRE(to_human_readable_repr(x, "", "[]")
+            == "Transf<3, uint8_t>([0, 1, 2])");
+    REQUIRE(to_human_readable_repr(x, "Transf", "[]") == "Transf([0, 1, 2])");
+    REQUIRE(to_human_readable_repr(x) == to_input_string(x));
+    REQUIRE(to_human_readable_repr(x, "", "{}", 3)
+            == "<transformation of degree 3 and rank 3>");
+    // Too many braces
+    REQUIRE_THROWS_AS(to_human_readable_repr(x, "", "xxx"),
+                      LibsemigroupsException);
+
+    auto y = make<Perm<3>>({0, 1, 2});
+    REQUIRE(to_human_readable_repr(y) == "Perm<3, uint8_t>({0, 1, 2})");
+    REQUIRE(to_human_readable_repr(y, "", "[]")
+            == "Perm<3, uint8_t>([0, 1, 2])");
+    REQUIRE(to_human_readable_repr(y) == to_input_string(y));
+    REQUIRE(to_human_readable_repr(y, "", "{}", 3)
+            == "<permutation of degree 3>");
+    // Too many braces
+    REQUIRE_THROWS_AS(to_human_readable_repr(y, "", "xxx"),
+                      LibsemigroupsException);
+
+    auto z = make<PPerm<4>>({0, 1, 2}, {1, 2, 3}, 4);
+    REQUIRE(to_human_readable_repr(z)
+            == "PPerm<4, uint8_t>({0, 1, 2}, {1, 2, 3}, 4)");
+    REQUIRE(to_human_readable_repr(z, "", "[]")
+            == "PPerm<4, uint8_t>([0, 1, 2], [1, 2, 3], 4)");
+    REQUIRE(to_human_readable_repr(z) == to_input_string(z));
+    REQUIRE(to_human_readable_repr(z, "", "{}", 3)
+            == "<partial permutation of degree 4 and rank 3>");
+    // Too many braces
+    REQUIRE_THROWS_AS(to_human_readable_repr(z, "", "xxx"),
+                      LibsemigroupsException);
+  }
 }  // namespace libsemigroups

--- a/tests/test-transf.cpp
+++ b/tests/test-transf.cpp
@@ -193,6 +193,17 @@ namespace libsemigroups {
                           "exceptions (dynamic)",
                           "[quick][pperm]") {
     using point_type = typename Transf<>::point_type;
+
+    auto x = make<PPerm<0, uint8_t>>({}, {}, 257);
+    REQUIRE(x * x == x);
+    x = make<PPerm<0, uint8_t>>({}, {}, 256);
+    REQUIRE(x * x == x);
+
+    REQUIRE_THROWS_AS((make<PPerm<0, uint8_t>>({255}, {255}, 256)),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS((make<PPerm<0, uint8_t>>({0}, {255}, 256)),
+                      LibsemigroupsException);
+
     REQUIRE_NOTHROW(PPerm<>());
     REQUIRE_NOTHROW(make<PPerm<>>({0}));
     REQUIRE_NOTHROW(make<PPerm<>>({UNDEFINED}));


### PR DESCRIPTION
This PR:
* fixes a corner case for transformations (those of degree equal to the maximum supported by the underlying integer type);
* adds some more checks to the partial perm `make` function (namely to not allow UNDEFINED to be among the values specified in the 3-argument constructor)
* adds `to_input_string` and `to_human_readable_repr` for transformations, partial perms, and perms.