### PR TITLE
word-graph: group digits in WordGraph repr

### DIFF
--- a/include/libsemigroups/word-graph.tpp
+++ b/include/libsemigroups/word-graph.tpp
@@ -1906,9 +1906,10 @@ namespace libsemigroups {
   template <typename Node>
   std::string to_human_readable_repr(WordGraph<Node> const& wg) {
     // TODO(2) could be more elaborate, include complete, etc
+    // TODO(2) number_of_edges can be a bit slow
     return fmt::format("<WordGraph with {} nodes, {} edges, & out-degree {}>",
-                       wg.number_of_nodes(),
-                       wg.number_of_edges(),
+                       detail::group_digits(wg.number_of_nodes()),
+                       detail::group_digits(wg.number_of_edges()),
                        wg.out_degree());
   }
 

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -757,11 +757,14 @@ namespace libsemigroups {
     REQUIRE(
         to_input_string(wg, "make<WordGraph<uint32_t>>(", "[]", ")")
         == "make<WordGraph<uint32_t>>(5, [[4294967295], [2], [3], [4], [0]])");
+    word_graph::add_cycle(wg, 1000);
+    REQUIRE(to_human_readable_repr(wg)
+            == "<WordGraph with 1,005 nodes, 1,004 edges, & out-degree 1>");
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
                           "043",
-                          "WordGraph to_input_string",
+                          "WordGraph hash_value",
                           "[quick]") {
     WordGraph<uint32_t> wg(0, 1);
     word_graph::add_cycle(wg, 5);


### PR DESCRIPTION
This is a very minor change that uses uses thousands separators in the repr of `WordGraph`s.