### PR TITLE
to: fix `to<Presentation>(kb)`

### DIFF
--- a/include/libsemigroups/to-presentation.hpp
+++ b/include/libsemigroups/to-presentation.hpp
@@ -30,8 +30,7 @@
 #include "presentation.hpp"        // for Presentation
 #include "word-range.hpp"          // for human_readable...
 
-#include "detail/knuth-bendix-impl.hpp"  // for KnuthBendixImpl
-
+// TODO(1): Make as many of these functions const as possible
 namespace libsemigroups {
 
   //! \defgroup to_presentation_group to<Presentation>
@@ -93,6 +92,15 @@ namespace libsemigroups {
   ////////////////////////////////////////////////////////////////////////
   // KnuthBendix -> Presentation
   ////////////////////////////////////////////////////////////////////////
+
+  template <typename Result,
+            typename WordIn,
+            typename Rewriter,
+            typename ReductionOrder>
+  auto to(KnuthBendix<WordIn, Rewriter, ReductionOrder>& kb)
+      -> std::enable_if_t<
+          std::is_same_v<Presentation<typename Result::word_type>, Result>,
+          Result>;
 
   //! \ingroup to_presentation_group
   //!

--- a/include/libsemigroups/to-presentation.hpp
+++ b/include/libsemigroups/to-presentation.hpp
@@ -93,6 +93,45 @@ namespace libsemigroups {
   // KnuthBendix -> Presentation
   ////////////////////////////////////////////////////////////////////////
 
+  //! \ingroup to_presentation_group
+  //!
+  //! \brief Make a presentation from a \ref_knuth_bendix object.
+  //!
+  //! Defined in `to-presentation.hpp`.
+  //!
+  //! Despite the hideous signature, this function should be invoked as follows:
+  //!
+  //! \code
+  //! to<Presentation<WordOut>>(kb);
+  //! \endcode
+  //!
+  //! This function constructs and returns a `Presentation<WordOut>` object
+  //! using the currently active rules of \p kb.
+  //!
+  //! No enumeration of the argument \p kb is performed, so it might be the
+  //! case that the resulting presentation does not define the same
+  //! semigroup/monoid as \p kb. To ensure that the resulting presentation
+  //! defines the same semigroup as \p kb, run \ref KnuthBendix::run (or any
+  //! other function that fully enumerates \p kb) prior to calling this
+  //! function.
+  //!
+  //! \tparam Result the return type, also used for SFINAE. Must be
+  //! `Presentation<WordOut>` for some type `WordOut`.
+  //! \tparam WordIn the type of the rules in the presentation of the
+  //! \ref_knuth_bendix object \p kb.
+  //! \tparam Rewriter the second template parameter for \ref_knuth_bendix.
+  //! \tparam ReductionOrder the third template parameter for \ref_knuth_bendix.
+  //!
+  //! \param kb the \ref_knuth_bendix object from which to obtain the rules.
+  //!
+  //! \returns An object of type \c Presentation<WordOut>.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  //!
+  //! \note
+  //! If the word type of the desired presentation is the same as that \p kb,
+  //! then the simpler `to<Presentation>(kb)` may be used instead.
   template <typename Result,
             typename WordIn,
             typename Rewriter,
@@ -129,7 +168,6 @@ namespace libsemigroups {
   //! \ref_knuth_bendix object \p kb.
   //! \tparam Rewriter the second template parameter for \ref_knuth_bendix.
   //! \tparam ReductionOrder the third template parameter for \ref_knuth_bendix.
-  //! constructed.
   //!
   //! \param kb the \ref_knuth_bendix object from which to obtain the rules.
   //!

--- a/include/libsemigroups/to-presentation.tpp
+++ b/include/libsemigroups/to-presentation.tpp
@@ -53,25 +53,29 @@ namespace libsemigroups {
   // KnuthBendix -> Presentation
   ////////////////////////////////////////////////////////////////////////
 
-  template <typename Result, typename Rewriter, typename ReductionOrder>
-  auto to(detail::KnuthBendixImpl<Rewriter, ReductionOrder>& kb)
+  template <typename Result,
+            typename WordIn,
+            typename Rewriter,
+            typename ReductionOrder>
+  auto to(KnuthBendix<WordIn, Rewriter, ReductionOrder>& kb)
       -> std::enable_if_t<
           std::is_same_v<Presentation<typename Result::word_type>, Result>,
           Result> {
-    using Word = typename Result::word_type;
-    if constexpr (std::is_same_v<Word, std::string>) {
-      auto const&               p_orig = kb.internal_presentation();
-      Presentation<std::string> p;
-      p.alphabet(p_orig.alphabet())
-          .contains_empty_word(p_orig.contains_empty_word());
+    using WordOut                      = typename Result::word_type;
+    Presentation<WordIn> const& p_orig = kb.presentation();
+    Presentation<WordIn>        p;
+    p.alphabet(p_orig.alphabet())
+        .contains_empty_word(p_orig.contains_empty_word());
 
-      for (auto const& rule : kb.active_rules()) {
-        presentation::add_rule(p, rule.first, rule.second);
-      }
+    for (auto const& rule : kb.active_rules()) {
+      presentation::add_rule(p, rule.first, rule.second);
+    }
+
+    if constexpr (std::is_same_v<WordIn, WordOut>) {
       return p;
     } else {
       // TODO(1) avoid double copy here
-      return to<Presentation<Word>>(to<Presentation<std::string>>(kb));
+      return to<Presentation<WordOut>>(p);
     }
   }
 

--- a/tests/test-knuth-bendix-2.cpp
+++ b/tests/test-knuth-bendix-2.cpp
@@ -1834,7 +1834,6 @@ namespace libsemigroups {
     p.contains_empty_word(true);
 
     KnuthBendix<word_type, TestType> kb(twosided, p);
-    p = to<Presentation>(kb);
 
     auto S = to<FroidurePin>(kb);
     REQUIRE(S.contains_one());

--- a/tests/test-to-presentation.cpp
+++ b/tests/test-to-presentation.cpp
@@ -382,55 +382,144 @@ namespace libsemigroups {
     }
   }
 
-  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("to<Presentation>",
-                                   "021",
-                                   "from KnuthBendix",
-                                   "[quick][to_presentation]",
-                                   string_string,
-                                   string_word,
-                                   word_string,
-                                   word_word) {
-    using W1 = typename TestType::first_type;
-    using W2 = typename TestType::second_type;
-    using literals::operator""_w;
-
+  LIBSEMIGROUPS_TEST_CASE("to<Presentation<std::string>>",
+                          "021",
+                          "from KnuthBendix<std::string>",
+                          "[quick][to_presentation]") {
     auto rg = ReportGuard(false);
 
-    Presentation<W1> p;
+    Presentation<std::string> p;
+    p.alphabet("hijkl");
+    presentation::add_rule(p, "hi", "j");
+    presentation::add_rule(p, "ij", "k");
+    presentation::add_rule(p, "jk", "l");
+    presentation::add_rule(p, "kl", "h");
+    presentation::add_rule(p, "lh", "i");
 
-    if constexpr (std::is_same_v<W1, std::string>) {
-      p.alphabet("hijkl");
-
-      presentation::add_rule(p, "hi", "j");
-      presentation::add_rule(p, "ij", "k");
-      presentation::add_rule(p, "jk", "l");
-      presentation::add_rule(p, "kl", "h");
-      presentation::add_rule(p, "lh", "i");
-    } else if constexpr (std::is_same_v<W1, word_type>) {
-      p.alphabet("02468"_w);
-
-      presentation::add_rule(p, "02"_w, "4"_w);
-      presentation::add_rule(p, "24"_w, "6"_w);
-      presentation::add_rule(p, "46"_w, "8"_w);
-      presentation::add_rule(p, "68"_w, "0"_w);
-      presentation::add_rule(p, "80"_w, "2"_w);
-    }
-
-    KnuthBendix<W1> kb(congruence_kind::twosided, p);
+    KnuthBendix<std::string> kb(congruence_kind::twosided, p);
     kb.run();
 
-    auto q = to<Presentation<W2>>(kb);
-    REQUIRE(q.alphabet().size() == 5);
+    auto q = to<Presentation<std::string>>(kb);
+    REQUIRE(q == to<Presentation>(kb));
+
+    REQUIRE(q.alphabet() == p.alphabet());
     REQUIRE(q.rules.size() == 48);
 
-    if constexpr (std::is_same_v<W1, W2>) {
-      REQUIRE(q.alphabet() == p.alphabet());
-      REQUIRE(q == to<Presentation>(kb));
-    } else if constexpr (std::is_same_v<W2, std::string>) {
-      REQUIRE(q.alphabet() == "abcde");
-    } else if constexpr (std::is_same_v<W2, word_type>) {
-      REQUIRE(q.alphabet() == "01234"_w);
-    }
+    presentation::sort_each_rule(q);
+    presentation::sort_rules(q);
+    REQUIRE(q.rules
+            == std::vector<std::string>{
+                "hi",  "j",  "hl",  "i",  "ih",  "j",  "ij",  "k",  "ji", "k",
+                "jk",  "l",  "kj",  "l",  "kl",  "h",  "lh",  "i",  "lk", "h",
+                "hhh", "l",  "iii", "h",  "ik",  "hh", "jh",  "hj", "jj", "hk",
+                "jl",  "ii", "kh",  "hk", "ki",  "hh", "kk",  "il", "li", "il",
+                "lj",  "ii", "ll",  "hj", "hhj", "il", "iil", "hhk"});
+  }
+  LIBSEMIGROUPS_TEST_CASE("to<Presentation<std::string>>",
+                          "022",
+                          "from KnuthBendix<word_type>",
+                          "[quick][to_presentation]") {
+    using literals::operator""_w;
+    auto            rg = ReportGuard(false);
+
+    Presentation<word_type> p;
+    p.alphabet("56789"_w);
+    presentation::add_rule(p, "56"_w, "7"_w);
+    presentation::add_rule(p, "67"_w, "8"_w);
+    presentation::add_rule(p, "78"_w, "9"_w);
+    presentation::add_rule(p, "89"_w, "5"_w);
+    presentation::add_rule(p, "95"_w, "6"_w);
+
+    KnuthBendix<word_type> kb(congruence_kind::twosided, p);
+    kb.run();
+
+    auto q = to<Presentation<std::string>>(kb);
+
+    REQUIRE(q.alphabet() == "abcde");
+    REQUIRE(q.rules.size() == 48);
+
+    presentation::sort_each_rule(q);
+    presentation::sort_rules(q);
+    REQUIRE(q.rules
+            == std::vector<std::string>{
+                "ab",  "c",  "ae",  "b",  "ba",  "c",  "bc",  "d",  "cb", "d",
+                "cd",  "e",  "dc",  "e",  "de",  "a",  "ea",  "b",  "ed", "a",
+                "aaa", "e",  "bbb", "a",  "bd",  "aa", "ca",  "ac", "cc", "ad",
+                "ce",  "bb", "da",  "ad", "db",  "aa", "dd",  "be", "eb", "be",
+                "ec",  "bb", "ee",  "ac", "aac", "be", "bbe", "aad"});
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("to<Presentation<word_type>>",
+                          "023",
+                          "from KnuthBendix<std::string>",
+                          "[quick][to_presentation]") {
+    using literals::operator""_w;
+    auto            rg = ReportGuard(false);
+
+    Presentation<std::string> p;
+    p.alphabet("hijkl");
+    presentation::add_rule(p, "hi", "j");
+    presentation::add_rule(p, "ij", "k");
+    presentation::add_rule(p, "jk", "l");
+    presentation::add_rule(p, "kl", "h");
+    presentation::add_rule(p, "lh", "i");
+
+    KnuthBendix<std::string> kb(congruence_kind::twosided, p);
+    kb.run();
+
+    auto q = to<Presentation<word_type>>(kb);
+
+    REQUIRE(q.alphabet() == "01234"_w);
+    REQUIRE(q.rules.size() == 48);
+
+    presentation::sort_each_rule(q);
+    presentation::sort_rules(q);
+    REQUIRE(q.rules
+            == std::vector<word_type>{
+                "01"_w, "2"_w,   "04"_w,  "1"_w,  "10"_w,  "2"_w,  "12"_w,
+                "3"_w,  "21"_w,  "3"_w,   "23"_w, "4"_w,   "32"_w, "4"_w,
+                "34"_w, "0"_w,   "40"_w,  "1"_w,  "43"_w,  "0"_w,  "000"_w,
+                "4"_w,  "111"_w, "0"_w,   "13"_w, "00"_w,  "20"_w, "02"_w,
+                "22"_w, "03"_w,  "24"_w,  "11"_w, "30"_w,  "03"_w, "31"_w,
+                "00"_w, "33"_w,  "14"_w,  "41"_w, "14"_w,  "42"_w, "11"_w,
+                "44"_w, "02"_w,  "002"_w, "14"_w, "114"_w, "003"_w});
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("to<Presentation<word_type>>",
+                          "024",
+                          "from KnuthBendix<word_type>",
+                          "[quick][to_presentation]") {
+    using literals::operator""_w;
+    auto            rg = ReportGuard(false);
+
+    Presentation<word_type> p;
+    p.alphabet("56789"_w);
+    presentation::add_rule(p, "56"_w, "7"_w);
+    presentation::add_rule(p, "67"_w, "8"_w);
+    presentation::add_rule(p, "78"_w, "9"_w);
+    presentation::add_rule(p, "89"_w, "5"_w);
+    presentation::add_rule(p, "95"_w, "6"_w);
+
+    KnuthBendix<word_type> kb(congruence_kind::twosided, p);
+    kb.run();
+
+    auto q = to<Presentation<word_type>>(kb);
+    REQUIRE(q == to<Presentation>(kb));
+
+    REQUIRE(q.alphabet() == p.alphabet());
+    REQUIRE(q.rules.size() == 48);
+
+    presentation::sort_each_rule(q);
+    presentation::sort_rules(q);
+    REQUIRE(q.rules
+            == std::vector<word_type>{
+                "56"_w, "7"_w,   "59"_w,  "6"_w,  "65"_w,  "7"_w,  "67"_w,
+                "8"_w,  "76"_w,  "8"_w,   "78"_w, "9"_w,   "87"_w, "9"_w,
+                "89"_w, "5"_w,   "95"_w,  "6"_w,  "98"_w,  "5"_w,  "555"_w,
+                "9"_w,  "666"_w, "5"_w,   "68"_w, "55"_w,  "75"_w, "57"_w,
+                "77"_w, "58"_w,  "79"_w,  "66"_w, "85"_w,  "58"_w, "86"_w,
+                "55"_w, "88"_w,  "69"_w,  "96"_w, "69"_w,  "97"_w, "66"_w,
+                "99"_w, "57"_w,  "557"_w, "69"_w, "669"_w, "558"_w});
   }
 
 }  // namespace libsemigroups

--- a/tests/test-to-presentation.cpp
+++ b/tests/test-to-presentation.cpp
@@ -415,7 +415,7 @@ namespace libsemigroups {
                 "jl",  "ii", "kh",  "hk", "ki",  "hh", "kk",  "il", "li", "il",
                 "lj",  "ii", "ll",  "hj", "hhj", "il", "iil", "hhk"});
   }
-  
+
   LIBSEMIGROUPS_TEST_CASE("to<Presentation<std::string>>",
                           "022",
                           "from KnuthBendix<word_type>",

--- a/tests/test-to-presentation.cpp
+++ b/tests/test-to-presentation.cpp
@@ -415,6 +415,7 @@ namespace libsemigroups {
                 "jl",  "ii", "kh",  "hk", "ki",  "hh", "kk",  "il", "li", "il",
                 "lj",  "ii", "ll",  "hj", "hhj", "il", "iil", "hhk"});
   }
+  
   LIBSEMIGROUPS_TEST_CASE("to<Presentation<std::string>>",
                           "022",
                           "from KnuthBendix<word_type>",


### PR DESCRIPTION
This PR refactors/fixes the overload of the `to` function that converts `KnuthBendix` objects to `Presentation` objects. In particular, it properly exposes the overload where we explicitly specify the type of presentation (e.g. `to<Presentation<std::string>>(kb)`), and no longer uses `KnuthBendixImpl`. It also adds some tests.