### PR TITLE
Prevent bad accesses of empty containers

### DIFF
--- a/include/libsemigroups/detail/containers.hpp
+++ b/include/libsemigroups/detail/containers.hpp
@@ -177,7 +177,7 @@ namespace libsemigroups {
       // Not noexcept because DynamicArray2::DynamicArray2(size_type, size_type)
       // can throw.
       explicit DynamicArray2(std::initializer_list<std::initializer_list<T>> il)
-          : DynamicArray2(il.begin()->size(), il.size()) {
+          : DynamicArray2(std::empty(il) ? 0 : il.begin()->size(), il.size()) {
         auto it = _vec.begin();
         for (auto const& row : il) {
           LIBSEMIGROUPS_ASSERT(row.size() == _nr_used_cols);

--- a/include/libsemigroups/matrix.hpp
+++ b/include/libsemigroups/matrix.hpp
@@ -2905,7 +2905,8 @@ namespace libsemigroups {
     //! \endcode
     explicit DynamicMatrix(
         std::initializer_list<std::initializer_list<scalar_type>> const& m)
-        : MatrixDynamicDim(m.size(), m.begin()->size()), MatrixCommon(m) {}
+        : MatrixDynamicDim(m.size(), std::empty(m) ? 0 : m.begin()->size()),
+          MatrixCommon(m) {}
 
     //! \brief Construct a matrix from std::vector of
     //! std::vector of scalars.
@@ -2922,7 +2923,8 @@ namespace libsemigroups {
     //! \f$O(mn)\f$ where \f$m\f$ is the number of rows and \f$n\f$ is the
     //! number of columns in the matrix being constructed.
     explicit DynamicMatrix(std::vector<std::vector<scalar_type>> const& m)
-        : MatrixDynamicDim(m.size(), m.begin()->size()), MatrixCommon(m) {}
+        : MatrixDynamicDim(m.size(), std::empty(m) ? 0 : m.begin()->size()),
+          MatrixCommon(m) {}
 
     //! \brief Construct a row from a row view.
     //!
@@ -3302,7 +3304,8 @@ namespace libsemigroups {
     explicit DynamicMatrix(
         Semiring const*                                                  sr,
         std::initializer_list<std::initializer_list<scalar_type>> const& rws)
-        : MatrixDynamicDim(rws.size(), rws.begin()->size()),
+        : MatrixDynamicDim(rws.size(),
+                           std::empty(rws) ? 0 : rws.begin()->size()),
           MatrixCommon(rws),
           _semiring(sr) {}
 
@@ -3680,7 +3683,7 @@ namespace libsemigroups {
         -> std::enable_if_t<IsStaticMatrix<Mat>> {
       // Only call this if you've already called throw_if_any_row_wrong_size
       uint64_t const R = m.size();
-      uint64_t const C = m.begin()->size();
+      uint64_t const C = std::empty(m) ? 0 : m.begin()->size();
       if (R != Mat::nr_rows || C != Mat::nr_cols) {
         LIBSEMIGROUPS_EXCEPTION(
             "invalid argument, cannot initialize an {}x{} matrix with compile "

--- a/include/libsemigroups/word-graph.hpp
+++ b/include/libsemigroups/word-graph.hpp
@@ -2693,7 +2693,7 @@ namespace libsemigroups {
   //! This function outputs the word graph \p wg to the stream \p os.
   //! The word graph is represented by the out-neighbours of each node ordered
   //! according to their labels. The symbol `-` is used to denote that an
-  //! edge is not defined. For example, the word graph with 1 nodes,
+  //! edge is not defined. For example, the word graph with 1 node,
   //! out-degree 2, and a single loop labelled 1 from node 0 to 0 is
   //! represented as
   //! `{{-, 0}}`.
@@ -2726,7 +2726,7 @@ namespace libsemigroups {
   //!
   //! This function constructs a word graph from its arguments whose
   //! out-degree is specified by the length of the first item
-  //! in the 2nd parameter.
+  //! in the second parameter, or 0 if the second parameter is empty.
   //!
   //! \tparam Return the return type. Must satisfy \ref IsWordGraph<Return>.
   //!

--- a/include/libsemigroups/word-graph.tpp
+++ b/include/libsemigroups/word-graph.tpp
@@ -1477,7 +1477,7 @@ namespace libsemigroups {
   std::enable_if_t<IsWordGraph<Return>, Return>
   make(size_t                                                      num_nodes,
        std::vector<std::vector<typename Return::node_type>> const& edges) {
-    Return result(num_nodes, edges.begin()->size());
+    Return result(num_nodes, std::empty(edges) ? 0 : edges.begin()->size());
     for (size_t i = 0; i < edges.size(); ++i) {
       for (size_t j = 0; j < (edges.begin() + i)->size(); ++j) {
         auto val = *((edges.begin() + i)->begin() + j);

--- a/tests/test-containers.cpp
+++ b/tests/test-containers.cpp
@@ -113,6 +113,15 @@ namespace libsemigroups {
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
                             "006",
+                            "construct from empty vector",
+                            "[containers][quick]") {
+      DynamicArray2<size_t> rv = DynamicArray2<size_t>(
+          std::initializer_list<std::initializer_list<size_t>>());
+      REQUIRE(rv.empty());
+    }
+
+    LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
+                            "007",
                             "add_rows",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(3, 7, 666);
@@ -137,7 +146,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "007",
+                            "008",
                             "add_rows",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(3, 7, 666);
@@ -156,7 +165,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "008",
+                            "009",
                             "add_cols",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(100, 2, 666);
@@ -175,7 +184,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "009",
+                            "010",
                             "set/get",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(100, 50, 666);
@@ -206,7 +215,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "010",
+                            "011",
                             "append 1/2",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(100, 50, 555);
@@ -241,7 +250,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "011",
+                            "012",
                             "append 2/2",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(10, 10, 555);
@@ -287,7 +296,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "012",
+                            "013",
                             "count",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(10, 10);
@@ -313,7 +322,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "013",
+                            "014",
                             "clear",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(10, 10);
@@ -327,7 +336,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "014",
+                            "015",
                             "begin_row and end_row",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(100, 2);
@@ -345,7 +354,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "015",
+                            "016",
                             "cbegin_row and cend_row",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(10, 10, 66);
@@ -357,7 +366,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "016",
+                            "017",
                             "iterator operator++ (postfix)",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(100, 2);  // cols, rows
@@ -418,7 +427,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "017",
+                            "018",
                             "iterator operator++ (prefix)",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(100, 2);  // cols, rows
@@ -529,7 +538,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "018",
+                            "019",
                             "iterator operator-- (postfix)",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(100, 2);  // cols, rows
@@ -568,7 +577,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "019",
+                            "020",
                             "iterator operator-- (prefix)",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(100, 2);  // cols, rows
@@ -607,7 +616,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "020",
+                            "021",
                             "operator=",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(10, 10, 3);
@@ -636,7 +645,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "021",
+                            "022",
                             "operator== and operator!=",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(10, 10, 3);
@@ -721,7 +730,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "022",
+                            "023",
                             "empty and clear",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(10, 10);
@@ -754,7 +763,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "023",
+                            "024",
                             "max_size",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(10, 10);
@@ -765,7 +774,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "024",
+                            "025",
                             "swap",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(10, 10, 3);
@@ -839,7 +848,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "025",
+                            "026",
                             "iterator arithmetic",
                             "[containers][quick]") {
       {
@@ -1022,7 +1031,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "026",
+                            "027",
                             "iterator comparison",
                             "[containers][quick]") {
       {
@@ -1052,7 +1061,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "027",
+                            "028",
                             "iterator operator=",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(10, 10, 1000);
@@ -1075,7 +1084,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "028",
+                            "029",
                             "iterator operator[]",
                             "[containers][quick]") {
       {
@@ -1131,7 +1140,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "029",
+                            "030",
                             "iterator operator->",
                             "[containers][quick][30]") {
       DynamicArray2<DynamicArray2<bool>> rv
@@ -1147,7 +1156,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "030",
+                            "031",
                             "const_iterator operator++/--",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv1 = DynamicArray2<size_t>(100, 2);  // cols, rows
@@ -1210,7 +1219,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "031",
+                            "032",
                             "const_iterator operator++/--",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(1, 1, 6);  // cols, rows
@@ -1223,7 +1232,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "032",
+                            "033",
                             "column iterators",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(3, 3);
@@ -1288,7 +1297,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "033",
+                            "034",
                             "column iterator arithmetic",
                             "[containers][quick][no-valgrind]") {
       {
@@ -1383,7 +1392,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "034",
+                            "035",
                             "iterator assignment constructor",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(100, 100);
@@ -1411,7 +1420,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "035",
+                            "036",
                             "reserve method",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(100, 100);
@@ -1421,7 +1430,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "036",
+                            "037",
                             "erase column",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(10, 10);
@@ -1440,7 +1449,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "037",
+                            "038",
                             "swap_rows",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(3, 10);
@@ -1462,7 +1471,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "038",
+                            "039",
                             "apply_row_permutation",
                             "[containers][quick]") {
       DynamicArray2<size_t> rv = DynamicArray2<size_t>(3, 10);
@@ -1482,7 +1491,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "039",
+                            "040",
                             "swap",
                             "[containers][quick]") {
       DynamicArray2<size_t> da = DynamicArray2<size_t>({{0, 1}, {2, 3}});
@@ -1498,7 +1507,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "040",
+                            "041",
                             "shrink_rows_to",
                             "[containers][quick]") {
       DynamicArray2<size_t> da = DynamicArray2<size_t>({{0, 1}, {2, 3}});
@@ -1530,7 +1539,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("DynamicArray2",
-                            "041",
+                            "042",
                             "shrink_rows_to - for range",
                             "[containers][quick]") {
       DynamicArray2<size_t> da = DynamicArray2<size_t>({{0, 1}, {2, 3}});
@@ -1566,7 +1575,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("StaticVector2",
-                            "042",
+                            "043",
                             "all",
                             "[containers][quick]") {
       StaticVector2<size_t, 3> sv;
@@ -1612,7 +1621,7 @@ namespace libsemigroups {
               == std::vector<size_t>({5}));
     }
 
-    LIBSEMIGROUPS_TEST_CASE("Array2", "043", "all", "[containers][quick]") {
+    LIBSEMIGROUPS_TEST_CASE("Array2", "044", "all", "[containers][quick]") {
       Array2<size_t, 3> rry;
       rry.fill(10);
       REQUIRE(std::vector<size_t>(rry.cbegin(0), rry.cend(0))
@@ -1647,7 +1656,7 @@ namespace libsemigroups {
     }
 
     LIBSEMIGROUPS_TEST_CASE("StaticTriVector2",
-                            "044",
+                            "045",
                             "all",
                             "[containers][quick]") {
       StaticTriVector2<size_t, 3> stv;

--- a/tests/test-matrix.cpp
+++ b/tests/test-matrix.cpp
@@ -1162,4 +1162,29 @@ namespace libsemigroups {
     delete sr;
   }
 
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Matrix",
+                                   "025",
+                                   "empty matrix",
+                                   "[quick]",
+                                   BMat<>,
+                                   IntMat<>,
+                                   MaxPlusMat<>,
+                                   MinPlusMat<>) {
+    TestType m = make<TestType>(
+        std::vector<std::vector<typename TestType::scalar_type>>());
+    REQUIRE(m.number_of_rows() == 0);
+    REQUIRE(m.number_of_cols() == 0);
+  }
+  LIBSEMIGROUPS_TEST_CASE("Matrix",
+                          "026",
+                          "empty matrix with Semiring",
+                          "[quick]") {
+    NTPSemiring<> const* sr = new NTPSemiring<>(23, 1);
+    auto                 x
+        = NTPMat<>(sr, std::initializer_list<std::initializer_list<size_t>>());
+    REQUIRE(x.number_of_rows() == 0);
+    REQUIRE(x.number_of_cols() == 0);
+    delete sr;
+  }
+
 }  // namespace libsemigroups

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -60,6 +60,16 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
                           "002",
+                          "constructor with empty targets",
+                          "[quick][word-graph]") {
+    auto wg = make<WordGraph<size_t>>(10, {});
+    REQUIRE(wg.number_of_nodes() == 10);
+    REQUIRE(wg.number_of_edges() == 0);
+    REQUIRE(wg.out_degree() == 0);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("WordGraph",
+                          "003",
                           "add nodes",
                           "[quick][word-graph]") {
     WordGraph<size_t> g(3);
@@ -73,7 +83,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "003",
+                          "004",
                           "add edges",
                           "[quick][word-graph]") {
     WordGraph<size_t> g(17, 31);
@@ -110,7 +120,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "004",
+                          "005",
                           "exceptions",
                           "[quick][word-graph]") {
     WordGraph<size_t> graph(10, 5);
@@ -127,14 +137,14 @@ namespace libsemigroups {
     REQUIRE_NOTHROW(graph.target(2, 0, 2));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("WordGraph", "005", "random", "[quick][word-graph]") {
+  LIBSEMIGROUPS_TEST_CASE("WordGraph", "006", "random", "[quick][word-graph]") {
     WordGraph graph = WordGraph<size_t>::random(10, 10);
     REQUIRE(graph.number_of_nodes() == 10);
     REQUIRE(graph.number_of_edges() == 100);
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "006",
+                          "007",
                           "reserve",
                           "[quick][word-graph]") {
     WordGraph<size_t> graph;
@@ -149,7 +159,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "007",
+                          "008",
                           "default constructors",
                           "[quick][word-graph]") {
     auto g1 = WordGraph<size_t>();
@@ -173,7 +183,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "008",
+                          "009",
                           "iterator to edges",
                           "[quick][word-graph]") {
     for (size_t n = 10; n < 512; n *= 4) {
@@ -195,7 +205,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "009",
+                          "010",
                           "reverse node iterator",
                           "[quick]") {
     using node_type = WordGraph<size_t>::node_type;
@@ -215,7 +225,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "010",
+                          "011",
                           "random/random_acyclic exceptions",
                           "[quick][no-valgrind]") {
     // Too few nodes
@@ -238,7 +248,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "011",
+                          "012",
                           "unsafe (next) neighbour",
                           "[quick]") {
     auto wg = binary_tree(10);
@@ -248,7 +258,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "012",
+                          "013",
                           "number_of_egdes incident to a node",
                           "[quick]") {
     auto wg = binary_tree(10);
@@ -261,7 +271,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "013",
+                          "014",
                           "induced_subgraph_no_checks",
                           "[quick]") {
     WordGraph<size_t> wg;
@@ -278,7 +288,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "014",
+                          "015",
                           "remove_target_no_checks",
                           "[quick]") {
     WordGraph<size_t> wg;
@@ -294,7 +304,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "015",
+                          "016",
                           "swap_edge_no_checks",
                           "[quick]") {
     WordGraph<size_t> wg;
@@ -309,7 +319,7 @@ namespace libsemigroups {
     REQUIRE(wg == make<WordGraph<size_t>>(3, {{0, UNDEFINED}, {1}, {2}}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("WordGraph", "016", "operator<<", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("WordGraph", "017", "operator<<", "[quick]") {
     WordGraph<uint64_t> wg;
     wg.add_nodes(3);
     wg.add_to_out_degree(2);
@@ -325,7 +335,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "017",
+                          "018",
                           "is_acyclic | 2-cycle",
                           "[quick]") {
     WordGraph<size_t> wg;
@@ -338,7 +348,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "018",
+                          "019",
                           "is_acyclic | 1-cycle",
                           "[quick]") {
     WordGraph<size_t> wg;
@@ -350,7 +360,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "019",
+                          "020",
                           "is_acyclic | multi-digraph",
                           "[quick]") {
     using node_type = WordGraph<size_t>::node_type;
@@ -364,7 +374,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "020",
+                          "021",
                           "is_acyclic | complete digraph 100",
                           "[quick]") {
     WordGraph<size_t> wg;
@@ -383,7 +393,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "021",
+                          "022",
                           "is_acyclic | acyclic digraph with 20000 nodes",
                           "[quick]") {
     WordGraph<size_t> wg;
@@ -404,7 +414,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "022",
+                          "023",
                           "is_acyclic | acyclic digraph with 10 million nodes",
                           "[standard]") {
     WordGraph<size_t> wg;
@@ -425,7 +435,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "023",
+                          "024",
                           "is_acyclic | for a node",
                           "[quick]") {
     using node_type = WordGraph<size_t>::node_type;
@@ -450,7 +460,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "024",
+                          "025",
                           "is_acyclic | for a node | 2",
                           "[quick]") {
     WordGraph<size_t> wg;
@@ -475,7 +485,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "025",
+                          "026",
                           "is_reachable | acyclic 20 node digraph",
                           "[quick]") {
     WordGraph<size_t> wg;
@@ -501,7 +511,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "026",
+                          "027",
                           "is_reachable | 100 node chain",
                           "[quick][no-valgrind]") {
     WordGraph<size_t> wg;
@@ -520,7 +530,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "027",
+                          "028",
                           "is_reachable | 100 node cycle",
                           "[quick][no-valgrind]") {
     WordGraph<size_t> wg;
@@ -535,7 +545,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "028",
+                          "029",
                           "is_reachable | 20 node clique",
                           "[quick]") {
     WordGraph<size_t> wg = clique(20);
@@ -551,7 +561,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "029",
+                          "030",
                           "follow_path | 20 node chain",
                           "[quick]") {
     WordGraph<size_t> wg = chain(20);
@@ -562,7 +572,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "030",
+                          "031",
                           "throw_if_label_out_of_bounds | 20 node chain",
                           "[quick]") {
     WordGraph<size_t> wg = chain(20);
@@ -571,7 +581,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "031",
+                          "032",
                           "last_node_on_path_no_checks | 20 node chain",
                           "[quick]") {
     WordGraph<size_t> wg    = chain(20);
@@ -590,13 +600,13 @@ namespace libsemigroups {
     REQUIRE(p.second == chain.cend() - 1);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("WordGraph", "032", "to_string", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("WordGraph", "033", "to_string", "[quick]") {
     WordGraph<uint64_t> wg = chain(6);
     REQUIRE(detail::to_string(wg)
             == "{6, {{1}, {2}, {3}, {4}, {5}, {18446744073709551615}}}");
   }
 
-  LIBSEMIGROUPS_TEST_CASE("WordGraph", "033", "make<WordGraph>", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("WordGraph", "034", "make<WordGraph>", "[quick]") {
     auto wg = make<WordGraph<uint8_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
     REQUIRE(detail::to_string(wg)
             == "{5, {{0, 0}, {1, 1}, {2, 255}, {3, 3}, {255, 255}}}");
@@ -609,7 +619,7 @@ namespace libsemigroups {
         == "{5, {{255, 255}, {255, 255}, {255, 255}, {255, 255}, {255, 255}}}");
   }
 
-  LIBSEMIGROUPS_TEST_CASE("WordGraph", "034", "is_connected", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("WordGraph", "035", "is_connected", "[quick]") {
     auto wg = make<WordGraph<size_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
     REQUIRE(!word_graph::is_connected(wg));
     wg = chain(1'000);
@@ -626,7 +636,7 @@ namespace libsemigroups {
     REQUIRE(word_graph::is_connected(wg));
   }
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "035",
+                          "036",
                           "is_strictly_cyclic",
                           "[quick][no-valgrind]") {
     auto wg = make<WordGraph<size_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
@@ -645,7 +655,7 @@ namespace libsemigroups {
     REQUIRE(word_graph::is_strictly_cyclic(wg));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("WordGraph", "036", "Joiner x 1", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("WordGraph", "037", "Joiner x 1", "[quick]") {
     WordGraph<size_t> x(
         make<WordGraph<size_t>>(3, {{0, 1, 2}, {0, 1, 2}, {0, 1, 2}}));
     WordGraph<size_t> y = x;
@@ -669,7 +679,7 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS(join(x, y), LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("WordGraph", "037", "Joiner x 2", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("WordGraph", "038", "Joiner x 2", "[quick]") {
     WordGraph<size_t> x(
         make<WordGraph<size_t>>(3, {{1, 1, 1}, {2, 2, 2}, {2, 2, 2}}));
 
@@ -686,7 +696,7 @@ namespace libsemigroups {
     REQUIRE(join.is_subrelation(y, xy));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("WordGraph", "038", "Meeter x 1", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("WordGraph", "039", "Meeter x 1", "[quick]") {
     // These word graphs were taken from the lattice of
     // 2-sided congruences of the free semigroup with 2
     // generators.
@@ -713,7 +723,7 @@ namespace libsemigroups {
     REQUIRE(xy == make<WordGraph<size_t>>(4, {{1, 2}, {3, 3}, {2, 2}, {3, 3}}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("WordGraph", "039", "Meeter x 2", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("WordGraph", "040", "Meeter x 2", "[quick]") {
     auto x = make<WordGraph<size_t>>(5, {{1, 0}, {1, 2}, {1, 2}});
     auto y = make<WordGraph<size_t>>(5, {{0, 1}, {0, 1}});
     REQUIRE(word_graph::number_of_nodes_reachable_from(x, 0) == 3);
@@ -730,7 +740,7 @@ namespace libsemigroups {
     REQUIRE(xy == make<WordGraph<size_t>>(1, {{0, 0}}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("WordGraph", "040", "Joiner incomplete", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("WordGraph", "041", "Joiner incomplete", "[quick]") {
     WordGraph<uint32_t> wg(0, 1);
     word_graph::add_cycle(wg, 5);
     wg.remove_target(0, 0);
@@ -738,7 +748,7 @@ namespace libsemigroups {
     REQUIRE(join(wg, wg) == make<WordGraph<uint32_t>>(1, {{UNDEFINED}}));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("WordGraph", "041", "Meeter incomplete", "[quick]") {
+  LIBSEMIGROUPS_TEST_CASE("WordGraph", "042", "Meeter incomplete", "[quick]") {
     WordGraph<uint32_t> wg(0, 1);
     word_graph::add_cycle(wg, 5);
     wg.remove_target(0, 0);
@@ -747,7 +757,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "042",
+                          "043",
                           "WordGraph to_input_string",
                           "[quick]") {
     WordGraph<uint32_t> wg(0, 1);
@@ -763,7 +773,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "043",
+                          "044",
                           "WordGraph hash_value",
                           "[quick]") {
     WordGraph<uint32_t> wg(0, 1);


### PR DESCRIPTION
This PR fixes a bug whereby we were trying to access the first element of a potentially empty container. It also adds some test cases.