### PR TITLE
Reorganise the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,58 +151,6 @@ tracker](https://github.com/libsemigroups/libsemigroups/issues).
 
 We'd like to thank the authors and contributors to these excellent projects!
 
-## Authors
-
-- [Reinis Cirpons][] (<rc234@st-andrews.ac.uk>)
-- [Joseph Edwards][] (<jde1@st-andrews.ac.uk>)
-- [James Mitchell](https://jdbm.me) (<jdm3@st-andrews.ac.uk>)
-
-## Contributors
-
-- [Luna Elliott](https://le27.github.io/L-Elliott/)
-  (<luna.elliott142857@gmail.com>)
-  contributed to the Schreier-Sims implementation.
-- Jan Engelhardt (<jengelh@inai.de>) contributed some bug fixes to the
-  build system, and a number of helpful issues.
-- Ilya Finkelshteyn (<ilyaf@appveyor.com>) contributed to the
-  continuous integration in AppVeyor.
-- Isuru Fernando (<isuruf@gmail.com>) contributed to the build system.
-- [Florent Hivert](https://www.lri.fr/~hivert/)
-  (<Florent.Hivert@lri.fr>) contributed many helpful ideas to
-  `libsemigroups`, and `HPCombi`.
-- [Max Horn](https://math.rptu.de/en/wgs/agag/people/head/prof-dr-max-horn)
-  (<max@quendi.de>) contributed some fixes.
-- [Jerry James](http://www.jamezone.org/) (<loganjerry@gmail.com>)
-  contributed some bugfixes.
-- [Julius Jonušas][] contributed to the implementation of the Froidure-Pin
-  algorithm.
-- [Samuel Lelièvre][] (<samuel.lelievre@gmail.com>) contributed a number of
-  fixes to the docs.
-- Alex Levine (<A.Levine@uea.ac.uk>) contributed to the Schreier-Sims
-  implementation.
-- Michael Orlitzky (<michael@orlitzky.com>) contributed to the build system.
-- [Dima Pasechnik](https://pasechnik.info/dima)
-  (<dima@pasechnik.info>) contributed to the build system.
-- Chris Russell contributed some tests for finitely presented
-  semigroups.
-- [Finn Smith][] (<fls3@st-andrews.ac.uk>)
-  contributed the implementation of the Konieczny and
-  Lallement-McFadden algorithm, to the Todd-Coxeter implementation,
-  and to BMat8s.
-- [Nicolas Thiéry](http://nicolas.thiery.name/)
-  (<nthiery@users.sf.net>) contributed to the build system, packaging
-  `libsemigroups` via conda, the python bindings and many helpful
-  conversations and suggestions.
-- [Maria Tsalakou][] (<mt200@st-andrews.ac.uk>) contributed to the Knuth-Bendix
-  implementation, related algorithms for the class `WordGraph`,
-  and to the implementation of the `Ukkonen` and `Kambites` classes.
-- [Wilf Wilson](https://wilf.me) (<wilf@wilf-wilson.net>) contributed some fixes.
-- Murray Whyte (<mw231@st-andrews.ac.uk>) contributed many examples of
-  finitely presented semigroups and monoids, to the documentation and reported a
-  number of bugs.
-- [Michael Young][] (<mct25@st-andrews.ac.uk>) contributed to the congruences
-  code in the v0.0.1 to v0.6.7.
-
 ## Acknowledgements
 
 We thank:
@@ -226,7 +174,6 @@ We thank:
 [Maria Tsalakou]: https://mariatsalakou.github.io/
 [Michael Young]: https://mtorpey.github.io/
 [Reinis Cirpons]: https://reinisc.id.lv
-[Samuel Lelièvre]: https://lelievre.perso.math.cnrs.fr/index-en.html
 [Carnegie Trust for the Universities of Scotland]: https://www.carnegie-trust.org/
 [School of Mathematics and Statistics, University of St Andrews]: https://www.st-andrews.ac.uk/mathematics-statistics/
 [Visualisation]: https://libsemigroups.github.io/libsemigroups/group__dot__group.html

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1013,6 +1013,7 @@ WARN_LOGFILE           =
 INPUT                  = "../include/libsemigroups" \
                          "../include/libsemigroups/detail" \
                          "../README.md" \
+                         "authors.md" \
                          "install.md" \
                          "changelog-v1.md" \
                          "changelog-v2.md" \

--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -8,10 +8,10 @@
     <tab type="user" visible="yes" url="_HEADING_" title="Library Info" />
     <tab type="user" visible="yes" url="@ref md_authors" title="Authors" />
     <tab type="user" visible="yes" url="@ref citelist" title="Bibliography" />
-    <tab type="user" visible="yes" url="@ref md_install" title="Install" />
-    <tab type="user" visible="yes" url="@ref md_changelog-v3" title="changelog - version 3" />
-    <tab type="user" visible="yes" url="@ref md_changelog-v2" title="changelog - version 2" />
-    <tab type="user" visible="yes" url="@ref md_changelog-v1" title="changelog - version 1" />
+    <tab type="user" visible="yes" url="@ref md_changelog-v3" title="Changelog - version 3" />
+    <tab type="user" visible="yes" url="@ref md_changelog-v2" title="Changelog - version 2" />
+    <tab type="user" visible="yes" url="@ref md_changelog-v1" title="Changelog - version 1" />
+    <tab type="user" visible="yes" url="@ref md_install" title="Installation" />
     <tab type="user" visible="yes" url="_HEADING_" title="Data structures" />
     <tab type="usergroup" visible="yes" url="@ref adapters_group" title="Adapters">
       <tab type="usergroup" visible="yes" url="[none]" title="No default implementation">

--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -5,6 +5,7 @@
 
   <!-- Navigation index tabs for HTML output -->
   <navindex>
+    <tab type="mainpage" visible="yes" title="" />
     <tab type="user" visible="yes" url="_HEADING_" title="Library Info" />
     <tab type="user" visible="yes" url="@ref md_authors" title="Authors" />
     <tab type="user" visible="yes" url="@ref citelist" title="Bibliography" />
@@ -542,8 +543,6 @@
         title="Todd-Coxeter helper functions" />
       <tab type="user" visible="yes" url="@ref to_todd_coxeter_group" title="to<ToddCoxeter>" />
     </tab>
-    <tab type="user" visible="yes" url="_HEADING_" title="Further info" />
-    <tab type="user" url="https://github.com/libsemigroups/libsemigroups" title="GitHub" />
 
     <!--
     <tab type="pages" visible="no" title="" intro=""/>

--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -5,8 +5,8 @@
 
   <!-- Navigation index tabs for HTML output -->
   <navindex>
-    <tab type="mainpage" visible="yes" title="" />
-    <tab type="user" visible="yes" url="_HEADING_" title="Installation and Changelog" />
+    <tab type="user" visible="yes" url="_HEADING_" title="Library Info" />
+    <tab type="user" visible="yes" url="@ref md_authors" title="Authors" />
     <tab type="user" visible="yes" url="@ref md_install" title="Install" />
     <tab type="user" visible="yes" url="@ref md_changelog-v3" title="changelog - version 3" />
     <tab type="user" visible="yes" url="@ref md_changelog-v2" title="changelog - version 2" />

--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -361,7 +361,7 @@
       <tab type="user" visible="yes" url="@ref libsemigroups::aho_corasick"
         title="AhoCorasick helper functions" />
     </tab>
-    <tab type="usergroup" visible="yes" url="@ref types_group" title="Types">
+    <tab type="usergroup" visible="yes" url="@ref types_group" title="Enums + Types">
       <tab type="user" visible="yes" url="@ref libsemigroups::SmallestInteger<N>"
         title="SmallestInteger" />
     </tab>

--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -7,6 +7,7 @@
   <navindex>
     <tab type="user" visible="yes" url="_HEADING_" title="Library Info" />
     <tab type="user" visible="yes" url="@ref md_authors" title="Authors" />
+    <tab type="user" visible="yes" url="@ref citelist" title="Bibliography" />
     <tab type="user" visible="yes" url="@ref md_install" title="Install" />
     <tab type="user" visible="yes" url="@ref md_changelog-v3" title="changelog - version 3" />
     <tab type="user" visible="yes" url="@ref md_changelog-v2" title="changelog - version 2" />
@@ -541,8 +542,6 @@
         title="Todd-Coxeter helper functions" />
       <tab type="user" visible="yes" url="@ref to_todd_coxeter_group" title="to<ToddCoxeter>" />
     </tab>
-    <tab type="user" visible="yes" url="_HEADING_" title="Bibliography" />
-    <tab type="user" visible="yes" url="@ref citelist" title="Bibliography" />
     <tab type="user" visible="yes" url="_HEADING_" title="Further info" />
     <tab type="user" url="https://github.com/libsemigroups/libsemigroups" title="GitHub" />
 

--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -314,7 +314,8 @@
     <tab type="usergroup" visible="yes" url="@ref exception_group" title="Exceptions">
       <tab type="user" visible="yes" url="@ref libsemigroups::LibsemigroupsException"
         title="LibsemigroupsException" />
-    </tab>
+      </tab>
+    <tab type="user" visible="yes" url="@ref make_group" title="The `make` function" />
     <tab type="usergroup" visible="yes" url="@ref orders_group" title="Orders">
       <tab type="user" visible="yes" url="@ref libsemigroups::LexicographicalCompare"
         title="LexicographicalCompare" />
@@ -353,14 +354,13 @@
       <tab type="user" visible="yes" url="@ref libsemigroups::ukkonen"
         title="Ukkonen helper functions" />
     </tab>
+    <tab type="user" visible="yes" url="@ref to_group" title="The `to` function" />
     <tab type="usergroup" visible="yes" url="@ref aho_corasick_group" title="Tries">
       <tab type="user" visible="yes" url="@ref libsemigroups::AhoCorasick"
         title="The AhoCorasick class" />
       <tab type="user" visible="yes" url="@ref libsemigroups::aho_corasick"
         title="AhoCorasick helper functions" />
     </tab>
-    <tab type="user" visible="yes" url="@ref make_group" title="The `make` function" />
-    <tab type="user" visible="yes" url="@ref to_group" title="The `to` function" />
     <tab type="usergroup" visible="yes" url="@ref types_group" title="Types">
       <tab type="user" visible="yes" url="@ref libsemigroups::SmallestInteger<N>"
         title="SmallestInteger" />

--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -188,6 +188,7 @@
         <tab type="user" visible="yes" url="@ref libsemigroups::Product<PBR>" title="Product" />
       </tab>
     </tab>
+    <tab type="user" visible="yes" url="@ref constants_group" title="Constants" />
     <tab type="usergroup" visible="yes" url="@ref elements_group" title="Elements">
       <tab type="usergroup" visible="yes" url="@ref bipart_group" title="Bipartitions">
         <tab type="user" visible="yes" url="@ref libsemigroups::Bipartition"
@@ -309,23 +310,9 @@
         <tab type="user" visible="yes" url="@ref make_perm_group" title="make<Perm>" />
       </tab>
     </tab>
-    <tab type="usergroup" visible="yes" url="@ref misc_group" title="Miscellaneous">
-      <tab type="user" visible="yes" url="@ref constants_group" title="Constants" />
-      <tab type="usergroup" visible="yes" url="@ref exception_group" title="Exceptions">
-        <tab type="user" visible="yes" url="@ref libsemigroups::LibsemigroupsException"
-          title="LibsemigroupsException" />
-      </tab>
-      <tab type="usergroup" visible="yes" url="@ref obvinf_group" title="Obviously infinite">
-        <tab type="user" visible="yes" url="@ref libsemigroups::IsObviouslyInfinite"
-          title="IsObviouslyInfinite" />
-      </tab>
-      <tab type="usergroup" visible="yes" url="@ref types_group" title="Types">
-        <tab type="user" visible="yes" url="@ref libsemigroups::SmallestInteger<N>"
-          title="SmallestInteger" />
-      </tab>
-      <tab type="user" visible="yes" url="@ref libsemigroups::Reporter" title="Reporter" />
-      <tab type="user" visible="yes" url="@ref libsemigroups::ReportGuard" title="ReportGuard" />
-      <tab type="user" visible="yes" url="@ref libsemigroups::Runner" title="Runner" />
+    <tab type="usergroup" visible="yes" url="@ref exception_group" title="Exceptions">
+      <tab type="user" visible="yes" url="@ref libsemigroups::LibsemigroupsException"
+        title="LibsemigroupsException" />
     </tab>
     <tab type="usergroup" visible="yes" url="@ref orders_group" title="Orders">
       <tab type="user" visible="yes" url="@ref libsemigroups::LexicographicalCompare"
@@ -346,6 +333,10 @@
       <tab type="user" visible="yes" url="@ref to_presentation_group" title="to<Presentation>" />
       <tab type="user" visible="yes" url="@ref to_inverse_presentation_group"
         title="to<InversePresentation>" />
+            <tab type="usergroup" visible="yes" url="@ref obvinf_group" title="Obviously infinite">
+      <tab type="user" visible="yes" url="@ref libsemigroups::IsObviouslyInfinite"
+        title="IsObviouslyInfinite" />
+      </tab>
     </tab>
     <tab type="usergroup" visible="yes" url="@ref ranges_group" title="Ranges">
       <tab type="user" visible="yes" url="@ref libsemigroups::Random" title="Random" />
@@ -369,6 +360,10 @@
     </tab>
     <tab type="user" visible="yes" url="@ref make_group" title="The `make` function" />
     <tab type="user" visible="yes" url="@ref to_group" title="The `to` function" />
+    <tab type="usergroup" visible="yes" url="@ref types_group" title="Types">
+      <tab type="user" visible="yes" url="@ref libsemigroups::SmallestInteger<N>"
+        title="SmallestInteger" />
+    </tab>
     <tab type="usergroup" visible="yes" url="@ref dot_group" title="Visualisation">
       <tab type="usergroup" visible="yes" url="@ref libsemigroups::Dot" title="The Dot class">
         <tab type="user" visible="yes" url="@ref libsemigroups::Dot::Edge" title="The Edge class" />
@@ -433,6 +428,11 @@
       <tab type="user" visible="yes" url="@ref congruence_helpers_group"
         title="Congruence helper functions" />
       <tab type="user" visible="yes" url="@ref to_cong_group" title="to<Congruence>" />
+    </tab>
+    <tab type="usergroup" visible="yes" url="@ref core_classes_group" title="Core classes">
+      <tab type="user" visible="yes" url="@ref libsemigroups::Reporter" title="Reporter" />
+      <tab type="user" visible="yes" url="@ref libsemigroups::ReportGuard" title="ReportGuard" />
+      <tab type="user" visible="yes" url="@ref libsemigroups::Runner" title="Runner" />
     </tab>
     <tab type="usergroup" visible="yes" url="@ref froidure_pin_group" title="Froidure-Pin">
       <tab type="user" visible="yes" url="@ref libsemigroups::FroidurePin"

--- a/docs/authors.md
+++ b/docs/authors.md
@@ -1,0 +1,52 @@
+## Authors
+
+- [Reinis Cirpons](https://reinisc.id.lv) (<rc234@st-andrews.ac.uk>)
+- [Joseph Edwards](https://github.com/Joseph-Edwards) (<jde1@st-andrews.ac.uk>)
+- [James Mitchell](https://jdbm.me) (<jdm3@st-andrews.ac.uk>)
+
+## Contributors
+
+- [Luna Elliott](https://le27.github.io/L-Elliott/)
+  (<luna.elliott142857@gmail.com>)
+  contributed to the Schreier-Sims implementation.
+- Jan Engelhardt (<jengelh@inai.de>) contributed some bug fixes to the
+  build system, and a number of helpful issues.
+- Ilya Finkelshteyn (<ilyaf@appveyor.com>) contributed to the
+  continuous integration in AppVeyor.
+- Isuru Fernando (<isuruf@gmail.com>) contributed to the build system.
+- [Florent Hivert](https://www.lri.fr/~hivert/)
+  (<Florent.Hivert@lri.fr>) contributed many helpful ideas to
+  `libsemigroups`, and `HPCombi`.
+- [Max Horn](https://math.rptu.de/en/wgs/agag/people/head/prof-dr-max-horn)
+  (<max@quendi.de>) contributed some fixes.
+- [Jerry James](http://www.jamezone.org/) (<loganjerry@gmail.com>)
+  contributed some bugfixes.
+- [Julius Jonušas](http://julius.jonusas.work/) contributed to the
+  implementation of the Froidure-Pin algorithm.
+- [Samuel Lelièvre](https://lelievre.perso.math.cnrs.fr/index-en.html) (<samuel.lelievre@gmail.com>)
+  contributed a number of fixes to the docs.
+- Alex Levine (<A.Levine@uea.ac.uk>) contributed to the Schreier-Sims
+  implementation.
+- Michael Orlitzky (<michael@orlitzky.com>) contributed to the build system.
+- [Dima Pasechnik](https://pasechnik.info/dima)
+  (<dima@pasechnik.info>) contributed to the build system.
+- Chris Russell contributed some tests for finitely presented
+  semigroups.
+- [Finn Smith](https://flsmith.github.io) (<fls3@st-andrews.ac.uk>)
+  contributed the implementation of the Konieczny and
+  Lallement-McFadden algorithm, to the Todd-Coxeter implementation,
+  and to BMat8s.
+- [Nicolas Thiéry](http://nicolas.thiery.name/)
+  (<nthiery@users.sf.net>) contributed to the build system, packaging
+  `libsemigroups` via conda, the python bindings and many helpful
+  conversations and suggestions.
+- [Maria Tsalakou](https://mariatsalakou.github.io/) (<mt200@st-andrews.ac.uk>)
+  contributed to the Knuth-Bendix implementation, related algorithms for the
+  class `WordGraph`, and to the implementation of the `Ukkonen` and `Kambites`
+  classes.
+- [Wilf Wilson](https://wilf.me) (<wilf@wilf-wilson.net>) contributed some fixes.
+- Murray Whyte (<mw231@st-andrews.ac.uk>) contributed many examples of
+  finitely presented semigroups and monoids, to the documentation and reported a
+  number of bugs.
+- [Michael Young](https://mtorpey.github.io/) (<mct25@st-andrews.ac.uk>)
+  contributed to the congruences code in the v0.0.1 to v0.6.7.

--- a/docs/header.html
+++ b/docs/header.html
@@ -1,8 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!-- HTML header for doxygen 1.13.2-->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$langISO">
 <head>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
-<meta http-equiv="X-UA-Compatible" content="IE=9"/>
+<meta http-equiv="X-UA-Compatible" content="IE=11"/>
 <meta name="generator" content="Doxygen $doxygenversion"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 
@@ -21,8 +22,15 @@
 
 <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
 <!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
+<!--BEGIN PROJECT_ICON-->
+<link rel="icon" href="$relpath^$projecticon" type="image/x-icon" />
+<!--END PROJECT_ICON-->
 <link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>
-<link rel="icon" href="$relpath^$projectlogo"/>
+<!--BEGIN DISABLE_INDEX-->
+  <!--BEGIN FULL_SIDEBAR-->
+<script type="text/javascript">var page_layout=1;</script>
+  <!--END FULL_SIDEBAR-->
+<!--END DISABLE_INDEX-->
 <script type="text/javascript" src="$relpath^jquery.js"></script>
 <script type="text/javascript" src="$relpath^dynsections.js"></script>
 <script type="text/javascript" src="$relpath^doxygen-awesome-darkmode-toggle.js"></script>
@@ -43,7 +51,11 @@ $extrastylesheet
 <a href="https://github.com/libsemigroups/libsemigroups" class="github-corner" title="View source on GitHub" target="_blank" rel="noopener noreferrer">
     <svg viewBox="0 0 250 250" width="40" height="40" style="position: absolute; top: 0; border: 0; right: 0; z-index: 99;" aria-hidden="true">
     <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
-
+<!--BEGIN DISABLE_INDEX-->
+  <!--BEGIN FULL_SIDEBAR-->
+<div id="side-nav" class="ui-resizable side-nav-resizable"><!-- do not remove this div, it is closed by doxygen! -->
+  <!--END FULL_SIDEBAR-->
+<!--END DISABLE_INDEX-->
 
 <div id="top"><!-- do not remove this div, it is closed by doxygen! -->
 
@@ -51,9 +63,9 @@ $extrastylesheet
 <div id="titlearea">
 <table cellspacing="0" cellpadding="0">
  <tbody>
- <tr style="height: 56px;">
+ <tr id="projectrow">
   <!--BEGIN PROJECT_LOGO-->
-  <td id="projectlogo"><img alt="Logo" src="$relpath^$projectlogo"/></td>
+  <td id="projectlogo"><img alt="Logo" src="$relpath^$projectlogo"$logosize/></td>
   <!--END PROJECT_LOGO-->
   <!--BEGIN PROJECT_NAME-->
   <td id="projectalign" style="padding-left: 0.5em;">
@@ -76,6 +88,11 @@ $extrastylesheet
    <!--END SEARCHENGINE-->
   <!--END DISABLE_INDEX-->
  </tr>
+   <!--BEGIN SEARCHENGINE-->
+   <!--BEGIN FULL_SIDEBAR-->
+   <tr><td colspan="2">$searchbox</td></tr>
+   <!--END FULL_SIDEBAR-->
+  <!--END SEARCHENGINE-->
  </tbody>
 </table>
 </div>

--- a/docs/header.html
+++ b/docs/header.html
@@ -61,6 +61,7 @@ $extrastylesheet
 
 <!--BEGIN TITLEAREA-->
 <div id="titlearea">
+<a href="index.html">
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
@@ -95,6 +96,7 @@ $extrastylesheet
   <!--END SEARCHENGINE-->
  </tbody>
 </table>
+</a>
 </div>
 <!--END TITLEAREA-->
 <!-- end header part -->

--- a/docs/pictures/to-table.svg
+++ b/docs/pictures/to-table.svg
@@ -14,10 +14,10 @@
   <sodipodi:namedview
      id="namedview1815"
      pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="pt" />

--- a/etc/check_doxygen_line_breaks.py
+++ b/etc/check_doxygen_line_breaks.py
@@ -22,7 +22,7 @@ command_with_line_break = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
-globs = ["include/libsemigroups/*.hpp", "include/libsemigroups/detail*.hpp"]
+globs = ["include/libsemigroups/*.hpp", "include/libsemigroups/detail/*.hpp"]
 
 
 def process_file(filename):
@@ -54,7 +54,7 @@ def process_path(pathname):
     """
     print(
         BOLD_TEXT
-        + f"Checking for for bad linebreaks in {pathname} . . ."
+        + f"Checking for bad linebreaks in {pathname} . . ."
         + END_COLOUR
     )
     if version_info[1] < 11:

--- a/include/libsemigroups/action.hpp
+++ b/include/libsemigroups/action.hpp
@@ -80,12 +80,14 @@ namespace libsemigroups {
   //! o.size();  // returns 65536
   //! \endcode
 
-  //! \ingroup action_group
+  //! \ingroup types_group
   //! \brief Enum class indicating the handedness or side of an action.
   //!
   //! The values in this enum can be used as a template parameter for the Action
   //! class to specify whether the action of the Action  is a left or right
   //! action.
+  //!
+  //! \sa action_group
   enum class side {
     //! This value indicates that the action in an Action instance should be a
     //! left action.

--- a/include/libsemigroups/constants.hpp
+++ b/include/libsemigroups/constants.hpp
@@ -83,8 +83,6 @@ namespace libsemigroups {
 
   //! \defgroup constants_group Constants
   //!
-  //! \ingroup misc_group
-  //!
   //! \brief Documentation for constant values.
   //!
   //! This file contains functionality for various constant values used in

--- a/include/libsemigroups/detail/report.hpp
+++ b/include/libsemigroups/detail/report.hpp
@@ -180,7 +180,7 @@ namespace libsemigroups {
     report_default("{} elapsed time {}", prefix, tmr);
   }
 
-  //! \ingroup misc_group
+  //! \ingroup core_classes_group
   //!
   //! \brief Struct for specifying whether or not to report about an algorithm's
   //! performance.

--- a/include/libsemigroups/exception.hpp
+++ b/include/libsemigroups/exception.hpp
@@ -33,8 +33,6 @@
 namespace libsemigroups {
   //! \defgroup exception_group Exceptions
   //!
-  //! \ingroup misc_group
-  //!
   //! \brief Documentation for exceptions.
   //!
   //! This file contains functionality for the exceptions used in

--- a/include/libsemigroups/forest.hpp
+++ b/include/libsemigroups/forest.hpp
@@ -469,7 +469,7 @@ namespace libsemigroups {
     //! particular, it is not checked whether or not \p n is less than
     //! \ref number_of_nodes.
     [[nodiscard]] const_iterator_path
-    cend_path_to_root_no_checks(node_type) const noexcept {
+    cend_path_to_root_no_checks(node_type n) const noexcept {
       return const_iterator_path(this, UNDEFINED);
     }
 

--- a/include/libsemigroups/obvinf.hpp
+++ b/include/libsemigroups/obvinf.hpp
@@ -63,7 +63,6 @@ namespace libsemigroups {
   }
 
   //! \defgroup obvinf_group Obviously infinite
-  //! \ingroup misc_group
   //!
   //! \brief Functions for checking if a finitely presented semigroup or monoid
   //! is obviously infinite.

--- a/include/libsemigroups/obvinf.hpp
+++ b/include/libsemigroups/obvinf.hpp
@@ -294,6 +294,27 @@ namespace libsemigroups {
       return *this;
     }
 
+    //! \brief Add rules from iterators to std::vector of std::string.
+    //!
+    //! This function adds the rules described by the iterators \p first and
+    //! \p last. The rules are translated to \ref word_type objects using the
+    //! position of each character in the 1st argument \p lphbt.
+    //!
+    //! \param lphbt the alphabet to use.
+    //!
+    //! \param first iterator pointing at the left-hand-side of the first rule
+    //! to add.
+    //!
+    //! \param last iterator pointing one beyond the right-hand-side of the last
+    //! rule to add.
+    //!
+    //! \returns A reference to `*this`.
+    //!
+    //! \exceptions
+    //! \no_libsemigroups_except
+    //!
+    //! \warning
+    //! This function does not check its arguments.
     IsObviouslyInfinite& add_rules_no_checks(
         char const*                                       lphbt,
         typename std::vector<std::string>::const_iterator first,

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -31,13 +31,8 @@
 #include "ranges.hpp"
 
 namespace libsemigroups {
-  //! \defgroup orders_group Orders
-  //! This page contains the documentation for several class and function
-  //! templates for comparing words or strings with respect to certain reduction
-  //! orderings.
+  //! \ingroup types_group
   //!
-  //! @{
-
   //! \brief The possible orderings of words and strings.
   //!
   //! The values in this enum can be used as the arguments for functions such as
@@ -45,6 +40,8 @@ namespace libsemigroups {
   //! specify which ordering should be used. The normal forms for congruence
   //! classes are given with respect to one of the orders specified by the
   //! values in this enum.
+  //!
+  //! \sa orders_group
   enum class Order : uint8_t {
     //! No ordering.
     none = 0,
@@ -64,6 +61,13 @@ namespace libsemigroups {
 
     // wreath TODO(later)
   };
+
+  //! \defgroup orders_group Orders
+  //! This page contains the documentation for several class and function
+  //! templates for comparing words or strings with respect to certain reduction
+  //! orderings.
+  //!
+  //! @{
 
   //! \brief Compare two objects of the same type using
   //! std::lexicographical_compare.

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -67,6 +67,8 @@ namespace libsemigroups {
   //! templates for comparing words or strings with respect to certain reduction
   //! orderings.
   //!
+  //! \sa \ref Order
+  //!
   //! @{
 
   //! \brief Compare two objects of the same type using

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -774,7 +774,30 @@ namespace libsemigroups {
     template <typename Word>
     void throw_if_bad_inverses(Presentation<Word> const& p, Word const& vals);
 
-    // TODO(doc)
+    //! \brief Return a representation of a presentation to appear in the
+    //! reporting output.
+    //!
+    //! Return a representation of a presentation that will appear in the
+    //! reporting output. The information that is provided is:
+    //! - the size of the alphabet (`|A|`);
+    //! - the number of rules (`|R|`);
+    //! - the range of values of the lengths of the rules (`|u| +  |v|`); and
+    //! - the sum of the lengths of the rules (`∑(|u| + |v|)`).
+    //!
+    //! \tparam Word the type of the words in the presentation.
+    //! \param p the presentation.
+    //!
+    //! \returns A value of type `std::string`.
+    //!
+    //! \exceptions
+    //! \no_libsemigroups_except
+    //!
+    //! \par Example
+    //! \code
+    //! Presentation<std::string> p;
+    //! presentation::to_report_string(p)
+    //! // "|A| = 0, |R| = 0, |u| + |v| ∈ [0, 0], ∑(|u| + |v|) = 0"
+    //! \endcode
     template <typename Word>
     std::string to_report_string(Presentation<Word> const& p);
 

--- a/include/libsemigroups/runner.hpp
+++ b/include/libsemigroups/runner.hpp
@@ -326,15 +326,44 @@ namespace libsemigroups {
       return _prefix;
     }
 
+    //! \brief Set the divider string for reporting.
+    //!
+    //! This function sets the return value of report_divider() to (a copy of)
+    //! the argument \p val.
+    //!
+    //! \param val the new value of the report divider.
+    //!
+    //! \returns A reference to \c this.
+    //!
+    //! \note This function is not thread-safe.
+    // Not noexcept because std::string::operator= isn't
     Reporter& report_divider(std::string const& val) {
       _divider = val;
       return *this;
     }
 
+    //! \brief Get the current divider string for reporting.
+    //!
+    //! This function gets the current value of the divider string for reporting
+    //! (set via report_divider(std::string const&)).
+    //!
+    //! \returns A const reference to the divider string.
+    //!
+    //! \exceptions
+    //! \noexcept
+    //!
+    //! \note This function is thread-safe.
     [[nodiscard]] std::string const& report_divider() const noexcept {
       return _divider;
     }
 
+    //! \brief Emits the current divider string for reporting.
+    //!
+    //! This function emits the current divider string for reporting
+    //! (set via report_divider(std::string const&), and retrieved via
+    //! report_divider()).
+    //!
+    //! \note This function is thread-safe.
     void emit_divider() {
       if (!_divider.empty()) {
         report_no_prefix(_divider, "");

--- a/include/libsemigroups/runner.hpp
+++ b/include/libsemigroups/runner.hpp
@@ -46,11 +46,16 @@
 
 namespace libsemigroups {
 
-  //! \defgroup misc_group Miscellaneous
-  //! In this section we describe some miscellaneous functionality in
-  //! \c libsemigroups.
+  //! \defgroup core_classes_group Core Classes
   //!
-  //! \hidegroupgraph
+  //! Many of the classes in \c libsemigroups implement algorithms, and hence
+  //! are runnable. During the running of these algorithms, it is often
+  //! desirable to report the state of the algorithm. Therefore, the classes
+  //! \ref Runner and \ref Reporter exist to provide common functions to many
+  //! classes that implement the main algorithms.
+  //!
+  //! This page describes the functionality in \c libsemigroups related to
+  //! running and reporting.
 
   //! \relates Reporter
   //! \brief The time between a given point and now.
@@ -78,7 +83,7 @@ namespace libsemigroups {
   //! A pseudonym for std::chrono::nanoseconds::max().
   constexpr std::chrono::nanoseconds FOREVER = std::chrono::nanoseconds::max();
 
-  //! \ingroup misc_group
+  //! \ingroup core_classes_group
   //! \brief Collection of values related to reporting.
   //!
   //! Defined in `runner.hpp`.
@@ -337,7 +342,7 @@ namespace libsemigroups {
     }
   };
 
-  //! \ingroup misc_group
+  //! \ingroup core_classes_group
   //!
   //! \brief Abstract class for derived classes that run an algorithm.
   //!

--- a/include/libsemigroups/to-presentation.hpp
+++ b/include/libsemigroups/to-presentation.hpp
@@ -175,6 +175,17 @@ namespace libsemigroups {
   //!
   //! \exceptions
   //! \no_libsemigroups_except
+#ifdef LIBSEMIGROUPS_PARSED_BY_DOXYGEN
+  // FIXME(1) this is the same hack as elsewhere (deliberately introducing a
+  // typo) because Doxygen conflates functions with trailing return type but the
+  // same name and signature.
+  template <template <typename...> typename Thing,
+            typename Word,
+            typename Rewriter typename ReductionOrder>
+  auto to(KnutBendix<Word, Rewriter, ReductionOrder>& kb)
+      -> std::enable_if_t<std::is_same_v<Thing<Word>, Presentation<Word>>,
+                          Presentation<Word>>;
+#else
   template <template <typename...> typename Thing,
             typename Word,
             typename Rewriter,
@@ -184,6 +195,7 @@ namespace libsemigroups {
                           Presentation<Word>> {
     return to<Presentation<Word>>(kb);
   }
+#endif
 
   ////////////////////////////////////////////////////////////////////////
   // Presentation + function -> Presentation

--- a/include/libsemigroups/types.hpp
+++ b/include/libsemigroups/types.hpp
@@ -32,8 +32,6 @@
 namespace libsemigroups {
   //! \defgroup types_group Types
   //!
-  //! \ingroup misc_group
-  //!
   //! \brief Documentation for types and aliases.
   //!
   //! This file contains functionality for various types used in

--- a/include/libsemigroups/word-graph.hpp
+++ b/include/libsemigroups/word-graph.hpp
@@ -2199,9 +2199,29 @@ namespace libsemigroups {
     [[nodiscard]] std::unordered_set<Node1>
     nodes_reachable_from(WordGraph<Node1> const& wg, Node2 source);
 
+    //! \brief Returns the std::unordered_set of nodes that can reach a given
+    //! node in a word graph.
+    //!
+    //! This function returns a std::unordered_set consisting of all the nodes
+    //! in the word graph \p wg that can reach \p target. This function can be
+    //! thought of like an inverse of `nodes_reachable_from`, in the sense that
+    //! the node `a` \f$\in\f$ `ancestor_of(b)` for some node `b` if and only if
+    //! `b` \f$\in\f$ `nodes_reachable_from(a)`.
+    //!
+    //! \tparam Node1 the node type of the word graph.
+    //! \tparam Node2 the type of the node \p target.
+    //!
+    //! \param wg the word graph.
+    //! \param target the target node.
+    //!
+    //! \returns A std::unordered_set consisting of all the nodes in the word
+    //! graph \p wg that can reach \p target.
+    //!
+    //! \throws LibsemigroupsException if \p target is out of bounds (greater
+    //! than or equal to WordGraph::number_of_nodes).
     template <typename Node1, typename Node2>
     [[nodiscard]] std::unordered_set<Node1>
-    ancestors_of(WordGraph<Node1> const& wg, Node2 source);
+    ancestors_of(WordGraph<Node1> const& wg, Node2 target);
 
     //! \brief Returns the std::unordered_set of nodes reachable from a given
     //! node in a word graph.
@@ -2228,9 +2248,30 @@ namespace libsemigroups {
     [[nodiscard]] std::unordered_set<Node1>
     nodes_reachable_from_no_checks(WordGraph<Node1> const& wg, Node2 source);
 
+    //! \brief Returns the std::unordered_set of nodes that can reach a given
+    //! node in a word graph.
+    //!
+    //! This function returns a std::unordered_set consisting of all the nodes
+    //! in the word graph \p wg that can reach \p target. This function can be
+    //! thought of like an inverse of `nodes_reachable_from`, in the sense that
+    //! the node `a` \f$\in\f$ `ancestor_of(b)` for some node `b` if and only if
+    //! `b` \f$\in\f$ `nodes_reachable_from(a)`.
+    //!
+    //! \tparam Node1 the node type of the word graph.
+    //! \tparam Node2 the type of the node \p target.
+    //!
+    //! \param wg the word graph.
+    //! \param target the target node.
+    //!
+    //! \returns A std::unordered_set consisting of all the nodes in the word
+    //! graph \p wg that can reach \p target.
+    //!
+    //! \warning The arguments are not checked, and in particular it is assumed
+    //! that \p target is a node of \p wg (i.e. less than
+    //! WordGraph::number_of_nodes).
     template <typename Node1, typename Node2>
     [[nodiscard]] std::unordered_set<Node1>
-    ancestors_of_no_checks(WordGraph<Node1> const& wg, Node2 source);
+    ancestors_of_no_checks(WordGraph<Node1> const& wg, Node2 target);
 
     //! \brief Returns the number of nodes reachable from a given node in a
     //! word graph.

--- a/include/libsemigroups/word-range.hpp
+++ b/include/libsemigroups/word-range.hpp
@@ -775,6 +775,8 @@ namespace libsemigroups {
       std::unordered_map<typename From::value_type, letter_type> _alphabet_map;
 
      public:
+      //! \brief The type of values an instance of ToWord will convert into
+      //! \ref word_type.
       using from_type = From;
 
       //! \brief Default constructor.


### PR DESCRIPTION
This PR updates the doc so that it is more similar to https://github.com/libsemigroups/libsemigroups_pybind11. This includes restructuring the sidebar, and making the project info at the top of the sidebar clickable. It also adds some doc that was missing.

As it stands, the **top level** sidebar headers, and some lower level headers, are the same between `libsemigroups` and `libsemigroups_pybind11` (with a small number of exceptions outlined below). I have not checked that the headers at all depths are the same between the two projects. Due to the differences between Sphinx and Doxygen, and Python and C++, I think that it is correct to not insist the sidebar structure be identical. 

There are some notable differences between the doc here and in `libsemigroups_pybind11`:
- `libsemigroups_pybind11` has an "Exceptions" tab in the package info, whereas `libsemigroups` does not, since the exceptions in `libsemigroups` do not offer any insight into the structure of the library (as they do in `libsemigroups_pybind11`). Instead, the `libsemigroups` "Exceptions" tab is in "Data Structures".
- `libsemigroups_pybind11` has an "Enums" tab, whereas `libseimgroups` has a "Types" tab, since we document some none-enum types.
- There are some things not implemented in `libsemigroups_pybind11`, such as `Ranges`. Therefore, there are more tabs in the sidebar of `libsemigroups` than there are in `libsemigroups_pybind11`.

I'm not sure where I stand on the documentation of Enums and types. In `libsemigroups_pybind11`, we have all of the top-level enums documented in the "Enums" tab. I have replicated this behaviour in `libsemigroups`, but something felt wrong about moving the `Order` enum out of the `Orders` tab. I am open to suggestions about which idea is better, because I can see the benefits of both. 