### PR TITLE
CI: Add a mac arm runner and update compiler versions

### DIFF
--- a/.github/workflows/compile-warnings.yml
+++ b/.github/workflows/compile-warnings.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [clang++-18, g++-14]
+        compiler: [clang++, g++]
     steps:
       - uses: actions/checkout@v4
       - name: Setup ccache . . .

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -59,9 +59,15 @@ jobs:
       - name: Run the quick tests (ex:no-cygwin)
         run: ./test_all "[quick][exclude:no-cygwin]"
   macos:
-    name: macOS
+    name: macOS (${{ matrix.os.name }})
     timeout-minutes: 60
-    runs-on: macOS-latest
+    runs-on: ${{ matrix.os.image_name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - { image_name: macos-latest, name: x86_64 }
+          - { image_name: macos-latest-large, name: arm64 }
     env:
       CXX: ccache clang++
       CXXFLAGS: -fdiagnostics-color
@@ -72,6 +78,8 @@ jobs:
         with:
           update_packager_index: false
           install_ccache: true
+      - name: Runner information . . .
+        run: uname --machine --processor --hardware-platform
       - name: Install dependencies . . .
         run: brew install autoconf automake libtool
       - name: Clang version . . .


### PR DESCRIPTION
This PR adds a job that runs the quick test on the `macos-latest-large` image. If I understand correctly, this currently runs macOS 14 on an arm64 processor. Hopefully, this will fail for the reasons highlighted in #758, and will make it easier to spot problems like this faster moving forwards.

Additionally, this PR unpins the compiler versions that we use to check for compiler warnings.  