### PR TITLE
Update compiler versions and add Mac arm runner

### DIFF
--- a/.github/workflows/compile-warnings.yml
+++ b/.github/workflows/compile-warnings.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [clang++-18, g++-14]
+        compiler: [clang++-19, g++-14]
     steps:
       - uses: actions/checkout@v4
       - name: Setup ccache . . .

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -14,6 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         sys:
+          # If you update the following list, please also update the compilers
+          # in compiler-warnings.yml to point to the latest version
           - { compiler: g++, version: 9 }
           - { compiler: g++, version: 10 }
           - { compiler: g++, version: 11 }

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -59,9 +59,15 @@ jobs:
       - name: Run the quick tests (ex:no-cygwin)
         run: ./test_all "[quick][exclude:no-cygwin]"
   macos:
-    name: macOS
+    name: "macOS-${{ matrix.os.arch }}"
     timeout-minutes: 60
-    runs-on: macOS-latest
+    runs-on: ${{ matrix.os.image_name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - { image_name: macos-latest, arch: arm }
+          - { image_name: macos-13, arch: x86 }
     env:
       CXX: ccache clang++
       CXXFLAGS: -fdiagnostics-color
@@ -72,6 +78,8 @@ jobs:
         with:
           update_packager_index: false
           install_ccache: true
+      - name: Runner information . . .
+        run: uname -a
       - name: Install dependencies . . .
         run: brew install autoconf automake libtool
       - name: Clang version . . .

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -1,5 +1,5 @@
 name: OS
-on: pull_request
+on: [pull_request, workflow_dispatch]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR supersedes #760. It adds a Mac arm runner, and updates the version of the compilers used to check for compiler warnings.