### PR TITLE
Release candidate for v3.1.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,5 +33,5 @@ abstract: >-
   algorithms for computing finite, and finitely presented,
   semigroups and monoids.
 license: GPL-3.0
-version: 3.1.1
-date-released: "2025-07-28"
+version: 3.1.2
+date-released: "2025-07-29"

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = libsemigroups
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v3.1.1
+PROJECT_NUMBER         = v3.1.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewers a

--- a/docs/changelog-v3.md
+++ b/docs/changelog-v3.md
@@ -1,5 +1,14 @@
 # Changelog - version 3
 
+## v3.1.2 (released 29/07/2025)
+
+This is a minor release fixing some more issues that were introduced in v3.1.0.
+Namely:
+
+* Remove remaining occurrences of ``std::basic_string<uint8_t>`` by
+  @joseph-edwards in
+  https://github.com/libsemigroups/libsemigroups/pull/772
+
 ## v3.1.1 (released 28/07/2025)
 
 This is a minor release fixing some issues in the previous release. It is

--- a/docs/install.md
+++ b/docs/install.md
@@ -34,10 +34,10 @@ To build `libsemigroups` from the github repository:
 
 To build `libsemigroups` from a release archive:
 
-    curl -L -O https://github.com/libsemigroups/libsemigroups/releases/latest/download/libsemigroups-3.1.1.tar.gz
-    tar -xf libsemigroups-3.1.1.tar.gz
-    rm -f libsemigroups-3.1.1.tar.gz
-    cd libsemigroups-3.1.1
+    curl -L -O https://github.com/libsemigroups/libsemigroups/releases/latest/download/libsemigroups-3.1.2.tar.gz
+    tar -xf libsemigroups-3.1.2.tar.gz
+    rm -f libsemigroups-3.1.2.tar.gz
+    cd libsemigroups-3.1.2
     ./configure && make -j8 && sudo make install
 
 ## Configuration options


### PR DESCRIPTION
This PR contains the necessary version number, date and changelog updates before the release of v3.1.2.