### PR TITLE
Balance presentation

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -87,6 +87,7 @@ jobs:
             libtool
             pkg-config
             compiler-rt
+            ld64
             ${{ matrix.sys.package }}
       - name: "Set environment variables . . ."
         run: |

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -94,7 +94,10 @@ jobs:
           echo "LD_LIBRARY_PATH=$MAMBA_ROOT_PREFIX/envs/builder/lib:/usr/local/lib" >> $GITHUB_ENV
           echo "PATH=$MAMBA_ROOT_PREFIX/envs/builder/bin:$PATH" >> $GITHUB_ENV
       - name: Compiler info . . .
-        run: ${{ matrix.sys.compiler }} --version
+        run: |
+          ${{ matrix.sys.compiler }} --version
+          ld -v
+
       - name: Configure . . .
         run: |
           ./autogen.sh

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build libsemigroups . . .
         run: sudo make install -j4
       - name: Clone libsemigroups_pybind11 . . .
-        run: git clone "$URL" --depth 1 --branch v1
+        run: git clone "$URL" --depth 1 --branch main
       - name: Install prerequisites for libsemigroups_pybind11 . . .
         run: |
           cd libsemigroups_pybind11

--- a/benchmarks/bench-todd-coxeter.cpp
+++ b/benchmarks/bench-todd-coxeter.cpp
@@ -36,7 +36,8 @@
 #include "libsemigroups/detail/report.hpp"  // for ReportGuard
 //
 namespace libsemigroups {
-  using literals::operator""_p;
+  using literals::            operator""_p;
+  using std::string_literals::operator""s;
   using strategy         = detail::ToddCoxeterImpl::options::strategy;
   using lookahead_extent = detail::ToddCoxeterImpl::options::lookahead_extent;
   using def_policy       = detail::ToddCoxeterImpl::options::def_policy;
@@ -1360,7 +1361,7 @@ namespace libsemigroups {
           p,
           "abbbbabbbbbbbbbbabbbbabbbbbbbbbbbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaa",
           "");
-      presentation::balance_no_checks(p, "abAB", "ABab");
+      presentation::balance_no_checks(p, "abAB"s, "ABab"s);
       presentation::sort_rules(p);
 
       emit_xml_presentation_tags(p, "SL219", 180);

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -41,11 +41,11 @@
 #include <utility>           // for move, pair
 #include <vector>            // for vector, operator!=
 
-#include "adapters.hpp"   // for Hash, EqualTo
-#include "constants.hpp"  // for Max, UNDEFINED, operator==
-#include "debug.hpp"      // for LIBSEMIGROUPS_ASSERT
-#include "is_specialization_of.hpp"
-#include "order.hpp"       // for ShortLexCompare
+#include "adapters.hpp"              // for Hash, EqualTo
+#include "constants.hpp"             // for Max, UNDEFINED, operator==
+#include "debug.hpp"                 // for LIBSEMIGROUPS_ASSERT
+#include "is_specialization_of.hpp"  // for is_specialization_of
+#include "order.hpp"                 // for ShortLexCompare
 #include "ranges.hpp"      // for seq, operator|, rx, take, chain, is_sorted
 #include "types.hpp"       // for word_type
 #include "ukkonen.hpp"     // for GreedyReduceHelper, Ukkonen
@@ -2578,6 +2578,184 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if \p has more than 49 generators.
     std::string to_gap_string(Presentation<std::string> const& p,
                               std::string const&               var_name);
+
+    //! \brief Find a rule.
+    //!
+    //! This function returns an iterator `it` pointing at the first
+    //! occurrence of \p lhs in an even index position of `p.rules` such
+    //! that `it + 1` points at \p rhs.
+    //!
+    //! \param p the presentation.
+    //! \param lhs the left-hand side of the rule.
+    //! \param rhs the right-hand side of the rule.
+    //!
+    //! \returns An iterator.
+    //!
+    //! \warning
+    //! This function does no checks on its argument. In particular, it does not
+    //! check that \p p is properly defined, namely that the length of
+    //! `p.rules` is even. If the rule we are trying to find is not in
+    //! `p.rules`, then bad things might happen.
+    template <typename Word>
+    [[nodiscard]] typename std::vector<Word>::iterator
+    find_rule_no_checks(Presentation<Word>& p,
+                        Word const&         lhs,
+                        Word const&         rhs);
+
+    //! \brief Find a rule.
+    //!
+    //! This function returns an iterator `it` pointing at the first
+    //! occurrence of \p lhs in an even index position of `p.rules` such
+    //! that `it + 1` points at \p rhs.
+    //!
+    //! \param p the presentation.
+    //! \param lhs the left-hand side of the rule.
+    //! \param rhs the right-hand side of the rule.
+    //!
+    //! \returns An iterator.
+    //!
+    //! \throws LibsemigroupsException if
+    //! `p.throw_if_bad_alphabet_or_rules()` throws.
+    template <typename Word>
+    [[nodiscard]] typename std::vector<Word>::iterator
+    find_rule(Presentation<Word>& p, Word const& lhs, Word const& rhs) {
+      p.throw_if_bad_alphabet_or_rules();
+      return find_rule_no_checks(p, lhs, rhs);
+    }
+
+    //! \brief Find a rule.
+    //!
+    //! This function returns an iterator `it` pointing at the first
+    //! occurrence of \p lhs in an even index position of `p.rules` such
+    //! that `it + 1` points at \p rhs.
+    //!
+    //! \param p the presentation.
+    //! \param lhs the left-hand side of the rule.
+    //! \param rhs the right-hand side of the rule.
+    //!
+    //! \returns An iterator.
+    //!
+    //! \warning
+    //! This function does no checks on its argument. In particular, it does not
+    //! check that \p p is properly defined, namely that the length of
+    //! `p.rules` is even. If the rule we are trying to find is not in
+    //! `p.rules`, then bad things might happen.
+    template <typename Word>
+    [[nodiscard]] typename std::vector<Word>::const_iterator
+    find_rule_no_checks(Presentation<Word> const& p,
+                        Word const&               lhs,
+                        Word const&               rhs) {
+      return find_rule_no_checks(const_cast<Presentation<Word>&>(p), lhs, rhs);
+    }
+
+    //! \brief Find a rule.
+    //!
+    //! This function returns an iterator `it` pointing at the first
+    //! occurrence of \p lhs in an even index position of `p.rules` such
+    //! that `it + 1` points at \p rhs.
+    //!
+    //! \param p the presentation.
+    //! \param lhs the left-hand side of the rule.
+    //! \param rhs the right-hand side of the rule.
+    //!
+    //! \returns An iterator.
+    //!
+    //! \throws LibsemigroupsException if
+    //! `p.throw_if_bad_alphabet_or_rules()` throws.
+    template <typename Word>
+    [[nodiscard]] typename std::vector<Word>::const_iterator
+    find_rule(Presentation<Word> const& p, Word const& lhs, Word const& rhs) {
+      return find_rule(const_cast<Presentation<Word>&>(p), lhs, rhs);
+    }
+
+    //! \brief Returns the index of a rule or \ref UNDEFINED.
+    //!
+    //! This function returns the minimum index \c i of \p lhs such that
+    //! `p.rules[i + 1]` equals \p rhs; or \ref UNDEFINED if there is not
+    //! such rule
+    //!
+    //! \param p the presentation.
+    //! \param lhs the left-hand side of the rule.
+    //! \param rhs the right-hand side of the rule.
+    //!
+    //! \returns The index of the rule or \ref UNDEFINED.
+    //!
+    //! \warning
+    //! This function does no checks on its argument. In particular, it does not
+    //! check that \p p is properly defined, namely that the length of
+    //! `p.rules` is even. If the rule we are trying to find is not in
+    //! `p.rules`, then bad things might happen.
+    template <typename Word>
+    [[nodiscard]] size_t index_rule_no_checks(Presentation<Word> const& p,
+                                              Word const&               lhs,
+                                              Word const&               rhs);
+
+    //! \brief Returns the index of a rule or \ref UNDEFINED.
+    //!
+    //! This function returns the minimum index \c i of \p lhs such that
+    //! `p.rules[i + 1]` equals \p rhs; or \ref UNDEFINED if there is not
+    //! such rule
+    //!
+    //! \param p the presentation.
+    //! \param lhs the left-hand side of the rule.
+    //! \param rhs the right-hand side of the rule.
+    //!
+    //! \returns The index of the rule or \ref UNDEFINED.
+    //!
+    //! \throws LibsemigroupsException if
+    //! `p.throw_if_bad_alphabet_or_rules()` throws.
+    template <typename Word>
+    [[nodiscard]] size_t index_rule(Presentation<Word> const& p,
+                                    Word const&               lhs,
+                                    Word const&               rhs) {
+      p.throw_if_bad_alphabet_or_rules();
+      return index_rule_no_checks(p, lhs, rhs);
+    }
+
+    //! \brief Check whether a rule belongs to a presentation.
+    //!
+    //! This function returns \c true if \p lhs and \p rhs form a rule in \p p.
+    //! That is if \p lhs occurs in an even index position in `p.rules` and
+    //! \p rhs is the next item in `p.rules`.
+    //!
+    //! \param p the presentation.
+    //! \param lhs the left-hand side of the rule.
+    //! \param rhs the right-hand side of the rule.
+    //!
+    //! \returns Whether or not \p lhs and \p rhs form a rule in \p p.
+    //!
+    //! \warning
+    //! This function does no checks on its argument. In particular, it does not
+    //! check that \p p is properly defined, namely that the length of
+    //! `p.rules` is even. If the rule we are trying to find is not in
+    //! `p.rules`, then bad things might happen.
+    template <typename Word>
+    [[nodiscard]] bool is_rule_no_checks(Presentation<Word> const& p,
+                                         Word const&               lhs,
+                                         Word const&               rhs) {
+      return find_rule_no_checks(p, lhs, rhs) != p.rules.end();
+    }
+
+    //! \brief Check whether a rule belongs to a presentation.
+    //!
+    //! This function returns \c true if \p lhs and \p rhs form a rule in \p p.
+    //! That is if \p lhs occurs in an even index position in `p.rules` and
+    //! \p rhs is the next item in `p.rules`.
+    //!
+    //! \param p the presentation.
+    //! \param lhs the left-hand side of the rule.
+    //! \param rhs the right-hand side of the rule.
+    //!
+    //! \returns Whether or not \p lhs and \p rhs form a rule in \p p.
+    //!
+    //! \throws LibsemigroupsException if
+    //! `p.throw_if_bad_alphabet_or_rules()` throws.
+    template <typename Word>
+    [[nodiscard]] bool is_rule(Presentation<Word> const& p,
+                               Word const&               lhs,
+                               Word const&               rhs) {
+      return find_rule(p, lhs, rhs) != p.rules.end();
+    }
 
   }  // namespace presentation
 

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -2282,21 +2282,15 @@ namespace libsemigroups {
     //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
     //! to allow std::string_view to be used for the parameters \p letters and
     //! \p inverses.
-    inline void balance_no_checks(Presentation<std::string>& p,
-                                  std::string_view           letters,
-                                  std::string_view           inverses) {
-      balance_no_checks<std::string, std::string_view>(p, letters, inverses);
-    }
-
-    //! \brief Balance the length of the left-hand and right-hand sides.
     //!
-    //! This is an overload for
-    //! \ref balance_no_checks(Presentation<Word>&, Word const&)
-    //! to allow std::string_view to be used for the parameters \p letters and
-    //! \p inverses.
-    inline void balance_no_checks(Presentation<std::string>& p,
-                                  std::string_view           inverses) {
-      balance_no_checks(p, std::string_view(p.alphabet()), inverses);
+    // clang-format off
+    // NOLINTNEXTLINE(whitespace/line_length)
+    //! \deprecated_alias_warning{balance_no_checks(Presentation<Word>&, Word const&, Word const&)}
+    // clang-format on
+    inline void balance_no_checks [[deprecated]] (Presentation<std::string>& p,
+                                                  std::string_view letters,
+                                                  std::string_view inverses) {
+      balance_no_checks<std::string, std::string_view>(p, letters, inverses);
     }
 
     //! \brief Balance the length of the left-hand and right-hand sides.
@@ -2305,50 +2299,16 @@ namespace libsemigroups {
     //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
     //! to allow string literals to be used for the parameters \p letters and
     //! \p inverses.
-    inline void balance_no_checks(Presentation<std::string>& p,
-                                  char const*                letters,
-                                  char const*                inverses) {
+    //!
+    // clang-format off
+    // NOLINTNEXTLINE(whitespace/line_length)
+    //! \deprecated_alias_warning{balance_no_checks(Presentation<Word>&, Word const&, Word const&)}
+    // clang-format on
+    inline void balance_no_checks [[deprecated]] (Presentation<std::string>& p,
+                                                  char const* letters,
+                                                  char const* inverses) {
       balance_no_checks(
           p, std::string_view(letters), std::string_view(inverses));
-    }
-
-    //! \brief Balance the length of the left-hand and right-hand sides.
-    //!
-    //! This is an overload for
-    //! \ref balance_no_checks(Presentation<Word>&, Word const&)
-    //! to allow std::initializer_list<char> to be used for the parameters
-    //! \p letters and \p inverses.
-    inline void balance_no_checks(Presentation<std::string>& p,
-                                  char const*                inverses) {
-      balance_no_checks(
-          p, std::string_view(p.alphabet()), std::string_view(inverses));
-    }
-
-    //! \brief Balance the length of the left-hand and right-hand sides.
-    //!
-    //! This is an overload for
-    //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
-    //! to allow std::initializer_list<char> to be used for the parameters
-    //! \p letters and \p inverses.
-    // There's some weirdness with {0} being interpreted as a string_view, which
-    // means that the next overload is required
-    inline void balance_no_checks(Presentation<std::string>&         p,
-                                  std::initializer_list<char> const& letters,
-                                  std::initializer_list<char> const& inverses) {
-      balance_no_checks(p, std::string(letters), std::string(inverses));
-    }
-
-    //! \brief Balance the length of the left-hand and right-hand sides.
-    //!
-    //! This is an overload for
-    //! \ref balance_no_checks(Presentation<Word>&, Word const&)
-    //! to allow std::initializer_list<char> to be used for the parameters
-    //! \p letters and \p inverses.
-    // There's some weirdness with {0} being interpreted as a string_view, which
-    // means that the next overload is required
-    inline void balance_no_checks(Presentation<std::string>&         p,
-                                  std::initializer_list<char> const& inverses) {
-      balance_no_checks(p, p.alphabet(), std::string(inverses));
     }
 
     //! \brief Balance the length of the left-hand and right-hand sides.
@@ -2418,78 +2378,6 @@ namespace libsemigroups {
                  Word const&         letters,
                  Word const&         inverses) {
       balance<Word, Word>(p, letters, inverses);
-    }
-
-    //! \brief Balance the length of the left-hand and right-hand sides.
-    //!
-    //! This is an overload for
-    //! \ref balance(Presentation<Word1>&, Word2 const&, Word2 const&)
-    //! to allow std::string_view to be used for the parameters \p letters and
-    //! \p inverses.
-    inline void balance(Presentation<std::string>& p,
-                        std::string_view           letters,
-                        std::string_view           inverses) {
-      balance<std::string, std::string_view>(p, letters, inverses);
-    }
-
-    //! \brief Balance the length of the left-hand and right-hand sides.
-    //!
-    //! This is an overload for
-    //! \ref balance(Presentation<Word>&, Word const&)
-    //! to allow std::string_view to be used for the parameters \p letters and
-    //! \p inverses.
-    inline void balance(Presentation<std::string>& p,
-                        std::string_view           inverses) {
-      balance<std::string, std::string_view>(p, p.alphabet(), inverses);
-    }
-
-    //! \brief Balance the length of the left-hand and right-hand sides.
-    //!
-    //! This is an overload for
-    //! \ref balance(Presentation<Word1>&, Word2 const&, Word2 const&)
-    //! to allow string literals to be used for the parameters \p letters and
-    //! \p inverses.
-    inline void balance(Presentation<std::string>& p,
-                        char const*                letters,
-                        char const*                inverses) {
-      balance(p, std::string_view(letters), std::string_view(inverses));
-    }
-
-    //! \brief Balance the length of the left-hand and right-hand sides.
-    //!
-    //! This is an overload for
-    //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
-    //! to allow string literals to be used for the parameters \p letters and
-    //! \p inverses.
-    inline void balance(Presentation<std::string>& p, char const* inverses) {
-      balance(p, std::string_view(p.alphabet()), std::string_view(inverses));
-    }
-
-    //! \brief Balance the length of the left-hand and right-hand sides.
-    //!
-    //! This is an overload for
-    //! \ref balance(Presentation<Word1>&, Word2 const&, Word2 const&)
-    //! to allow std::initializer_list<char> to be used for the parameters
-    //! \p letters and \p inverses.
-    // There's some weirdness with {0} being interpreted as a string_view, which
-    // means that the next overload is required
-    inline void balance(Presentation<std::string>&         p,
-                        std::initializer_list<char> const& letters,
-                        std::initializer_list<char> const& inverses) {
-      balance(p, std::string(letters), std::string(inverses));
-    }
-
-    //! \brief Balance the length of the left-hand and right-hand sides.
-    //!
-    //! This is an overload for
-    //! \ref balance(Presentation<Word1>&, Word2 const&, Word2 const&)
-    //! to allow std::initializer_list<char> to be used for the parameters
-    //! \p letters and \p inverses.
-    // There's some weirdness with {0} being interpreted as a string_view, which
-    // means that the next overload is required
-    inline void balance(Presentation<std::string>&         p,
-                        std::initializer_list<char> const& inverses) {
-      balance(p, p.alphabet(), std::string(inverses));
     }
 
     //! \brief Detect inverses and balance the length of the left-hand and

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -2200,6 +2200,8 @@ namespace libsemigroups {
     //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
     //! to allow, for example, std::initializer_list to be used for the
     //! parameters \p letters and \p inverses.
+    // Note that this doesn't work when Word = std::string and so we also
+    // require an overload specifically taking initializer_list's too.
     template <typename Word>
     void balance_no_checks(Presentation<Word>& p,
                            Word const&         letters,
@@ -2211,7 +2213,19 @@ namespace libsemigroups {
     //!
     //! This is an overload for
     //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
-    //! to allow, string literals to be used for the parameters \p letters and
+    //! to allow std::string_view to be used for the parameters \p letters and
+    //! \p inverses.
+    inline void balance_no_checks(Presentation<std::string>& p,
+                                  std::string_view           letters,
+                                  std::string_view           inverses) {
+      balance_no_checks<std::string, std::string_view>(p, letters, inverses);
+    }
+
+    //! \brief Balance the length of the left-hand and right-hand sides.
+    //!
+    //! This is an overload for
+    //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
+    //! to allow string literals to be used for the parameters \p letters and
     //! \p inverses.
     inline void balance_no_checks(Presentation<std::string>& p,
                                   char const*                letters,
@@ -2224,19 +2238,104 @@ namespace libsemigroups {
     //!
     //! This is an overload for
     //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
-    //! to allow, std::string_view to be used for the parameters \p letters and
-    //! \p inverses.
-    inline void balance_no_checks(Presentation<std::string>& p,
-                                  std::string_view           letters,
-                                  std::string_view           inverses) {
-      balance_no_checks<std::string, std::string_view>(p, letters, inverses);
+    //! to allow std::initializer_list<char> to be used for the parameters
+    //! \p letters and \p inverses.
+    // There's some weirdness with {0} being interpreted as a string_view, which
+    // means that the next overload is required
+    inline void balance_no_checks(Presentation<std::string>&         p,
+                                  std::initializer_list<char> const& letters,
+                                  std::initializer_list<char> const& inverses) {
+      balance_no_checks(p, std::string(letters), std::string(inverses));
     }
 
-    // TODO(later) add balance that checks p contains empty word, no duplicate
-    // letters in alphabet, and inverses are valid.
+    //! \brief Balance the length of the left-hand and right-hand sides.
+    //!
+    //! See
+    //! \ref balance(Presentation<Word1>&, Word2 const&, Word2 const&)
+    //! for details about this function.
+    //!
+    //! \tparam Word1 the type of the words in the presentation.
+    //! \tparam Word2 the type of the words \p letters and \p inverses.
+    //! \param p the presentation.
+    //! \param letters the letters that can be replaced in the left-hand side.
+    //! \param inverses the inverses of the letters.
+    //!
+    //! \throws LibsemigroupsException if \ref throw_if_bad_alphabet_or_rules
+    //! throws.
+    //! \throws LibsemigroupsException if \ref throw_if_bad_inverses throws
+    //! when called with \p letters and \p inverses. This does not check that
+    //! the values in \p inverses are actually inverses for the values in
+    //! \p letters, and balances the relations as described in
+    //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
+    //! assuming that this is the case.
+    template <typename Word1, typename Word2>
+    void balance(Presentation<Word1>& p,
+                 Word2 const&         letters,
+                 Word2 const&         inverses) {
+      p.throw_if_bad_alphabet_or_rules();
+      throw_if_bad_inverses(p, letters, inverses);
+
+      balance_no_checks(p, letters, inverses);
+    }
+
+    //! \brief Balance the length of the left-hand and right-hand sides.
+    //!
+    //! This is an overload for
+    //! \ref balance(Presentation<Word1>&, Word2 const&, Word2 const&)
+    //! to allow, for example, std::initializer_list to be used for the
+    //! parameters \p letters and \p inverses.
+    // Note that this doesn't work when Word = std::string and so we also
+    // require an overload specifically taking initializer_list's too.
+    template <typename Word>
+    void balance(Presentation<Word>& p,
+                 Word const&         letters,
+                 Word const&         inverses) {
+      balance<Word, Word>(p, letters, inverses);
+    }
+
+    //! \brief Balance the length of the left-hand and right-hand sides.
+    //!
+    //! This is an overload for
+    //! \ref balance(Presentation<Word1>&, Word2 const&, Word2 const&)
+    //! to allow std::string_view to be used for the parameters \p letters and
+    //! \p inverses.
+    inline void balance(Presentation<std::string>& p,
+                        std::string_view           letters,
+                        std::string_view           inverses) {
+      balance<std::string, std::string_view>(p, letters, inverses);
+    }
+
+    //! \brief Balance the length of the left-hand and right-hand sides.
+    //!
+    //! This is an overload for
+    //! \ref balance(Presentation<Word1>&, Word2 const&, Word2 const&)
+    //! to allow string literals to be used for the parameters \p letters and
+    //! \p inverses.
+    inline void balance(Presentation<std::string>& p,
+                        char const*                letters,
+                        char const*                inverses) {
+      balance(p, std::string_view(letters), std::string_view(inverses));
+    }
+
+    //! \brief Balance the length of the left-hand and right-hand sides.
+    //!
+    //! This is an overload for
+    //! \ref balance(Presentation<Word1>&, Word2 const&, Word2 const&)
+    //! to allow std::initializer_list<char> to be used for the parameters
+    //! \p letters and \p inverses.
+    // There's some weirdness with {0} being interpreted as a string_view, which
+    // means that the next overload is required
+    inline void balance(Presentation<std::string>&         p,
+                        std::initializer_list<char> const& letters,
+                        std::initializer_list<char> const& inverses) {
+      balance(p, std::string(letters), std::string(inverses));
+    }
 
     // TODO version of balance that only specified inverses, and uses the
     // alphabet as the letters
+
+    // TODO version that detects inverse rules in the presentation and uses
+    // those if possible
 
     //! \brief Add all cyclic permutations of a word as relators in a
     //! presentation.
@@ -2329,7 +2428,7 @@ namespace libsemigroups {
     //!
     //! This is an overload for
     //! \ref add_cyclic_conjugates(Presentation<Word1>&, Word2 const&)
-    //! to allow, string literals to be used for the parameters \p relator.
+    //! to allow string literals to be used for the parameters \p relator.
     inline void add_cyclic_conjugates(Presentation<std::string>& p,
                                       char const*                relator) {
       add_cyclic_conjugates<std::string, std::string_view>(

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -2450,8 +2450,31 @@ namespace libsemigroups {
       balance(p, p.alphabet(), std::string(inverses));
     }
 
-    // TODO version that detects inverse rules in the presentation and uses
-    // those if possible
+    //! \brief Detect inverses and balance the length of the left-hand and
+    //! right-hand sides.
+    //!
+    //! This function calls
+    //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
+    //! where the 2nd and 3rd arguments are deduced from the rules in the
+    //! presentation if possible as follows: the rules of the presentation
+    //! where one side has length 2 and the other has length 0 are detected.
+    //! For any such rule we remember that the first letter is the inverse of
+    //! the second and vice versa. If there are no such rules, then no changes
+    //! are made. If there are multiple different such rules and we deduce
+    //! conflicting values for the inverse of a letter, then an exception is
+    //! thrown.
+    //!
+    //! \tparam Word the type of the words in the presentation.
+    //! \param p the presentation.
+    //!
+    //! \throws LibsemigroupsException if
+    //! \ref Presentation::throw_if_bad_alphabet_or_rules throws.
+    //! \throws LibsemigroupsException if conflicting inverses for any letter
+    //! are detected.
+    // There's no no_check version of this function because we need to try and
+    // detect the inverse and if we cannot we have to throw an exception.
+    template <typename Word>
+    void balance(Presentation<Word>& p);
 
     //! \brief Add all cyclic permutations of a word as relators in a
     //! presentation.

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -250,6 +250,41 @@ namespace libsemigroups {
     //! * \ref throw_if_bad_alphabet_or_rules
     Presentation& alphabet(word_type&& lphbt);
 
+    //! \brief Set the alphabet from string_view.
+    //!
+    //! This is an overload for \ref alphabet(word_type&&) to allow
+    //! std::string_view to be used for the parameter \p lphbt.
+    //!
+    //! \warning This function is only enabled if \ref word_type is std::string.
+    template <typename Return = Presentation&>
+    auto alphabet(std::string_view lphbt)
+        -> std::enable_if_t<std::is_same_v<std::string, word_type>, Return&> {
+      return alphabet(std::string(lphbt));
+    }
+
+    //! \brief Set the alphabet from string literal.
+    //!
+    //! This is an overload for \ref alphabet(word_type&&) to allow
+    //! string literals to be used for the parameter \p lphbt.
+    //!
+    //! \warning This function is only enabled if \ref word_type is std::string.
+    template <typename Return = Presentation&>
+    auto alphabet(char const* lphbt)
+        -> std::enable_if_t<std::is_same_v<std::string, word_type>, Return> {
+      return alphabet(std::string(lphbt));
+    }
+
+    //! \brief Set the alphabet from std::initializer_list.
+    //!
+    //! This is an overload for \ref alphabet(word_type&&) to allow
+    //! std::initializer_list to be used for the parameter \p lphbt.
+    // There's some weirdness with {0} being interpreted as a string_view, which
+    // means that the next overload is required
+    Presentation& alphabet(
+        std::initializer_list<typename word_type::value_type> const& lphbt) {
+      return alphabet(word_type(lphbt));
+    }
+
     //! \brief Set the alphabet to be the letters in the rules.
     //!
     //! Sets the alphabet to be the letters in \ref rules.

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -2307,8 +2307,7 @@ namespace libsemigroups {
     inline void balance_no_checks [[deprecated]] (Presentation<std::string>& p,
                                                   char const* letters,
                                                   char const* inverses) {
-      balance_no_checks(
-          p, std::string_view(letters), std::string_view(inverses));
+      balance_no_checks(p, std::string(letters), std::string(inverses));
     }
 
     //! \brief Balance the length of the left-hand and right-hand sides.

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -785,30 +785,60 @@ namespace libsemigroups {
       }
     }
 
-    //! \brief throw_if_bad_alphabet_or_rules if \p vals act as semigroup
-    //! inverses in \p p.
+    //! \brief Throws an exception if \p vals do not define valid inverses.
     //!
-    //! Check if the values in \p vals act as semigroup inverses for the letters
-    //! of the alphabet of \p p. Specifically, it checks that the \f$i\f$th
-    //! value in \p vals acts as an inverse for the \f$i\f$th value in
+    //! This function checks if the values in \p inverses are valid semigroup
+    //! inverses for `p.alphabet()`. Specifically, it checks that the \f$i\f$th
+    //! value in \p inverses is an inverse for the \f$i\f$th value in
     //! `p.alphabet()`.
     //!
     //! Let \f$x_i\f$ be the \f$i\f$th letter in `p.alphabet()`, and
-    //! suppose that \f$x_i=v_j\f$ is in the \f$j\f$th position of \p vals. This
-    //! function checks that \f$v_i = x_j\f$, and therefore that
-    //! \f$(x_i^{-1})^{-1} = x\f$.
+    //! let \f$y_i\f$ be the \f$i\f$th letter in \p inverses. Then this function
+    //! checks that:
+    //! * `p.alphabet()` and \p inverses contain the same letters;
+    //! * \p inverses are duplicate-free;
+    //! * if \f$x_i = y_j\f$, then \f$x_j = y_i\f$ and therefore that
+    //! \f$(x_i^{-1})^{-1} = x_i\f$.
     //!
-    //! \tparam Word the type of the words in the presentation.
+    //! \tparam Word1 the type of the words in the presentation.
+    //! \tparam Word2 the type of the arguments \p letters and \p inverses.
     //! \param p the presentation.
-    //! \param vals the values to check if the act as inverses.
+    //! \param inverses the proposed inverses for \p letters.
     //!
-    //! \throws Libsemigroups_Exception if any of the following apply:
-    //! * the length of \p vals is not the same as the length of `p.alphabet()`
-    //! * `p.throw_if_letter_not_in_alphabet(vals)` throws
-    //! * \p vals contains duplicate letters
-    //! * the values in \p vals do not serve as semigroup inverses.
-    template <typename Word>
-    void throw_if_bad_inverses(Presentation<Word> const& p, Word const& vals);
+    //! \throws Libsemigroups_Exception if any of the conditions listed above
+    //! do not hold.
+    template <typename Word1, typename Word2>
+    void throw_if_bad_inverses(Presentation<Word1> const& p,
+                               Word2 const&               inverses);
+
+    //! \brief Throws an exception if the argument \p inverses does not define
+    //! valid inverses for \p letters.
+    //!
+    //! This function checks if the values in \p inverses are valid semigroup
+    //! inverses for \p letters. Specifically, it
+    //! checks that the \f$i\f$th value in \p inverses is an inverse for the
+    //! \f$i\f$th value in `letters`.
+    //!
+    //! Let \f$x_i\f$ be the \f$i\f$th letter in \p letters, and
+    //! let \f$y_i\f$ be the \f$i\f$th letter in \p inverses. Then this function
+    //! checks that:
+    //! * \p letters and \p inverses contain the same letters;
+    //! * \p letters and \p inverses are duplicate-free;
+    //! * if \f$x_i = y_j\f$, then \f$x_j = y_i\f$ and therefore that
+    //! \f$(x_i^{-1})^{-1} = x_i\f$.
+    //!
+    //! \tparam Word1 the type of the words in the presentation.
+    //! \tparam Word2 the type of the arguments \p letters and \p inverses.
+    //! \param p the presentation.
+    //! \param letters the letters in the alphabet.
+    //! \param inverses the proposed inverses for \p letters.
+    //!
+    //! \throws Libsemigroups_Exception if any of the conditions listed above
+    //! do not hold.
+    template <typename Word1, typename Word2>
+    void throw_if_bad_inverses(Presentation<Word1> const& p,
+                               Word2 const&               letters,
+                               Word2 const&               inverses);
 
     //! \brief Return a representation of a presentation to appear in the
     //! reporting output.

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -2211,6 +2211,31 @@ namespace libsemigroups {
 
     //! \brief Balance the length of the left-hand and right-hand sides.
     //!
+    //! This function just calls
+    //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
+    //! where the 2nd parameter is defined to be `p.alphabet()`.
+    //!
+    //! \tparam Word the type of the words in the presentation.
+    //! \param p the presentation.
+    //! \param inverses the inverses of the letters.
+    //!
+    //! \exceptions
+    //! \no_libsemigroups_except
+    //!
+    //! \warning
+    //! This function assumes that the semigroup defined by \p p is isomorphic
+    //! to a group, and that \p inverses are valid. However, this function does
+    //! no checks on its arguments. If the previous assumptions do not hold,
+    //! there is no guarantee the the semigroup \f$S\f$ defined by \p p before
+    //! this function is called will be isomorphic to the semigroup \f$S'\f$
+    //! defined by \p p after this function is called.
+    template <typename Word>
+    void balance_no_checks(Presentation<Word>& p, Word const& inverses) {
+      balance_no_checks(p, p.alphabet(), inverses);
+    }
+
+    //! \brief Balance the length of the left-hand and right-hand sides.
+    //!
     //! This is an overload for
     //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
     //! to allow std::string_view to be used for the parameters \p letters and
@@ -2219,6 +2244,17 @@ namespace libsemigroups {
                                   std::string_view           letters,
                                   std::string_view           inverses) {
       balance_no_checks<std::string, std::string_view>(p, letters, inverses);
+    }
+
+    //! \brief Balance the length of the left-hand and right-hand sides.
+    //!
+    //! This is an overload for
+    //! \ref balance_no_checks(Presentation<Word>&, Word const&)
+    //! to allow std::string_view to be used for the parameters \p letters and
+    //! \p inverses.
+    inline void balance_no_checks(Presentation<std::string>& p,
+                                  std::string_view           inverses) {
+      balance_no_checks(p, std::string_view(p.alphabet()), inverses);
     }
 
     //! \brief Balance the length of the left-hand and right-hand sides.
@@ -2237,6 +2273,18 @@ namespace libsemigroups {
     //! \brief Balance the length of the left-hand and right-hand sides.
     //!
     //! This is an overload for
+    //! \ref balance_no_checks(Presentation<Word>&, Word const&)
+    //! to allow std::initializer_list<char> to be used for the parameters
+    //! \p letters and \p inverses.
+    inline void balance_no_checks(Presentation<std::string>& p,
+                                  char const*                inverses) {
+      balance_no_checks(
+          p, std::string_view(p.alphabet()), std::string_view(inverses));
+    }
+
+    //! \brief Balance the length of the left-hand and right-hand sides.
+    //!
+    //! This is an overload for
     //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
     //! to allow std::initializer_list<char> to be used for the parameters
     //! \p letters and \p inverses.
@@ -2246,6 +2294,19 @@ namespace libsemigroups {
                                   std::initializer_list<char> const& letters,
                                   std::initializer_list<char> const& inverses) {
       balance_no_checks(p, std::string(letters), std::string(inverses));
+    }
+
+    //! \brief Balance the length of the left-hand and right-hand sides.
+    //!
+    //! This is an overload for
+    //! \ref balance_no_checks(Presentation<Word>&, Word const&)
+    //! to allow std::initializer_list<char> to be used for the parameters
+    //! \p letters and \p inverses.
+    // There's some weirdness with {0} being interpreted as a string_view, which
+    // means that the next overload is required
+    inline void balance_no_checks(Presentation<std::string>&         p,
+                                  std::initializer_list<char> const& inverses) {
+      balance_no_checks(p, p.alphabet(), std::string(inverses));
     }
 
     //! \brief Balance the length of the left-hand and right-hand sides.
@@ -2280,6 +2341,30 @@ namespace libsemigroups {
 
     //! \brief Balance the length of the left-hand and right-hand sides.
     //!
+    //! This function just calls
+    //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
+    //! where the 2nd parameter is defined to be `p.alphabet()`.
+    //!
+    //! \tparam Word the type of the words in the presentation.
+    //! \param p the presentation.
+    //! \param inverses the inverses of the letters.
+    //!
+    //! \throws LibsemigroupsException if
+    //! \ref Presentation::throw_if_bad_alphabet_or_rules throws.
+    //! \throws LibsemigroupsException if \ref throw_if_bad_inverses throws
+    //! when called with `p.alphabet()` and \p inverses. This function does not
+    //! check that the values in \p inverses are actually inverses for the
+    //! values in `p.alphabet()`, and balances the relations as described in
+    //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
+    //! assuming that this is the case.
+    template <typename Word>
+    void balance(Presentation<Word>& p, Word const& inverses) {
+      throw_if_bad_inverses(p, p.alphabet(), inverses);
+      balance_no_checks(p, p.alphabet(), inverses);
+    }
+
+    //! \brief Balance the length of the left-hand and right-hand sides.
+    //!
     //! This is an overload for
     //! \ref balance(Presentation<Word1>&, Word2 const&, Word2 const&)
     //! to allow, for example, std::initializer_list to be used for the
@@ -2308,6 +2393,17 @@ namespace libsemigroups {
     //! \brief Balance the length of the left-hand and right-hand sides.
     //!
     //! This is an overload for
+    //! \ref balance(Presentation<Word>&, Word const&)
+    //! to allow std::string_view to be used for the parameters \p letters and
+    //! \p inverses.
+    inline void balance(Presentation<std::string>& p,
+                        std::string_view           inverses) {
+      balance<std::string, std::string_view>(p, p.alphabet(), inverses);
+    }
+
+    //! \brief Balance the length of the left-hand and right-hand sides.
+    //!
+    //! This is an overload for
     //! \ref balance(Presentation<Word1>&, Word2 const&, Word2 const&)
     //! to allow string literals to be used for the parameters \p letters and
     //! \p inverses.
@@ -2315,6 +2411,16 @@ namespace libsemigroups {
                         char const*                letters,
                         char const*                inverses) {
       balance(p, std::string_view(letters), std::string_view(inverses));
+    }
+
+    //! \brief Balance the length of the left-hand and right-hand sides.
+    //!
+    //! This is an overload for
+    //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
+    //! to allow string literals to be used for the parameters \p letters and
+    //! \p inverses.
+    inline void balance(Presentation<std::string>& p, char const* inverses) {
+      balance(p, std::string_view(p.alphabet()), std::string_view(inverses));
     }
 
     //! \brief Balance the length of the left-hand and right-hand sides.
@@ -2331,8 +2437,18 @@ namespace libsemigroups {
       balance(p, std::string(letters), std::string(inverses));
     }
 
-    // TODO version of balance that only specified inverses, and uses the
-    // alphabet as the letters
+    //! \brief Balance the length of the left-hand and right-hand sides.
+    //!
+    //! This is an overload for
+    //! \ref balance(Presentation<Word1>&, Word2 const&, Word2 const&)
+    //! to allow std::initializer_list<char> to be used for the parameters
+    //! \p letters and \p inverses.
+    // There's some weirdness with {0} being interpreted as a string_view, which
+    // means that the next overload is required
+    inline void balance(Presentation<std::string>&         p,
+                        std::initializer_list<char> const& inverses) {
+      balance(p, p.alphabet(), std::string(inverses));
+    }
 
     // TODO version that detects inverse rules in the presentation and uses
     // those if possible

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -2162,6 +2162,48 @@ namespace libsemigroups {
                                       Word const&                 letters,
                                       std::initializer_list<Word> words);
 
+    //! \brief Detect inverses.
+    //!
+    //! This function tries to deduce any inverses defined by the rules of
+    //! presentation in the following way: the rules of the presentation
+    //! where one side has length 2 and the other has length 0 are detected.
+    //! For any such rule we remember that the first letter is the inverse of
+    //! the second and vice versa. If there are no such rules, then no changes
+    //! are made. If there are multiple different such rules and we deduce
+    //! conflicting values for the inverse of a letter, then an exception is
+    //! thrown.
+    //!
+    //! \tparam Word the type of the words in the presentation.
+    //! \param p the presentation.
+    //! \param letters the word to store the letters with inverses.
+    //! \param inverses the word to store the inverses found.
+    //!
+    //! \throws LibsemigroupsException if
+    //! \ref Presentation::throw_if_bad_alphabet_or_rules throws.
+    //! \throws LibsemigroupsException if conflicting inverses for any letter
+    //! are detected.
+    template <typename Word>
+    void try_detect_inverses(Presentation<Word>& p,
+                             Word&               letters,
+                             Word&               inverses);
+
+    //! \brief Detect inverses.
+    //!
+    //! This function constructs two \c Word objects to store the letters and
+    //! inverses, performs
+    //! \ref try_detect_inverses(Presentation<Word>&, Word&, Word&)
+    //! and then returns the result.
+    //!
+    //! \tparam Word the type of the words in the presentation.
+    //! \param p the presentation.
+    //!
+    //! \throws LibsemigroupsException if
+    //! \ref Presentation::throw_if_bad_alphabet_or_rules throws.
+    //! \throws LibsemigroupsException if conflicting inverses for any letter
+    //! are detected.
+    template <typename Word>
+    std::pair<Word, Word> try_detect_inverses(Presentation<Word>& p);
+
     //! \brief Balance the length of the left-hand and right-hand sides.
     //!
     //! This function first sorts the sides of each rules so that the larger

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -2312,7 +2312,7 @@ namespace libsemigroups {
     //! \brief Balance the length of the left-hand and right-hand sides.
     //!
     //! See
-    //! \ref balance(Presentation<Word1>&, Word2 const&, Word2 const&)
+    //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
     //! for details about this function.
     //!
     //! \tparam Word1 the type of the words in the presentation.
@@ -2321,11 +2321,11 @@ namespace libsemigroups {
     //! \param letters the letters that can be replaced in the left-hand side.
     //! \param inverses the inverses of the letters.
     //!
-    //! \throws LibsemigroupsException if \ref throw_if_bad_alphabet_or_rules
-    //! throws.
-    //! \throws LibsemigroupsException if \ref throw_if_bad_inverses throws
-    //! when called with \p letters and \p inverses. This does not check that
-    //! the values in \p inverses are actually inverses for the values in
+    //! \throws LibsemigroupsException if
+    //! \ref Presentation::throw_if_bad_alphabet_or_rules throws.
+    //! \throws LibsemigroupsException if \ref throw_if_bad_inverses throws when
+    //! called with \p letters and \p inverses. This does not check that the
+    //! values in \p inverses are actually inverses for the values in
     //! \p letters, and balances the relations as described in
     //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
     //! assuming that this is the case.

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -2162,21 +2162,26 @@ namespace libsemigroups {
                                       Word const&                 letters,
                                       std::initializer_list<Word> words);
 
-    //! \brief Detect inverses.
+    //! \brief Try to detect group inverses.
     //!
-    //! This function tries to deduce any inverses defined by the rules of
-    //! presentation in the following way: the rules of the presentation
-    //! where one side has length 2 and the other has length 0 are detected.
-    //! For any such rule we remember that the first letter is the inverse of
-    //! the second and vice versa. If there are no such rules, then no changes
-    //! are made. If there are multiple different such rules and we deduce
-    //! conflicting values for the inverse of a letter, then an exception is
-    //! thrown.
+    //! This function tries to deduce group theoretic inverses defined by the
+    //! rules of the presentation \p p as following: the rules of the
+    //! presentation where one side has length 2 and the other has length 0 are
+    //! detected. For any such rule we remember that the first letter is a
+    //! possible inverse of the second. If rules of the form `ab=1` and `ba=1`
+    //! are detected, then \c a has inverse \c b and vice versa. If there are
+    //! multiple different such rules and we deduce conflicting values for the
+    //! inverse of a letter, then an exception is thrown.
+    //!
+    //! Those letters where an inverse is detected are pushed into the back of
+    //! the parameter \p letters, and the detected inverse is pushed into \p
+    //! inverses. The parameters \p letters and \p inverses are modified
+    //! in-place, and are not cleared before adding letters or their inverses.
     //!
     //! \tparam Word the type of the words in the presentation.
     //! \param p the presentation.
-    //! \param letters the word to store the letters with inverses.
-    //! \param inverses the word to store the inverses found.
+    //! \param letters the word to contain the letters with inverses.
+    //! \param inverses the word to contain the inverses found.
     //!
     //! \throws LibsemigroupsException if
     //! \ref Presentation::throw_if_bad_alphabet_or_rules throws.
@@ -2187,12 +2192,19 @@ namespace libsemigroups {
                              Word&               letters,
                              Word&               inverses);
 
-    //! \brief Detect inverses.
+    //! \brief Try to detect group inverses.
     //!
     //! This function constructs two \c Word objects to store the letters and
     //! inverses, performs
     //! \ref try_detect_inverses(Presentation<Word>&, Word&, Word&)
-    //! and then returns the result.
+    //! and then returns the result \c pair as a std::pair where:
+    //!
+    //! * `pair.first` is the list of letters such that an inverse was
+    //! detected;
+    //! * `pair.second` is the list of inverses of the letters in `pair.first`
+    //! (where the letter in position \c i is the inverse of `pair.first[i]`,
+    //! and vice versa).
+    //!
     //!
     //! \tparam Word the type of the words in the presentation.
     //! \param p the presentation.
@@ -2385,13 +2397,7 @@ namespace libsemigroups {
     //! This function calls
     //! \ref balance_no_checks(Presentation<Word1>&, Word2 const&, Word2 const&)
     //! where the 2nd and 3rd arguments are deduced from the rules in the
-    //! presentation if possible as follows: the rules of the presentation
-    //! where one side has length 2 and the other has length 0 are detected.
-    //! For any such rule we remember that the first letter is the inverse of
-    //! the second and vice versa. If there are no such rules, then no changes
-    //! are made. If there are multiple different such rules and we deduce
-    //! conflicting values for the inverse of a letter, then an exception is
-    //! thrown.
+    //! using \ref try_detect_inverses.
     //!
     //! \tparam Word the type of the words in the presentation.
     //! \param p the presentation.

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -2299,9 +2299,10 @@ namespace libsemigroups {
     // NOLINTNEXTLINE(whitespace/line_length)
     //! \deprecated_alias_warning{balance_no_checks(Presentation<Word>&, Word const&, Word const&)}
     // clang-format on
-    inline void balance_no_checks [[deprecated]] (Presentation<std::string>& p,
-                                                  std::string_view letters,
-                                                  std::string_view inverses) {
+    static inline void balance_no_checks
+        [[deprecated]] (Presentation<std::string>& p,
+                        std::string_view           letters,
+                        std::string_view           inverses) {
       balance_no_checks<std::string, std::string_view>(p, letters, inverses);
     }
 
@@ -2316,9 +2317,10 @@ namespace libsemigroups {
     // NOLINTNEXTLINE(whitespace/line_length)
     //! \deprecated_alias_warning{balance_no_checks(Presentation<Word>&, Word const&, Word const&)}
     // clang-format on
-    inline void balance_no_checks [[deprecated]] (Presentation<std::string>& p,
-                                                  char const* letters,
-                                                  char const* inverses) {
+    static inline void balance_no_checks
+        [[deprecated]] (Presentation<std::string>& p,
+                        char const*                letters,
+                        char const*                inverses) {
       balance_no_checks(p, std::string(letters), std::string(inverses));
     }
 

--- a/include/libsemigroups/presentation.tpp
+++ b/include/libsemigroups/presentation.tpp
@@ -1106,7 +1106,15 @@ namespace libsemigroups {
       if (!p.contains_empty_word()) {
         return;
       }
+      auto [letters, inverses] = try_detect_inverses(p);
+      balance_no_checks(p, letters, inverses);
+    }
 
+    template <typename Word>
+    void try_detect_inverses(Presentation<Word>& p,
+                             Word&               letters,
+                             Word&               inverses) {
+      p.throw_if_bad_alphabet_or_rules();
       using value_type = typename Word::value_type;
       // values in this map are pairs <p> such that <p.first> is a found
       // inverse for the key, and <p.second> is the index of the rule showing
@@ -1119,41 +1127,43 @@ namespace libsemigroups {
           std::swap(lhs, rhs);
         }
         if (lhs.size() == 2 && rhs.empty()) {
-          if (!is_rule(p, {lhs[1], lhs[0]}, {})
-              && !is_rule(p, {}, {lhs[1], lhs[0]})) {
-            continue;
-          }
-          for (size_t i = 0; i != 2; ++i) {
-            auto letter = lhs[i], inverse = lhs[(i + 1) % 2];
-            auto [it, inserted] = map.emplace(letter, std::pair{inverse, pos});
+          auto letter = lhs[0], inverse = lhs[1];
+          auto [it, inserted] = map.emplace(letter, std::pair{inverse, pos});
 
-            if (!inserted && it->second.first != inverse) {
-              value_type alt_inverse = it->second.first;
-              size_t     alt_pos     = it->second.second;
-              LIBSEMIGROUPS_EXCEPTION(
-                  "the rules {} = {} (rule {}) and {} = {} (rule {}) yield "
-                  "the conflicting values {} != {} for the inverse of {}, "
-                  "please use the 2- or 3-argument version of this function "
-                  "to explicitly specify the inverses",
-                  detail::to_printable(lhs),
-                  detail::to_printable(rhs),
-                  pos / 2,
-                  detail::to_printable(p.rules[alt_pos]),
-                  detail::to_printable(p.rules[alt_pos + 1]),
-                  alt_pos / 2,
-                  detail::to_printable(inverse),
-                  detail::to_printable(alt_inverse),
-                  detail::to_printable(letter));
-            }
+          if (!inserted && it->second.first != inverse) {
+            value_type alt_inverse = it->second.first;
+            size_t     alt_pos     = it->second.second;
+            LIBSEMIGROUPS_EXCEPTION(
+                "the rules {} = {} (rule {}) and {} = {} (rule {}) yield "
+                "the conflicting values {} != {} for the inverse of {}, "
+                "please use the 2- or 3-argument version of this function "
+                "to explicitly specify the inverses",
+                detail::to_printable(lhs),
+                detail::to_printable(rhs),
+                pos / 2,
+                detail::to_printable(p.rules[alt_pos]),
+                detail::to_printable(p.rules[alt_pos + 1]),
+                alt_pos / 2,
+                detail::to_printable(inverse),
+                detail::to_printable(alt_inverse),
+                detail::to_printable(letter));
           }
         }
       }
-      Word letters, inverses;
       for (auto const& [key, val] : map) {
-        letters.push_back(key);
-        inverses.push_back(val.first);
+        if (map[val.first].first == key) {
+          letters.push_back(key);
+          inverses.push_back(val.first);
+        }
       }
-      balance_no_checks(p, letters, inverses);
+    }
+
+    template <typename Word>
+    std::pair<Word, Word> try_detect_inverses(Presentation<Word>& p) {
+      Word letters;
+      Word inverses;
+      try_detect_inverses(p, letters, inverses);
+      return {letters, inverses};
     }
 
     template <typename Word1, typename Word2>

--- a/include/libsemigroups/presentation.tpp
+++ b/include/libsemigroups/presentation.tpp
@@ -323,7 +323,7 @@ namespace libsemigroups {
       // get a more meaningful exception message
       p.throw_if_letter_not_in_alphabet(vals.begin(), vals.end());
 
-      Word1 cpy = vals;
+      Word1 cpy(vals);
       std::sort(cpy.begin(), cpy.end());
       for (auto it = cpy.cbegin(); it < cpy.cend() - 1; ++it) {
         if (*it == *(it + 1)) {
@@ -351,14 +351,17 @@ namespace libsemigroups {
       }
     }
 
-    template <typename Word>
-    void throw_if_bad_inverses(Presentation<Word> const& p,
-                               Word const&               letters,
-                               Word const&               inverses) {
+    template <typename Word1, typename Word2>
+    void throw_if_bad_inverses(Presentation<Word1> const& p,
+                               Word2 const&               letters,
+                               Word2 const&               inverses) {
       if (letters == p.alphabet()) {
         throw_if_bad_inverses(p, inverses);
       } else {
-        Presentation<Word> q;
+        // Must check that letters is valid because it obviously is when we
+        // create q.
+        p.throw_if_letter_not_in_alphabet(letters.begin(), letters.end());
+        Presentation<Word1> q;
         q.alphabet(letters);
         throw_if_bad_inverses(q, inverses);
       }

--- a/include/libsemigroups/presentation.tpp
+++ b/include/libsemigroups/presentation.tpp
@@ -310,8 +310,9 @@ namespace libsemigroups {
       }
     }
 
-    template <typename Word>
-    void throw_if_bad_inverses(Presentation<Word> const& p, Word const& vals) {
+    template <typename Word1, typename Word2>
+    void throw_if_bad_inverses(Presentation<Word1> const& p,
+                               Word2 const&               vals) {
       if (vals.size() != p.alphabet().size()) {
         LIBSEMIGROUPS_EXCEPTION(
             "invalid number of inverses, expected {} but found {}",
@@ -322,7 +323,7 @@ namespace libsemigroups {
       // get a more meaningful exception message
       p.throw_if_letter_not_in_alphabet(vals.begin(), vals.end());
 
-      Word cpy = vals;
+      Word1 cpy = vals;
       std::sort(cpy.begin(), cpy.end());
       for (auto it = cpy.cbegin(); it < cpy.cend() - 1; ++it) {
         if (*it == *(it + 1)) {
@@ -347,6 +348,19 @@ namespace libsemigroups {
             break;
           }
         }
+      }
+    }
+
+    template <typename Word>
+    void throw_if_bad_inverses(Presentation<Word> const& p,
+                               Word const&               letters,
+                               Word const&               inverses) {
+      if (letters == p.alphabet()) {
+        throw_if_bad_inverses(p, inverses);
+      } else {
+        Presentation<Word> q;
+        q.alphabet(letters);
+        throw_if_bad_inverses(q, inverses);
       }
     }
 

--- a/include/libsemigroups/presentation.tpp
+++ b/include/libsemigroups/presentation.tpp
@@ -1121,6 +1121,29 @@ namespace libsemigroups {
       add_cyclic_conjugates_no_checks(p, relator);
     }
 
+    template <typename Word>
+    [[nodiscard]] typename std::vector<Word>::iterator
+    find_rule_no_checks(Presentation<Word>& p,
+                        Word const&         lhs,
+                        Word const&         rhs) {
+      for (auto it = p.rules.begin(); it != p.rules.end(); it += 2) {
+        if (*it == lhs && *(it + 1) == rhs) {
+          return it;
+        }
+      }
+      return p.rules.end();
+    }
+
+    template <typename Word>
+    [[nodiscard]] size_t index_rule_no_checks(Presentation<Word> const& p,
+                                              Word const&               lhs,
+                                              Word const&               rhs) {
+      auto it = find_rule_no_checks(p, lhs, rhs);
+      if (it != p.rules.cend()) {
+        return std::distance(p.rules.begin(), it);
+      }
+      return UNDEFINED;
+    }
   }  // namespace presentation
 
   template <typename Word>

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -472,9 +472,6 @@ namespace libsemigroups {
     }
 
     template <typename W>
-    void check_balance() {}
-
-    template <typename W>
     void check_sort_each_rule() {
       Presentation<W> p;
       p.rules.push_back(W({0, 1, 2, 1}));
@@ -1436,7 +1433,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Presentation",
                                    "023",
-                                   "helpers balance_no_checks (all)",
+                                   "helpers balance_no_checks (3 args)",
                                    "[quick][presentation]",
                                    std::string,
                                    word_type) {
@@ -1525,6 +1522,74 @@ namespace libsemigroups {
                                {2, 1, 1, 1, 1},
                                {1, 2, 4},
                                {7, 6, 5}}));
+    p.alphabet({0, 1, 2});
+    p.rules = {{1, 1, 1, 1, 1, 1, 1, 1},
+               {},
+               {2, 2, 2, 1, 1, 1},
+               {},
+               {2, 2, 2, 2, 2},
+               {2, 2}};
+    presentation::balance_no_checks(p, {0, 1}, {1, 0});
+    REQUIRE(p.rules
+            == std::vector<W>({{1, 1, 1, 1},
+                               {0, 0, 0, 0},
+                               {2, 2, 2},
+                               {0, 0, 0},
+                               {2, 2, 2, 2, 2},
+                               {2, 2}}));
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "084",
+                          "helpers balance (3 args, word_type)",
+                          "[quick][presentation]") {
+    auto rg = ReportGuard(false);
+
+    Presentation<word_type> p;
+    p.alphabet(2).contains_empty_word(true);
+    presentation::add_rule(p, {0, 0, 0, 0, 0, 0, 0, 0}, {});
+    presentation::balance(p, {0}, {0});
+    REQUIRE(p.rules == std::vector<word_type>({{0, 0, 0, 0}, {0, 0, 0, 0}}));
+    REQUIRE_EXCEPTION_MSG(presentation::balance(p, {0, 0}, {0}),
+                          "invalid alphabet [0, 0], duplicate letter 0!");
+    REQUIRE_EXCEPTION_MSG(presentation::balance(p, {0, 1}, {0, 0}),
+                          "invalid inverses, the letter 0 is duplicated!");
+    REQUIRE_EXCEPTION_MSG(presentation::balance(p, {0, 1}, {0}),
+                          "invalid number of inverses, expected 2 but found 1");
+    REQUIRE_EXCEPTION_MSG(presentation::balance(p, {2, 1}, {1, 2}),
+                          "invalid letter 2, valid letters are [0, 1]");
+  }
+
+  // Separate test because exception messages are different
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "085",
+                          "helpers balance (3 args, std::string)",
+                          "[quick][presentation]") {
+    auto rg = ReportGuard(false);
+
+    Presentation<std::string> p;
+    p.alphabet({0, 1}).contains_empty_word(true);
+    presentation::add_rule(p, {0, 0, 0, 0, 0, 0, 0, 0}, {});
+    presentation::balance(p, std::string(1, 0), std::string(1, 0));
+    REQUIRE(p.rules == std::vector<std::string>({{0, 0, 0, 0}, {0, 0, 0, 0}}));
+    REQUIRE_EXCEPTION_MSG(presentation::balance(p, {0, 0}, {0}),
+                          "invalid alphabet (char values) [0, 0], duplicate "
+                          "letter (char with value) 0!");
+    REQUIRE_EXCEPTION_MSG(
+        presentation::balance(p, {0, 1}, {0, 0}),
+        "invalid inverses, the letter (char with value) 0 is duplicated!");
+    REQUIRE_EXCEPTION_MSG(presentation::balance(p, {0, 1}, {0}),
+                          "invalid number of inverses, expected 2 but found 1");
+    REQUIRE_EXCEPTION_MSG(presentation::balance(p, {2, 1}, {1, 2}),
+                          "invalid letter (char with value) 2, valid letters "
+                          "are (char values) [0, 1]");
+    p.alphabet("ab").contains_empty_word(true);
+    p.rules = {"aaaaaaaaa", "b"};
+    presentation::balance(p, "ab", "ba");
+    REQUIRE(p.rules == std::vector<std::string>({"aaaaa", "bbbbb"}));
+    p.rules = {"aaaaaaaaa", "b"};
+    presentation::balance(p, std::string_view("ab"), std::string_view("ba"));
+    REQUIRE(p.rules == std::vector<std::string>({"aaaaa", "bbbbb"}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -471,88 +471,7 @@ namespace libsemigroups {
     }
 
     template <typename W>
-    void check_balance() {
-      Presentation<W> p;
-      p.contains_empty_word(true);
-      presentation::add_rule_no_checks(p, {1, 1, 1, 1, 1, 1, 1, 1}, {});
-      REQUIRE(p.rules == std::vector<W>({{1, 1, 1, 1, 1, 1, 1, 1}, {}}));
-      presentation::balance_no_checks(p, {1}, {1});
-      REQUIRE(p.rules == std::vector<W>({{1, 1, 1, 1}, {1, 1, 1, 1}}));
-
-      presentation::add_rule_no_checks(p, {1, 1, 1}, {1, 1, 1, 1, 1, 1});
-      presentation::balance_no_checks(p, {1}, {1});
-      REQUIRE(p.rules
-              == std::vector<W>(
-                  {{1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1}}));
-
-      presentation::add_rule_no_checks(p, {1, 1}, {});
-      REQUIRE(p.rules
-              == std::vector<W>({{1, 1, 1, 1},
-                                 {1, 1, 1, 1},
-                                 {1, 1, 1, 1, 1},
-                                 {1, 1, 1, 1},
-                                 {1, 1},
-                                 {}}));
-      presentation::balance_no_checks(p, {1}, {1});
-      REQUIRE(p.rules
-              == std::vector<W>({{1, 1, 1, 1},
-                                 {1, 1, 1, 1},
-                                 {1, 1, 1, 1, 1},
-                                 {1, 1, 1, 1},
-                                 {1, 1},
-                                 {}}));
-
-      presentation::add_rule_no_checks(
-          p, {1, 2, 2, 1}, {2, 1, 1, 1, 1, 1, 1, 1, 1, 2});
-      presentation::balance_no_checks(p, {2}, {1});
-      REQUIRE(p.rules
-              == std::vector<W>({{1, 1, 1, 1},
-                                 {1, 1, 1, 1},
-                                 {1, 1, 1, 1, 1},
-                                 {1, 1, 1, 1},
-                                 {1, 1},
-                                 {},
-                                 {1, 1, 1, 1, 1, 1, 1, 1},
-                                 {1, 1, 2, 2, 1, 1}}));
-      presentation::balance_no_checks(p, {1}, {3});
-      REQUIRE(p.rules
-              == std::vector<W>({{1, 1, 1, 1},
-                                 {1, 1, 1, 1},
-                                 {1, 1, 1, 1, 1},
-                                 {1, 1, 1, 1},
-                                 {1},
-                                 {3},
-                                 {1, 1, 1, 1, 1, 1, 1},
-                                 {1, 1, 2, 2, 1, 1, 3}}));
-      presentation::add_rule_no_checks(p, {2, 1, 1, 1, 1, 1, 1, 2, 2, 2}, {});
-      presentation::balance_no_checks(p, {1, 2}, {3, 4});
-      REQUIRE(p.rules
-              == std::vector<W>({{1, 1, 1, 1},
-                                 {1, 1, 1, 1},
-                                 {1, 1, 1, 1, 1},
-                                 {1, 1, 1, 1},
-                                 {3},
-                                 {1},
-                                 {1, 1, 2, 2, 1, 1, 3},
-                                 {1, 1, 1, 1, 1, 1, 1},
-                                 {2, 1, 1, 1, 1},
-                                 {4, 4, 4, 3, 3}}));
-      presentation::add_rule_no_checks(p, {1, 2, 3, 1, 2, 4}, {});
-      presentation::balance_no_checks(p, {1, 2, 3}, {5, 6, 7});
-      REQUIRE(p.rules
-              == std::vector<W>({{1, 1, 1, 1},
-                                 {1, 1, 1, 1},
-                                 {1, 1, 1, 1, 1},
-                                 {1, 1, 1, 1},
-                                 {3},
-                                 {1},
-                                 {1, 1, 2, 2, 1, 1, 3},
-                                 {1, 1, 1, 1, 1, 1, 1},
-                                 {4, 4, 4, 3, 3},
-                                 {2, 1, 1, 1, 1},
-                                 {1, 2, 4},
-                                 {7, 6, 5}}));
-    }
+    void check_balance() {}
 
     template <typename W>
     void check_sort_each_rule() {
@@ -1514,15 +1433,97 @@ namespace libsemigroups {
                       LibsemigroupsException);
   }
 
-  LIBSEMIGROUPS_TEST_CASE("Presentation",
-                          "023",
-                          "helpers balance_no_checks (all)",
-                          "[quick][presentation]") {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Presentation",
+                                   "023",
+                                   "helpers balance_no_checks (all)",
+                                   "[quick][presentation]",
+                                   std::string,
+                                   word_type) {
+    // TODO(1) Add StaticVector1<uint16_t, 10>. Can't do this until
+    // StaticVector1 has .front or . end
     auto rg = ReportGuard(false);
-    check_balance<word_type>();
-    // TODO(1) Can't do this until StaticVector1 has .front or . end
-    // check_balance<StaticVector1<uint16_t, 10>>();
-    check_balance<std::string>();
+    using W = TestType;
+
+    Presentation<W> p;
+    p.contains_empty_word(true);
+    presentation::add_rule_no_checks(p, {1, 1, 1, 1, 1, 1, 1, 1}, {});
+    REQUIRE(p.rules == std::vector<W>({{1, 1, 1, 1, 1, 1, 1, 1}, {}}));
+    presentation::balance_no_checks(p, {1}, {1});
+    REQUIRE(p.rules == std::vector<W>({{1, 1, 1, 1}, {1, 1, 1, 1}}));
+
+    presentation::add_rule_no_checks(p, {1, 1, 1}, {1, 1, 1, 1, 1, 1});
+    presentation::balance_no_checks(p, {1}, {1});
+    REQUIRE(p.rules
+            == std::vector<W>(
+                {{1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1}}));
+
+    presentation::add_rule_no_checks(p, {1, 1}, {});
+    REQUIRE(p.rules
+            == std::vector<W>({{1, 1, 1, 1},
+                               {1, 1, 1, 1},
+                               {1, 1, 1, 1, 1},
+                               {1, 1, 1, 1},
+                               {1, 1},
+                               {}}));
+    presentation::balance_no_checks(p, {1}, {1});
+    REQUIRE(p.rules
+            == std::vector<W>({{1, 1, 1, 1},
+                               {1, 1, 1, 1},
+                               {1, 1, 1, 1, 1},
+                               {1, 1, 1, 1},
+                               {1, 1},
+                               {}}));
+
+    presentation::add_rule_no_checks(
+        p, {1, 2, 2, 1}, {2, 1, 1, 1, 1, 1, 1, 1, 1, 2});
+    presentation::balance_no_checks(p, {2}, {1});
+    REQUIRE(p.rules
+            == std::vector<W>({{1, 1, 1, 1},
+                               {1, 1, 1, 1},
+                               {1, 1, 1, 1, 1},
+                               {1, 1, 1, 1},
+                               {1, 1},
+                               {},
+                               {1, 1, 1, 1, 1, 1, 1, 1},
+                               {1, 1, 2, 2, 1, 1}}));
+    presentation::balance_no_checks(p, {1}, {3});
+    REQUIRE(p.rules
+            == std::vector<W>({{1, 1, 1, 1},
+                               {1, 1, 1, 1},
+                               {1, 1, 1, 1, 1},
+                               {1, 1, 1, 1},
+                               {1},
+                               {3},
+                               {1, 1, 1, 1, 1, 1, 1},
+                               {1, 1, 2, 2, 1, 1, 3}}));
+    presentation::add_rule_no_checks(p, {2, 1, 1, 1, 1, 1, 1, 2, 2, 2}, {});
+    presentation::balance_no_checks(p, {1, 2}, {3, 4});
+    REQUIRE(p.rules
+            == std::vector<W>({{1, 1, 1, 1},
+                               {1, 1, 1, 1},
+                               {1, 1, 1, 1, 1},
+                               {1, 1, 1, 1},
+                               {3},
+                               {1},
+                               {1, 1, 2, 2, 1, 1, 3},
+                               {1, 1, 1, 1, 1, 1, 1},
+                               {2, 1, 1, 1, 1},
+                               {4, 4, 4, 3, 3}}));
+    presentation::add_rule_no_checks(p, {1, 2, 3, 1, 2, 4}, {});
+    presentation::balance_no_checks(p, {1, 2, 3}, {5, 6, 7});
+    REQUIRE(p.rules
+            == std::vector<W>({{1, 1, 1, 1},
+                               {1, 1, 1, 1},
+                               {1, 1, 1, 1, 1},
+                               {1, 1, 1, 1},
+                               {3},
+                               {1},
+                               {1, 1, 2, 2, 1, 1, 3},
+                               {1, 1, 1, 1, 1, 1, 1},
+                               {4, 4, 4, 3, 3},
+                               {2, 1, 1, 1, 1},
+                               {1, 2, 4},
+                               {7, 6, 5}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -1650,6 +1650,93 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "088",
+                          "helpers balance (1 arg)",
+                          "[quick][presentation]") {
+    Presentation<std::string> p;
+    p.alphabet("abc").contains_empty_word(true);
+
+    p.rules = {"ab",
+               "",
+               "ba",
+               "",
+               "aaaaaaaaaaaaa",
+               "",
+               "bbbbbbbb",
+               "",
+               "cccccccccccc",
+               "cccccc",
+               "bbbbbbbbccccccaaaaccccaaaaaaa",
+               ""};
+
+    presentation::balance(p);
+    REQUIRE(p.rules
+            == std::vector<std::string>({"ab",
+                                         "",
+                                         "ba",
+                                         "",
+                                         "aaaaaaa",
+                                         "bbbbbb",
+                                         "bbbb",
+                                         "aaaa",
+                                         "cccccccccccc",
+                                         "cccccc",
+                                         "bccccccaaaacccc",
+                                         "aaaaaaabbbbbbb"}));
+
+    p.rules = {"",
+               "ab",
+               "aaaaaaaaaaaaa",
+               "",
+               "bbbbbbbb",
+               "",
+               "ba",
+               "",
+               "cccccccccccc",
+               "cccccc",
+               "bbbbbbbbccccccaaaaccccaaaaaaa",
+               ""};
+    presentation::balance(p);
+    REQUIRE(p.rules
+            == std::vector<std::string>({"ab",
+                                         "",
+                                         "aaaaaaa",
+                                         "bbbbbb",
+                                         "bbbb",
+                                         "aaaa",
+                                         "ba",
+                                         "",
+                                         "cccccccccccc",
+                                         "cccccc",
+                                         "bccccccaaaacccc",
+                                         "aaaaaaabbbbbbb"}));
+    p.rules = {"", "aa", "ba", ""};
+    // ba = 1 doesn't count because we are missing ab=1 also
+    REQUIRE_NOTHROW(presentation::balance(p));
+
+    p.rules = {"", "aa", "ba", "", "ab", ""};
+    REQUIRE_EXCEPTION_MSG(
+        presentation::balance(p),
+        "the rules \"ba\" = \"\" (rule 1) and \"aa\" = \"\" (rule 0) yield the "
+        "conflicting values 'b' != 'a' for the inverse of 'a', please use the "
+        "2- or 3-argument version of this function to explicitly specify the "
+        "inverses");
+    p.rules = {"", "ab", "ba", "", "cb", "", "bc", ""};
+    REQUIRE_EXCEPTION_MSG(
+        presentation::balance(p),
+        "the rules \"cb\" = \"\" (rule 2) and \"ab\" = \"\" (rule 0) yield the "
+        "conflicting values 'c' != 'a' for the inverse of 'b', please use the "
+        "2- or 3-argument version of this function to explicitly specify the "
+        "inverses");
+    p.rules = {"", "ab", "cb"};
+    REQUIRE_THROWS_AS(presentation::balance(p), LibsemigroupsException);
+
+    p.rules.clear();
+    p.contains_empty_word(false);
+    REQUIRE_NOTHROW(presentation::balance(p));
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
                           "024",
                           "helpers balance_no_checks (std::string)",
                           "[quick][presentation]") {

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -67,6 +67,7 @@ namespace libsemigroups {
 
   using literals::operator""_w;
   using detail::StaticVector1;
+  using std::string_literals::operator""s;
 
   struct LibsemigroupsException;  // forward decl
 
@@ -3307,6 +3308,43 @@ namespace libsemigroups {
     REQUIRE(presentation::to_report_string(p)
             == "|A| = 0, |R| = 0, |u| + |v| ∈ [0, 0], "
                "∑(|u| + |v|) = 0\n");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "082",
+                          "throw_if_bad_inverses 2 args",
+                          "[quick][presentation]") {
+    Presentation<std::string> p;
+    p.alphabet("abc");
+    REQUIRE_EXCEPTION_MSG(presentation::throw_if_bad_inverses(p, "adc"s),
+                          "invalid letter 'd', valid letters are \"abc\"");
+    REQUIRE_EXCEPTION_MSG(
+        presentation::throw_if_bad_inverses(p, "bca"s),
+        "invalid inverses, 'a' ^ -1 = 'b' but 'b' ^ -1 = 'c'");
+    REQUIRE_EXCEPTION_MSG(presentation::throw_if_bad_inverses(p, "aac"s),
+                          "invalid inverses, the letter 'a' is duplicated!");
+    REQUIRE_EXCEPTION_MSG(presentation::throw_if_bad_inverses(p, "ac"s),
+                          "invalid number of inverses, expected 3 but found 2");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "083",
+                          "throw_if_bad_inverses 3 args",
+                          "[quick][presentation]") {
+    Presentation<std::string> p;
+    p.alphabet("abc");
+    REQUIRE_NOTHROW(presentation::throw_if_bad_inverses(p, "ab"s, "ab"s));
+    REQUIRE_NOTHROW(presentation::throw_if_bad_inverses(p, "ab"s, "ba"s));
+    REQUIRE_EXCEPTION_MSG(presentation::throw_if_bad_inverses(p, "bc"s, "ac"s),
+                          "invalid letter 'a', valid letters are \"bc\"");
+    REQUIRE_EXCEPTION_MSG(presentation::throw_if_bad_inverses(p, "aa"s, "bb"s),
+                          "invalid alphabet \"aa\", duplicate letter 'a'!");
+    REQUIRE_EXCEPTION_MSG(presentation::throw_if_bad_inverses(p, "ab"s, "bb"s),
+                          "invalid inverses, the letter 'b' is duplicated!");
+    REQUIRE_EXCEPTION_MSG(presentation::throw_if_bad_inverses(p, "ab"s, "bac"s),
+                          "invalid number of inverses, expected 2 but found 3");
+    REQUIRE_EXCEPTION_MSG(presentation::throw_if_bad_inverses(p, "abc"s, "ba"s),
+                          "invalid number of inverses, expected 3 but found 2");
   }
 
 }  // namespace libsemigroups

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -27,7 +27,6 @@
 #include <initializer_list>  // for initializer_list
 #include <iterator>          // for distance
 #include <string>            // for basic_string, operator==
-#include <string_view>       // for string_view
 #include <tuple>             // for _Swallow_assign, ignore
 #include <type_traits>       // for is_same, is_unsigned_v
 #include <unordered_map>     // for operator==, operator!=
@@ -1606,10 +1605,7 @@ namespace libsemigroups {
                           "are (char values) [0, 1]");
     p.alphabet("ab").contains_empty_word(true);
     p.rules = {"aaaaaaaaa", "b"};
-    presentation::balance(p, "ab", "ba");
-    REQUIRE(p.rules == std::vector<std::string>({"aaaaa", "bbbbb"}));
-    p.rules = {"aaaaaaaaa", "b"};
-    presentation::balance(p, std::string_view("ab"), std::string_view("ba"));
+    presentation::balance(p, "ab"s, "ba"s);
     REQUIRE(p.rules == std::vector<std::string>({"aaaaa", "bbbbb"}));
   }
 
@@ -1623,11 +1619,11 @@ namespace libsemigroups {
     p.alphabet("ab").contains_empty_word(true);
 
     p.rules = {"aaaaaaaaa", "b"};
-    presentation::balance_no_checks(p, "ba");
+    presentation::balance_no_checks(p, "ba"s);
     REQUIRE(p.rules == std::vector<std::string>({"aaaaa", "bbbbb"}));
 
     p.rules = {"aaaaaaaaa", "b"};
-    presentation::balance_no_checks(p, std::string_view("ab"));
+    presentation::balance_no_checks(p, "ab"s);
     REQUIRE(p.rules == std::vector<std::string>({"aaaaa", "baaaa"}));
 
     p.alphabet({0, 1}).contains_empty_word(true);
@@ -1744,18 +1740,18 @@ namespace libsemigroups {
     Presentation<std::string> p;
     p.contains_empty_word(true);
     presentation::add_rule_no_checks(p, "aaaaaaaa", "");
-    presentation::balance_no_checks(p, "a", "a");
+    presentation::balance_no_checks(p, "a"s, "a"s);
     presentation::add_rule_no_checks(p, "aaa", "aaaaaa");
-    presentation::balance_no_checks(p, "a", "a");
+    presentation::balance_no_checks(p, "a"s, "a"s);
     presentation::add_rule_no_checks(p, "aa", "");
-    presentation::balance_no_checks(p, "a", "a");
+    presentation::balance_no_checks(p, "a"s, "a"s);
     presentation::add_rule_no_checks(p, "abba", "baaaaaaaab");
-    presentation::balance_no_checks(p, "b", "a");
-    presentation::balance_no_checks(p, "a", "c");
+    presentation::balance_no_checks(p, "b"s, "a"s);
+    presentation::balance_no_checks(p, "a"s, "c"s);
     presentation::add_rule_no_checks(p, "baaaaaabbb", "");
-    presentation::balance_no_checks(p, "ab", "cd");
+    presentation::balance_no_checks(p, "ab"s, "cd"s);
     presentation::add_rule_no_checks(p, "abcabd", "");
-    presentation::balance_no_checks(p, "abc", "efg");
+    presentation::balance_no_checks(p, "abc"s, "efg"s);
     REQUIRE(p.rules
             == std::vector<std::string>(  // codespell:begin-ignore
                 {"aaaa",

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -1717,14 +1717,14 @@ namespace libsemigroups {
     p.rules = {"", "aa", "ba", "", "ab", ""};
     REQUIRE_EXCEPTION_MSG(
         presentation::balance(p),
-        "the rules \"ba\" = \"\" (rule 1) and \"aa\" = \"\" (rule 0) yield the "
+        "the rules \"ab\" = \"\" (rule 2) and \"aa\" = \"\" (rule 0) yield the "
         "conflicting values 'b' != 'a' for the inverse of 'a', please use the "
         "2- or 3-argument version of this function to explicitly specify the "
         "inverses");
     p.rules = {"", "ab", "ba", "", "cb", "", "bc", ""};
     REQUIRE_EXCEPTION_MSG(
         presentation::balance(p),
-        "the rules \"cb\" = \"\" (rule 2) and \"ab\" = \"\" (rule 0) yield the "
+        "the rules \"bc\" = \"\" (rule 3) and \"ba\" = \"\" (rule 1) yield the "
         "conflicting values 'c' != 'a' for the inverse of 'b', please use the "
         "2- or 3-argument version of this function to explicitly specify the "
         "inverses");

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -1539,6 +1539,27 @@ namespace libsemigroups {
                                {2, 2}}));
   }
 
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Presentation",
+                                   "086",
+                                   "helpers balance_no_checks (2 args)",
+                                   "[quick][presentation]",
+                                   std::string,
+                                   word_type) {
+    // TODO
+    // TODO(1) Add StaticVector1<uint16_t, 10>. Can't do this until
+    // StaticVector1 has .front or . end
+    auto rg = ReportGuard(false);
+    using W = TestType;
+
+    Presentation<W> p;
+    p.contains_empty_word(true).alphabet({0});
+
+    presentation::add_rule(p, {0, 0, 0, 0, 0, 0, 0, 0}, {});
+    REQUIRE(p.rules == std::vector<W>({{0, 0, 0, 0, 0, 0, 0, 0}, {}}));
+    presentation::balance_no_checks(p, {0});
+    REQUIRE(p.rules == std::vector<W>({{0, 0, 0, 0}, {0, 0, 0, 0}}));
+  }
+
   LIBSEMIGROUPS_TEST_CASE("Presentation",
                           "084",
                           "helpers balance (3 args, word_type)",
@@ -1590,6 +1611,42 @@ namespace libsemigroups {
     p.rules = {"aaaaaaaaa", "b"};
     presentation::balance(p, std::string_view("ab"), std::string_view("ba"));
     REQUIRE(p.rules == std::vector<std::string>({"aaaaa", "bbbbb"}));
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "087",
+                          "helpers balance (2 args, std::string)",
+                          "[quick][presentation]") {
+    auto rg = ReportGuard(false);
+
+    Presentation<std::string> p;
+    p.alphabet("ab").contains_empty_word(true);
+
+    p.rules = {"aaaaaaaaa", "b"};
+    presentation::balance_no_checks(p, "ba");
+    REQUIRE(p.rules == std::vector<std::string>({"aaaaa", "bbbbb"}));
+
+    p.rules = {"aaaaaaaaa", "b"};
+    presentation::balance_no_checks(p, std::string_view("ab"));
+    REQUIRE(p.rules == std::vector<std::string>({"aaaaa", "baaaa"}));
+
+    p.alphabet({0, 1}).contains_empty_word(true);
+    p.rules = {{
+                   0,
+                   0,
+                   0,
+                   0,
+                   0,
+                   0,
+                   0,
+                   0,
+                   0,
+               },
+               {1}};
+    presentation::balance_no_checks(p, {0, 1});
+
+    REQUIRE(p.rules
+            == std::vector<std::string>({{0, 0, 0, 0, 0}, {1, 0, 0, 0, 0}}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -3469,4 +3469,78 @@ namespace libsemigroups {
                           "invalid number of inverses, expected 3 but found 2");
   }
 
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "089",
+                          "is_rule (std::string)",
+                          "[quick][presentation]") {
+    Presentation<std::string> p;
+    p.alphabet("abc").contains_empty_word(true);
+    p.rules = {"aaa", "", "ba", "", "ba", "ab"};
+    REQUIRE(presentation::is_rule(p, "ba"s, "ab"s));
+    REQUIRE(!presentation::is_rule(p, "ba"s, "aa"s));
+    REQUIRE(!presentation::is_rule(p, "ba"s, "aa"s));
+    REQUIRE(presentation::is_rule(p, "aaa"s, ""s));
+    REQUIRE(!presentation::is_rule(p, ""s, "ba"s));
+
+    p.rules = {"aaa", "", "ba", "", "ba"};
+    REQUIRE_THROWS_AS(presentation::is_rule(p, ""s, ""s),
+                      LibsemigroupsException);
+    REQUIRE(presentation::is_rule_no_checks(p, "ba"s, ""s));
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "090",
+                          "find_rule (std::string)",
+                          "[quick][presentation]") {
+    Presentation<std::string> p;
+    p.alphabet("abc").contains_empty_word(true);
+    p.rules = {"aaa", "", "ba", "", "ba", "ab"};
+
+    auto it = presentation::find_rule(p, "ba"s, "ab"s);
+    REQUIRE(std::distance(p.rules.begin(), it) == 4);
+
+    it = presentation::find_rule(p, "ba"s, "aa"s);
+    REQUIRE(it == p.rules.end());
+
+    it = presentation::find_rule(p, "aaa"s, ""s);
+    REQUIRE(std::distance(p.rules.begin(), it) == 0);
+
+    p.rules = {"aaa", "", "ba", "", "ba"};
+    REQUIRE_THROWS_AS(presentation::find_rule(p, ""s, ""s),
+                      LibsemigroupsException);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "091",
+                          "index_rule (std::string)",
+                          "[quick][presentation]") {
+    Presentation<std::string> p;
+    p.alphabet("abc").contains_empty_word(true);
+    p.rules = {"aaa", "", "ba", "", "ba", "ab"};
+
+    REQUIRE(presentation::index_rule(p, "ba"s, "ab"s) == 4);
+    REQUIRE(presentation::index_rule(p, "ba"s, "aa"s) == UNDEFINED);
+    REQUIRE(presentation::index_rule(p, "aaa"s, ""s) == 0);
+    REQUIRE(presentation::index_rule(p, ""s, "ba"s) == UNDEFINED);
+
+    p.rules = {"aaa", "", "ba", "", "ba"};
+    REQUIRE_THROWS_AS(presentation::index_rule(p, ""s, ""s),
+                      LibsemigroupsException);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "092",
+                          "index_rule (word_type)",
+                          "[quick][presentation]") {
+    Presentation<word_type> p;
+    p.alphabet(3).contains_empty_word(true);
+    p.rules = {000_w, ""_w, 10_w, ""_w, 10_w, 01_w};
+
+    REQUIRE(presentation::index_rule(p, 10_w, 01_w) == 4);
+    REQUIRE(presentation::index_rule(p, 10_w, 00_w) == UNDEFINED);
+    REQUIRE(presentation::index_rule(p, 000_w, ""_w) == 0);
+    REQUIRE(presentation::index_rule(p, ""_w, 10_w) == UNDEFINED);
+    REQUIRE(presentation::index_rule(p, {}, {1, 0}) == UNDEFINED);
+  }
+
 }  // namespace libsemigroups

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -70,6 +70,7 @@ namespace libsemigroups {
 
   using word_graph_type = typename Sims1::word_graph_type;
   using node_type       = typename word_graph_type::node_type;
+  using std::string_literals::operator""s;
 
   using namespace literals;
 
@@ -3208,7 +3209,7 @@ namespace libsemigroups {
     presentation::add_rule(p, "Aba", "aab");
     presentation::sort_each_rule(p);
     presentation::sort_rules(p);
-    presentation::balance_no_checks(p, "abcABC", "ABCabc");
+    presentation::balance_no_checks(p, "abcABC"s, "ABCabc"s);
 
     REQUIRE(presentation::longest_subword_reducing_length(p) == "aa");
     presentation::replace_word_with_new_generator(p, "aa");

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -80,6 +80,7 @@ namespace libsemigroups {
 
   using TCE     = detail::TCE;
   using options = detail::ToddCoxeterImpl::options;
+  using std::string_literals::operator""s;
 
   using namespace literals;
   using namespace rx;
@@ -4824,7 +4825,7 @@ namespace libsemigroups {
     presentation::add_rule(p, "(ACac)^4"_p, "");
     presentation::add_rule(p, "BabAA"_p, "");
     presentation::add_rule(p, "(abc)^7"_p, "");
-    presentation::balance_no_checks(p, p.alphabet(), "ABCabc");
+    presentation::balance_no_checks(p, p.alphabet(), "ABCabc"s);
 
     ToddCoxeter tc(twosided, p);
     tc.strategy(options::strategy::felsch).use_relations_in_extra(true);


### PR DESCRIPTION
This function adds:

* a check version of `balance`
* a 2-argument version of `balance` and `balance_no_checks` only taking the inverses and using the entire alphabet for the "letters" argument of the 3-arg version
* a 1-argument version that auto-detects the inverses in rules (only works when they can be unambiguously determined and throws an exception when they cannot be)

a couple of other small things that are related to the above.

Completed on the train from somewhere south of York, and Koln.