### PR TITLE
Check `is_obviously_infinite` before running in `Congruence::number_of_classes`

### DIFF
--- a/include/libsemigroups/cong-class.tpp
+++ b/include/libsemigroups/cong-class.tpp
@@ -247,6 +247,9 @@ namespace libsemigroups {
 
   template <typename Word>
   uint64_t Congruence<Word>::number_of_classes() {
+    if (is_obviously_infinite(*this)) {
+      return POSITIVE_INFINITY;
+    }
     run();
     auto winner_kind = _runner_kinds[_race.winner_index()];
     if (winner_kind == RunnerKind::TC) {

--- a/tests/test-cong.cpp
+++ b/tests/test-cong.cpp
@@ -538,6 +538,9 @@ namespace libsemigroups {
     // non-trivial classes.
     // REQUIRE(cong.number_of_non_trivial_classes() == 0);
     REQUIRE(cong.number_of_classes() == POSITIVE_INFINITY);
+    // cong hasn't started yet, because the presentation is obviously infinite.
+    REQUIRE(!cong.started());
+    cong.run();
     REQUIRE(cong.has<KnuthBendix<std::string>>());
     REQUIRE(
         knuth_bendix::non_trivial_classes(*cong.get<KnuthBendix<std::string>>(),
@@ -1350,6 +1353,8 @@ namespace libsemigroups {
     REQUIRE(c.has<ToddCoxeter<std::string>>());
     REQUIRE(c.has<Kambites<std::string>>());
     REQUIRE(c.number_of_classes() == POSITIVE_INFINITY);
+    REQUIRE(!c.started());
+    c.run();
     REQUIRE(c.number_of_runners() == 1);
     REQUIRE(!c.has<ToddCoxeter<std::string>>());
     REQUIRE(!c.has<Kambites<std::string>>());

--- a/tests/test-cong.cpp
+++ b/tests/test-cong.cpp
@@ -1373,4 +1373,16 @@ namespace libsemigroups {
                "letters, 1 rule, and length 10> with 1 gen. pair, 4 runners>");
   }
 
+  LIBSEMIGROUPS_TEST_CASE("Congruence",
+                          "040",
+                          "obviously infinite",
+                          "[quick][cong]") {
+    auto                      rg = ReportGuard(true);
+    Presentation<std::string> p;
+    p.alphabet("ab");
+    presentation::add_rule(p, "bab", "ba");
+    Congruence c(twosided, p);
+    REQUIRE(c.number_of_classes() == POSITIVE_INFINITY);
+  }
+
 }  // namespace libsemigroups


### PR DESCRIPTION
This PR adds a check to see if a `Congruence` object is obviously infinite before calling `run` when computing `Congruence::number_of_classes`.

Closes #789.