### PR TITLE
`is_obviously_infinite(Kambites)` respects generating pairs

### DIFF
--- a/include/libsemigroups/obvinf.hpp
+++ b/include/libsemigroups/obvinf.hpp
@@ -614,7 +614,13 @@ namespace libsemigroups {
     if (k.finished() && k.small_overlap_class() >= 3) {
       return true;
     }
-    if (is_obviously_infinite(k.presentation())) {
+    auto const&         p = k.presentation();
+    IsObviouslyInfinite ioi(p.alphabet().size());
+    ioi.add_rules_no_checks(p.alphabet(), p.rules.cbegin(), p.rules.cend());
+    ioi.add_rules_no_checks(p.alphabet(),
+                            k.internal_generating_pairs().cbegin(),
+                            k.internal_generating_pairs().cend());
+    if (ioi.result()) {
       return true;
     }
     return k.small_overlap_class() >= 3;

--- a/tests/test-kambites.cpp
+++ b/tests/test-kambites.cpp
@@ -2276,16 +2276,29 @@ namespace libsemigroups {
                           "is_obviously_infinite respects generating pairs",
                           "[quick][kambites]") {
     auto rg = ReportGuard(false);
+    {
+      Presentation<word_type> p;
+      p.contains_empty_word(true).alphabet(2);
+      presentation::add_rule(p, 01_w, {});
 
-    Presentation<word_type> p;
-    p.contains_empty_word(true).alphabet(2);
-    presentation::add_rule(p, 01_w, {});
+      REQUIRE(is_obviously_infinite(p));
 
-    REQUIRE(is_obviously_infinite(p));
+      Kambites k(twosided, p);
+      REQUIRE(is_obviously_infinite(k));
+      kambites::add_generating_pair(k, 111_w, {});
+      REQUIRE(!is_obviously_infinite(k));
+    }
+    {
+      Presentation<std::string> p;
+      p.contains_empty_word(true).alphabet("ab");
+      presentation::add_rule(p, "ab", "");
 
-    Kambites k(twosided, p);
-    REQUIRE(is_obviously_infinite(k));
-    kambites::add_generating_pair(k, 111_w, {});
-    REQUIRE(!is_obviously_infinite(k));
+      REQUIRE(is_obviously_infinite(p));
+
+      Kambites k(twosided, p);
+      REQUIRE(is_obviously_infinite(k));
+      kambites::add_generating_pair(k, "bbb", "");
+      REQUIRE(!is_obviously_infinite(k));
+    }
   }
 }  // namespace libsemigroups

--- a/tests/test-kambites.cpp
+++ b/tests/test-kambites.cpp
@@ -2270,4 +2270,22 @@ namespace libsemigroups {
                "with 7 letters, 2 rules, and length 10> with small overlap "
                "class +∞>");
   }
+
+  LIBSEMIGROUPS_TEST_CASE("Kambites",
+                          "047",
+                          "is_obviously_infinite respects generating pairs",
+                          "[quick][kambites]") {
+    auto rg = ReportGuard(false);
+
+    Presentation<word_type> p;
+    p.contains_empty_word(true).alphabet(2);
+    presentation::add_rule(p, 01_w, {});
+
+    REQUIRE(is_obviously_infinite(p));
+
+    Kambites k(twosided, p);
+    REQUIRE(is_obviously_infinite(k));
+    kambites::add_generating_pair(k, 111_w, {});
+    REQUIRE(!is_obviously_infinite(k));
+  }
 }  // namespace libsemigroups


### PR DESCRIPTION
This PR updates the `Kambites` overload of `is_obviously_infinite` so that the presentation defined by `Kambites::presentation` + any generating pairs is checked for infinite-ness, not just the `Kambites::presentation`.

This is now consistent with what happens with `ToddCoxeter` and `KnuthBendix`.