### PR TITLE
Use the offiical `cygwin/cygwin-install-action`

### DIFF
--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -42,14 +42,16 @@ jobs:
     name: Cygwin
     defaults:
       run:
-        shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
+        shell: C:\cygwin\bin\bash.exe --login -o igncr '{0}'
     timeout-minutes: 60
     runs-on: windows-latest
     env:
       CHERE_INVOKING: 1
     steps:
-      - uses: gap-actions/setup-cygwin@v1
       - uses: actions/checkout@v5
+      - uses: cygwin/cygwin-install-action@v6
+        with:
+          packages: gcc-g++,libtool,autoconf,automake
       - name: Configure . . .
         run: ./autogen.sh && ./configure --disable-eigen --disable-hpcombi CXXFLAGS="-Os"
       - name: Build libsemigroups . . .


### PR DESCRIPTION
This PR replaces `gap-actions/setup-cygwin` with `cygwin/cygwin-install-action`. This supersedes #786.