### PR TITLE
Add an option to compile with external backward

### DIFF
--- a/.github/workflows/config-options.yml
+++ b/.github/workflows/config-options.yml
@@ -56,6 +56,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        external-backward:
+          - --with-external-backward
+          - ""
         external-fmt:
           - --with-external-fmt
           - ""
@@ -63,14 +66,16 @@ jobs:
           - --with-external-eigen
           - ""
         exclude:
+          - external-backward: ""
           - external-fmt: ""
             external-eigen: ""
     env:
       CXX: ccache g++
       CXXFLAGS: -fdiagnostics-color
-      CONFIGFLAGS: ${{ matrix.external-fmt }} ${{ matrix.external-eigen }}
+      CONFIGFLAGS: ${{ matrix.external-backward }} ${{ matrix.external-fmt }} ${{ matrix.external-eigen }}
       PKG_CONFIG_PATH: /home/runner/micromamba/envs/libsemigroups/lib/pkgconfig:/home/runner/micromamba/envs/libsemigroups/share/pkgconfig/
       LD_LIBRARY_PATH: /home/runner/micromamba/envs/libsemigroups/lib
+      BACKWARD_CPPFLAGS: -I/home/runner/micromamba/envs/libsemigroups/lib
     steps:
       - uses: actions/checkout@v5
       - name: Setup ccache . . .
@@ -89,15 +94,7 @@ jobs:
           ./configure CXX="$CXX" CXXFLAGS="$CXXFLAGS" $CONFIGFLAGS
       - name: Build libsemigroups . . .
         run: make -j4
-      - name: Build and run tests for eigen
-        if: ${{ matrix.external-fmt == '' }}
-        run: |
-          make test_obvinf test_word_graph test_cong -j4
-          ./test_cong [quick]
-          ./test_obvinf [quick]
-          ./test_word_graph [quick]
       - name: Build and run all quick tests . . .
-        if: ${{ matrix.external-fmt != '' }}
         run: |
           make test_all -j4
           ./test_all [quick]

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,8 @@ else
 AM_CPPFLAGS = -DNDEBUG
 endif
 
+AM_CPPFLAGS += $(BACKWARD_CPPFLAGS)
+
 AM_CPPFLAGS += $(CODE_COVERAGE_CPPFLAGS)
 AM_CXXFLAGS += $(CODE_COVERAGE_CXXFLAGS)
 
@@ -193,8 +195,13 @@ magicenuminclude_HEADERS += third_party/magic_enum-0.9.7/include/magic_enum/magi
 rxrangesincludedir = $(includedir)/libsemigroups/rx
 rxrangesinclude_HEADERS = third_party/rx-ranges/include/rx/ranges.hpp
 
+## Define backwardincludedir outside the conditional
+## LIBSEMIGROUPS_WITH_INTERNAL_BACKWARD because it is used by
+## uninstall-hook
 backwardcppincludedir = $(includedir)/libsemigroups/backward-cpp
+if LIBSEMIGROUPS_WITH_INTERNAL_BACKWARD
 backwardcppinclude_HEADERS=third_party/backward-cpp/backward.hpp
+endif
 
 ## Define hpcombiincludedir outside the conditional
 ## LIBSEMIGROUPS_HPCOMBI_ENABLED because it is used by

--- a/configure.ac
+++ b/configure.ac
@@ -116,35 +116,13 @@ AS_IF([test "x$compile_warnings" = "xyes"],
        -Wold-style-cast])
    AC_SUBST([WARNING_CXXFLAGS])])
 
-########################################
-# backward
-########################################
-
-AC_MSG_CHECKING([whether to enable backward mode])
-
-# Check if --enable-backward or --disable-backward was specified, and provide
-# the help string for the flag. If a flag was specified, set the value of
-# backward accordingly. Otherwise, if a flag was not specified, set backward to
-# yes.
-AC_ARG_ENABLE([backward],
-    [AS_HELP_STRING([--disable-backward], [disable backward])],
-    [case "${enableval}" in
-        yes) backward=yes ;;
-        no)  backward=no ;;
-        *) AC_MSG_ERROR([bad value ${enableval} for --enable-backward]) ;;
-    esac],
-    [backward=yes]
-  )
-AC_MSG_RESULT([$backward])
-
-AS_IF([test "x$backward" = "xyes"], [
-  AC_CHECK_HEADER(execinfo.h,
-    [AC_DEFINE([BACKWARD_ENABLED], [1], [define if building with backward-cpp enabled])],
-    [AC_MSG_WARN([backward enabled but execinfo.h not found, disabling backward!])])
-])
 
 # Check if code coverage mode is enabled
 AX_CODE_COVERAGE()
+
+# Check if the vendored backward should be used or not, or if backward should be
+# disabled altogether
+AX_CHECK_BACKWARD()
 
 # Check if HPCombi is enable, and available
 AX_CHECK_HPCOMBI()

--- a/docs/install.md
+++ b/docs/install.md
@@ -45,22 +45,25 @@ To build `libsemigroups` from a release archive:
 In addition to the usual `autoconf` configuration options, the following
 configuration options are available for `libsemigroups`:
 
-| Option                     | Description                                        |
-| -------------------------- | -------------------------------------------------- |
-| \--enable-code-coverage    | enable code coverage support (default=no)          |
-| \--enable-compile-warnings | enable compiler warnings (default=no)              |
-| \--enable-debug            | enable debug mode (default=no)                     |
-| \--enable-eigen            | enable `eigen` (default=yes)                       |
-| \--enable-hpcombi          | enable `HPCombi` (default=yes)                     |
-| \--with-external-fmt       | do not use the included copy of fmt (default=no)   |
-| \--with-external-eigen     | do not use the included copy of eigen (default=no) |
-| \--disable-popcnt          | do not use \_\_builtin_popcountl (default=yes)     |
-| \--disable-clzll           | do not use \_\_builtin_clzll (default=yes)         |
+| Option                     | Description                                             |
+| -------------------------- | ------------------------------------------------------- |
+| \--enable-backward         | enable `backward` for better stack traces (default=yes) |
+| \--enable-code-coverage    | enable code coverage support (default=no)               |
+| \--enable-compile-warnings | enable compiler warnings (default=no)                   |
+| \--enable-debug            | enable debug mode (default=no)                          |
+| \--enable-eigen            | enable `eigen` (default=yes)                            |
+| \--enable-hpcombi          | enable `HPCombi` (default=yes)                          |
+| \--with-external-backward  | do not use the included copy of backward (default=no)   |
+| \--with-external-fmt       | do not use the included copy of fmt (default=no)        |
+| \--with-external-eigen     | do not use the included copy of eigen (default=no)      |
+| \--disable-popcnt          | do not use \_\_builtin_popcountl (default=yes)          |
+| \--disable-clzll           | do not use \_\_builtin_clzll (default=yes)              |
 
 Debug mode significantly degrades the performance of `libsemigroups`. Note that
 the flags `--enable-eigen` and `--with-external-eigen` are independent of each
 other, and so both flags should be included to enable `eigen` and use an
-external `eigen`.
+external `eigen`. The same is true of `--enable-backward` and
+`--with-external-backward`.
 
 ## Make install
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ channels:
 dependencies:
   - eigen
   - fmt
+  - backward-cpp

--- a/m4/ax_check_backward.m4
+++ b/m4/ax_check_backward.m4
@@ -1,0 +1,56 @@
+dnl handle backward checks
+
+AC_DEFUN([AX_CHECK_BACKWARD], [
+  AC_MSG_CHECKING([whether to enable backward mode])
+
+  # Check if --enable-backward or --disable-backward was specified, and provide
+  # the help string for the flag. If a flag was specified, set the value of
+  # backward accordingly. Otherwise, if a flag was not specified, set backward to
+  # yes.
+  AC_ARG_ENABLE([backward],
+    [AS_HELP_STRING([--disable-backward], [disable backward (default: no)])],
+    [case "${enableval}" in
+      yes) backward=yes ;;
+      no)  backward=no ;;
+      *) AC_MSG_ERROR([bad value ${enableval} for --enable-backward]) ;;
+    esac],
+    [backward=yes]
+  )
+  AC_MSG_RESULT([$backward])
+
+  AS_IF([test "x$backward" = "xyes"], [
+    AC_CHECK_HEADER(execinfo.h,
+      [AC_DEFINE([BACKWARD_ENABLED], [1], [define if building with backward enabled])],
+      [AC_MSG_WARN([backward enabled but execinfo.h not found, disabling backward!])])
+  ])
+  
+  if test "x$backward" = xyes; then
+    AC_MSG_CHECKING([whether to use external backward])
+    AC_ARG_WITH(
+      [external-backward],
+      [AS_HELP_STRING([--with-external-backward], [use the external backward (default: no)])],
+      [], 
+      [with_external_backward=no]
+    )
+    AC_MSG_RESULT([$with_external_backward])
+   
+    if test "x$with_external_backward" = xyes;  then
+      TMP_CPPFLAGS="$CPPFLAGS"
+      CPPFLAGS+="$BACKWARD_CPPFLAGS"
+      AC_CHECK_HEADER(backward.hpp,
+        [],
+        [AC_MSG_ERROR([--with-external-backward has been specified, but backward.hpp cannot be found. Consider specifying BACKWARD_CPPFLAGS to include the path to backward.hpp.])]
+      )
+      CPPFLAGS="$TMP_CPPFLAGS"
+    else
+      AC_SUBST(BACKWARD_CFLAGS, ['-I$(srcdir)/third_party/backward-cpp/'])
+    fi
+    AC_SUBST([BACKWARD_CPPFLAGS])
+  fi
+
+  dnl The following makes LIBSEMIGROUPS_WITH_INTERNAL_BACKWARD usable in Makefile.am
+  AM_CONDITIONAL([LIBSEMIGROUPS_WITH_INTERNAL_BACKWARD], [test "x$enable_backward" = xyes && test "x$with_external_backward" != xyes])
+])
+
+
+


### PR DESCRIPTION
This PR adds the compiler flag `--with-external-backward` to enable compiling with an external version of backward.

It's not clear to me how backward really works, so I don't know whether the tests are thorough enough. I'm not familiar with any way to test the output of a compiler error in the CI.