### PR TITLE
Manually brew install ccache

### DIFF
--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -75,11 +75,13 @@ jobs:
       CXXFLAGS: -fdiagnostics-color
     steps:
       - uses: actions/checkout@v5
+      - name: Install ccache
+        run: brew install ccache
       - name: Setup ccache . . .
         uses: Chocobo1/setup-ccache-action@v1
         with:
           update_packager_index: false
-          install_ccache: true
+          install_ccache: false
       - name: Runner information . . .
         run: uname -a
       - name: Install dependencies . . .


### PR DESCRIPTION
For some reason, [setup-ccache-action](https://github.com/Chocobo1/setup-ccache-action) has become quite slow on our macos-13 runner. This PR manually changes that job so that `ccache` is manually installed, and then uses setup-ccache-action to do the configuration.

Closes #805  