### PR TITLE
todd-coxeter: fix bug in reduce

### DIFF
--- a/include/libsemigroups/detail/todd-coxeter-impl.tpp
+++ b/include/libsemigroups/detail/todd-coxeter-impl.tpp
@@ -98,6 +98,7 @@ namespace libsemigroups {
     OutputIterator
     ToddCoxeterImpl::current_word_of_no_checks(OutputIterator d_first,
                                                index_type     i) const {
+      LIBSEMIGROUPS_ASSERT(i != UNDEFINED);
       if (!is_standardized()) {
         // We must standardize here o/w there's no bijection between the numbers
         // 0, ..., n - 1 on to the nodes of the word graph.
@@ -106,6 +107,7 @@ namespace libsemigroups {
         // TODO(1) bit fishy here too
         const_cast<ToddCoxeterImpl*>(this)->standardize(Order::shortlex);
       }
+
       size_t const offset
           = (internal_presentation().contains_empty_word() ? 0 : 1);
 
@@ -217,8 +219,11 @@ namespace libsemigroups {
       if (finished()
           || (kind() == congruence_kind::onesided
               && !internal_generating_pairs().empty())) {
-        return current_word_of_no_checks(
-            d_first, current_index_of_no_checks(first, last));
+        index_type pos = current_index_of_no_checks(first, last);
+        if (pos == UNDEFINED) {
+          return std::copy(first, last, d_first);
+        }
+        return current_word_of_no_checks(d_first, pos);
       }
 
       node_type const s = current_word_graph().initial_node();

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -5194,4 +5194,20 @@ namespace libsemigroups {
                       LibsemigroupsException);
   }
 
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "126",
+                          "reduce_no_run_no_checks on unstarted",
+                          "[todd-coxeter][quick]") {
+    Presentation<word_type> p;
+    p.alphabet(2).contains_empty_word(true);
+
+    presentation::add_rule(p, 000_w, 0_w);
+    presentation::add_rule(p, 1111_w, 1_w);
+    presentation::add_rule(p, 0101_w, 00_w);
+    ToddCoxeter tc(onesided, p);
+    todd_coxeter::add_generating_pair(tc, 01_w, 10_w);
+
+    REQUIRE(todd_coxeter::reduce_no_run_no_checks(tc, 0101_w) == 0101_w);
+  }
+
 }  // namespace libsemigroups


### PR DESCRIPTION
I introduced this bug in PR #754 when fixing `reduce_no_run_no_checks` for one-sided congruences.