### PR TITLE
Add dev environment

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -144,7 +144,17 @@ a ***non-bugfix release*** is one of the form ``x.y.z -> x+1.y.z`` or
 Tools for developers
 --------------------
 
-The following tools may be useful for developers of ``libsemigroups``.
+The following tools may be useful for developers of ``libsemigroups``. Their use
+is explained in the following sections, and all of them cen be installed in a
+conda/mamba environment by running
+
+.. code-block:: console
+
+  source etc/make-dev-environment.sh
+
+This script requires a conda-flavoured package manager. A good choice is
+``mamba``, and instructions on how to install it can be found on the
+`mamba installation page <https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html>`_.
 
 ``clang-format``
 ~~~~~~~~~~~~~~~~

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - clang-format-15
   - codespell
   - cpplint
+  - doxygen
   - gitpython
   - matplotlib
   - numpy

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -1,0 +1,21 @@
+name: libsemigroups_dev
+
+channels:
+  - conda-forge
+  - nodefaults
+
+dependencies:
+  - python>=3.13
+  - bs4
+  - clang-format-15
+  - codespell
+  - cpplint
+  - gitpython
+  - matplotlib
+  - numpy
+  - pandas
+  - pip
+  - rich
+  - seaborn
+  - pip:
+      - accepts

--- a/etc/make-dev-environment.sh
+++ b/etc/make-dev-environment.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+is_sourced() {
+    if [ -n "$ZSH_VERSION" ]; then
+        case $ZSH_EVAL_CONTEXT in *:file:*) return 0 ;; esac
+    else
+        case ${0##*/} in dash | -dash | bash | -bash | ksh | -ksh | sh | -sh) return 0 ;; esac
+    fi
+    return 1 # NOT sourced.
+}
+
+is_sourced && sourced=1 || sourced=0
+if [[ $sourced -ne 1 ]]; then
+    echo This script must be sourced, rather than run directly. Please try again with:
+    echo source $(basename "$0")
+    exit
+fi
+
+unset sourced
+
+if [[ $# -eq 0 ]]; then
+    dev_env_pkg_manager=mamba
+else
+    dev_env_pkg_manager=$1
+fi
+
+if { $dev_env_pkg_manager env list | grep 'libsemigroups_dev'; } >/dev/null 2>&1; then
+    echo The environment libsemigroups_dev already exists. Stopping ...
+    unset dev_env_pkg_manager
+    return
+else
+    echo Making libsemigroups_dev environment using $dev_env_pkg_manager ...
+    echo
+    $dev_env_pkg_manager env create -f dev-environment.yml
+    if [[ $? -ne 0 ]]; then
+        echo The environment was not successfully created. Stopping ...
+        unset dev_env_pkg_manager
+        return
+    fi
+    echo Activating libsemigroups_dev ...
+    echo
+    $dev_env_pkg_manager activate libsemigroups_dev
+    if [[ $? -ne 0 ]]; then
+        echo The environment cannot be activated. Please try activating it yourself.
+        unset dev_env_pkg_manager
+        return
+    fi
+fi
+
+unset dev_env_pkg_manager


### PR DESCRIPTION
Similar to the environment we have for `libsemigroups_pybind11`, this PR adds a script and a YAML file that will enable `libsemigroups` developers to easily install a suite of tools that are useful in the development process.

My personal favourite is `clang-format-15`. I can't believe it's been available on `conda-forge` all this time!

I've probably missed some useful tools, so please comment any that should be included. 