### PR TITLE
dev: add missing dependencies to yml file

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -6,12 +6,18 @@ channels:
 
 dependencies:
   - python>=3.13
+  - autoconf
+  - automake
   - bs4
+  - ccache
   - clang-format-15
   - codespell
   - cpplint
   - doxygen
   - gitpython
+  - graphviz
+  - libtool
+  - lxml
   - matplotlib
   - numpy
   - pandas


### PR DESCRIPTION
graphviz is required to build the doc, and lxml is required for using etc/generate_pybind11.py.