### PR TITLE
Deprecate `report_every`

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -310,7 +310,8 @@ ALIASES                = "exceptions=\par Exceptions" \
                          "ref_knuth_bendix=\ref knuth_bendix_class_group \"KnuthBendix\"" \
                          "ref_kambites=\ref kambites_class_group \"Kambites\"" \
                          "ref_congruence=\ref congruence_class_group \"Congruence\"" \
-                         "deprecated_alias_warning{1}=\warning This alias is deprecated and will be removed from `libsemigroups` in v4, please use `\1` instead."
+                         "deprecated_alias_warning{1}=\warning This alias is deprecated and will be removed from `libsemigroups` in v4, please use `\1` instead."\
+                         "deprecated_alias_warning=\warning This alias is deprecated and will be removed from `libsemigroups` in v4."
 
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources

--- a/include/libsemigroups/detail/knuth-bendix-impl.tpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.tpp
@@ -654,7 +654,7 @@ namespace libsemigroups {
       std::atomic_bool pause = false;
       if (reporting_enabled()) {
         detail::Ticker t([&]() { report_progress_from_thread(pause); },
-                         report_every());
+                         std::chrono::seconds(1));
         run_real(pause);
       } else {
         run_real(pause);

--- a/include/libsemigroups/detail/todd-coxeter-impl.hpp
+++ b/include/libsemigroups/detail/todd-coxeter-impl.hpp
@@ -727,11 +727,11 @@ namespace libsemigroups {
 #ifndef LIBSEMIGROUPS_PARSED_BY_DOXYGEN
       // This is documented in Reporter, so we don't duplicate the doc here.
       template <typename Time>
-      void report_every(Time val) {
+      [[deprecated]] void report_every(Time val) {
         CongruenceCommon::report_every(val);
       }
 
-      [[nodiscard]] nanoseconds report_every() const noexcept {
+      [[deprecated]] [[nodiscard]] nanoseconds report_every() const noexcept {
         return Reporter::report_every();
       }
 #endif

--- a/include/libsemigroups/detail/todd-coxeter-impl.hpp
+++ b/include/libsemigroups/detail/todd-coxeter-impl.hpp
@@ -728,11 +728,17 @@ namespace libsemigroups {
       // This is documented in Reporter, so we don't duplicate the doc here.
       template <typename Time>
       [[deprecated]] void report_every(Time val) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         CongruenceCommon::report_every(val);
+#pragma GCC diagnostic pop
       }
 
       [[deprecated]] [[nodiscard]] nanoseconds report_every() const noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         return Reporter::report_every();
+#pragma GCC diagnostic pop
       }
 #endif
 

--- a/include/libsemigroups/runner.hpp
+++ b/include/libsemigroups/runner.hpp
@@ -186,7 +186,9 @@ namespace libsemigroups {
     //!
     //! \sa
     //! report_every(Time)
-    Reporter& report_every(nanoseconds val) noexcept {
+    //!
+    //! \deprecated_alias_warning
+    [[deprecated]] Reporter& report_every(nanoseconds val) noexcept {
       _last_report          = std::chrono::high_resolution_clock::now();
       _report_time_interval = val;
       return *this;
@@ -210,8 +212,10 @@ namespace libsemigroups {
     //! \noexcept
     //!
     //! \note This function is not thread-safe.
+    //!
+    //! \deprecated_alias_warning
     template <typename Time>
-    Reporter& report_every(Time t) noexcept {
+    [[deprecated]] Reporter& report_every(Time t) noexcept {
       return report_every(nanoseconds(t));
     }
 
@@ -224,7 +228,9 @@ namespace libsemigroups {
     //! \noexcept
     //!
     //! \note This function is thread-safe.
-    [[nodiscard]] nanoseconds report_every() const noexcept {
+    //!
+    //! \deprecated_alias_warning
+    [[deprecated]] [[nodiscard]] nanoseconds report_every() const noexcept {
       return _report_time_interval;
     }
 

--- a/include/libsemigroups/runner.hpp
+++ b/include/libsemigroups/runner.hpp
@@ -216,7 +216,10 @@ namespace libsemigroups {
     //! \deprecated_alias_warning
     template <typename Time>
     [[deprecated]] Reporter& report_every(Time t) noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       return report_every(nanoseconds(t));
+#pragma GCC diagnostic pop
     }
 
     //! \brief Get the minimum elapsed time between reports.

--- a/tests/test-action.cpp
+++ b/tests/test-action.cpp
@@ -547,7 +547,6 @@ namespace libsemigroups {
     REQUIRE((o.range() | rx::to_vector()) == std::vector<uint8_t>({0}));
     o.add_generator(Perm({1, 0, 2, 3, 4, 5, 6, 7}));
     o.add_generator(Perm({1, 2, 3, 4, 5, 6, 7, 0}));
-    o.report_every(std::chrono::nanoseconds(10));
 
     REQUIRE(o.current_size() == 1);
     REQUIRE(o.size() == 8);

--- a/tests/test-runner.cpp
+++ b/tests/test-runner.cpp
@@ -235,6 +235,8 @@ namespace libsemigroups {
       auto        rg = ReportGuard(false);
       TestRunner1 tr;
       REQUIRE(!tr.report());
+      // We include this deprecated function so that we can still test tr.report
+      // without increasing the runtime of this test to one second.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       tr.report_every(std::chrono::milliseconds(10));

--- a/tests/test-runner.cpp
+++ b/tests/test-runner.cpp
@@ -87,9 +87,6 @@ namespace libsemigroups {
     LIBSEMIGROUPS_TEST_CASE("Reporter", "000", "Code coverage", "[quick]") {
       Reporter r;
       REQUIRE(!r.report());
-      REQUIRE(r.report_every() == std::chrono::seconds(1));
-      r.report_every(std::chrono::seconds(2));
-      REQUIRE(r.report_every() == std::chrono::seconds(2));
       REQUIRE_NOTHROW(r.last_report());
       r.reset_last_report();
       REQUIRE(delta(r.last_report()) < std::chrono::seconds(1));
@@ -97,26 +94,20 @@ namespace libsemigroups {
       REQUIRE(r.report_prefix() == "Banana");
       r.init();
       REQUIRE(r.report_prefix() == "");
-      REQUIRE(r.report_every() == std::chrono::seconds(1));
       r.report_prefix("Banana");
-      r.report_every(std::chrono::seconds(32));
 
       Reporter s;
       s = r;
       REQUIRE(s.report_prefix() == "Banana");
-      REQUIRE(s.report_every() == std::chrono::seconds(32));
       REQUIRE(s.last_report() == r.last_report());
       s.init();
       REQUIRE(s.report_prefix() == "");
-      REQUIRE(s.report_every() == std::chrono::seconds(1));
 
       Reporter t(std::move(r));
       REQUIRE(t.report_prefix() == "Banana");
-      REQUIRE(t.report_every() == std::chrono::seconds(32));
 
       t = std::move(s);
       REQUIRE(t.report_prefix() == "");
-      REQUIRE(t.report_every() == std::chrono::seconds(1));
 
       s.report_divider("666");
       REQUIRE(s.report_divider() == "666");
@@ -244,7 +235,10 @@ namespace libsemigroups {
       auto        rg = ReportGuard(false);
       TestRunner1 tr;
       REQUIRE(!tr.report());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       tr.report_every(std::chrono::milliseconds(10));
+#pragma GCC diagnostic pop
       tr.run_for(std::chrono::milliseconds(20));
       REQUIRE(tr.report());
     }

--- a/tests/test-stephen.cpp
+++ b/tests/test-stephen.cpp
@@ -607,7 +607,6 @@ namespace libsemigroups {
     REQUIRE(S.finished());
     S.run();
     stephen::set_word(S, to_word("abbbddbcbcbc"));  // resets
-    S.report_every(std::chrono::microseconds(10));
 
     S.run();
 

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -1450,7 +1450,6 @@ namespace libsemigroups {
 
     ToddCoxeter tc2(onesided, tc1);
     tc2.lookahead_next(1);
-    tc2.report_every(1);
     todd_coxeter::add_generating_pair(tc2, 0_w, 00_w);
 
     section_hlt(tc2);


### PR DESCRIPTION
This PR deprecates the `Runner::report_every` function. Setting the report interval to less than one second generates too much output, and setting the report interval to more than one second means that any comparison between two intervals is likely not useful. I'm less convinced in the latter of those arguments, so am happy to hear other opinions.

Partly closes #804, but I couldn't see any reference to a `report_interval` function, so I'm not sure what was meant to be deprecated there.