### PR TITLE
Forest dot function

### DIFF
--- a/include/libsemigroups/dot.hpp
+++ b/include/libsemigroups/dot.hpp
@@ -82,6 +82,7 @@ namespace libsemigroups {
   //! various of the data structures and algorithms in `libsemigroups`:
   //!
   //! * \ref aho_corasick::dot(AhoCorasick&)
+  //! * \ref forest::dot(Forest const&)
   //! * \ref stephen::dot(Stephen<PresentationType>&)
   //! * \ref ukkonen::dot(Ukkonen const&)
   //! * \ref word_graph::dot(WordGraph<Node> const&)

--- a/include/libsemigroups/forest.hpp
+++ b/include/libsemigroups/forest.hpp
@@ -28,6 +28,7 @@
 
 #include "constants.hpp"  // for UNDEFINED, operator!=, operator==
 #include "debug.hpp"      // for LIBSEMIGROUPS_ASSERT
+#include "dot.hpp"        // for Dot
 #include "exception.hpp"  // for LIBSEMIGROUPS_EXCEPTION
 #include "types.hpp"      // for word_type, enable_if_is_same
 
@@ -831,6 +832,33 @@ namespace libsemigroups {
     //!
     //! \sa \ref Forest::throw_if_not_acyclic
     [[nodiscard]] bool is_forest(Forest const& f);
+
+    //! \brief Returns a \ref Dot object representing a Forest.
+    //!
+    //! This function returns a \ref Dot object representing the Forest
+    //! \p f.
+    //!
+    //! \param f the Forest.
+    //!
+    //! \returns A \ref Dot object.
+    [[nodiscard]] Dot dot(Forest const& f);
+
+    //! \brief Returns a \ref Dot object representing a Forest.
+    //!
+    //! This function returns a \ref Dot object representing the Forest
+    //! \p f. If \p labels is not empty, then each node is labelled with the
+    //! path from that node to the root of its tree with each letter replaced by
+    //! the string in the corresponding position of \p labels. If \p labels is
+    //! empty, then the nodes are not labelled by their paths.
+    //!
+    //! \param f the Forest.
+    //! \param labels substitute for each edge label.
+    //!
+    //! \returns A \ref Dot object.
+    //!
+    //! \throws LibsemigroupsException if the size of \p labels is not the same
+    //! as the \ref max_label plus one.
+    Dot dot(Forest const& f, std::vector<std::string> const& labels);
 
   }  // namespace forest
 }  // namespace libsemigroups

--- a/tests/test-forest.cpp
+++ b/tests/test-forest.cpp
@@ -303,4 +303,96 @@ namespace libsemigroups {
         f.throw_if_not_acyclic(),
         "the Forest object contains the loop [0] and is invalid");
   }
+
+  LIBSEMIGROUPS_TEST_CASE("Forest", "011", "dot", "[quick]") {
+    Forest f = make<Forest>(
+        {UNDEFINED, 4, 0, 0, UNDEFINED, 3, 8, 1, 1, 12, 12, 8, 3},
+        {UNDEFINED, 0, 0, 1, UNDEFINED, 0, 1, 1, 0, 0, 1, 0, 1});
+
+    REQUIRE(forest::dot(f).to_string() == R"vogon(digraph Forest {
+  rankdir="BT"
+  0  [label="0: ε", shape="box"]
+  1  [label="1: 0", shape="box"]
+  10  [label="10: 111", shape="box"]
+  11  [label="11: 000", shape="box"]
+  12  [label="12: 11", shape="box"]
+  2  [label="2: 0", shape="box"]
+  3  [label="3: 1", shape="box"]
+  4  [label="4: ε", shape="box"]
+  5  [label="5: 01", shape="box"]
+  6  [label="6: 100", shape="box"]
+  7  [label="7: 10", shape="box"]
+  8  [label="8: 00", shape="box"]
+  9  [label="9: 011", shape="box"]
+  1 -> 4  [color="#00ff00"]
+  2 -> 0  [color="#00ff00"]
+  3 -> 0  [color="#ff00ff"]
+  5 -> 3  [color="#00ff00"]
+  6 -> 8  [color="#ff00ff"]
+  7 -> 1  [color="#ff00ff"]
+  8 -> 1  [color="#00ff00"]
+  9 -> 12  [color="#00ff00"]
+  10 -> 12  [color="#ff00ff"]
+  11 -> 8  [color="#00ff00"]
+  12 -> 3  [color="#ff00ff"]
+})vogon");
+
+    REQUIRE(forest::dot(f, {"a", "b"}).to_string() == R"vogon(digraph Forest {
+  rankdir="BT"
+  0  [label="0: ε", shape="box"]
+  1  [label="1: a", shape="box"]
+  10  [label="10: bbb", shape="box"]
+  11  [label="11: aaa", shape="box"]
+  12  [label="12: bb", shape="box"]
+  2  [label="2: a", shape="box"]
+  3  [label="3: b", shape="box"]
+  4  [label="4: ε", shape="box"]
+  5  [label="5: ab", shape="box"]
+  6  [label="6: baa", shape="box"]
+  7  [label="7: ba", shape="box"]
+  8  [label="8: aa", shape="box"]
+  9  [label="9: abb", shape="box"]
+  1 -> 4  [color="#00ff00"]
+  2 -> 0  [color="#00ff00"]
+  3 -> 0  [color="#ff00ff"]
+  5 -> 3  [color="#00ff00"]
+  6 -> 8  [color="#ff00ff"]
+  7 -> 1  [color="#ff00ff"]
+  8 -> 1  [color="#00ff00"]
+  9 -> 12  [color="#00ff00"]
+  10 -> 12  [color="#ff00ff"]
+  11 -> 8  [color="#00ff00"]
+  12 -> 3  [color="#ff00ff"]
+})vogon");
+
+    REQUIRE_THROWS_AS(forest::dot(f, {"a", "b", "c"}), LibsemigroupsException);
+
+    REQUIRE(forest::dot(f, {}).to_string() == R"vogon(digraph Forest {
+  rankdir="BT"
+  0  [shape="box"]
+  1  [shape="box"]
+  10  [shape="box"]
+  11  [shape="box"]
+  12  [shape="box"]
+  2  [shape="box"]
+  3  [shape="box"]
+  4  [shape="box"]
+  5  [shape="box"]
+  6  [shape="box"]
+  7  [shape="box"]
+  8  [shape="box"]
+  9  [shape="box"]
+  1 -> 4  [color="#00ff00"]
+  2 -> 0  [color="#00ff00"]
+  3 -> 0  [color="#ff00ff"]
+  5 -> 3  [color="#00ff00"]
+  6 -> 8  [color="#ff00ff"]
+  7 -> 1  [color="#ff00ff"]
+  8 -> 1  [color="#00ff00"]
+  9 -> 12  [color="#00ff00"]
+  10 -> 12  [color="#ff00ff"]
+  11 -> 8  [color="#00ff00"]
+  12 -> 3  [color="#ff00ff"]
+})vogon");
+  }
 }  // namespace libsemigroups


### PR DESCRIPTION
This PR adds the function `forest::dot` for producing a `Dot` object from a `Forest`.