### PR TITLE
CI: Don’t sudo pip install

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Building libsemigroups_pybind11 . . .
         run: |
           cd libsemigroups_pybind11
-          sudo -H pip3 install .
+          pip3 install .
       - name: Running libsemigroups_pybind11 tests. . .
         run: |
           cd libsemigroups_pybind11


### PR DESCRIPTION
This PR removes the sudo prefix from the pip commands in the CI, as this is generally discouraged.