### PR TITLE
Use new macOS runners

### DIFF
--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -69,7 +69,7 @@ jobs:
       matrix:
         os:
           - { image_name: macos-latest, arch: arm }
-          - { image_name: macos-13, arch: x86 }
+          - { image_name: macos-15-intel, arch: x86 }
     env:
       CXX: ccache clang++
       CXXFLAGS: -fdiagnostics-color


### PR DESCRIPTION
This PR uses the new `macos-15-intel` runner, because the [macOS 13 runner is closing down](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/).