### PR TITLE
Prevent overlapping cache keys in the CI

### DIFF
--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -60,16 +60,43 @@ jobs:
         run: make test_all.exe -j4
       - name: Run the quick tests (ex:no-cygwin)
         run: ./test_all "[quick][exclude:no-cygwin]"
-  macos:
-    name: "macOS-${{ matrix.os.arch }}"
+  # TODO: Turn the macOS jobs back into a matrix once the following is resolved:
+  # https://github.com/Chocobo1/setup-ccache-action/issues/25
+  macos-arm:
+    name: "macOS-arm"
     timeout-minutes: 60
-    runs-on: ${{ matrix.os.image_name }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - { image_name: macos-latest, arch: arm }
-          - { image_name: macos-15-intel, arch: x86 }
+    runs-on: macos-latest
+    env:
+      CXX: ccache clang++
+      CXXFLAGS: -fdiagnostics-color
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup ccache . . .
+        uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
+          install_ccache: true
+      - name: Runner information . . .
+        run: uname -a
+      - name: Install dependencies . . .
+        run: brew install autoconf automake libtool
+      - name: Clang version . . .
+        run: clang++ --version
+      - name: Configure . . .
+        run: |
+          mkdir -p m4
+          ./autogen.sh
+          ./configure CXX="$CXX" CXXFLAGS="$CXXFLAGS" --disable-backward
+      - name: Build libsemigroups . . .
+        run: make -j4
+      - name: Build test_all . . .
+        run: make test_all -j4
+      - name: Run the quick tests . . .
+        run: ./test_all "[quick]"
+  macos-x86:
+    name: "macOS-x86"
+    timeout-minutes: 60
+    runs-on: macos-15-intel
     env:
       CXX: ccache clang++
       CXXFLAGS: -fdiagnostics-color


### PR DESCRIPTION
This PR temporarily fixes #852 by preventing the creation of different cache files having the same cache key.

This works by splitting the old macos job that contained a matrix into two distinct jobs. As these jobs have different names, the corresponding cache files get different keys.

Once [the upstream issue](https://github.com/Chocobo1/setup-ccache-action/issues/25) is resolved, it would be nice to revert this change and stick with the matrix. 