### PR TITLE
Initialise `p` in `throw_if_is_acyclic`

### DIFF
--- a/src/forest.cpp
+++ b/src/forest.cpp
@@ -135,8 +135,8 @@ namespace libsemigroups {
     size_t              current = 0;
 
     for (Forest::node_type m = 0; m != number_of_nodes(); ++m) {
-      auto      n = m;
-      node_type p;
+      auto      n      = m;
+      node_type p      = UNDEFINED;
       size_t    length = 0;
       while (n != UNDEFINED && seen[n] == not_yet_seen) {
         seen[n] = current;


### PR DESCRIPTION
This pr initialises `p` to be `UNDEFINED` in `throw_if_is_acyclic` and thus fixes #860.

Having looked at the logic of `throw_if_is_acyclic`, I don't think it was actually possible for `p` to ever be uninitialised. Nonetheless, this makes the warning go away, and is a sensible initial value.