### PR TITLE
sims: rm bad assert

### DIFF
--- a/include/libsemigroups/sims.hpp
+++ b/include/libsemigroups/sims.hpp
@@ -1987,6 +1987,10 @@ namespace libsemigroups {
   //!
   //! If no such WordGraph can be found, then an empty WordGraph is
   //! returned (with `0` nodes and `0` edges).
+  //!
+  //! \note To use RepOrc to compute a *faithful* transformation representation
+  //! it is necessary that \ref target_size equals the size of the semigroup or
+  //! monoid defined by the input \ref RepOrc::presentation.
   class RepOrc : public SimsSettings<RepOrc> {
    private:
     size_t _min;
@@ -2119,6 +2123,12 @@ namespace libsemigroups {
     //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \note To use RepOrc to compute a *faithful* transformation
+    //! representation it is necessary that \ref target_size equals the size of
+    //! the semigroup or monoid defined by the input \ref RepOrc::presentation.
+    //! No checks are performed that the parameter \p val is less than or equal
+    //! to the size of the semigroup.
     RepOrc& target_size(size_t val) noexcept {
       _size = val;
       return *this;
@@ -2181,6 +2191,11 @@ namespace libsemigroups {
   //!
   //! If no such WordGraph can be found, then an empty WordGraph is
   //! returned (with `0` nodes and `0` edges).
+  //!
+  //! \note To use MinimalRepOrc to compute a *faithful* transformation
+  //! representation it is necessary that \ref target_size equals the size of
+  //! the semigroup or monoid defined by the input \ref
+  //! MinimalRepOrc::presentation.
   class MinimalRepOrc : public SimsSettings<MinimalRepOrc> {
    private:
     size_t _size;
@@ -2219,6 +2234,12 @@ namespace libsemigroups {
     //!
     //! \exceptions
     //! \noexcept
+    //!
+    //! \note To use MinimalRepOrc to compute a *faithful* transformation
+    //! representation it is necessary that \ref target_size equals the size of
+    //! the semigroup or monoid defined by the input
+    //! \ref MinimalRepOrc::presentation. No checks are performed that the
+    //! parameter \p val is less than or equal to the size of the semigroup.
     MinimalRepOrc& target_size(size_t val) noexcept {
       _size = val;
       return *this;

--- a/src/sims.cpp
+++ b/src/sims.cpp
@@ -1280,7 +1280,11 @@ namespace libsemigroups {
             S.add_generator(id);
           }
         }
-        LIBSEMIGROUPS_ASSERT(S.size() <= _size);
+
+        // Tempting to have the following assertion (included until v3.4.0
+        // inclusive) but since _size is set by target_size(), it is
+        // arbitrary, and can, for example be less than S.size().
+        // LIBSEMIGROUPS_ASSERT(S.size() <= _size);
         if (S.size() == _size) {
           return true;
         }

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -4973,6 +4973,37 @@ namespace libsemigroups {
     REQUIRE(d.number_of_nodes() == 6);
   }
 
+  // The next test arose from misconfiguring the RepOrc object in the GAP
+  // package Semigroups, which lead to the failure of the assertion in the hook
+  // function in RepOrc::word_graph (that the size of the generated semigroup be
+  // less than or equal to the value set by RepOrc::target_size). The assertion
+  // is basically nonsense, and would be triggered by this test case if it
+  // still existed.
+  LIBSEMIGROUPS_TEST_CASE("Sims1", "137", "bad assert", "[quick][low-index]") {
+    auto rg = ReportGuard(false);
+
+    auto S = make<FroidurePin>({Bipartition({{1, -1}, {2, -2}, {3, -3}}),
+                                Bipartition({{1, -2}, {2, -3}, {3, -1}}),
+                                Bipartition({{1, -2}, {2, -1}, {3, -3}}),
+                                Bipartition({{1}, {2, -2}, {3, -3}, {-1}}),
+                                Bipartition({{1, 2, -1, -2}, {3, -3}})});
+    auto p = to<Presentation<word_type>>(S);
+    REQUIRE(!p.contains_empty_word());
+    p.contains_empty_word(true);
+
+    // p defines a semigroup of size 204
+
+    RepOrc orc;
+    auto   d = orc.presentation(p)
+                 .min_nodes(0)
+                 .max_nodes(203)
+                 .target_size(203)
+                 .number_of_threads(std::thread::hardware_concurrency())
+                 .word_graph();
+
+    REQUIRE(d.number_of_nodes() != 0);
+  }
+
   // TODO(1): test fails for now, uncomment when we get Sims<Word> to work as
   // per forthcoming changes to congruence interface and friends
   // LIBSEMIGROUPS_TEST_CASE("Sims1",


### PR DESCRIPTION
This PR removes an invalid assertion from the hook function in `RepOrc`. @reiniscirpons could you possibly review? 