### PR TITLE
Use new clang-format action

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Run clang-format style check for C/C++/Protobuf programs.
-        uses: jidicula/clang-format-action@v4.16.0
+        uses: joseph-edwards/clang-format-action@v1.0.1
         with:
           clang-format-version: 15
           exclude-regex: '(tests\/catch_*.*pp|benchmarks\/catch_*.*pp)'


### PR DESCRIPTION
This PR switches from our usual clang-format action, to one that I have made. This is a temporary fix until https://github.com/jidicula/clang-format-action/issues/267 is resolved. 