### PR TITLE
Restore clang-format action

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -18,9 +18,10 @@ jobs:
           - benchmarks
     steps:
       - uses: actions/checkout@v6
-      - name: Run clang-format style check for C/C++/Protobuf programs.
+      - name: Run clang-format style check for C++.
         uses: jidicula/clang-format-action@v4.16.0
         with:
           clang-format-version: 15
+          include-regex: '^.*\.(c|h|t)pp$'
           exclude-regex: '(tests\/catch_*.*pp|benchmarks\/catch_*.*pp)'
           check-path: ${{ matrix.path }}


### PR DESCRIPTION
Now that https://github.com/jidicula/clang-format-action/issues/267 is resolved, we can go back to using the old clang-format action.

This will almost certainly be more robust than the one that I cobbled together.