### PR TITLE
Fix overlapping cache keys

### DIFF
--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           update_packager_index: false
           install_ccache: true
+          override_cache_key: "macos_${{ matrix.os.arch }}"
       - name: Runner information . . .
         run: uname -a
       - name: Install dependencies . . .


### PR DESCRIPTION
Fixes #900.

This PR simplifies the macOS workflow by merging the two jobs into one with a matrix (this is how the workflows used to be configured). Additionally, it fixes the issue of incorrect cache hits by overriding the default cache key.