### PR TITLE
Remove redundant 'already finished' reporting

### DIFF
--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -208,11 +208,6 @@ namespace libsemigroups {
       } else {
         set_state(state::not_running);
       }
-    } else {
-      // This line is definitely tested, but not showing up in code coverage for
-      // JDM
-      // NOTE: no dividers here
-      report_default("{}: already finished, not running\n", report_prefix());
     }
   }
 


### PR DESCRIPTION
Drop the else branch in src/runner.cpp that reported "already finished, not running". This removes a noisy reporting path.

Resolves:

https://github.com/semigroups/Semigroups/issues/1169