### PR TITLE
Make the "Defined in *.hpp" statements consistent

### DIFF
--- a/include/libsemigroups/cong-helpers.hpp
+++ b/include/libsemigroups/cong-helpers.hpp
@@ -70,7 +70,7 @@ namespace libsemigroups {
   //!
   //! \brief Helper functions for the \ref_congruence class template.
   //!
-  //! Defined in \c cong-helpers.hpp.
+  //! Defined in `cong-helpers.hpp`.
   //!
   //! This page would contain documentation for helper functions for the
   //! \ref_congruence class template. However, at present, there are no helper

--- a/include/libsemigroups/detail/knuth-bendix-impl.hpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.hpp
@@ -935,7 +935,7 @@ namespace libsemigroups {
   //!
   //! \brief Insert into std::ostream.
   //!
-  //! Defined in \c knuth-bendix-impl.hpp.
+  //! Defined in `knuth-bendix-impl.hpp`.
   //!
   //! This function allows a \ref_knuth_bendix object to be left shifted into a
   //! std::ostream, such as std::cout. The currently active rules of the
@@ -961,7 +961,7 @@ namespace libsemigroups {
   //!
   //! \brief Return a string representation of a \ref_knuth_bendix instance.
   //!
-  //! Defined in \c knuth-bendix-impl.hpp.
+  //! Defined in `knuth-bendix-impl.hpp`.
   //!
   //! This function returns a string representation of a \ref_knuth_bendix
   //! instance, specifying the size of the underlying alphabet and the number

--- a/include/libsemigroups/detail/knuth-bendix-impl.hpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.hpp
@@ -935,7 +935,7 @@ namespace libsemigroups {
   //!
   //! \brief Insert into std::ostream.
   //!
-  //! Defined in \c knuth-bendix.hpp.
+  //! Defined in \c knuth-bendix-impl.hpp.
   //!
   //! This function allows a \ref_knuth_bendix object to be left shifted into a
   //! std::ostream, such as std::cout. The currently active rules of the
@@ -961,7 +961,7 @@ namespace libsemigroups {
   //!
   //! \brief Return a string representation of a \ref_knuth_bendix instance.
   //!
-  //! Defined in \c knuth-bendix.hpp.
+  //! Defined in \c knuth-bendix-impl.hpp.
   //!
   //! This function returns a string representation of a \ref_knuth_bendix
   //! instance, specifying the size of the underlying alphabet and the number

--- a/include/libsemigroups/kambites-class.hpp
+++ b/include/libsemigroups/kambites-class.hpp
@@ -59,7 +59,7 @@ namespace libsemigroups {
 
   //! \defgroup kambites_group Kambites
   //!
-  //! Defined in `kambites.hpp`.
+  //! Defined in `kambites-class.hpp`.
   //!
   //! On this page there are links to the documentation for the algorithms in
   //! `libsemigroups` for small overlap monoids by Mark %Kambites and the
@@ -131,7 +131,7 @@ namespace libsemigroups {
   //!
   //! \hideinheritancegraph
   //!
-  //! Defined in `kambites.hpp`.
+  //! Defined in `kambites-class.hpp`.
   //!
   //! This page describes the class template \ref_kambites for determining the
   //! small overlap class of a presentation, and, for small overlap monoids
@@ -1079,7 +1079,7 @@ namespace libsemigroups {
   //
   //! \brief Deduction guide.
   //!
-  //! Defined in `kambites.hpp`.
+  //! Defined in `kambites-class.hpp`.
   //!
   //! Deduction guide to construct a `Kambites<Word>` from a
   //! `Presentation<Word>` const reference.
@@ -1090,7 +1090,7 @@ namespace libsemigroups {
   //
   //! \brief Deduction guide.
   //!
-  //! Defined in `kambites.hpp`.
+  //! Defined in `kambites-class.hpp`.
   //!
   //! Deduction guide to construct a `Kambites<Word>` from a
   //! `Presentation<Word>` rvalue reference.
@@ -1101,7 +1101,7 @@ namespace libsemigroups {
   //
   //! \brief Deduction guide.
   //!
-  //! Defined in `kambites.hpp`.
+  //! Defined in `kambites-class.hpp`.
   //!
   //! Deduction guide to construct a `Kambites<Word>` from a
   //! `Kambites<Word>` const reference.
@@ -1112,7 +1112,7 @@ namespace libsemigroups {
   //
   //! \brief Deduction guide.
   //!
-  //! Defined in `kambites.hpp`.
+  //! Defined in `kambites-class.hpp`.
   //!
   //! Deduction guide to construct a `Kambites<Word>` from a
   //! `Kambites<Word>` rvalue reference.
@@ -1123,7 +1123,7 @@ namespace libsemigroups {
   //!
   //! \brief Return a human readable representation of a \ref_kambites object.
   //!
-  //! Defined in `kambites.hpp`.
+  //! Defined in `kambites-class.hpp`.
   //!
   //! This function returns a human readable representation of a
   //! \ref_kambites object.

--- a/include/libsemigroups/kambites-helpers.hpp
+++ b/include/libsemigroups/kambites-helpers.hpp
@@ -42,7 +42,7 @@ namespace libsemigroups {
 
     //! \brief Returns a range object containing normal forms.
     //!
-    //! Defined in \c kambites.hpp.
+    //! Defined in \c kambites-helpers.hpp.
     //!
     //! This function returns a range object containing short-lex normal forms
     //! of the classes of the congruence represented by a \ref_kambites
@@ -70,7 +70,7 @@ namespace libsemigroups {
   //!
   //! \brief Helper functions for the \ref_kambites class template.
   //!
-  //! Defined in \c kambites.hpp.
+  //! Defined in \c kambites-helpers.hpp.
   //!
   //! This page would contain documentation for helper functions for the
   //! \ref_kambites class template. However, at present, there are no helper

--- a/include/libsemigroups/kambites-helpers.hpp
+++ b/include/libsemigroups/kambites-helpers.hpp
@@ -42,7 +42,7 @@ namespace libsemigroups {
 
     //! \brief Returns a range object containing normal forms.
     //!
-    //! Defined in \c kambites-helpers.hpp.
+    //! Defined in `kambites-helpers.hpp`.
     //!
     //! This function returns a range object containing short-lex normal forms
     //! of the classes of the congruence represented by a \ref_kambites
@@ -70,7 +70,7 @@ namespace libsemigroups {
   //!
   //! \brief Helper functions for the \ref_kambites class template.
   //!
-  //! Defined in \c kambites-helpers.hpp.
+  //! Defined in `kambites-helpers.hpp`.
   //!
   //! This page would contain documentation for helper functions for the
   //! \ref_kambites class template. However, at present, there are no helper

--- a/include/libsemigroups/knuth-bendix-class.hpp
+++ b/include/libsemigroups/knuth-bendix-class.hpp
@@ -53,7 +53,7 @@ namespace libsemigroups {
   //! \brief Class template containing an implementation of the Knuth-Bendix
   //! Algorithm.
   //!
-  //! Defined in \c knuth-bendix-class.hpp.
+  //! Defined in `knuth-bendix-class.hpp`.
   //!
   //! On this page we describe the functionality relating to the Knuth-Bendix
   //! algorithm for semigroups and monoids in \c libsemigroups. This page

--- a/include/libsemigroups/knuth-bendix-helpers.hpp
+++ b/include/libsemigroups/knuth-bendix-helpers.hpp
@@ -55,7 +55,7 @@ namespace libsemigroups {
 
     //! \brief Returns a range object containing the normal forms.
     //!
-    //! Defined in \c knuth-bendix-helpers.hpp.
+    //! Defined in `knuth-bendix-helpers.hpp`.
     //!
     //! This function returns a range object containing normal forms of the
     //! classes of the congruence represented by an instance of
@@ -90,7 +90,7 @@ namespace libsemigroups {
     //! \brief Find the non-trivial classes of the quotient of one
     //! \ref_knuth_bendix instance in another.
     //!
-    //! Defined in \c knuth-bendix-helpers.hpp.
+    //! Defined in `knuth-bendix-helpers.hpp`.
     //!
     //! This function returns the classes with size at least \f$2\f$ in the
     //! normal forms of \p kb2 in \p kb1 (the greater congruence, with fewer
@@ -139,7 +139,7 @@ namespace libsemigroups {
   //!
   //! \brief Helper functions for the \ref_knuth_bendix class.
   //!
-  //! Defined in \c knuth-bendix-helpers.hpp.
+  //! Defined in `knuth-bendix-helpers.hpp`.
   //!
   //! This page contains documentation for some helper functions for the
   //! \ref_knuth_bendix class. In particular, these functions include versions
@@ -164,7 +164,7 @@ namespace libsemigroups {
     //! \brief Run the Knuth-Bendix algorithm by considering all overlaps of
     //! a given length.
     //!
-    //! Defined in \c knuth-bendix-helpers.hpp.
+    //! Defined in `knuth-bendix-helpers.hpp`.
     //!
     //! This function runs the Knuth-Bendix algorithm on the rewriting
     //! system represented by a \ref_knuth_bendix instance by considering all
@@ -194,7 +194,7 @@ namespace libsemigroups {
     //!
     //! \brief Check if the all rules are reduced with respect to each other.
     //!
-    //! Defined in \c knuth-bendix-helpers.hpp.
+    //! Defined in `knuth-bendix-helpers.hpp`.
     //!
     //! \tparam Word the type of the words in the
     //! \ref KnuthBendix::presentation.
@@ -269,7 +269,7 @@ namespace libsemigroups {
     //! \brief Return an iterator pointing at the left hand side of a redundant
     //! rule.
     //!
-    //! Defined in \c knuth-bendix-helpers.hpp.
+    //! Defined in `knuth-bendix-helpers.hpp`.
     //!
     //! Starting with the last rule in the presentation, this function
     //! attempts to run the Knuth-Bendix algorithm on the rules of the

--- a/include/libsemigroups/konieczny.tpp
+++ b/include/libsemigroups/konieczny.tpp
@@ -1364,7 +1364,7 @@ namespace libsemigroups {
   // RegularDClass
   /////////////////////////////////////////////////////////////////////////////
 
-  // Defined in `konieczny.hpp`.
+  // Defined in `konieczny.tpp`.
   //
   // The nested class Konieczny::RegularDClass inherits from DClass and
   // represents a regular \f$\mathscr{D}\f$-class via a frame as
@@ -1988,7 +1988,7 @@ namespace libsemigroups {
   // NonRegularDClass
   /////////////////////////////////////////////////////////////////////////////
 
-  // Defined in `konieczny.hpp`.
+  // Defined in `konieczny.tpp`.
   //
   // The nested class Konieczny::NonRegularDClass inherits from DClass
   // and represents a regular \f$\mathscr{D}\f$-class via a frame as

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -652,7 +652,7 @@ namespace libsemigroups {
   //!
   //! \brief Deduction guide.
   //!
-  //! Defined in `presentation.hpp`
+  //! Defined in `presentation.hpp`.
   //!
   //! Deduction guide to construct a `Presentation<Word>` from a
   //! `Presentation<Word> const&`.
@@ -663,7 +663,7 @@ namespace libsemigroups {
   //!
   //! \brief Deduction guide.
   //!
-  //! Defined in `presentation.hpp`
+  //! Defined in `presentation.hpp`.
   //!
   //! Deduction guide to construct a `Presentation<Word>` from a
   //! `Presentation<Word>&&`.

--- a/include/libsemigroups/runner.hpp
+++ b/include/libsemigroups/runner.hpp
@@ -72,7 +72,7 @@ namespace libsemigroups {
   //! \brief Value indicating forever (system dependent but possibly approx.
   //! 292 years).
   //!
-  //! Defined in \c runner.hpp
+  //! Defined in `runner.hpp`.
   //!
   //! A pseudonym for std::chrono::nanoseconds::max().
   constexpr std::chrono::nanoseconds FOREVER = std::chrono::nanoseconds::max();
@@ -380,7 +380,7 @@ namespace libsemigroups {
   //!
   //! \brief Abstract class for derived classes that run an algorithm.
   //!
-  //! Defined in \c runner.hpp
+  //! Defined in `runner.hpp`.
   //!
   //! Many of the classes in `libsemigroups` implementing the algorithms
   //! that are the reason for the existence of this library, are derived from

--- a/include/libsemigroups/schreier-sims.hpp
+++ b/include/libsemigroups/schreier-sims.hpp
@@ -145,7 +145,7 @@ namespace libsemigroups {
   //! \brief A deterministic version of the Schreier-Sims algorithm acting on a
   //! small number of points.
   //!
-  //! Defined in \c schreier-sims.hpp.
+  //! Defined in `schreier-sims.hpp`.
   //!
   //! This class implements a deterministic version of the Schreier-Sims
   //! algorithm acting on a relatively small number of points (\f$< 1000\f$).

--- a/include/libsemigroups/stephen.hpp
+++ b/include/libsemigroups/stephen.hpp
@@ -70,7 +70,7 @@ namespace libsemigroups {
   //! \brief For constructing the word graph of left factors of a word in an
   //! f.p. semigroup.
   //!
-  //! Defined in `sims.hpp`.
+  //! Defined in `stephen.hpp`.
   //!
   //! This class implements Stephen's procedure for constructing
   //! the WordGraph corresponding to the left factors of a word in a finitely

--- a/include/libsemigroups/stephen.hpp
+++ b/include/libsemigroups/stephen.hpp
@@ -464,7 +464,7 @@ namespace libsemigroups {
   //!
   //! \brief Deduction guide.
   //!
-  //! Defined in `stephen.hpp`
+  //! Defined in `stephen.hpp`.
   //!
   //! Deduction guide to construct a `Stephen<Presentation<word_type>>` from a
   //! `Presentation<word_type> const&`.
@@ -474,7 +474,7 @@ namespace libsemigroups {
   //!
   //! \brief Deduction guide.
   //!
-  //! Defined in `stephen.hpp`
+  //! Defined in `stephen.hpp`.
   //!
   //! Deduction guide to construct a `Stephen<Presentation<word_type>>` from a
   //! `Presentation<word_type>&`.
@@ -484,7 +484,7 @@ namespace libsemigroups {
   //!
   //! \brief Deduction guide.
   //!
-  //! Defined in `stephen.hpp`
+  //! Defined in `stephen.hpp`.
   //!
   //! Deduction guide to construct a `Stephen<Presentation<word_type>>` from a
   //! `Presentation<word_type>&&`.
@@ -494,7 +494,7 @@ namespace libsemigroups {
   //!
   //! \brief Deduction guide.
   //!
-  //! Defined in `stephen.hpp`
+  //! Defined in `stephen.hpp`.
   //!
   //! Deduction guide to construct a `Stephen<Presentation<word_type>>` from a
   //! `std::shared_ptr<Presentation<word_type>>&&`.
@@ -505,7 +505,7 @@ namespace libsemigroups {
   //!
   //! \brief Deduction guide.
   //!
-  //! Defined in `stephen.hpp`
+  //! Defined in `stephen.hpp`.
   //!
   //! Deduction guide to construct a `Stephen<InversePresentation<word_type>>`
   //! from an `InversePresentation<word_type> const&`.
@@ -516,7 +516,7 @@ namespace libsemigroups {
   //!
   //! \brief Deduction guide.
   //!
-  //! Defined in `stephen.hpp`
+  //! Defined in `stephen.hpp`.
   //!
   //! Deduction guide to construct a `Stephen<InversePresentation<word_type>>`
   //! from an `InversePresentation<word_type>&`.
@@ -527,7 +527,7 @@ namespace libsemigroups {
   //!
   //! \brief Deduction guide.
   //!
-  //! Defined in `stephen.hpp`
+  //! Defined in `stephen.hpp`.
   //!
   //! Deduction guide to construct a `Stephen<InversePresentation<word_type>>`
   //! from an `InversePresentation<word_type>&&`.
@@ -538,7 +538,7 @@ namespace libsemigroups {
   //!
   //! \brief Deduction guide.
   //!
-  //! Defined in `stephen.hpp`
+  //! Defined in `stephen.hpp`.
   //!
   //! Deduction guide to construct a `Stephen<InversePresentation<word_type>>`
   //! from a `std::shared_ptr<InversePresentation<word_type>>&&`.
@@ -553,7 +553,7 @@ namespace libsemigroups {
   //!
   //! \brief Helper functions for the \ref Stephen class.
   //!
-  //! Defined in \c stephen.hpp.
+  //! Defined in `stephen.hpp`.
   //!
   //! This page contains documentation for some helper functions for the
   //! \ref Stephen class. The helpers documented on this page all belong to the

--- a/include/libsemigroups/to-cong.hpp
+++ b/include/libsemigroups/to-cong.hpp
@@ -44,7 +44,7 @@ namespace libsemigroups {
   //!
   //! \brief Convert a \ref FroidurePin object to a \ref_congruence.
   //!
-  //! Defined in \c to-cong.hpp
+  //! Defined in `to-cong.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!
@@ -81,7 +81,7 @@ namespace libsemigroups {
   //!
   //! \brief Convert a \ref WordGraph object to a \ref_congruence.
   //!
-  //! Defined in \c to-cong.hpp
+  //! Defined in `to-cong.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!

--- a/include/libsemigroups/to-froidure-pin.hpp
+++ b/include/libsemigroups/to-froidure-pin.hpp
@@ -84,7 +84,7 @@ namespace libsemigroups {
   //! \ingroup to_froidure_pin_group
   //! \brief Convert a Congruence object to a FroidurePin object.
   //!
-  //! Defined in \c to-froidure-pin.hpp
+  //! Defined in `to-froidure-pin.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!
@@ -116,7 +116,7 @@ namespace libsemigroups {
   //! \ingroup to_froidure_pin_group
   //! \brief Convert a Kambites object to a FroidurePin object.
   //!
-  //! Defined in \c to-froidure-pin.hpp
+  //! Defined in `to-froidure-pin.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!
@@ -154,7 +154,7 @@ namespace libsemigroups {
   //!
   //! \brief Convert a \ref_knuth_bendix object to a FroidurePin object.
   //!
-  //! Defined in \c to-froidure-pin.hpp
+  //! Defined in `to-froidure-pin.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!
@@ -188,7 +188,7 @@ namespace libsemigroups {
   //!
   //! \brief Convert a \ref Konieczny object to a FroidurePin object.
   //!
-  //! Defined in \c to-froidure-pin.hpp
+  //! Defined in `to-froidure-pin.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!
@@ -221,7 +221,7 @@ namespace libsemigroups {
   //! \ingroup to_froidure_pin_group
   //! \brief Convert a \ref_todd_coxeter object to a FroidurePin object.
   //!
-  //! Defined in \c to-froidure-pin.hpp
+  //! Defined in `to-froidure-pin.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!
@@ -259,7 +259,7 @@ namespace libsemigroups {
   //! \anchor to_froidure_pin
   //! \brief Convert a WordGraph object to a FroidurePin object.
   //!
-  //! Defined in \c to-froidure-pin.hpp
+  //! Defined in `to-froidure-pin.hpp`.
   //!
   //! This function converts a WordGraph object to a FroidurePin object.
   //! Unlike the other functions on this page, this function should be invoked
@@ -321,7 +321,7 @@ namespace libsemigroups {
   //! \ingroup to_froidure_pin_group
   //! \brief Convert a WordGraph object to a FroidurePin object.
   //!
-  //! Defined in \c to-froidure-pin.hpp
+  //! Defined in `to-froidure-pin.hpp`.
   //!
   //! Calls `to<FroidurePin>(wg, 0, wg.number_of_nodes())`.
   //!

--- a/include/libsemigroups/to-knuth-bendix.hpp
+++ b/include/libsemigroups/to-knuth-bendix.hpp
@@ -53,7 +53,7 @@ namespace libsemigroups {
   //!
   //! \brief Convert a \ref FroidurePin object to a \ref_knuth_bendix object.
   //!
-  //! Defined in \c to-knuth-bendix.hpp
+  //! Defined in `to-knuth-bendix.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!
@@ -88,7 +88,7 @@ namespace libsemigroups {
   //!
   //! \brief Convert a \ref_todd_coxeter object to a \ref_knuth_bendix object.
   //!
-  //! Defined in \c to-knuth-bendix.hpp
+  //! Defined in `to-knuth-bendix.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!
@@ -123,7 +123,7 @@ namespace libsemigroups {
   //!
   //! \brief Convert a \ref_todd_coxeter object to a \ref_knuth_bendix object.
   //!
-  //! Defined in \c to-knuth-bendix.hpp
+  //! Defined in `to-knuth-bendix.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!

--- a/include/libsemigroups/to-presentation.hpp
+++ b/include/libsemigroups/to-presentation.hpp
@@ -216,7 +216,7 @@ namespace libsemigroups {
   //!
   //! \brief Make a presentation from a \ref_kambites
   //!
-  //! Defined in `to-presentation.hpp`
+  //! Defined in `to-presentation.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!
@@ -280,7 +280,7 @@ namespace libsemigroups {
   //!
   //! \brief Make a presentation from a \ref_todd_coxeter object.
   //!
-  //! Defined in `to-presentation.hpp`
+  //! Defined in `to-presentation.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!
@@ -344,7 +344,7 @@ namespace libsemigroups {
   //!
   //! \brief Make a presentation from a \ref_congruence
   //!
-  //! Defined in `to-presentation.hpp`
+  //! Defined in `to-presentation.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!
@@ -408,7 +408,7 @@ namespace libsemigroups {
   //!
   //! \brief Make a presentation from a Stephen object.
   //!
-  //! Defined in `to-presentation.hpp`
+  //! Defined in `to-presentation.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!

--- a/include/libsemigroups/to-todd-coxeter.hpp
+++ b/include/libsemigroups/to-todd-coxeter.hpp
@@ -54,7 +54,7 @@ namespace libsemigroups {
   //!
   //! \brief Convert a \ref FroidurePin object to a \ref_todd_coxeter object.
   //!
-  //! Defined in \c to-todd-coxeter.hpp
+  //! Defined in `to-todd-coxeter.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!
@@ -104,7 +104,7 @@ namespace libsemigroups {
   //!
   //! \brief Convert a \ref_knuth_bendix object to a \ref_todd_coxeter object.
   //!
-  //! Defined in \c to-todd-coxeter.hpp
+  //! Defined in `to-todd-coxeter.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!

--- a/include/libsemigroups/to-word-graph.hpp
+++ b/include/libsemigroups/to-word-graph.hpp
@@ -50,7 +50,7 @@ namespace libsemigroups {
   //!
   //! \brief Convert a Forest to a WordGraph.
   //!
-  //! Defined in \c to-word-graph.hpp
+  //! Defined in `to-word-graph.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!
@@ -74,7 +74,7 @@ namespace libsemigroups {
   //!
   //! \brief Convert a WordGraphView to a WordGraph.
   //!
-  //! Defined in \c to-word-graph.hpp
+  //! Defined in `to-word-graph.hpp`.
   //!
   //! Despite the hideous signature, this function should be invoked as follows:
   //!

--- a/include/libsemigroups/todd-coxeter-helpers.hpp
+++ b/include/libsemigroups/todd-coxeter-helpers.hpp
@@ -64,7 +64,7 @@ namespace libsemigroups {
     //!
     //! \brief Helper functions for the \ref_todd_coxeter class.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This page contains documentation for many helper functions for the
     //! \ref_todd_coxeter class. In particular, these functions include versions
@@ -88,7 +88,7 @@ namespace libsemigroups {
 
     //! \brief Returns the current index of the class containing a word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function just calls
     //! \code_no_test
@@ -111,7 +111,7 @@ namespace libsemigroups {
 
     //! \brief Returns the current index of the class containing a word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function just calls
     //! \code_no_test
@@ -134,7 +134,7 @@ namespace libsemigroups {
 
     //! \brief Returns the index of the class containing a word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function just calls
     //! \code_no_test
@@ -157,7 +157,7 @@ namespace libsemigroups {
 
     //! \brief Returns the index of the class containing a word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function just calls
     //! \code_no_test
@@ -179,7 +179,7 @@ namespace libsemigroups {
 
     //! \brief Returns the current index of the class containing a word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function just calls
     //! \code_no_test
@@ -204,7 +204,7 @@ namespace libsemigroups {
 
     //! \brief Returns the current index of the class containing a word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function just calls
     //! \code_no_test
@@ -229,7 +229,7 @@ namespace libsemigroups {
 
     //! \brief Returns the index of the class containing a word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function just calls
     //! \code_no_test
@@ -254,7 +254,7 @@ namespace libsemigroups {
 
     //! \brief Returns the index of the class containing a word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function just calls
     //! \code_no_test
@@ -278,7 +278,7 @@ namespace libsemigroups {
 
     //! \brief Returns the current index of the class containing a word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function just calls
     //! \code_no_test
@@ -300,7 +300,7 @@ namespace libsemigroups {
 
     //! \brief Returns the current index of the class containing a word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function just calls
     //! \code_no_test
@@ -322,7 +322,7 @@ namespace libsemigroups {
 
     //! \brief Returns the index of the class containing a word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function just calls
     //! \code_no_test
@@ -344,7 +344,7 @@ namespace libsemigroups {
 
     //! \brief Returns the index of the class containing a word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function just calls
     //! \code_no_test
@@ -370,7 +370,7 @@ namespace libsemigroups {
 
     //! \brief Returns a word representing a class with given index.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! See ToddCoxeter::word_of_no_checks for details.
     //!
@@ -387,7 +387,7 @@ namespace libsemigroups {
 
     //! \brief Returns a word representing a class with given index.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! See ToddCoxeter::word_of for details.
     //!
@@ -403,7 +403,7 @@ namespace libsemigroups {
 
     //! \brief Returns a word representing a class with given index.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! See ToddCoxeter::word_of_no_checks for details.
     //!
@@ -419,7 +419,7 @@ namespace libsemigroups {
 
     //! \brief Returns a word representing a class with given index.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! See ToddCoxeter::word_of for details.
     //!
@@ -440,7 +440,7 @@ namespace libsemigroups {
     //! \brief Returns a range object containing every word in the congruence
     //! class with given index.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function returns a range object containing every word in belonging
     //! to the class with index \p n in the congruence represented by the
@@ -482,7 +482,7 @@ namespace libsemigroups {
     //! \brief Returns a range object containing every word in the congruence
     //! class with given index.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function returns a range object containing every word in belonging
     //! to the class with index \p n in the congruence represented by the
@@ -527,7 +527,7 @@ namespace libsemigroups {
     //! \brief Returns a range object containing every word in the congruence
     //! class of a word given by iterators.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function returns a range object containing every word in belonging
     //! to the same class as the word (contained in the range from \p first to
@@ -558,7 +558,7 @@ namespace libsemigroups {
     //! \brief Returns a range object containing every word in the congruence
     //! class of a word given by iterators.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function returns a range object containing every word in belonging
     //! to the same class as the word (contained in the range from \p first to
@@ -589,7 +589,7 @@ namespace libsemigroups {
     //! \brief Returns a range object containing every word in the congruence
     //! class of a given word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function returns a range object containing every word in
     //! belonging to the same class as the input word \p w in the congruence
@@ -617,7 +617,7 @@ namespace libsemigroups {
     //! \brief Returns a range object containing every word in the congruence
     //! class of a given word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function returns a range object containing every word in
     //! belonging to the same class as the input word \p w in the congruence
@@ -646,7 +646,7 @@ namespace libsemigroups {
     //! \brief Returns a range object containing every word in the congruence
     //! class of a given word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function returns a range object containing every word in
     //! belonging to the same class as the input word \p w in the congruence
@@ -676,7 +676,7 @@ namespace libsemigroups {
     //! \brief Returns a range object containing every word in the congruence
     //! class of a given word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function returns a range object containing every word in
     //! belonging to the same class as the input word \p w in the congruence
@@ -706,7 +706,7 @@ namespace libsemigroups {
     //! \brief Returns a range object containing every word in the congruence
     //! class of a given word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function returns a range object containing every word in
     //! belonging to the same class as the input word \p w in the congruence
@@ -734,7 +734,7 @@ namespace libsemigroups {
     //! \brief Returns a range object containing every word in the congruence
     //! class of a given word.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function returns a range object containing every word in
     //! belonging to the same class as the input word \p w in the congruence
@@ -773,7 +773,7 @@ namespace libsemigroups {
 
     //! \brief Check if the congruence has more than one class.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! Returns tril::TRUE if it is possible to show that the congruence is
     //! non-trivial; tril::FALSE if the congruence is already known to be
@@ -810,7 +810,7 @@ namespace libsemigroups {
 
     //! \brief Perform a lookbehind.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function performs a "lookbehind" on the argument \p tc which is
     //! defined as follows. For every node \c n in the so-far computed
@@ -878,7 +878,7 @@ namespace libsemigroups {
     //! \brief Return an iterator pointing at the left hand side of a redundant
     //! rule.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! Starting with the last rule in the presentation, this function
     //! attempts to run the Todd-Coxeter algorithm on the rules of the
@@ -925,7 +925,7 @@ namespace libsemigroups {
 
     //! \brief Returns a range object containing the normal forms.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function returns a range object containing normal forms of the
     //! classes of the congruence represented by an instance of
@@ -954,7 +954,7 @@ namespace libsemigroups {
 
     //! \brief Partition a range of words.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function returns the partition of the words in the range \p r
     //! induced by the \ref_todd_coxeter instance \p tc. This function triggers
@@ -988,7 +988,7 @@ namespace libsemigroups {
     //! \brief Find the non-trivial classes in the partition of the normal
     //! forms of one \ref_todd_coxeter instance in another.
     //!
-    //! Defined in \c todd-coxeter-helpers.hpp.
+    //! Defined in `todd-coxeter-helpers.hpp`.
     //!
     //! This function returns the classes with size at least \f$2\f$ in the
     //! partition of the normal forms of \p tc2 according to the


### PR DESCRIPTION
This PR updates the statements of the form
```
\\! Defined in `foo.hpp`.
```
so that:
- they all filenames are correct;
- all filenames are enclosed within backticks; and
- all statements end with a full stop.
