### PR TITLE
Support an external copy of magic_enum

### DIFF
--- a/.github/workflows/config-options.yml
+++ b/.github/workflows/config-options.yml
@@ -51,7 +51,7 @@ jobs:
 
   external-deps:
     timeout-minutes: 45
-    name: ${{ matrix.external-backward }} ${{ matrix.external-fmt }} ${{ matrix.external-eigen }}
+    name: ${{ matrix.external-backward }} ${{ matrix.external-fmt }} ${{ matrix.external-eigen }} ${{ matrix.external-magic-enum }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -65,14 +65,18 @@ jobs:
         external-eigen:
           - --with-external-eigen
           - ""
+        external-magic-enum:
+          - --with-external-magic-enum
+          - ""
         exclude:
           - external-backward: ""
             external-fmt: ""
             external-eigen: ""
+            external-magic-enum: ""
     env:
       CXX: ccache g++
       CXXFLAGS: -fdiagnostics-color
-      CONFIGFLAGS: ${{ matrix.external-backward }} ${{ matrix.external-fmt }} ${{ matrix.external-eigen }}
+      CONFIGFLAGS: ${{ matrix.external-backward }} ${{ matrix.external-fmt }} ${{ matrix.external-eigen }} ${{ matrix.external-magic-enum }}
       PKG_CONFIG_PATH: /home/runner/micromamba/envs/libsemigroups/lib/pkgconfig:/home/runner/micromamba/envs/libsemigroups/share/pkgconfig/
       LD_LIBRARY_PATH: /home/runner/micromamba/envs/libsemigroups/lib
       BACKWARD_CPPFLAGS: -I/home/runner/micromamba/envs/libsemigroups/include

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ AM_CXXFLAGS += -std=gnu++17 -O3 -Wall -Wextra
 AM_CXXFLAGS += $(WARNING_CXXFLAGS)
 AM_CXXFLAGS += $(FMT_CFLAGS)
 AM_CXXFLAGS += $(EIGEN3_CFLAGS)
+AM_CXXFLAGS += $(MAGICENUM_CFLAGS)
 if USE_BUNDLED_MAGIC_ENUM
 AM_CXXFLAGS += -I$(abs_top_srcdir)/third_party/magic_enum-0.9.7/include
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -219,6 +219,7 @@ detailinclude_HEADERS += include/libsemigroups/detail/word-iterators.hpp
 catch2includedir = $(includedir)/libsemigroups/Catch2-3.14.0/
 catch2include_HEADERS = third_party/Catch2-3.14.0/catch_amalgamated.hpp
 
+if USE_BUNDLED_MAGIC_ENUM
 magicenumincludedir = $(includedir)/libsemigroups/magic_enum
 magicenuminclude_HEADERS = third_party/magic_enum-0.9.7/include/magic_enum/magic_enum.hpp
 magicenuminclude_HEADERS += third_party/magic_enum-0.9.7/include/magic_enum/magic_enum_all.hpp
@@ -229,6 +230,7 @@ magicenuminclude_HEADERS += third_party/magic_enum-0.9.7/include/magic_enum/magi
 magicenuminclude_HEADERS += third_party/magic_enum-0.9.7/include/magic_enum/magic_enum_iostream.hpp
 magicenuminclude_HEADERS += third_party/magic_enum-0.9.7/include/magic_enum/magic_enum_switch.hpp
 magicenuminclude_HEADERS += third_party/magic_enum-0.9.7/include/magic_enum/magic_enum_utility.hpp
+endif
 
 rxrangesincludedir = $(includedir)/libsemigroups/rx
 rxrangesinclude_HEADERS = third_party/rx-ranges/include/rx/ranges.hpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,11 +8,13 @@ AM_CXXFLAGS += -I$(abs_top_srcdir)/third_party/Catch2-3.14.0
 AM_CXXFLAGS += -I$(abs_top_srcdir)/third_party/HPCombi-1.1.2/include
 AM_CXXFLAGS += -I$(abs_top_srcdir)/third_party/HPCombi-1.1.2/third_party
 AM_CXXFLAGS += -I$(abs_top_srcdir)/third_party/rx-ranges/include
-AM_CXXFLAGS += -I$(abs_top_srcdir)/third_party/magic_enum-0.9.7/include
 AM_CXXFLAGS += -std=gnu++17 -O3 -Wall -Wextra
 AM_CXXFLAGS += $(WARNING_CXXFLAGS)
 AM_CXXFLAGS += $(FMT_CFLAGS)
 AM_CXXFLAGS += $(EIGEN3_CFLAGS)
+if USE_BUNDLED_MAGIC_ENUM
+AM_CXXFLAGS += -I$(abs_top_srcdir)/third_party/magic_enum-0.9.7/include
+endif
 if LIBSEMIGROUPS_HPCOMBI_ENABLED
 AM_CXXFLAGS += $(HPCOMBI_CXXFLAGS)
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -135,6 +135,9 @@ AX_CHECK_FMT()
 # disabled altogether
 AX_CHECK_EIGEN()
 
+# Check for an external magic_enum
+AX_CHECK_MAGIC_ENUM()
+
 dnl Output configured files
 
 dnl compiler builtins

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,10 @@
 name: libsemigroups
 
 channels:
-- conda-forge
+  - conda-forge
 
 dependencies:
   - eigen
   - fmt
   - backward-cpp
+  - magic_enum

--- a/m4/ax_check_magic_enum.m4
+++ b/m4/ax_check_magic_enum.m4
@@ -1,10 +1,5 @@
 # handle magic_enum checks
 #
-# magic_enum ships a pkg-config file, but the $includedir doesn't
-# contain the leading "magic_enum", so unless you are doing something
-# really weird, it's easier to just try magic_enum/magic_enum.hpp
-# since that's what you'll be including anyway.
-#
 AC_DEFUN([AX_CHECK_MAGIC_ENUM], [
   AC_ARG_WITH(
     [external-magic-enum],
@@ -17,7 +12,10 @@ AC_DEFUN([AX_CHECK_MAGIC_ENUM], [
 
   AS_IF([test "x$with_external_magic_enum" = xyes], [
     # Check if we can use magic_enum from the system. If not, error.
-    AC_CHECK_HEADER([magic_enum/magic_enum.hpp], [
+    # The version constraint is to ensure that the headers relative to
+    # $includedir are magic_enum/foo.hpp. In 0.9.6, the magic_enum/
+    # prefix was not used.
+    PKG_CHECK_MODULES(MAGICENUM, [magic_enum >= 0.9.7], [
       AC_MSG_NOTICE([external magic_enum will be used])
     ], [
       AC_MSG_ERROR([external magic_enum not found])

--- a/m4/ax_check_magic_enum.m4
+++ b/m4/ax_check_magic_enum.m4
@@ -1,0 +1,27 @@
+# handle magic_enum checks
+#
+# magic_enum ships a pkg-config file, but the $includedir doesn't
+# contain the leading "magic_enum", so unless you are doing something
+# really weird, it's easier to just try magic_enum/magic_enum.hpp
+# since that's what you'll be including anyway.
+#
+AC_DEFUN([AX_CHECK_MAGIC_ENUM], [
+  AC_ARG_WITH(
+    [external-magic-enum],
+    [AS_HELP_STRING([--with-external-magic-enum], [use external magic_enum (default: no)])],
+    [],
+    [with_external_magic_enum=no]
+  )
+  AC_MSG_CHECKING([whether to use external magic_enum])
+  AC_MSG_RESULT([$with_external_magic_enum])
+
+  AS_IF([test "x$with_external_magic_enum" = xyes], [
+    # Check if we can use magic_enum from the system. If not, error.
+    AC_CHECK_HEADER([magic_enum/magic_enum.hpp], [
+      AC_MSG_NOTICE([external magic_enum will be used])
+    ], [
+      AC_MSG_ERROR([external magic_enum not found])
+    ])
+  ])
+  AM_CONDITIONAL([USE_BUNDLED_MAGIC_ENUM], [test "x$with_external_magic_enum" != xyes])
+])

--- a/m4/ax_check_magic_enum.m4
+++ b/m4/ax_check_magic_enum.m4
@@ -15,10 +15,17 @@ AC_DEFUN([AX_CHECK_MAGIC_ENUM], [
     # The version constraint is to ensure that the headers relative to
     # $includedir are magic_enum/foo.hpp. In 0.9.6, the magic_enum/
     # prefix was not used.
-    PKG_CHECK_MODULES(MAGICENUM, [magic_enum >= 0.9.7], [
-      AC_MSG_NOTICE([external magic_enum will be used])
+    m4_ifdef([PKG_CHECK_MODULES], [
+      PKG_CHECK_MODULES(MAGICENUM, [magic_enum >= 0.9.7], [
+        AC_MSG_NOTICE([external magic_enum will be used])
+      ], [
+        AC_MSG_ERROR([external magic_enum not found])
+      ])
     ], [
-      AC_MSG_ERROR([external magic_enum not found])
+      AC_MSG_ERROR(m4_normalize([
+        cannot use flag --with-external-magic-enum, the libsemigroups configure file
+        was created on a system without m4 macros for pkg-config available...
+      ]))
     ])
   ])
   AM_CONDITIONAL([USE_BUNDLED_MAGIC_ENUM], [test "x$with_external_magic_enum" != xyes])


### PR DESCRIPTION
You are more and more likely to find magic_enum installed on the system:

* https://repology.org/project/magic-enum/versions

We have it on Gentoo, and it's pretty easy in this case, so I made a nice option for it:

1. Add a new `AX_CHECK_MAGIC_ENUM()` macro for `--with-external-magic-enum={yes,no}`
2. Run that macro in `./configure`
3. If `$with_external_magic_enum = yes`, skip adding `third_party/...` to the include path, and do not try to install any files from the bundled copy of magic_enum.

That's pretty much it, since in this case the code already uses

```C
#include <magic_enum/magic_enum.hpp>
```

which is how you include the copy from `/usr/include` anyway.
