### PR TITLE
Add parsing for commutators in `operator""_p`

### DIFF
--- a/include/libsemigroups/word-range.hpp
+++ b/include/libsemigroups/word-range.hpp
@@ -2056,13 +2056,26 @@ namespace libsemigroups {
     //! This operator provides a convenient concise means of constructing a
     //! std::string from an algebraic expression.
     //! For example, \c "((ab)^3cc)^2"_p equals
-    //! \c "abababccabababcc" and \c "a^0"_p equals the empty string \c "".
+    //! \c "abababccabababcc", \c "(ab,ba)" equals \c "BAABabba" and \c "a^0"_p
+    //! equals the empty string \c "".
     //!
     //! This function has the following behaviour:
     //! * arbitrarily nested brackets;
     //! * spaces are ignored;
     //! * redundant matched brackets are ignored;
-    //! * only the characters in \c "()^ " and in \c a-zA-Z0-9 are allowed.
+    //! * \c ^ is treated as the power binary operator;
+    //! * \c , is treated as the commutator binary operator;
+    //! * only the characters in \c "()^, " and in \c a-zA-Z0-9 are allowed.
+    //!
+    //! When using \c , as the commutator operator, it is not possible to
+    //! specify what the inverse of each letter should be. Instead, it is
+    //! assumed that the inverse of a lowercase letter is the corresponding
+    //! uppercase letter, and the inverse of an uppercase letter is the
+    //! corresponding lowercase letter. If this is requirement is not applicable
+    //! for your use case, see \ref presentation::commutator instead.
+    //!
+    //! Additionally, it is not possible to specify commutators using square
+    //! brackets. Round brackets must be used instead.
     //!
     //! \param w the letters of the word.
     //! \param n the length of \p w (defaults to the length of \p w).

--- a/src/word-range.cpp
+++ b/src/word-range.cpp
@@ -567,6 +567,18 @@ namespace libsemigroups {
     }
 
     namespace {
+      bool is_op(const char val) {
+        return std::string_view{",*^"}.find(val) != std::string_view::npos;
+      }
+
+      // Check op1 < op2 with respect to the order , < * < ^
+      bool compare_ops(const char op1, const char op2) {
+        LIBSEMIGROUPS_ASSERT(is_op(op1));
+        LIBSEMIGROUPS_ASSERT(is_op(op2));
+        std::string_view ops{",*^"};
+        return ops.find(op1) < ops.find(op2);
+      }
+
       // The next function implements the Shunting Yard Algorithm to convert
       // the expression in input to reverse Polish notation, as described
       // here: https://en.wikipedia.org/wiki/Shunting_yard_algorithm
@@ -582,10 +594,12 @@ namespace libsemigroups {
                 "Illegal character \'*\' in position {} of \"{}\"", i, input);
           }
           input_copy += input[i];
-          if ((std::isalpha(input[i])
+          // Add a <*> after input[i] if input[i] is:
+          //  - a digit or letter followed by a letter or an open bracket; or
+          //  - a close bracket followed by a letter
+          if (((std::isdigit(input[i]) || std::isalpha(input[i]))
                && (std::isalpha(input[i + 1]) || input[i + 1] == '('))
-              || (std::isdigit(input[i]) && !std::isdigit(input[i + 1])
-                  && input[i + 1] != ')')
+
               || (input[i] == ')' && std::isalpha(input[i + 1]))) {
             input_copy += "*";
           }
@@ -596,14 +610,13 @@ namespace libsemigroups {
         std::stack<char> ops;
 
         for (size_t i = 0; i < input_copy.size(); ++i) {
-          if (std::isalpha(input_copy[i])) {
+          if (std::isalpha(input_copy[i]) || (std::isdigit(input_copy[i]))) {
             output += input_copy[i];
-          } else if (std::isdigit(input_copy[i])) {
-            output += input_copy[i];
-          } else if (input_copy[i] == '(' || input_copy[i] == '^') {
+          } else if (input_copy[i] == '(') {
             ops.push(input_copy[i]);
-          } else if (input_copy[i] == '*') {
-            while (!ops.empty() && ops.top() != '(') {
+          } else if (is_op(input_copy[i])) {
+            while (!ops.empty() && ops.top() != '('
+                   && compare_ops(input_copy[i], ops.top())) {
               output += ops.top();
               ops.pop();
             }
@@ -656,6 +669,27 @@ namespace libsemigroups {
         return true;
       }
 
+      std::string get_unique_letters(std::string const& x) {
+        std::unordered_set<char> seen;
+        std::string              result;
+        for (char c : x) {
+          if (seen.insert(c).second)
+            result += c;
+        }
+
+        return result;
+      }
+
+      std::string swap_case(std::string s) {
+        std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
+          if (std::isupper(c)) {
+            return std::tolower(c);
+          }
+          return std::toupper(c);
+        });
+        return s;
+      }
+
       std::string evaluate_rpn(std::string const& rpn,
                                std::string const& orig) {
         using namespace words;  // NOLINT(build/namespaces)
@@ -693,6 +727,32 @@ namespace libsemigroups {
             } else {
               LIBSEMIGROUPS_EXCEPTION(
                   "Missing argument(s) for operator \'*\', "
+                  "expected 2 arguments found {} in \"{}\"",
+                  stck.empty() ? "0" : fmt::format("\"{}\"", stck.top()),
+                  orig);
+            }
+          } else if (term == ',') {
+            in_digits = false;
+            if (try_pop_two(stck, pr)) {
+              for (std::string word : {pr.first, pr.second}) {
+                auto it = std::find_if_not(
+                    word.begin(), word.end(), [](auto const& c) {
+                      return std::isalpha(c);
+                    });
+                if (it != word.end()) {
+                  LIBSEMIGROUPS_EXCEPTION(
+                      "Incorrect arguments for operator \',\', expected only "
+                      "letters, found \"^{}\"  in \"{}\"",
+                      *it,
+                      orig);
+                }
+              }
+              std::string alphabet = get_unique_letters(pr.second + pr.first);
+              stck.push(presentation::commutator_no_checks(
+                  pr.second, pr.first, alphabet, swap_case(alphabet)));
+            } else {
+              LIBSEMIGROUPS_EXCEPTION(
+                  "Missing argument(s) for operator \',\', "
                   "expected 2 arguments found {} in \"{}\"",
                   stck.empty() ? "0" : fmt::format("\"{}\"", stck.top()),
                   orig);

--- a/src/word-range.cpp
+++ b/src/word-range.cpp
@@ -670,14 +670,8 @@ namespace libsemigroups {
       }
 
       std::string get_unique_letters(std::string const& x) {
-        std::unordered_set<char> seen;
-        std::string              result;
-        for (char c : x) {
-          if (seen.insert(c).second)
-            result += c;
-        }
-
-        return result;
+        std::unordered_set seen(x.begin(), x.end());
+        return std::string(seen.begin(), seen.end());
       }
 
       std::string swap_case(std::string s) {

--- a/tests/test-word-range.cpp
+++ b/tests/test-word-range.cpp
@@ -985,9 +985,10 @@ namespace libsemigroups {
     REQUIRE(""_p == "");
     REQUIRE("a"_p == "a");
 
-    // This one looks a bit weird, but we are treating the comma as the
+    // These look a bit weird, but we are treating the comma as the
     // commutator operator, so the brackets aren't strictly necessary
     REQUIRE("a,b"_p == "ABab");
+    REQUIRE("a^2,b^3"_p == "AABBBaabbb");
 
     REQUIRE_THROWS_AS("a*a*b*bc"_p, LibsemigroupsException);
     REQUIRE("           "_p == "");

--- a/tests/test-word-range.cpp
+++ b/tests/test-word-range.cpp
@@ -972,11 +972,22 @@ namespace libsemigroups {
     REQUIRE("X^3(yx^2)"_p == "XXXyxx");
     REQUIRE("b(aX)^3x"_p == "baXaXaXx");
     REQUIRE("((a)b^2y)^10"_p == "abbyabbyabbyabbyabbyabbyabbyabbyabbyabby");
+    REQUIRE("(a,b)"_p == "ABab");
+    REQUIRE("(aB,bA)"_p == "bAaBaBbA");
+    REQUIRE("(abbab,babaa)"_p == "BABBAAABABabbabbabaa");
+    REQUIRE("(a^2,b^3)^2"_p == "AABBBaabbbAABBBaabbb");
+    REQUIRE("((a^2,(ab)^2),b^3)"_p == "((aa,abab),bbb)"_p);
+    REQUIRE("((a^2,(ab)^2),b^3)"_p == "(AABABAaaabab,bbb)"_p);
+    REQUIRE("((a^2,(ab)^2),b^3)"_p == "BABAAAababaaBBBAABABAaaababbbb");
 
     REQUIRE("()"_p == "");
     REQUIRE("y^0"_p == "");
     REQUIRE(""_p == "");
     REQUIRE("a"_p == "a");
+
+    // This one looks a bit weird, but we are treating the comma as the
+    // commutator operator, so the brackets aren't strictly necessary
+    REQUIRE("a,b"_p == "ABab");
 
     REQUIRE_THROWS_AS("a*a*b*bc"_p, LibsemigroupsException);
     REQUIRE("           "_p == "");
@@ -986,6 +997,15 @@ namespace libsemigroups {
     REQUIRE_THROWS_AS("(a*b)^3*bc"_p, LibsemigroupsException);
     REQUIRE_THROWS_AS("(2^2)"_p, LibsemigroupsException);
     REQUIRE_THROWS_AS("2*2"_p, LibsemigroupsException);
+    REQUIRE_THROWS_AS("(a,,a)"_p, LibsemigroupsException);
+    REQUIRE_THROWS_AS("(a,)"_p, LibsemigroupsException);
+    REQUIRE_THROWS_AS("(a,^)"_p, LibsemigroupsException);
+    REQUIRE_THROWS_AS("(a,2)"_p, LibsemigroupsException);
+    REQUIRE_THROWS_AS("(a,,)"_p, LibsemigroupsException);
+    REQUIRE_THROWS_AS("(,a)"_p, LibsemigroupsException);
+    REQUIRE_THROWS_AS("(^,a)"_p, LibsemigroupsException);
+    REQUIRE_THROWS_AS("(2,a)"_p, LibsemigroupsException);
+    REQUIRE_THROWS_AS("(,,a)"_p, LibsemigroupsException);
 
     REQUIRE_THROWS_AS("(()()()((((())()())"_p, LibsemigroupsException);
     REQUIRE_THROWS_AS("("_p, LibsemigroupsException);


### PR DESCRIPTION
This PR adds functionality for parsing commutators when using the `operator""_p` function. This is achieved by considering the comma to be the commutator binary operator, and assuming that the inverse of lowercase letters are the corresponding uppercase letter, and vice versa. This assumption is made clear in the doc.

It is not possible to use square brackets as one might want when specifying a commutator, but the additional work to match two different types of brackets didn't seem justified. One possible fix would be to treat all brackets as equal. This has the advantage of allowing strings like `"[a,b]"` to be parsed, but the disadvantage of also allowing strings like `"[a,b)"` to be parsed. In either case, this could be deferred to a later date. 