### PR TITLE
ToddCoxeter: throw if non-core strategy and run_for

### DIFF
--- a/src/detail/todd-coxeter-impl.cpp
+++ b/src/detail/todd-coxeter-impl.cpp
@@ -818,9 +818,10 @@ namespace libsemigroups::detail {
                && strategy() != options::strategy::hlt
                && strategy() != options::strategy::lookahead
                && strategy() != options::strategy::lookbehind
-               && running_until()) {
-      LIBSEMIGROUPS_EXCEPTION("the strategy {} cannot be used with run_until !",
-                              strategy());
+               && (running_until() || running_for())) {
+      LIBSEMIGROUPS_EXCEPTION("the strategy {} cannot be used with {} !",
+                              strategy(),
+                              (running_until() ? "run_until" : "run_for"));
     } else if (internal_presentation().rules.empty()
                && !internal_presentation().alphabet().empty()
                && (internal_generating_pairs().empty()

--- a/src/todd-coxeter-helpers.cpp
+++ b/src/todd-coxeter-helpers.cpp
@@ -41,6 +41,8 @@ namespace libsemigroups {
       detail::ToddCoxeterImpl::Definitions>;
 
   namespace todd_coxeter {
+    // This function doesn't take a const reference for tc because
+    // tc.number_of_classes() is not const.
     [[nodiscard]] tril is_non_trivial(detail::ToddCoxeterImpl&  tc,
                                       size_t                    tries,
                                       std::chrono::milliseconds try_for,
@@ -57,6 +59,7 @@ namespace libsemigroups {
         report_default(
             "trying to show non-triviality: {} / {}\n", try_ + 1, tries);
         detail::ToddCoxeterImpl copy(tc);
+        copy.strategy(detail::ToddCoxeterImpl::options::strategy::hlt);
         copy.save(true);
         while (!copy.finished()) {
           copy.run_for(try_for);

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -1778,6 +1778,7 @@ namespace libsemigroups {
     auto   p = presentation::examples::symmetric_group_Moo97_a(n);
 
     ToddCoxeter tc(twosided, p);
+    tc.run_for(std::chrono::microseconds(1));
 
     section_hlt(tc);
     section_felsch(tc);
@@ -1786,7 +1787,6 @@ namespace libsemigroups {
     section_R_over_C_style(tc);
     section_Rc_style(tc);
 
-    tc.run_for(std::chrono::microseconds(1));
     REQUIRE(is_non_trivial(tc) == tril::TRUE);
     // REQUIRE(!tc.finished());
     tc.standardize(Order::shortlex);

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -5419,4 +5419,27 @@ namespace libsemigroups {
     tc.init();
     REQUIRE(f.number_of_nodes() == 0);
   }
+
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "133",
+                          "non-core strategies run_for/run_until exceptions",
+                          "[todd-coxeter][quick]") {
+    auto rg = ReportGuard(false);
+
+    Presentation<word_type> p;
+    p.alphabet(2);
+    presentation::add_rule(p, 000_w, 0_w);
+    presentation::add_rule(p, 0_w, 11_w);
+    ToddCoxeter tc(twosided, p);
+
+    section_Rc_style(tc);
+    section_R_over_C_style(tc);
+    section_CR_style(tc);
+    section_Cr_style(tc);
+
+    REQUIRE_THROWS_AS(tc.run_until([] { return false; }),
+                      LibsemigroupsException);
+    REQUIRE_THROWS_AS(tc.run_for(std::chrono::microseconds(1)),
+                      LibsemigroupsException);
+  }
 }  // namespace libsemigroups


### PR DESCRIPTION
This PR adds checks that `run_for` is not called on a `ToddCoxeter` object `tc` unless the strategy of `tc` is one of:
* `felsch`;
* `hlt`;
* `lookahead`; or
* `lookbehind`.  