### PR TITLE
Fix typo in `strategy` doc

### DIFF
--- a/include/libsemigroups/todd-coxeter-class.hpp
+++ b/include/libsemigroups/todd-coxeter-class.hpp
@@ -164,7 +164,7 @@ namespace libsemigroups {
       //! Several of the strategies mimic
       //! [ACE](https://staff.itee.uq.edu.au/havas/) strategies of the same
       //! name. The [ACE](https://staff.itee.uq.edu.au/havas/) strategy \"R*\"
-      //! is equivalent to \c strategy(options::strategy::hlt).save(true).
+      //! is equivalent to `strategy(options::strategy::hlt).save(true)`.
       enum class strategy {
         //! This value indicates that the HLT (Hazelgrove-Leech-Trotter)
         //! strategy should be used. This is analogous to


### PR DESCRIPTION
This PR fixes a small typesetting issue in the strategy doc:

## Before
<img width="730" height="67" alt="image" src="https://github.com/user-attachments/assets/79331b46-5a6e-43c4-a8a3-f12a51528fe7" />


## After
<img width="730" height="67" alt="image" src="https://github.com/user-attachments/assets/3747468b-b8eb-41e5-959c-26a7ec5d949e" />
