### PR TITLE
Add repology to install info

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -40,6 +40,12 @@ To build `libsemigroups` from a release archive:
     cd libsemigroups-3.5.5
     ./configure && make -j8 && sudo make install
 
+## From a package repository
+
+The `libsemigroups` library is available through several package repositories:
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/libsemigroups.svg)](https://repology.org/project/libsemigroups/versions)
+
 ## Configuration options
 
 In addition to the usual `autoconf` configuration options, the following


### PR DESCRIPTION
Resolves #974.
 
This PR adds some info from repology to the install page:
<img width="1190" height="949" alt="image" src="https://github.com/user-attachments/assets/a46efbd8-bf1e-4eed-8ef4-df9e39757491" />
