### PR TITLE
Some more functionality for `dot` and `WordGraph`s

### DIFF
--- a/include/libsemigroups/dot.hpp
+++ b/include/libsemigroups/dot.hpp
@@ -568,9 +568,7 @@ namespace libsemigroups {
     //! \param name the name.
     //!
     //! \returns A \c bool.
-    [[nodiscard]] bool is_node(std::string const& name) const {
-      return _nodes.count(name);
-    }
+    [[nodiscard]] bool is_node(std::string const& name) const;
 
     //! \brief Check if there is a node with name obtained from an object.
     //!
@@ -661,9 +659,8 @@ namespace libsemigroups {
     Edge& add_edge(Thing1&& head, Thing2&& tail) {
       auto head_str = detail::dot_to_string(std::forward<Thing1>(head));
       auto tail_str = detail::dot_to_string(std::forward<Thing2>(tail));
-      // throw_if_not_node(head_str);
-      // TODO think about what to do
-      // throw_if_not_node(tail_str);
+      throw_if_not_node(head_str);
+      throw_if_not_node(tail_str);
       _edges.emplace_back(head_str, tail_str);
       return _edges.back();
     }

--- a/include/libsemigroups/dot.hpp
+++ b/include/libsemigroups/dot.hpp
@@ -121,8 +121,8 @@ namespace libsemigroups {
       //! double quotes.
       string,
 
-      //! Value indicating that the value of an attribute should be enclosed in
-      //! double quotes.
+      //! Value indicating that the value of an attribute should not be enclosed
+      //! in double quotes.
       html
     };
 

--- a/include/libsemigroups/dot.hpp
+++ b/include/libsemigroups/dot.hpp
@@ -115,6 +115,17 @@ namespace libsemigroups {
   //! [Graphviz]: https://www.graphviz.org
   class Dot {
    public:
+    //! Enum to indicate the kind of attribute.
+    enum class Attr : uint8_t {
+      //! Value indicating that the value of an attribute should be enclosed in
+      //! double quotes.
+      string,
+
+      //! Value indicating that the value of an attribute should be enclosed in
+      //! double quotes.
+      html
+    };
+
     //! \brief This nested struct represents a node in the represented graph.
     //!
     //! Defined in `dot.hpp`.
@@ -172,6 +183,7 @@ namespace libsemigroups {
       //!
       //! \param key the name of the attribute.
       //! \param val the value of the attribute.
+      //! \param kind whether to enclose \p val in double quotes or not.
       //!
       //! \returns A reference to \c this.
       //!
@@ -182,10 +194,12 @@ namespace libsemigroups {
       //! [Graphviz documentation]: https://www.graphviz.org/docs/nodes/
       //! [DOT]: https://www.graphviz.org/doc/info/lang.html
       template <typename Thing1, typename Thing2>
-      Node& add_attr(Thing1&& key, Thing2&& val) {
+      Node& add_attr(Thing1&& key, Thing2&& val, Attr kind = Attr::string) {
         auto key_str = detail::dot_to_string(std::forward<Thing1>(key));
         auto val_str = detail::dot_to_string(std::forward<Thing2>(val));
-
+        if (kind == Attr::string) {
+          val_str = fmt::format("\"{}\"", val_str);
+        }
         add_or_replace_attr(attrs, key_str, val_str);
         return *this;
       }
@@ -228,6 +242,7 @@ namespace libsemigroups {
       //!
       //! \param key the name of the attribute.
       //! \param val the value of the attribute.
+      //! \param kind whether to enclose \p val in double quotes or not.
       //!
       //! \returns A reference to \c this.
       //!
@@ -238,9 +253,12 @@ namespace libsemigroups {
       //! [Graphviz documentation]: https://www.graphviz.org/docs/nodes/
       //! [DOT]: https://www.graphviz.org/doc/info/lang.html
       template <typename Thing1, typename Thing2>
-      Edge& add_attr(Thing1&& key, Thing2&& val) {
+      Edge& add_attr(Thing1&& key, Thing2&& val, Attr kind = Attr::string) {
         auto key_str = detail::dot_to_string(std::forward<Thing1>(key));
         auto val_str = detail::dot_to_string(std::forward<Thing2>(val));
+        if (kind == Attr::string) {
+          val_str = fmt::format("\"{}\"", val_str);
+        }
 
         add_or_replace_attr(attrs, key_str, val_str);
         return *this;
@@ -495,6 +513,7 @@ namespace libsemigroups {
     //!
     //! \param key the name of the attribute.
     //! \param val the value of the attribute.
+    //! \param kind whether to enclose \p val in double quotes or not.
     //!
     //! \returns A reference to \c this.
     //!
@@ -505,9 +524,12 @@ namespace libsemigroups {
     //! [Graphviz documentation]: https://www.graphviz.org/docs/nodes/
     //! [DOT]: https://www.graphviz.org/doc/info/lang.html
     template <typename Thing1, typename Thing2>
-    Dot& add_attr(Thing1&& key, Thing2&& val) {
+    Dot& add_attr(Thing1&& key, Thing2&& val, Attr kind = Attr::string) {
       auto key_str = detail::dot_to_string(std::forward<Thing1>(key));
       auto val_str = detail::dot_to_string(std::forward<Thing2>(val));
+      if (kind == Attr::string) {
+        val_str = fmt::format("\"{}\"", val_str);
+      }
 
       add_or_replace_attr(_attrs, key_str, val_str);
       return *this;
@@ -639,8 +661,9 @@ namespace libsemigroups {
     Edge& add_edge(Thing1&& head, Thing2&& tail) {
       auto head_str = detail::dot_to_string(std::forward<Thing1>(head));
       auto tail_str = detail::dot_to_string(std::forward<Thing2>(tail));
-      throw_if_not_node(head_str);
-      throw_if_not_node(tail_str);
+      // throw_if_not_node(head_str);
+      // TODO think about what to do
+      // throw_if_not_node(tail_str);
       _edges.emplace_back(head_str, tail_str);
       return _edges.back();
     }
@@ -738,6 +761,20 @@ namespace libsemigroups {
   //! \exceptions
   //! \no_libsemigroups_except
   std::string to_human_readable_repr(Dot::Edge const& e);
+
+  //! \relates Dot
+  //!
+  //! \brief Return a human readable representation of a Dot::Attr object.
+  //!
+  //! Return a human readable representation of a Dot::Attr object.
+  //!
+  //! \param a the Dot::Attr object.
+  //! \param sep separator to use between "Dot" and "Attr" (defaults to "::").
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  std::string to_human_readable_repr(Dot::Attr const&   a,
+                                     std::string const& sep = "::");
 
   //! \relates Dot
   //!

--- a/include/libsemigroups/froidure-pin-base.hpp
+++ b/include/libsemigroups/froidure-pin-base.hpp
@@ -2418,6 +2418,196 @@ namespace libsemigroups {
     [[nodiscard]] rx::iterator_range<FroidurePinBase::const_rule_iterator>
     rules(FroidurePinBase& fpb);
 
+    //! \brief Returns a \ref Dot object representing the right Cayley graph.
+    //!
+    //! This function returns a \ref Dot object representing the current right
+    //! Cayley graph of the FroidurePinBase instance \p s. The generators are
+    //! labelled by the characters in \p gen_names, and the nodes are labelled
+    //! by the words in the generators that correspond to their positions in
+    //! \p s.
+    //!
+    //! \param s the FroidurePinBase instance.
+    //! \param gen_names the labels for the generators of \p s.
+    //!
+    //! \returns A \ref Dot object representing the current right Cayley graph
+    //! of \p s.
+    //!
+    //! \throws LibsemigroupsException if \p gen_names has size different from
+    //! `s.number_of_generators()`.
+    //! \throws LibsemigroupsException if \p s has more generators than there
+    //! are colours in Dot::colors.
+    //!
+    //! \note This function may trigger an enumeration in order to compute the
+    //! node labels.
+    //!
+    //! \sa dot_cayley_graph.
+    [[nodiscard]] Dot
+    dot_current_right_cayley_graph(FroidurePinBase const& s,
+                                   std::string const&     gen_names);
+
+    //! \brief Returns a \ref Dot object representing the right Cayley graph.
+    //!
+    //! This function calls FroidurePinBase::run on the FroidurePinBase instance
+    //! \p s, and then returns a \ref Dot object representing the right Cayley
+    //! graph of \p s. The generators are labelled by the characters in \p
+    //! gen_names, and the nodes are labelled by the words in the generators
+    //! that correspond to their positions in \p s.
+    //!
+    //! \param s the FroidurePinBase instance.
+    //! \param gen_names the labels for the generators of \p s.
+    //!
+    //! \returns A \ref Dot object representing the right Cayley graph of \p s.
+    //!
+    //! \throws LibsemigroupsException if \p gen_names has size different from
+    //! `s.number_of_generators()`.
+    //! \throws LibsemigroupsException if \p s has more generators than there
+    //! are colours in Dot::colors.
+    //!
+    //! \note This function triggers a full enumeration of \p s.
+    //!
+    //! \sa dot_current_right_cayley_graph.
+    [[nodiscard]] Dot dot_right_cayley_graph(FroidurePinBase&   s,
+                                             std::string const& gen_names);
+
+    //! \brief Returns a \ref Dot object representing the left Cayley graph.
+    //!
+    //! This function returns a \ref Dot object representing the current left
+    //! Cayley graph of the FroidurePinBase instance \p s. The generators are
+    //! labelled by the characters in \p gen_names, and the nodes are labelled
+    //! by the words in the generators that correspond to their positions in
+    //! \p s.
+    //!
+    //! \param s the FroidurePinBase instance.
+    //! \param gen_names the labels for the generators of \p s.
+    //!
+    //! \returns A \ref Dot object representing the current left Cayley graph
+    //! of \p s.
+    //!
+    //! \throws LibsemigroupsException if \p gen_names has size different from
+    //! `s.number_of_generators()`.
+    //! \throws LibsemigroupsException if \p s has more generators than there
+    //! are colours in Dot::colors.
+    //!
+    //! \note This function may trigger an enumeration in order to compute the
+    //! node labels.
+    //!
+    //! \sa dot_cayley_graph.
+    [[nodiscard]] Dot
+    dot_current_left_cayley_graph(FroidurePinBase const& s,
+                                  std::string const&     gen_names);
+
+    //! \brief Returns a \ref Dot object representing the left Cayley graph.
+    //!
+    //! This function calls FroidurePinBase::run on the FroidurePinBase instance
+    //! \p s, and then returns a \ref Dot object representing the left Cayley
+    //! graph of \p s. The generators are labelled by the characters in \p
+    //! gen_names, and the nodes are labelled by the words in the generators
+    //! that correspond to their positions in \p s.
+    //!
+    //! \param s the FroidurePinBase instance.
+    //! \param gen_names the labels for the generators of \p s.
+    //!
+    //! \returns A \ref Dot object representing the left Cayley graph of \p s.
+    //!
+    //! \throws LibsemigroupsException if \p gen_names has size different from
+    //! `s.number_of_generators()`.
+    //! \throws LibsemigroupsException if \p s has more generators than there
+    //! are colours in Dot::colors.
+    //!
+    //! \note This function triggers a full enumeration of \p s.
+    //!
+    //! \sa dot_current_left_cayley_graph.
+    [[nodiscard]] Dot dot_left_cayley_graph(FroidurePinBase&   s,
+                                            std::string const& gen_names);
+
+    //! \brief Returns a \ref Dot object representing the right Cayley graph.
+    //!
+    //! This function returns a \ref Dot object representing the current right
+    //! Cayley graph of the FroidurePinBase instance \p s. The generators are
+    //! labelled using the first `s.number_of_generators()` characters from
+    //! libsemigroups' default human readable alphabet, and the nodes are
+    //! labelled by the words in the generators that correspond to their
+    //! positions in \p s.
+    //!
+    //! \param s the FroidurePinBase instance.
+    //!
+    //! \returns A \ref Dot object representing the current right Cayley graph
+    //! of \p s.
+    //!
+    //! \throws LibsemigroupsException if \p s has more generators than there
+    //! are colours in Dot::colors.
+    //!
+    //! \note This function may trigger an enumeration in order to compute the
+    //! node labels.
+    //!
+    //! \sa dot_cayley_graph.
+    [[nodiscard]] Dot dot_current_right_cayley_graph(FroidurePinBase const& s);
+
+    //! \brief Returns a \ref Dot object representing the right Cayley graph.
+    //!
+    //! This function calls FroidurePinBase::run on the FroidurePinBase instance
+    //! \p s, and then returns a \ref Dot object representing the right Cayley
+    //! graph of \p s. The generators are labelled using the first
+    //! `s.number_of_generators()` characters from libsemigroups' default human
+    //! readable alphabet, and the nodes are labelled by the words in the
+    //! generators that correspond to their positions in \p s.
+    //!
+    //! \param s the FroidurePinBase instance.
+    //!
+    //! \returns A \ref Dot object representing the right Cayley graph of \p s.
+    //!
+    //! \throws LibsemigroupsException if \p s has more generators than there
+    //! are colours in Dot::colors.
+    //!
+    //! \note This function triggers a full enumeration of \p s.
+    //!
+    //! \sa dot_current_right_cayley_graph.
+    [[nodiscard]] Dot dot_right_cayley_graph(FroidurePinBase& s);
+
+    //! \brief Returns a \ref Dot object representing the left Cayley graph.
+    //!
+    //! This function returns a \ref Dot object representing the current left
+    //! Cayley graph of the FroidurePinBase instance \p s. The generators are
+    //! labelled using the first `s.number_of_generators()` characters from
+    //! libsemigroups' default human readable alphabet, and the nodes are
+    //! labelled by the words in the generators that correspond to their
+    //! positions in \p s.
+    //!
+    //! \param s the FroidurePinBase instance.
+    //!
+    //! \returns A \ref Dot object representing the current left Cayley graph
+    //! of \p s.
+    //!
+    //! \throws LibsemigroupsException if \p s has more generators than there
+    //! are colours in Dot::colors.
+    //!
+    //! \note This function may trigger an enumeration in order to compute the
+    //! node labels.
+    //!
+    //! \sa dot_cayley_graph.
+    [[nodiscard]] Dot dot_current_left_cayley_graph(FroidurePinBase const& s);
+
+    //! \brief Returns a \ref Dot object representing the left Cayley graph.
+    //!
+    //! This function calls FroidurePinBase::run on the FroidurePinBase instance
+    //! \p s, and then returns a \ref Dot object representing the left Cayley
+    //! graph of \p s. The generators are labelled using the first
+    //! `s.number_of_generators()` characters from libsemigroups' default human
+    //! readable alphabet, and the nodes are labelled by the words in the
+    //! generators that correspond to their positions in \p s.
+    //!
+    //! \param s the FroidurePinBase instance.
+    //!
+    //! \returns A \ref Dot object representing the left Cayley graph of \p s.
+    //!
+    //! \throws LibsemigroupsException if \p s has more generators than there
+    //! are colours in Dot::colors.
+    //!
+    //! \note This function triggers a full enumeration of \p s.
+    //!
+    //! \sa dot_current_left_cayley_graph.
+    [[nodiscard]] Dot dot_left_cayley_graph(FroidurePinBase& s);
+
   }  // namespace froidure_pin
 }  // namespace libsemigroups
 #endif  // LIBSEMIGROUPS_FROIDURE_PIN_BASE_HPP_

--- a/include/libsemigroups/froidure-pin-base.hpp
+++ b/include/libsemigroups/froidure-pin-base.hpp
@@ -2500,8 +2500,8 @@ namespace libsemigroups {
     //!
     //! This function calls FroidurePinBase::run on the FroidurePinBase instance
     //! \p s, and then returns a \ref Dot object representing the left Cayley
-    //! graph of \p s. The generators are labelled by the characters in \p
-    //! gen_names, and the nodes are labelled by the words in the generators
+    //! graph of \p s. The generators are labelled by the characters in
+    //! \p gen_names, and the nodes are labelled by the words in the generators
     //! that correspond to their positions in \p s.
     //!
     //! \param s the FroidurePinBase instance.

--- a/include/libsemigroups/froidure-pin.hpp
+++ b/include/libsemigroups/froidure-pin.hpp
@@ -34,6 +34,7 @@
 #include "exception.hpp"          // for LIBSEMIGROUPS_EXCEPTION
 #include "froidure-pin-base.hpp"  // for FroidurePinBase, FroidurePinBase::s...
 #include "types.hpp"              // for letter_type, word_type
+#include "word-range.hpp"         // for ToString
 
 #include "detail/bruidhinn-traits.hpp"  // for detail::BruidhinnTraits
 #include "detail/iterator.hpp"          // for ConstIteratorStateless

--- a/include/libsemigroups/froidure-pin.tpp
+++ b/include/libsemigroups/froidure-pin.tpp
@@ -1466,7 +1466,6 @@ namespace libsemigroups {
                   typename FroidurePin<Element, Traits>::const_reference x) {
       return minimal_factorisation(fp, w, x);
     }
-
   }  // namespace froidure_pin
 
 }  // namespace libsemigroups

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -199,6 +199,68 @@ namespace libsemigroups {
         return dot(WordGraphView<Node>(wg));
       }
 
+      //! \brief Returns a labelled \ref Dot object representing a word graph
+      //! view.
+      //!
+      //! This function returns a \ref Dot object representing the word graph
+      //! view \p wg. The nodes of the returned graph are labelled using
+      //! \p node_labels, and the colours used for edges are shown in a legend
+      //! labelled by \p edge_labels.
+      //!
+      //! \tparam Node the type of the nodes of the WordGraphView.
+      //!
+      //! \param wg the word graph view.
+      //! \param node_labels the labels for the nodes of \p wg.
+      //! \param edge_labels the labels for the edge labels of \p wg.
+      //!
+      //! \returns A \ref Dot object representing \p wg.
+      //!
+      //! \throws LibsemigroupsException if \p node_labels has size different
+      //! from `wg.number_of_nodes()`.
+      //! \throws LibsemigroupsException if \p edge_labels has size different
+      //! from `wg.out_degree()`.
+      //! \throws LibsemigroupsException if the out-degree of \p wg is greater
+      //! than the number of colours in Dot::colors.
+      //!
+      //! \note This function does not trigger an enumeration.
+      template <typename Node>
+      [[nodiscard]] Dot dot(WordGraphView<Node> const&      wg,
+                            std::vector<std::string> const& node_labels,
+                            std::vector<std::string> const& edge_labels);
+
+      //! \brief Returns a labelled \ref Dot object representing a word graph.
+      //!
+      //! This function returns a \ref Dot object representing the word graph
+      //! \p wg. The nodes of the returned graph are labelled using
+      //! \p node_labels, and the colours used for edges are shown in a legend
+      //! labelled by \p edge_labels.
+      //!
+      //! \tparam Node the type of the nodes of the WordGraph.
+      //!
+      //! \param wg the word graph.
+      //! \param node_labels the labels for the nodes of \p wg.
+      //! \param edge_labels the labels for the edge labels of \p wg.
+      //!
+      //! \returns A \ref Dot object representing \p wg.
+      //!
+      //! \throws LibsemigroupsException if \p node_labels has size different
+      //! from `wg.number_of_nodes()`.
+      //! \throws LibsemigroupsException if \p edge_labels has size different
+      //! from `wg.out_degree()`.
+      //! \throws LibsemigroupsException if the out-degree of \p wg is greater
+      //! than the number of colours in Dot::colors.
+      //!
+      //! \note This function does not trigger an enumeration.
+      //!
+      //! \sa dot(WordGraphView<Node> const&,
+      //! std::vector<std::string> const&, std::vector<std::string> const&).
+      template <typename Node>
+      [[nodiscard]] Dot dot(WordGraph<Node> const&          wg,
+                            std::vector<std::string> const& node_labels,
+                            std::vector<std::string> const& edge_labels) {
+        return dot(WordGraphView<Node>(wg), node_labels, edge_labels);
+      }
+
       //! \brief Compares two word graphs on a range of nodes.
       //!
       //! This function returns \c true if the word graphs \p x and \p y are

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -1023,6 +1023,76 @@ namespace libsemigroups {
       }
 
       template <typename Node>
+      Dot dot(WordGraphView<Node> const&      wg,
+              std::vector<std::string> const& node_labels,
+              std::vector<std::string> const& edge_labels) {
+        if (node_labels.size() != wg.number_of_nodes()) {
+          LIBSEMIGROUPS_EXCEPTION(
+              "expected the 2nd argument (node labels) to have size {}, the "
+              "number of nodes of the 1st argument (word graph), but found {}",
+              wg.number_of_nodes(),
+              node_labels.size());
+        } else if (edge_labels.size() != wg.out_degree()) {
+          LIBSEMIGROUPS_EXCEPTION(
+              "expected the 3rd argument (edge labels) to have size {}, the "
+              "out-degree of the 1st argument (word graph), but found {}",
+              wg.out_degree(),
+              edge_labels.size());
+        } else if (Dot::colors.size() < wg.out_degree()) {
+          LIBSEMIGROUPS_EXCEPTION("the 1st argument (word graph) must have out "
+                                  "degree at most {}, found {}",
+                                  Dot::colors.size(),
+                                  wg.out_degree());
+        }
+
+        Dot result = dot(wg);
+
+        auto const out_degree = wg.out_degree();
+        size_t     i          = 0;
+        for (auto& node : result.nodes()) {
+          node.add_attr("label", node_labels[i++]);
+        }
+
+        auto start_table = "<<table border=\"0\" cellpadding=\"2\" "
+                           "cellspacing=\"0\" cellborder=\"0\">\n";
+        auto end_table   = "</table>>\n";
+
+        std::string label = start_table;
+        for (size_t index = 0; index < out_degree; ++index) {
+          label += fmt::format(
+              "<tr><td align=\"right\" port=\"port{}\">{}&nbsp;</td></tr>\n",
+              index,
+              edge_labels[index]);
+        }
+        label += end_table;
+
+        Dot legend;
+        legend.name("legend").add_attr("node [shape=plaintext]");
+
+        // HTML table for the head of the arrows in the legend
+        legend.add_node("head").add_attr("label", label, Dot::Attr::html);
+
+        label = start_table;
+        for (size_t index = 0; index < out_degree; ++index) {
+          label += fmt::format(
+              "<tr><td align=\"right\" port=\"port{}\">&nbsp;</td></tr>\n",
+              index);
+        }
+        label += end_table;
+
+        // HTML table for the tail of the arrows in the legend
+        legend.add_node("tail").add_attr("label", label, Dot::Attr::html);
+        for (size_t index = 0; index < out_degree; ++index) {
+          legend
+              .add_edge(fmt::format("head:port{}:e", index),
+                        fmt::format("tail:port{}:w", index))
+              .add_attr("color", result.colors[index]);
+        }
+        result.add_subgraph(legend);
+        return result;
+      }
+
+      template <typename Node>
       bool equal_to(WordGraph<Node> const& x,
                     WordGraph<Node> const& y,
                     Node                   first,

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -39,7 +39,7 @@ namespace libsemigroups {
       for (auto const& attr : map) {
         if (!attr.second.empty()) {
           s += fmt::format(
-              "{}{}=\"{}\"",
+              "{}{}={}",
               sep,
               attr.first,
               attr.second == "__NONE__" ? "" : attr.second);  // TODO(2) fixme
@@ -76,7 +76,9 @@ namespace libsemigroups {
       auto old_name = node.name;
       node.name     = subgraph.name() + "_" + node.name;
       add_node(node.name);
-      node.add_attr("label", old_name);
+      if (!node.attrs.count("label")) {
+        node.add_attr("label", old_name);
+      }
     }
 
     for (auto& edge : subgraph.edges()) {
@@ -170,6 +172,10 @@ namespace libsemigroups {
 
   std::string to_human_readable_repr(Dot::Edge const& e) {
     return fmt::format("<dot edge \"{}\" -> \"{}\">", e.head, e.tail);
+  }
+
+  std::string to_human_readable_repr(Dot::Attr const&, std::string const& sep) {
+    return fmt::format("<enum Dot{}Attr>", sep);
   }
 
   std::string to_human_readable_repr(Dot::Kind const&, std::string const& sep) {

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -152,6 +152,26 @@ namespace libsemigroups {
     }
   }
 
+  bool Dot::is_node(std::string const& name) const {
+    if (_nodes.count(name)) {
+      return true;
+    }
+    auto pos = name.find(":");
+    if (pos == std::string::npos) {
+      return false;
+    }
+    for (auto const& [key, val] : _nodes) {
+      if (key.size() >= pos
+          && std::equal(name.begin(),
+                        name.begin() + pos,
+                        key.begin(),
+                        key.begin() + pos)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   Dot::Edge::~Edge() = default;
 
   Dot::Node::~Node() = default;

--- a/src/froidure-pin-base.cpp
+++ b/src/froidure-pin-base.cpp
@@ -22,16 +22,17 @@
 #include <cstdint>    // for uint64_t
 #include <vector>     // for vector
 
-#include "libsemigroups/constants.hpp"  // for Undefined, Max, UNDEF...
-#include "libsemigroups/debug.hpp"      // for LIBSEMIGROUPS_ASSERT
-#include "libsemigroups/exception.hpp"  // for LIBSEMIGROUPS_EXCEPTION
-#include "libsemigroups/runner.hpp"     // for Runner
-#include "libsemigroups/types.hpp"      // for letter_type, word_type
+#include "libsemigroups/constants.hpp"   // for Undefined, Max, UNDEF...
+#include "libsemigroups/debug.hpp"       // for LIBSEMIGROUPS_ASSERT
+#include "libsemigroups/exception.hpp"   // for LIBSEMIGROUPS_EXCEPTION
+#include "libsemigroups/runner.hpp"      // for Runner
+#include "libsemigroups/types.hpp"       // for letter_type, word_type
+#include "libsemigroups/word-graph.hpp"  // for WordGraph
+#include "libsemigroups/word-range.hpp"  // for chars_in_human_readable_order
 
 #include "libsemigroups/detail/containers.hpp"  // for DynamicArray2
 #include "libsemigroups/detail/report.hpp"      // for REPORT_DEFAULT, Reporter
 #include "libsemigroups/detail/string.hpp"      // for group_digits
-#include "libsemigroups/word-graph.hpp"
 
 namespace libsemigroups {
   using element_index_type = FroidurePinBase::element_index_type;
@@ -432,6 +433,90 @@ namespace libsemigroups {
     rx::iterator_range<FroidurePinBase::const_rule_iterator>
     rules(FroidurePinBase& fpb) {
       return rx::iterator_range(fpb.cbegin_rules(), fpb.cend_rules());
+    }
+
+    namespace {
+      [[nodiscard]] Dot
+      dot_cayley_graph(FroidurePinBase const&                             s,
+                       typename FroidurePinBase::cayley_graph_type const& wg,
+                       std::string const& gen_names) {
+        LIBSEMIGROUPS_ASSERT(&wg == &s.current_right_cayley_graph()
+                             || &wg == &s.current_left_cayley_graph());
+        if (gen_names.size() != s.number_of_generators()) {
+          LIBSEMIGROUPS_EXCEPTION("expected the 2nd argument (generator names) "
+                                  "to have size {}, but found {}",
+                                  s.number_of_generators(),
+                                  gen_names.size());
+        }
+        ToString to_string(gen_names);
+
+        std::vector<std::string> node_labels;
+        for (size_t i = 0; i < s.current_size(); ++i) {
+          node_labels.push_back(to_string(
+              froidure_pin::current_minimal_factorisation_no_checks(s, i)));
+        }
+        std::vector<std::string> edge_labels;
+        for (size_t i = 0; i < s.number_of_generators(); ++i) {
+          edge_labels.push_back(to_string(word_type({i})));
+        }
+        return v4::word_graph::dot(wg, node_labels, edge_labels);
+      }
+
+      [[nodiscard]] Dot
+      dot_cayley_graph(FroidurePinBase const&                             s,
+                       typename FroidurePinBase::cayley_graph_type const& wg) {
+        if (Dot::colors.size() < s.number_of_generators()) {
+          LIBSEMIGROUPS_EXCEPTION(
+              "the 1st argument (FroidurePinBase) must have at "
+              "most {} generators, found {}",
+              Dot::colors.size(),
+              s.number_of_generators());
+        }
+        std::string gen_names(detail::chars_in_human_readable_order().begin(),
+                              detail::chars_in_human_readable_order().begin()
+                                  + s.number_of_generators());
+        return dot_cayley_graph(s, wg, gen_names);
+      }
+    }  // namespace
+
+    Dot dot_current_right_cayley_graph(FroidurePinBase const& s,
+                                       std::string const&     gen_names) {
+      return dot_cayley_graph(s, s.current_right_cayley_graph(), gen_names);
+    }
+
+    Dot dot_right_cayley_graph(FroidurePinBase&   s,
+                               std::string const& gen_names) {
+      s.run();
+      return dot_current_right_cayley_graph(s, gen_names);
+    }
+
+    Dot dot_current_left_cayley_graph(FroidurePinBase const& s,
+                                      std::string const&     gen_names) {
+      return dot_cayley_graph(s, s.current_left_cayley_graph(), gen_names);
+    }
+
+    Dot dot_left_cayley_graph(FroidurePinBase&   s,
+                              std::string const& gen_names) {
+      s.run();
+      return dot_current_left_cayley_graph(s, gen_names);
+    }
+
+    Dot dot_current_right_cayley_graph(FroidurePinBase const& s) {
+      return dot_cayley_graph(s, s.current_right_cayley_graph());
+    }
+
+    Dot dot_right_cayley_graph(FroidurePinBase& s) {
+      s.run();
+      return dot_current_right_cayley_graph(s);
+    }
+
+    Dot dot_current_left_cayley_graph(FroidurePinBase const& s) {
+      return dot_cayley_graph(s, s.current_left_cayley_graph());
+    }
+
+    Dot dot_left_cayley_graph(FroidurePinBase& s) {
+      s.run();
+      return dot_current_left_cayley_graph(s);
     }
 
   }  // namespace froidure_pin

--- a/tests/test-dot.cpp
+++ b/tests/test-dot.cpp
@@ -41,15 +41,16 @@ namespace libsemigroups {
     REQUIRE(edges[0].head == "0");
     REQUIRE(edges[0].tail == "0");
     REQUIRE(edges[0].attrs
-            == std::map<std::string, std::string>{{"color", "#00ff00"}});
+            == std::map<std::string, std::string>{{"color", "\"#00ff00\""}});
     edges[0].add_attr("style", "dashed");
     REQUIRE(edges[0].attrs
-            == std::map<std::string, std::string>{{"color", "#00ff00"},
-                                                  {"style", "dashed"}});
+            == std::map<std::string, std::string>{{"color", "\"#00ff00\""},
+                                                  {"style", "\"dashed\""}});
+    // setting attributes in this way is "as is"
     edges[0].attrs["color"] = "blue";
     REQUIRE(edges[0].attrs
             == std::map<std::string, std::string>{{"color", "blue"},
-                                                  {"style", "dashed"}});
+                                                  {"style", "\"dashed\""}});
   }
 
   LIBSEMIGROUPS_TEST_CASE("Dot::Node",
@@ -61,14 +62,15 @@ namespace libsemigroups {
     auto      nodes = d.nodes() | to_vector();
     REQUIRE((nodes.size()) == 3);
     REQUIRE(nodes[0].attrs
-            == std::map<std::string, std::string>{{"shape", "box"}});
+            == std::map<std::string, std::string>{{"shape", "\"box\""}});
     nodes[0].add_attr("shape", "circle");
     REQUIRE(nodes[0].attrs
-            == std::map<std::string, std::string>{{"shape", "circle"}});
+            == std::map<std::string, std::string>{{"shape", "\"circle\""}});
+    // setting attributes in this way is "as is"
     nodes[0].attrs["color"] = "blue";
     REQUIRE(nodes[0].attrs
             == std::map<std::string, std::string>{{"color", "blue"},
-                                                  {"shape", "circle"}});
+                                                  {"shape", "\"circle\""}});
   }
 
   LIBSEMIGROUPS_TEST_CASE("Dot", "002", "dot attributes", "[dot][quick]") {
@@ -80,7 +82,7 @@ namespace libsemigroups {
     d.add_attr("splines", "line");
     REQUIRE(d.attrs()
             == std::map<std::string, std::string>{{"node [shape=circle]", ""},
-                                                  {"splines", "line"}});
+                                                  {"splines", "\"line\""}});
   }
 
   LIBSEMIGROUPS_TEST_CASE("Dot", "003", "add_node", "[dot][quick]") {
@@ -104,7 +106,7 @@ namespace libsemigroups {
     REQUIRE(e.attrs == std::map<std::string, std::string>{});
     e.add_attr("color", "#00FF00");
     REQUIRE(e.attrs
-            == std::map<std::string, std::string>{{"color", "#00FF00"}});
+            == std::map<std::string, std::string>{{"color", "\"#00FF00\""}});
   }
 
   LIBSEMIGROUPS_TEST_CASE("Dot", "005", "add_subgraph", "[dot][quick]") {
@@ -133,5 +135,13 @@ namespace libsemigroups {
     REQUIRE(d.kind() == Dot::Kind::graph);
     d.kind(Dot::Kind::subgraph);
     REQUIRE(d.kind() == Dot::Kind::subgraph);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Dot::Attr",
+                          "007",
+                          "to_human_readable_repr",
+                          "[dot][quick]") {
+    REQUIRE(to_human_readable_repr(Dot::Attr::string) == "<enum Dot::Attr>");
+    REQUIRE(to_human_readable_repr(Dot::Attr::html, ".") == "<enum Dot.Attr>");
   }
 }  // namespace libsemigroups

--- a/tests/test-dot.cpp
+++ b/tests/test-dot.cpp
@@ -144,4 +144,11 @@ namespace libsemigroups {
     REQUIRE(to_human_readable_repr(Dot::Attr::string) == "<enum Dot::Attr>");
     REQUIRE(to_human_readable_repr(Dot::Attr::html, ".") == "<enum Dot.Attr>");
   }
+
+  LIBSEMIGROUPS_TEST_CASE("Dot", "008", "is_node", "[dot][quick]") {
+    Dot d;
+    d.add_node("cat");
+    REQUIRE(d.is_node("cat:dog"));
+    REQUIRE(d.is_node("cat"));
+  }
 }  // namespace libsemigroups

--- a/tests/test-froidure-pin-transf.cpp
+++ b/tests/test-froidure-pin-transf.cpp
@@ -20,6 +20,7 @@
 #include <cstddef>    // for size_t
 #include <cstdint>    // for uint_fast8_t, uint16_t
 #include <iterator>   // for make_reverse_iterator
+#include <tuple>      // for ignore
 #include <vector>     // for vector
 
 #include "test-main.hpp"
@@ -2512,6 +2513,279 @@ namespace libsemigroups {
     REQUIRE_NOTHROW(S.add_generator(make<Transf<>>({0, 1, 2, 3, 3, 3})));
     REQUIRE_THROWS_AS(S.add_generator(make<Transf<>>({0, 1, 2, 3, 3, 3, 3})),
                       LibsemigroupsException);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "120",
+                          "dot_cayley_graph",
+                          "[quick][froidure-pin][transf]") {
+    auto                  rg = ReportGuard(false);
+    FroidurePin<Transf<>> S;
+    S.add_generator(make<Transf<>>({0, 0, 2}));
+    S.add_generator(make<Transf<>>({0, 1, 1}));
+
+    Dot dot = froidure_pin::dot_right_cayley_graph(S, "ab");
+    REQUIRE(dot.to_string()
+            == "digraph WordGraph {\n"
+               "\n"
+               "subgraph cluster_legend {\n"
+               "  label=\"legend\"node [shape=plaintext]\n"
+               "  \n"
+               "  cluster_legend_head  [label=<<table border=\"0\" "
+               "cellpadding=\"2\" cellspacing=\"0\" cellborder=\"0\">\n"
+               "<tr><td align=\"right\" port=\"port0\">a&nbsp;</td></tr>\n"
+               "<tr><td align=\"right\" port=\"port1\">b&nbsp;</td></tr>\n"
+               "</table>>\n"
+               "]\n"
+               "  cluster_legend_tail  [label=<<table border=\"0\" "
+               "cellpadding=\"2\" cellspacing=\"0\" cellborder=\"0\">\n"
+               "<tr><td align=\"right\" port=\"port0\">&nbsp;</td></tr>\n"
+               "<tr><td align=\"right\" port=\"port1\">&nbsp;</td></tr>\n"
+               "</table>>\n"
+               "]\n"
+               "  cluster_legend_head:port0:e -> "
+               "cluster_legend_tail:port0:w  [color=\"#00ff00\", "
+               "constraint=\"false\"]\n"
+               "  cluster_legend_head:port1:e -> "
+               "cluster_legend_tail:port1:w  [color=\"#ff00ff\", "
+               "constraint=\"false\"]\n"
+               "}\n"
+               "  0  [label=\"a\", shape=\"box\"]\n"
+               "  1  [label=\"b\", shape=\"box\"]\n"
+               "  2  [label=\"ab\", shape=\"box\"]\n"
+               "  3  [label=\"ba\", shape=\"box\"]\n"
+               "  0 -> 0  [color=\"#00ff00\"]\n"
+               "  0 -> 2  [color=\"#ff00ff\"]\n"
+               "  1 -> 3  [color=\"#00ff00\"]\n"
+               "  1 -> 1  [color=\"#ff00ff\"]\n"
+               "  2 -> 3  [color=\"#00ff00\"]\n"
+               "  2 -> 2  [color=\"#ff00ff\"]\n"
+               "  3 -> 3  [color=\"#00ff00\"]\n"
+               "  3 -> 3  [color=\"#ff00ff\"]\n"
+               "}");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "121",
+                          "exception: dot_cayley_graph",
+                          "[quick][froidure-pin][transf]") {
+    auto                  rg = ReportGuard(false);
+    FroidurePin<Transf<>> S;
+    S.add_generator(make<Transf<>>({0, 0, 2}));
+    S.add_generator(make<Transf<>>({0, 1, 1}));
+    S.run();
+
+    FroidurePin<Transf<>> T;
+    T.add_generator(make<Transf<>>({0, 0, 1}));
+    REQUIRE_EXCEPTION_MSG(
+        std::ignore = froidure_pin::dot_current_right_cayley_graph(S, "abc"),
+        "expected the 2nd argument (generator names) to have "
+        "size 2, but found 3");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "122",
+                          "dot_cayley_graph [default labels]",
+                          "[quick][froidure-pin][transf]") {
+    auto                  rg = ReportGuard(false);
+    FroidurePin<Transf<>> S;
+    S.add_generator(make<Transf<>>({0, 0, 2}));
+    S.add_generator(make<Transf<>>({0, 1, 1}));
+
+    REQUIRE(
+        froidure_pin::dot_current_right_cayley_graph(S).to_string()
+        == froidure_pin::dot_current_right_cayley_graph(S, "ab").to_string());
+    REQUIRE(
+        froidure_pin::dot_current_left_cayley_graph(S).to_string()
+        == froidure_pin::dot_current_left_cayley_graph(S, "ab").to_string());
+
+    FroidurePin<Transf<>> U;
+    for (size_t i = 0; i < Dot::colors.size() + 1; ++i) {
+      U.add_generator(make<Transf<>>({0, 1}));
+    }
+    U.run();
+    REQUIRE_EXCEPTION_MSG(
+        std::ignore = froidure_pin::dot_current_right_cayley_graph(U),
+        "the 1st argument (FroidurePinBase) must have at most 24 generators, "
+        "found 25");
+    REQUIRE_EXCEPTION_MSG(
+        std::ignore = froidure_pin::dot_current_left_cayley_graph(U),
+        "the 1st argument (FroidurePinBase) must have at most 24 generators, "
+        "found 25");
+
+    FroidurePin<Transf<>> V;
+    for (size_t i = 0; i < 257; ++i) {
+      V.add_generator(make<Transf<>>({0, 1}));
+    }
+    REQUIRE_EXCEPTION_MSG(
+        std::ignore = froidure_pin::dot_current_right_cayley_graph(V),
+        "the 1st argument (FroidurePinBase) must have at most 24 generators, "
+        "found 257");
+    REQUIRE_EXCEPTION_MSG(
+        std::ignore = froidure_pin::dot_current_left_cayley_graph(V),
+        "the 1st argument (FroidurePinBase) must have at most 24 generators, "
+        "found 257");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("FroidurePin<Transf>",
+                          "123",
+                          "dot_cayley_graph",
+                          "[quick][froidure-pin][transf]") {
+    auto rg = ReportGuard(false);
+
+    auto make_example = []() {
+      FroidurePin<Transf<>> S;
+      S.add_generator(make<Transf<>>({0, 0, 2}));
+      S.add_generator(make<Transf<>>({0, 1, 1}));
+      return S;
+    };
+
+    std::string current_right_cayley_graph
+        = "digraph WordGraph {\n"
+          "\n"
+          "subgraph cluster_legend {\n"
+          "  label=\"legend\"node [shape=plaintext]\n"
+          "  \n"
+          "  cluster_legend_head  [label=<<table border=\"0\" "
+          "cellpadding=\"2\" cellspacing=\"0\" cellborder=\"0\">\n"
+          "<tr><td align=\"right\" port=\"port0\">a&nbsp;</td></tr>\n"
+          "<tr><td align=\"right\" port=\"port1\">b&nbsp;</td></tr>\n"
+          "</table>>\n"
+          "]\n"
+          "  cluster_legend_tail  [label=<<table border=\"0\" "
+          "cellpadding=\"2\" cellspacing=\"0\" cellborder=\"0\">\n"
+          "<tr><td align=\"right\" port=\"port0\">&nbsp;</td></tr>\n"
+          "<tr><td align=\"right\" port=\"port1\">&nbsp;</td></tr>\n"
+          "</table>>\n"
+          "]\n"
+          "  cluster_legend_head:port0:e -> "
+          "cluster_legend_tail:port0:w  [color=\"#00ff00\", "
+          "constraint=\"false\"]\n"
+          "  cluster_legend_head:port1:e -> "
+          "cluster_legend_tail:port1:w  [color=\"#ff00ff\", "
+          "constraint=\"false\"]\n"
+          "}\n"
+          "  0  [label=\"a\", shape=\"box\"]\n"
+          "  1  [label=\"b\", shape=\"box\"]\n"
+          "}";
+
+    std::string right_cayley_graph
+        = "digraph WordGraph {\n"
+          "\n"
+          "subgraph cluster_legend {\n"
+          "  label=\"legend\"node [shape=plaintext]\n"
+          "  \n"
+          "  cluster_legend_head  [label=<<table border=\"0\" "
+          "cellpadding=\"2\" cellspacing=\"0\" cellborder=\"0\">\n"
+          "<tr><td align=\"right\" port=\"port0\">a&nbsp;</td></tr>\n"
+          "<tr><td align=\"right\" port=\"port1\">b&nbsp;</td></tr>\n"
+          "</table>>\n"
+          "]\n"
+          "  cluster_legend_tail  [label=<<table border=\"0\" "
+          "cellpadding=\"2\" cellspacing=\"0\" cellborder=\"0\">\n"
+          "<tr><td align=\"right\" port=\"port0\">&nbsp;</td></tr>\n"
+          "<tr><td align=\"right\" port=\"port1\">&nbsp;</td></tr>\n"
+          "</table>>\n"
+          "]\n"
+          "  cluster_legend_head:port0:e -> "
+          "cluster_legend_tail:port0:w  [color=\"#00ff00\", "
+          "constraint=\"false\"]\n"
+          "  cluster_legend_head:port1:e -> "
+          "cluster_legend_tail:port1:w  [color=\"#ff00ff\", "
+          "constraint=\"false\"]\n"
+          "}\n"
+          "  0  [label=\"a\", shape=\"box\"]\n"
+          "  1  [label=\"b\", shape=\"box\"]\n"
+          "  2  [label=\"ab\", shape=\"box\"]\n"
+          "  3  [label=\"ba\", shape=\"box\"]\n"
+          "  0 -> 0  [color=\"#00ff00\"]\n"
+          "  0 -> 2  [color=\"#ff00ff\"]\n"
+          "  1 -> 3  [color=\"#00ff00\"]\n"
+          "  1 -> 1  [color=\"#ff00ff\"]\n"
+          "  2 -> 3  [color=\"#00ff00\"]\n"
+          "  2 -> 2  [color=\"#ff00ff\"]\n"
+          "  3 -> 3  [color=\"#00ff00\"]\n"
+          "  3 -> 3  [color=\"#ff00ff\"]\n"
+          "}";
+
+    std::string current_left_cayley_graph = current_right_cayley_graph;
+
+    std::string left_cayley_graph
+        = "digraph WordGraph {\n"
+          "\n"
+          "subgraph cluster_legend {\n"
+          "  label=\"legend\"node [shape=plaintext]\n"
+          "  \n"
+          "  cluster_legend_head  [label=<<table border=\"0\" "
+          "cellpadding=\"2\" cellspacing=\"0\" cellborder=\"0\">\n"
+          "<tr><td align=\"right\" port=\"port0\">a&nbsp;</td></tr>\n"
+          "<tr><td align=\"right\" port=\"port1\">b&nbsp;</td></tr>\n"
+          "</table>>\n"
+          "]\n"
+          "  cluster_legend_tail  [label=<<table border=\"0\" "
+          "cellpadding=\"2\" cellspacing=\"0\" cellborder=\"0\">\n"
+          "<tr><td align=\"right\" port=\"port0\">&nbsp;</td></tr>\n"
+          "<tr><td align=\"right\" port=\"port1\">&nbsp;</td></tr>\n"
+          "</table>>\n"
+          "]\n"
+          "  cluster_legend_head:port0:e -> "
+          "cluster_legend_tail:port0:w  [color=\"#00ff00\", "
+          "constraint=\"false\"]\n"
+          "  cluster_legend_head:port1:e -> "
+          "cluster_legend_tail:port1:w  [color=\"#ff00ff\", "
+          "constraint=\"false\"]\n"
+          "}\n"
+          "  0  [label=\"a\", shape=\"box\"]\n"
+          "  1  [label=\"b\", shape=\"box\"]\n"
+          "  2  [label=\"ab\", shape=\"box\"]\n"
+          "  3  [label=\"ba\", shape=\"box\"]\n"
+          "  0 -> 0  [color=\"#00ff00\"]\n"
+          "  0 -> 3  [color=\"#ff00ff\"]\n"
+          "  1 -> 2  [color=\"#00ff00\"]\n"
+          "  1 -> 1  [color=\"#ff00ff\"]\n"
+          "  2 -> 2  [color=\"#00ff00\"]\n"
+          "  2 -> 3  [color=\"#ff00ff\"]\n"
+          "  3 -> 3  [color=\"#00ff00\"]\n"
+          "  3 -> 3  [color=\"#ff00ff\"]\n"
+          "}";
+
+    auto S = make_example();
+    REQUIRE(froidure_pin::dot_current_right_cayley_graph(S, "ab").to_string()
+            == current_right_cayley_graph);
+    REQUIRE(froidure_pin::dot_right_cayley_graph(S, "ab").to_string()
+            == right_cayley_graph);
+    REQUIRE(
+        froidure_pin::dot_right_cayley_graph(S, "ab").to_string()
+        == froidure_pin::dot_current_right_cayley_graph(S, "ab").to_string());
+    REQUIRE(S.finished());
+
+    auto T = make_example();
+    REQUIRE(froidure_pin::dot_current_right_cayley_graph(T).to_string()
+            == current_right_cayley_graph);
+    REQUIRE(froidure_pin::dot_right_cayley_graph(T).to_string()
+            == right_cayley_graph);
+    REQUIRE(froidure_pin::dot_right_cayley_graph(T).to_string()
+            == froidure_pin::dot_current_right_cayley_graph(T).to_string());
+    REQUIRE(T.finished());
+
+    auto U = make_example();
+    REQUIRE(froidure_pin::dot_current_left_cayley_graph(U, "ab").to_string()
+            == current_left_cayley_graph);
+    REQUIRE(froidure_pin::dot_left_cayley_graph(U, "ab").to_string()
+            == left_cayley_graph);
+    REQUIRE(
+        froidure_pin::dot_left_cayley_graph(U, "ab").to_string()
+        == froidure_pin::dot_current_left_cayley_graph(U, "ab").to_string());
+    REQUIRE(U.finished());
+
+    auto V = make_example();
+    REQUIRE(froidure_pin::dot_current_left_cayley_graph(V).to_string()
+            == current_left_cayley_graph);
+    REQUIRE(froidure_pin::dot_left_cayley_graph(V).to_string()
+            == left_cayley_graph);
+    REQUIRE(froidure_pin::dot_left_cayley_graph(V).to_string()
+            == froidure_pin::dot_current_left_cayley_graph(V).to_string());
+    REQUIRE(V.finished());
   }
 
 }  // namespace libsemigroups

--- a/tests/test-word-graph-view.cpp
+++ b/tests/test-word-graph-view.cpp
@@ -451,6 +451,14 @@ namespace libsemigroups {
         v.throw_if_any_target_out_of_bounds(),
         "target out of bounds, the edge with source 1 and label 0 has target "
         "2, but expected value in the range [0, 2)");
+
+    WordGraph<size_t> graph(1, Dot::colors.size() + 1);
+    v.init(graph);
+    REQUIRE_EXCEPTION_MSG(
+        std::ignore = v4::word_graph::dot(
+            v, {"a"}, std::vector<std::string>(v.out_degree(), "a")),
+        "the 1st argument (word graph) must have out degree at most 24, "
+        "found 25");
   }
 
 }  // namespace libsemigroups

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -802,4 +802,74 @@ namespace libsemigroups {
     WordGraph<uint32_t> wg(0, 1);
     REQUIRE_THROWS_AS(wg.disjoint_union_inplace(wg), LibsemigroupsException);
   }
+
+  LIBSEMIGROUPS_TEST_CASE("WordGraph", "046", "3-arg dot", "[quick]") {
+    auto rg = ReportGuard(false);
+    auto wg
+        = v4::make<WordGraph<uint32_t>>(4, {{0, 2}, {3, 1}, {3, 2}, {3, 3}});
+
+    std::vector<std::string> node_labels = {"a", "b", "ab", "ba"};
+    std::vector<std::string> edge_labels = {"a", "b"};
+    Dot dot = v4::word_graph::dot(wg, node_labels, edge_labels);
+    REQUIRE(dot.to_string()
+            == "digraph WordGraph {\n"
+               "\n"
+               "subgraph cluster_legend {\n"
+               "  label=\"legend\"node [shape=plaintext]\n"
+               "  \n"
+               "  cluster_legend_head  [label=<<table border=\"0\" "
+               "cellpadding=\"2\" cellspacing=\"0\" cellborder=\"0\">\n"
+               "<tr><td align=\"right\" port=\"port0\">a&nbsp;</td></tr>\n"
+               "<tr><td align=\"right\" port=\"port1\">b&nbsp;</td></tr>\n"
+               "</table>>\n"
+               "]\n"
+               "  cluster_legend_tail  [label=<<table border=\"0\" "
+               "cellpadding=\"2\" cellspacing=\"0\" cellborder=\"0\">\n"
+               "<tr><td align=\"right\" port=\"port0\">&nbsp;</td></tr>\n"
+               "<tr><td align=\"right\" port=\"port1\">&nbsp;</td></tr>\n"
+               "</table>>\n"
+               "]\n"
+               "  cluster_legend_head:port0:e -> "
+               "cluster_legend_tail:port0:w  [color=\"#00ff00\", "
+               "constraint=\"false\"]\n"
+               "  cluster_legend_head:port1:e -> "
+               "cluster_legend_tail:port1:w  [color=\"#ff00ff\", "
+               "constraint=\"false\"]\n"
+               "}\n"
+               "  0  [label=\"a\", shape=\"box\"]\n"
+               "  1  [label=\"b\", shape=\"box\"]\n"
+               "  2  [label=\"ab\", shape=\"box\"]\n"
+               "  3  [label=\"ba\", shape=\"box\"]\n"
+               "  0 -> 0  [color=\"#00ff00\"]\n"
+               "  0 -> 2  [color=\"#ff00ff\"]\n"
+               "  1 -> 3  [color=\"#00ff00\"]\n"
+               "  1 -> 1  [color=\"#ff00ff\"]\n"
+               "  2 -> 3  [color=\"#00ff00\"]\n"
+               "  2 -> 2  [color=\"#ff00ff\"]\n"
+               "  3 -> 3  [color=\"#00ff00\"]\n"
+               "  3 -> 3  [color=\"#ff00ff\"]\n"
+               "}");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("WordGraph",
+                          "047",
+                          "exception: 3-arg dot",
+                          "[quick]") {
+    auto rg = ReportGuard(false);
+    auto wg
+        = v4::make<WordGraph<uint32_t>>(4, {{0, 1}, {1, 2}, {2, 3}, {3, 2}});
+
+    std::vector<std::string> node_labels = {"a", "b", "ab", "ba"};
+    std::vector<std::string> edge_labels = {"a", "b"};
+
+    REQUIRE_EXCEPTION_MSG(
+        std::ignore = v4::word_graph::dot(wg, {"a", "b", "ab"}, edge_labels),
+        "expected the 2nd argument (node labels) to have size 4, the number of "
+        "nodes of the 1st argument (word graph), but found 3");
+
+    REQUIRE_EXCEPTION_MSG(
+        std::ignore = v4::word_graph::dot(wg, node_labels, {"a"}),
+        "expected the 3rd argument (edge labels) to have size 2, the "
+        "out-degree of the 1st argument (word graph), but found 1");
+  }
 }  // namespace libsemigroups


### PR DESCRIPTION
This PR adds better drawing of word graphs with node and edge labels, and also some helpers for `FroidurePin` that produce the node/edge labels automatically.