### PR TITLE
words: fix CTAD for older libc++

### DIFF
--- a/src/word-range.cpp
+++ b/src/word-range.cpp
@@ -670,7 +670,7 @@ namespace libsemigroups {
       }
 
       std::string get_unique_letters(std::string const& x) {
-        std::unordered_set seen(x.begin(), x.end());
+        std::unordered_set<char> seen(x.begin(), x.end());
         return std::string(seen.begin(), seen.end());
       }
 


### PR DESCRIPTION
This patch addresses the issue with older libc++ versions not supporting iterator-pair deduction guides for unordered_set, which fixes the downstream error in https://github.com/JuliaPackaging/Yggdrasil/pull/13743