### PR TITLE
presentation: `to_gap_string` use the same gen. names

### DIFF
--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -3125,7 +3125,7 @@ namespace libsemigroups {
           p, std::string_view(relator));
     }
 
-    //! \brief Return the code that would create \p p in GAP.
+    //! \brief Return the code that would create a presentation in GAP.
     //!
     //! This function returns the string of GAP code that could be used to
     //! create an object with the same alphabet and rules as \p p in GAP.
@@ -3133,13 +3133,12 @@ namespace libsemigroups {
     //! or monoids.
     //!
     //! \param p the presentation.
-    //! \param var_name the name of the variable to be used in GAP.
-    //!
-    //! \throws LibsemigroupsException if \p has more than 49 generators.
+    //! \param var_name the name of the variable to be used in GAP (defaults to
+    //! ``\"S\"`).
     std::string to_gap_string(Presentation<word_type> const& p,
-                              std::string const&             var_name);
+                              std::string const&             var_name = "S");
 
-    //! \brief Return the code that would create \p p in GAP.
+    //! \brief Return the code that would create a presentation in GAP.
     //!
     //! This function returns the string of GAP code that could be used to
     //! create an object with the same alphabet and rules as \p p in GAP.
@@ -3147,11 +3146,10 @@ namespace libsemigroups {
     //! or monoids.
     //!
     //! \param p the presentation.
-    //! \param var_name the name of the variable to be used in GAP.
-    //!
-    //! \throws LibsemigroupsException if \p has more than 49 generators.
+    //! \param var_name the name of the variable to be used in GAP (defaults to
+    //! ``\"S\"`).
     std::string to_gap_string(Presentation<std::string> const& p,
-                              std::string const&               var_name);
+                              std::string const&               var_name = "S");
 
     //! \brief Find a rule.
     //!

--- a/src/presentation.cpp
+++ b/src/presentation.cpp
@@ -171,61 +171,75 @@ namespace libsemigroups {
       return replace_word_with_new_generator(p, w, w + std::strlen(w));
     }
 
+    namespace {
+      template <typename Func>
+      std::string to_gap_string(Presentation<word_type> const& p,
+                                std::string const&             var_name,
+                                Func&&                         func) {
+        p.throw_if_bad_alphabet_or_rules();
+
+        std::string result = "F := Free";
+        if (p.contains_empty_word()) {
+          result += "Monoid(";
+        } else {
+          result += "Semigroup(";
+        }
+
+        auto to_gap_word = [&func](word_type const& w) -> std::string {
+          if (w.empty()) {
+            return "One(F)";
+          }
+          std::string w_as_str;
+          std::string sep = "";
+          for (auto it = w.cbegin(); it < w.cend(); ++it) {
+            w_as_str += fmt::format("{}{}", sep, func(*it));
+            sep = " * ";
+          }
+          return w_as_str;
+        };
+
+        std::string sep = "";
+        for (auto it = p.alphabet().cbegin(); it != p.alphabet().cend(); ++it) {
+          result += fmt::format("{}\"{}\"", sep, func(*it));
+          sep = ", ";
+        }
+        result += ");\n";
+
+        result += "AssignGeneratorVariables(F);;\n";
+
+        result += "R := [";
+        sep = "";
+        for (auto it = p.rules.cbegin(); it < p.rules.cend(); it += 2) {
+          result += fmt::format("{}\n       [{}, {}]",
+                                sep,
+                                to_gap_word(*it),
+                                to_gap_word(*(it + 1)));
+          sep = ",";
+        }
+        result += "\n     ];\n";
+        result += var_name + " := F / R;\n";
+        return result;
+      }
+
+    }  // namespace
+
     std::string to_gap_string(Presentation<word_type> const& p,
                               std::string const&             var_name) {
-      p.throw_if_bad_alphabet_or_rules();
-      if (p.alphabet().size() > 49) {
-        LIBSEMIGROUPS_EXCEPTION("expected at most 49 generators, found {}!",
-                                p.alphabet().size());
-      }
+      std::string_view const prefix = p.contains_empty_word() ? "m" : "s";
 
-      auto to_gap_word = [](word_type const& w) -> std::string {
-        if (w.empty()) {
-          return "One(F)";
-        }
-        std::string out;
-        std::string sep = "";
-        for (auto it = w.cbegin(); it < w.cend(); ++it) {
-          out += sep + words::human_readable_letter<>(*it);
-          sep = " * ";
-        }
-        return out;
+      auto func = [&prefix](letter_type a) -> std::string {
+        return fmt::format("{}{}", prefix, a);
       };
 
-      std::string out = "F := Free";
-      if (p.contains_empty_word()) {
-        out += "Monoid(";
-      } else {
-        out += "Semigroup(";
-      }
-
-      std::string sep = "";
-      for (auto it = p.alphabet().cbegin(); it != p.alphabet().cend(); ++it) {
-        out += fmt::format(
-            "{}\"{}\"", sep, words::human_readable_letter<>(*it));
-        sep = ", ";
-      }
-      out += ");\n";
-
-      out += "AssignGeneratorVariables(F);;\n";
-
-      out += "R := [";
-      sep = "";
-      for (auto it = p.rules.cbegin(); it < p.rules.cend(); it += 2) {
-        out += fmt::format("{}\n          [{}, {}]",
-                           sep,
-                           to_gap_word(*it),
-                           to_gap_word(*(it + 1)));
-        sep = ", ";
-      }
-      out += "\n         ];\n";
-      out += var_name + " := F / R;\n";
-      return out;
+      return to_gap_string(p, var_name, func);
     }
 
     std::string to_gap_string(Presentation<std::string> const& p,
                               std::string const&               var_name) {
-      return to_gap_string(v4::to<Presentation<word_type>>(p), var_name);
+      auto func = [&p](letter_type a) -> std::string {
+        return std::string(1, p.letter(a));
+      };
+      return to_gap_string(v4::to<Presentation<word_type>>(p), var_name, func);
     }
 
   }  // namespace presentation

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -2966,41 +2966,71 @@ namespace libsemigroups {
 
     p.alphabet(50);
     std::string var_name("my_var");
-    REQUIRE_EXCEPTION_MSG(presentation::to_gap_string(p, var_name),
-                          "expected at most 49 generators, found 50!");
+    REQUIRE_NOTHROW(presentation::to_gap_string(p, var_name));
 
     p.init();
-    p.alphabet("abc");
-    presentation::add_rule_no_checks(p, "abba", "bac");
-    presentation::add_rule_no_checks(p, "ba", "ab");
-    presentation::add_rule_no_checks(p, "cab", "ba");
+    p.alphabet("byr");
+    presentation::add_rule(p, "byyb", "ybr");
+    presentation::add_rule(p, "yb", "by");
+    presentation::add_rule(p, "rby", "yb");
 
     REQUIRE(presentation::to_gap_string(p, var_name)
-            == "F := FreeSemigroup(\"a\", \"b\", "
-               "\"c\");\n"
+            == "F := FreeSemigroup(\"b\", \"y\", \"r\");\n"
                "AssignGeneratorVariables(F);;\n"
                "R := [\n"
-               "          [a * b * b * a, b * a * "
-               "c], \n"
-               "          [b * a, a * b], \n"
-               "          [c * a * b, b * a]\n"
-               "         ];\n"
+               "       [b * y * y * b, y * b * r],\n"
+               "       [y * b, b * y],\n"
+               "       [r * b * y, y * b]\n"
+               "     ];\n"
                "my_var := F / R;\n");
 
     p.contains_empty_word(true);
-    presentation::add_rule_no_checks(p, "cba", "");
+    presentation::add_rule(p, "ryb", "");
     REQUIRE(presentation::to_gap_string(p, var_name)
-            == "F := FreeMonoid(\"a\", \"b\", "
-               "\"c\");\n"
+            == "F := FreeMonoid(\"b\", \"y\", \"r\");\n"
                "AssignGeneratorVariables(F);;\n"
                "R := [\n"
-               "          [a * b * b * a, b * a * "
-               "c], \n"
-               "          [b * a, a * b], \n"
-               "          [c * a * b, b * a], \n"
-               "          [c * b * a, One(F)]\n"
-               "         ];\n"
+               "       [b * y * y * b, y * b * r],\n"
+               "       [y * b, b * y],\n"
+               "       [r * b * y, y * b],\n"
+               "       [r * y * b, One(F)]\n"
+               "     ];\n"
                "my_var := F / R;\n");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "004",
+                          "to_gap_string",
+                          "[quick][presentation]") {
+    auto                    rg = ReportGuard(false);
+    Presentation<word_type> p;
+    p.alphabet(3);
+    std::string var_name("my_var");
+
+    presentation::add_rule(p, 0101_w, 012_w);
+    presentation::add_rule(p, 012_w, 0_w);
+    presentation::add_rule(p, 120_w, 11_w);
+
+    REQUIRE(presentation::to_gap_string(p)
+            == "F := FreeSemigroup(\"s0\", \"s1\", \"s2\");\n"
+               "AssignGeneratorVariables(F);;\n"
+               "R := [\n"
+               "       [s0 * s1 * s0 * s1, s0 * s1 * s2],\n"
+               "       [s0 * s1 * s2, s0],\n"
+               "       [s1 * s2 * s0, s1 * s1]\n"
+               "     ];\n"
+               "S := F / R;\n");
+
+    p.contains_empty_word(true);
+    REQUIRE(presentation::to_gap_string(p)
+            == "F := FreeMonoid(\"m0\", \"m1\", \"m2\");\n"
+               "AssignGeneratorVariables(F);;\n"
+               "R := [\n"
+               "       [m0 * m1 * m0 * m1, m0 * m1 * m2],\n"
+               "       [m0 * m1 * m2, m0],\n"
+               "       [m1 * m2 * m0, m1 * m1]\n"
+               "     ];\n"
+               "S := F / R;\n");
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("InversePresentation",


### PR DESCRIPTION
Updates `to_gap_string` to use the same generator names in GAP as in libsemigroups. Also add a default value for the variable name (this because when using this in python especially, I almost always forget the second argument, or don't care what value it has).