### PR TITLE
Presentation: add missing checks functions

### DIFF
--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -2258,6 +2258,24 @@ namespace libsemigroups {
       }
     }
 
+    //! \brief Add rules that define each letter as an idempotent.
+    //!
+    //! Adds rules to \p p of the form \f$a^2 = a\f$ for every letter \f$a\f$ in
+    //! \p letters.
+    //!
+    //! \tparam Word the type of the words in the presentation.
+    //! \param p the presentation to add rules to.
+    //! \param letters the letters to make idempotent.
+    //!
+    //! \throws LibsemigroupsException if any letter in \p letters is not in
+    //! `p.alphabet()`.
+    template <typename Word>
+    void add_idempotent_rules(Presentation<Word>& p, Word const& letters) {
+      p.throw_if_letter_not_in_alphabet(std::cbegin(letters),
+                                        std::cend(letters));
+      add_idempotent_rules_no_checks(p, letters);
+    }
+
     //! \brief Add rules that define involution.
     //!
     //! Adds rules to \p p of the form \f$a^2 = \varepsilon\f$ for every letter
@@ -2280,6 +2298,20 @@ namespace libsemigroups {
         add_rule_no_checks(p, {x, x}, {});
       }
     }
+
+    //! \brief Add rules that define involution.
+    //!
+    //! Adds rules to \p p of the form \f$a^2 = \varepsilon\f$ for every letter
+    //! \f$a\f$ in \p letters.
+    //!
+    //! \tparam Word the type of the words in the presentation.
+    //! \param p the presentation to add rules to.
+    //! \param letters the letters to add involution rules for.
+    //!
+    //! \throws LibsemigroupsException if any letter in \p letters is not in
+    //! `p.alphabet()`, or if `p.contains_empty_word()` returns `false`.
+    template <typename Word>
+    void add_involution_rules(Presentation<Word>& p, word_type const& letters);
 
     //! \brief Add rules so specific letters commute.
     //!
@@ -2304,6 +2336,23 @@ namespace libsemigroups {
 
     //! \brief Add rules so specific letters commute.
     //!
+    //! Adds rules to \p p of the form \f$uv = vu\f$ for every letter \f$u\f$ in
+    //! \p letters1 and \f$v\f$ in \p letters2.
+    //!
+    //! \tparam Word the type of the words in the presentation.
+    //! \param p the presentation to add rules to.
+    //! \param letters1 the first collection of letters to add rules for.
+    //! \param letters2 the second collection of letters to add rules for.
+    //!
+    //! \throws LibsemigroupsException if any letter in \p letters1 or
+    //! \p letters2 is not in `p.alphabet()`.
+    template <typename Word>
+    void add_commutes_rules(Presentation<Word>& p,
+                            Word const&         letters1,
+                            Word const&         letters2);
+
+    //! \brief Add rules so specific letters commute.
+    //!
     //! Adds rules to \p p of the form \f$uv = vu\f$ for every pair of letters
     //! \f$u, v\f$ in \p letters.
     //!
@@ -2321,6 +2370,24 @@ namespace libsemigroups {
     void add_commutes_rules_no_checks(Presentation<Word>& p,
                                       Word const&         letters) {
       add_commutes_rules_no_checks(p, letters, letters);
+    }
+
+    //! \brief Add rules so specific letters commute.
+    //!
+    //! Adds rules to \p p of the form \f$uv = vu\f$ for every pair of letters
+    //! \f$u, v\f$ in \p letters.
+    //!
+    //! \tparam Word the type of the words in the presentation.
+    //! \param p the presentation to add rules to.
+    //! \param letters the collection of letters to add rules for.
+    //!
+    //! \throws LibsemigroupsException if any letter in \p letters is not in
+    //! `p.alphabet()`.
+    template <typename Word>
+    void add_commutes_rules(Presentation<Word>& p, Word const& letters) {
+      p.throw_if_letter_not_in_alphabet(std::cbegin(letters),
+                                        std::cend(letters));
+      add_commutes_rules_no_checks(p, letters);
     }
 
     //! \brief Add rules so specific letters commute with specific words.
@@ -2343,6 +2410,23 @@ namespace libsemigroups {
     void add_commutes_rules_no_checks(Presentation<Word>&         p,
                                       Word const&                 letters,
                                       std::initializer_list<Word> words);
+
+    //! \brief Add rules so specific letters commute with specific words.
+    //!
+    //! Adds rules to \p p of the form \f$uv = vu\f$ for every letter \f$u\f$ in
+    //! \p letters and \f$v\f$ in \p words.
+    //!
+    //! \tparam Word the type of the words in the presentation.
+    //! \param p the presentation to add rules to.
+    //! \param letters the collection of letters to add rules for.
+    //! \param words the collection of words to add rules for.
+    //!
+    //! \throws LibsemigroupsException if any letter in \p letters, or any
+    //! letter in any word in \p words, is not in `p.alphabet()`.
+    template <typename Word>
+    void add_commutes_rules(Presentation<Word>&         p,
+                            Word const&                 letters,
+                            std::initializer_list<Word> words);
 
     ////////////////////////////////////////////////////////////////////////
     // commutator - Word
@@ -2580,8 +2664,8 @@ namespace libsemigroups {
     //! \brief Add a commutator rule without checks.
     //!
     //! Adds the rule \f$x^{-1}y^{-1}xy = id\f$ to \p p, after attempting to
-    //! detect inverses from the rules in \p p, using \ref
-    //! try_detect_group_inverses. If \p id is \ref UNDEFINED, then the
+    //! detect inverses from the rules in \p p, using
+    //! \ref try_detect_group_inverses. If \p id is \ref UNDEFINED, then the
     //! right-hand side is the empty word.
     //!
     //! \tparam Word the type of the words in the presentation.
@@ -2674,8 +2758,8 @@ namespace libsemigroups {
     //! \brief Add a commutator rule.
     //!
     //! Adds the rule \f$x^{-1}y^{-1}xy = id\f$ to \p p, after attempting to
-    //! detect inverses from the rules in \p p, using \ref
-    //! try_detect_group_inverses. If \p id is \ref UNDEFINED, then the
+    //! detect inverses from the rules in \p p, using
+    //! \ref try_detect_group_inverses. If \p id is \ref UNDEFINED, then the
     //! right-hand side is the empty word.
     //!
     //! \tparam Word the type of the words in the presentation.
@@ -2686,9 +2770,9 @@ namespace libsemigroups {
     //! \param id the identity letter, or \ref UNDEFINED for the empty word.
     //!
     //! \throws LibsemigroupsException if \p x, \p y, or \p id contains a
-    //! letter not belonging to `p.alphabet()`, if \ref
-    //! try_detect_group_inverses throws, or if \p x or \p y contains a letter
-    //! for which no inverse was detected.
+    //! letter not belonging to `p.alphabet()`, if
+    //! \ref try_detect_group_inverses throws, or if \p x or \p y contains a
+    //! letter for which no inverse was detected.
     //!
     //! \sa
     //! \ref Presentation::throw_if_letter_not_in_alphabet,

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -2293,7 +2293,7 @@ namespace libsemigroups {
     //! are performed.
     template <typename Word>
     void add_involution_rules_no_checks(Presentation<Word>& p,
-                                        word_type const&    letters) {
+                                        Word const&         letters) {
       for (auto x : letters) {
         add_rule_no_checks(p, {x, x}, {});
       }
@@ -2311,7 +2311,7 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if any letter in \p letters is not in
     //! `p.alphabet()`, or if `p.contains_empty_word()` returns `false`.
     template <typename Word>
-    void add_involution_rules(Presentation<Word>& p, word_type const& letters);
+    void add_involution_rules(Presentation<Word>& p, Word const& letters);
 
     //! \brief Add rules so specific letters commute.
     //!

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -2235,7 +2235,7 @@ namespace libsemigroups {
       return try_detect_group_inverses(p);
     }
 
-    //! \brief Add rules that define each letter as an idempotent.
+    //! \brief Add rules that define idempotents.
     //!
     //! Adds rules to \p p of the form \f$a^2 = a\f$ for every letter \f$a\f$ in
     //! \p letters.
@@ -2258,7 +2258,7 @@ namespace libsemigroups {
       }
     }
 
-    //! \brief Add rules that define each letter as an idempotent.
+    //! \brief Add rules that define idempotents.
     //!
     //! Adds rules to \p p of the form \f$a^2 = a\f$ for every letter \f$a\f$ in
     //! \p letters.
@@ -2276,7 +2276,7 @@ namespace libsemigroups {
       add_idempotent_rules_no_checks(p, letters);
     }
 
-    //! \brief Add rules that define involution.
+    //! \brief Add rules that define involutions.
     //!
     //! Adds rules to \p p of the form \f$a^2 = \varepsilon\f$ for every letter
     //! \f$a\f$ in \p letters.
@@ -2299,7 +2299,7 @@ namespace libsemigroups {
       }
     }
 
-    //! \brief Add rules that define involution.
+    //! \brief Add rules that define involutions.
     //!
     //! Adds rules to \p p of the form \f$a^2 = \varepsilon\f$ for every letter
     //! \f$a\f$ in \p letters.
@@ -2393,7 +2393,7 @@ namespace libsemigroups {
     //! \brief Add rules so specific letters commute with specific words.
     //!
     //! Adds rules to \p p of the form \f$uv = vu\f$ for every letter \f$u\f$ in
-    //! \p letters and \f$v\f$ in \p words.
+    //! \p letters and word \f$v\f$ in \p words.
     //!
     //! \tparam Word the type of the words in the presentation.
     //! \param p the presentation to add rules to.
@@ -2414,7 +2414,7 @@ namespace libsemigroups {
     //! \brief Add rules so specific letters commute with specific words.
     //!
     //! Adds rules to \p p of the form \f$uv = vu\f$ for every letter \f$u\f$ in
-    //! \p letters and \f$v\f$ in \p words.
+    //! \p letters and word \f$v\f$ in \p words.
     //!
     //! \tparam Word the type of the words in the presentation.
     //! \param p the presentation to add rules to.

--- a/include/libsemigroups/presentation.tpp
+++ b/include/libsemigroups/presentation.tpp
@@ -1335,7 +1335,7 @@ namespace libsemigroups {
     }
 
     template <typename Word>
-    void add_involution_rules(Presentation<Word>& p, word_type const& letters) {
+    void add_involution_rules(Presentation<Word>& p, Word const& letters) {
       p.throw_if_letter_not_in_alphabet(std::begin(letters), std::end(letters));
       if (!p.contains_empty_word()) {
         LIBSEMIGROUPS_EXCEPTION("this function requires the presentation to "

--- a/include/libsemigroups/presentation.tpp
+++ b/include/libsemigroups/presentation.tpp
@@ -1061,6 +1061,17 @@ namespace libsemigroups {
     }
 
     template <typename Word>
+    void add_commutes_rules(Presentation<Word>& p,
+                            Word const&         letters1,
+                            Word const&         letters2) {
+      p.throw_if_letter_not_in_alphabet(std::cbegin(letters1),
+                                        std::cend(letters1));
+      p.throw_if_letter_not_in_alphabet(std::cbegin(letters2),
+                                        std::cend(letters2));
+      add_commutes_rules_no_checks(p, letters1, letters2);
+    }
+
+    template <typename Word>
     void add_commutes_rules_no_checks(Presentation<Word>&         p,
                                       Word const&                 letters,
                                       std::initializer_list<Word> words) {
@@ -1076,6 +1087,18 @@ namespace libsemigroups {
         }
       }
       presentation::add_rules_no_checks(p, q);
+    }
+
+    template <typename Word>
+    void add_commutes_rules(Presentation<Word>&         p,
+                            Word const&                 letters,
+                            std::initializer_list<Word> words) {
+      p.throw_if_letter_not_in_alphabet(std::cbegin(letters),
+                                        std::cend(letters));
+      for (Word const& word : words) {
+        p.throw_if_letter_not_in_alphabet(std::cbegin(word), std::cend(word));
+      }
+      add_commutes_rules_no_checks(p, letters, words);
     }
 
     template <typename Word>
@@ -1309,6 +1332,17 @@ namespace libsemigroups {
       Word inverses;
       try_detect_group_inverses(p, letters, inverses);
       return {letters, inverses};
+    }
+
+    template <typename Word>
+    void add_involution_rules(Presentation<Word>& p, word_type const& letters) {
+      p.throw_if_letter_not_in_alphabet(std::begin(letters), std::end(letters));
+      if (!p.contains_empty_word()) {
+        LIBSEMIGROUPS_EXCEPTION("this function requires the presentation to "
+                                "contain the empty word, did you mean to "
+                                "call contains_empty_word(true) first?");
+      }
+      add_involution_rules_no_checks(p, letters);
     }
 
     template <typename Word1, typename Word2>

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -489,12 +489,18 @@ namespace libsemigroups {
     using W            = TestType;
     auto            rg = ReportGuard(false);
     Presentation<W> p;
-    presentation::add_rule_no_checks(p, {0, 1, 2, 1}, {0, 0});
-    presentation::add_commutes_rules_no_checks(p, {0}, {1});
-    p.alphabet_from_rules();
+    REQUIRE_THROWS_AS(presentation::add_commutes_rules(p, {0}, {1}),
+                      LibsemigroupsException);
+    p.alphabet({0});
+    REQUIRE_THROWS_AS(presentation::add_commutes_rules(p, {0}, {1}),
+                      LibsemigroupsException);
+    p.alphabet({0, 1, 2});
+    presentation::add_rule(p, {0, 1, 2, 1}, {0, 0});
+    REQUIRE_NOTHROW(presentation::add_commutes_rules(p, {0}, {1}));
+
     REQUIRE(p.rules == std::vector<W>({{0, 1, 2, 1}, {0, 0}, {0, 1}, {1, 0}}));
 
-    presentation::add_commutes_rules_no_checks(p, {1, 1}, {2});
+    presentation::add_commutes_rules(p, {1, 1}, {2});
     REQUIRE(p.rules
             == std::vector<W>({{0, 1, 2, 1},
                                {0, 0},
@@ -505,7 +511,7 @@ namespace libsemigroups {
                                {2, 1},
                                {1, 2}}));
 
-    presentation::add_commutes_rules_no_checks(p, {2});
+    presentation::add_commutes_rules(p, {2});
     REQUIRE(p.rules
             == std::vector<W>({{0, 1, 2, 1},
                                {0, 0},
@@ -516,7 +522,7 @@ namespace libsemigroups {
                                {2, 1},
                                {1, 2}}));
 
-    presentation::add_commutes_rules_no_checks(p, {2, 0});
+    presentation::add_commutes_rules(p, {2, 0});
     REQUIRE(p.rules
             == std::vector<W>({{0, 1, 2, 1},
                                {0, 0},
@@ -529,13 +535,13 @@ namespace libsemigroups {
                                {2, 0},
                                {0, 2}}));
 
-    presentation::add_commutes_rules_no_checks(p,
-                                               {1, 2},
-                                               {{0, 0, 1},
-                                                {
-                                                    1,
-                                                    0,
-                                                }});
+    presentation::add_commutes_rules(p,
+                                     {1, 2},
+                                     {{0, 0, 1},
+                                      {
+                                          1,
+                                          0,
+                                      }});
     REQUIRE(p.rules
             == std::vector<W>({
                 {0, 1, 2, 1},
@@ -569,9 +575,11 @@ namespace libsemigroups {
     using W            = TestType;
     auto            rg = ReportGuard(false);
     Presentation<W> p;
-    presentation::add_rule_no_checks(p, {0, 1, 2, 1}, {0, 0});
-    presentation::add_idempotent_rules_no_checks(p, {0, 1});
-    p.alphabet_from_rules();
+    REQUIRE_THROWS_AS(presentation::add_idempotent_rules(p, {0, 1}),
+                      LibsemigroupsException);
+    p.alphabet({0, 1, 2});
+    presentation::add_rule(p, {0, 1, 2, 1}, {0, 0});
+    REQUIRE_NOTHROW(presentation::add_idempotent_rules(p, {0, 1}));
     REQUIRE(
         p.rules
         == std::vector<W>({{0, 1, 2, 1}, {0, 0}, {0, 0}, {0}, {1, 1}, {1}}));
@@ -587,14 +595,17 @@ namespace libsemigroups {
     using W            = TestType;
     auto            rg = ReportGuard(false);
     Presentation<W> p;
-    presentation::add_rule_no_checks(p, {0, 1, 2, 1}, {0, 0});
-    presentation::add_involution_rules_no_checks(p, {0, 1});
+    REQUIRE_THROWS_AS(presentation::add_involution_rules(p, {0, 1}),
+                      LibsemigroupsException);
+    p.alphabet({0, 1, 2});
+    REQUIRE_THROWS_AS(presentation::add_involution_rules(p, {0, 1}),
+                      LibsemigroupsException);
+    p.contains_empty_word(true);
+    presentation::add_rule(p, {0, 1, 2, 1}, {0, 0});
+    REQUIRE_NOTHROW(presentation::add_involution_rules(p, {0, 1}));
     REQUIRE(p.rules
             == std::vector<W>({{0, 1, 2, 1}, {0, 0}, {0, 0}, {}, {1, 1}, {}}));
-    REQUIRE_THROWS_AS(p.throw_if_bad_alphabet_or_rules(),
-                      LibsemigroupsException);
-    p.alphabet_from_rules();
-    p.contains_empty_word(true);
+    REQUIRE_NOTHROW(p.throw_if_bad_alphabet_or_rules());
     p.throw_if_bad_alphabet_or_rules();
   }
 


### PR DESCRIPTION
This PR adds the following functions:
- `add_idempotent_rules`,
- `add_involution_rules`, and
-  `add_commutes_rules`.

The `_no_checks` versions of these functions already existed.