### PR TITLE
presentation: add_commutes_rules with vector

### DIFF
--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -2407,9 +2407,34 @@ namespace libsemigroups {
     //! No checks that the arguments describe words over the alphabet of \p p
     //! are performed.
     template <typename Word>
+    void add_commutes_rules_no_checks(Presentation<Word>&      p,
+                                      Word const&              letters,
+                                      std::vector<Word> const& words);
+
+    //! \brief Add rules so specific letters commute with specific words.
+    //!
+    //! Adds rules to \p p of the form \f$uv = vu\f$ for every letter \f$u\f$ in
+    //! \p letters and word \f$v\f$ in \p words.
+    //!
+    //! \tparam Word the type of the words in the presentation.
+    //! \param p the presentation to add rules to.
+    //! \param letters the collection of letters to add rules for.
+    //! \param words the collection of words to add rules for.
+    //!
+    //! \exceptions
+    //! \no_libsemigroups_except
+    //!
+    //! \warning
+    //! No checks that the arguments describe words over the alphabet of \p p
+    //! are performed.
+    // TODO (1): remove this in v4; this convenience function is only really
+    // useful in the tests
+    template <typename Word>
     void add_commutes_rules_no_checks(Presentation<Word>&         p,
                                       Word const&                 letters,
-                                      std::initializer_list<Word> words);
+                                      std::initializer_list<Word> words) {
+      add_commutes_rules_no_checks(p, letters, std::vector(words));
+    }
 
     //! \brief Add rules so specific letters commute with specific words.
     //!
@@ -2424,9 +2449,30 @@ namespace libsemigroups {
     //! \throws LibsemigroupsException if any letter in \p letters, or any
     //! letter in any word in \p words, is not in `p.alphabet()`.
     template <typename Word>
+    void add_commutes_rules(Presentation<Word>&      p,
+                            Word const&              letters,
+                            std::vector<Word> const& words);
+
+    //! \brief Add rules so specific letters commute with specific words.
+    //!
+    //! Adds rules to \p p of the form \f$uv = vu\f$ for every letter \f$u\f$ in
+    //! \p letters and word \f$v\f$ in \p words.
+    //!
+    //! \tparam Word the type of the words in the presentation.
+    //! \param p the presentation to add rules to.
+    //! \param letters the collection of letters to add rules for.
+    //! \param words the collection of words to add rules for.
+    //!
+    //! \throws LibsemigroupsException if any letter in \p letters, or any
+    //! letter in any word in \p words, is not in `p.alphabet()`.
+    // TODO (1): remove this in v4; this convenience function is only really
+    // useful in the tests
+    template <typename Word>
     void add_commutes_rules(Presentation<Word>&         p,
                             Word const&                 letters,
-                            std::initializer_list<Word> words);
+                            std::initializer_list<Word> words) {
+      add_commutes_rules(p, letters, std::vector(words));
+    }
 
     ////////////////////////////////////////////////////////////////////////
     // commutator - Word

--- a/include/libsemigroups/presentation.tpp
+++ b/include/libsemigroups/presentation.tpp
@@ -1072,9 +1072,9 @@ namespace libsemigroups {
     }
 
     template <typename Word>
-    void add_commutes_rules_no_checks(Presentation<Word>&         p,
-                                      Word const&                 letters,
-                                      std::initializer_list<Word> words) {
+    void add_commutes_rules_no_checks(Presentation<Word>&      p,
+                                      Word const&              letters,
+                                      std::vector<Word> const& words) {
       using words::operator+;
 
       Presentation<Word> q;
@@ -1090,9 +1090,9 @@ namespace libsemigroups {
     }
 
     template <typename Word>
-    void add_commutes_rules(Presentation<Word>&         p,
-                            Word const&                 letters,
-                            std::initializer_list<Word> words) {
+    void add_commutes_rules(Presentation<Word>&      p,
+                            Word const&              letters,
+                            std::vector<Word> const& words) {
       p.throw_if_letter_not_in_alphabet(std::cbegin(letters),
                                         std::cend(letters));
       for (Word const& word : words) {

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -489,18 +489,18 @@ namespace libsemigroups {
     using W            = TestType;
     auto            rg = ReportGuard(false);
     Presentation<W> p;
-    REQUIRE_THROWS_AS(presentation::add_commutes_rules(p, {0}, {1}),
+    REQUIRE_THROWS_AS(presentation::add_commutes_rules(p, W{0}, W{1}),
                       LibsemigroupsException);
     p.alphabet({0});
-    REQUIRE_THROWS_AS(presentation::add_commutes_rules(p, {0}, {1}),
+    REQUIRE_THROWS_AS(presentation::add_commutes_rules(p, W{0}, W{1}),
                       LibsemigroupsException);
     p.alphabet({0, 1, 2});
     presentation::add_rule(p, {0, 1, 2, 1}, {0, 0});
-    REQUIRE_NOTHROW(presentation::add_commutes_rules(p, {0}, {1}));
+    REQUIRE_NOTHROW(presentation::add_commutes_rules(p, W{0}, W{1}));
 
     REQUIRE(p.rules == std::vector<W>({{0, 1, 2, 1}, {0, 0}, {0, 1}, {1, 0}}));
 
-    presentation::add_commutes_rules(p, {1, 1}, {2});
+    presentation::add_commutes_rules(p, W{1, 1}, W{2});
     REQUIRE(p.rules
             == std::vector<W>({{0, 1, 2, 1},
                                {0, 0},


### PR DESCRIPTION
This PR adds the overload `presentation::add_commutes_rules(Presentation<Word>&, Word const&, std::vector<Word> const&)` and the corresponding `_no_checks` version.