### PR TITLE
Codex/add pre commit format hooks

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
-skip = ./third_party,./.git,./benchmarks/catch_*.*pp,./tests/catch_*.*pp,./config,./autom4te.cache,./m4,./aclocal.m4,./configure,./libtool,./configure~,./tests/test-knuth-bendix-*.cpp,./docs/html/*,./docs/xml/*,./tests/gap.g,config.log,gh-pages,tmp,./benchmarks/sims/3-manifolds/benchmark.py,./docs/doxygen-awesome-css/doxygen-custom/*
-ignore-words-list=nd,nam,wit,toword,towords,theses,elment,groupe
+skip = ./third_party,./.git,./benchmarks/catch_*.*pp,./tests/catch_*.*pp,./config,./autom4te.cache,./m4,./aclocal.m4,./configure,./libtool,./configure~,./docs/html/*,./docs/xml/*,config.log,gh-pages,tmp,./docs/doxygen-awesome-css/*
+ignore-words-list=toword,towords,theses,groupe
 ignore-multiline-regex=codespell:begin-ignore.*codespell:end-ignore

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,17 @@
 repos:
   - repo: local
     hooks:
-      - id: clang-format
-        name: clang-format
+      - id: clang-format-local
+        name: clang-format-local
         entry: clang-format-15 --dry-run --Werror
         language: system
         files: ^(include/libsemigroups|src|tests|benchmarks)/.*\.(c|h|t)pp$
         exclude: ^(tests|benchmarks)/catch_.*\.(c|h|t)pp$
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: "v15.0.7"
+    hooks:
+      - id: clang-format
+        name: clang-format-online
+        files: ^(include/libsemigroups|src|tests|benchmarks)/.*\.(c|h|t)pp$
+        exclude: ^(tests|benchmarks)/catch_.*\.(c|h|t)pp$
+        args: ["--dry-run", "--Werror"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: clang-format
+        name: clang-format
+        entry: clang-format-15 --dry-run --Werror
+        language: system
+        files: ^(include/libsemigroups|src|tests|benchmarks)/.*\.(c|h|t)pp$
+        exclude: ^(tests|benchmarks)/catch_.*\.(c|h|t)pp$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,41 @@
+exclude: |
+  (?x)^(
+    third_party/.*|
+    (tests|benchmarks)/catch_.*\.(c|h|t)pp|
+    m4/.*|
+    docs/doxygen-awesome-css/.*
+  )$
 repos:
-  - repo: local
-    hooks:
-      - id: clang-format-local
-        name: clang-format-local
-        entry: clang-format-15 --dry-run --Werror
-        language: system
-        files: ^(include/libsemigroups|src|tests|benchmarks)/.*\.(c|h|t)pp$
-        exclude: ^(tests|benchmarks)/catch_.*\.(c|h|t)pp$
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: "v15.0.7"
+    rev: v15.0.7
     hooks:
       - id: clang-format
-        name: clang-format-online
         files: ^(include/libsemigroups|src|tests|benchmarks)/.*\.(c|h|t)pp$
-        exclude: ^(tests|benchmarks)/catch_.*\.(c|h|t)pp$
-        args: ["--dry-run", "--Werror"]
+  - repo: https://github.com/cpplint/cpplint
+    rev: 2.0.2
+    hooks:
+      - id: cpplint
+        stages: ["pre-push"]
+        files: |
+          (?x)^(
+            include/libsemigroups/.*\.(h|t)pp|
+            src/.*\.cpp|
+            tests/.*\.cpp|
+            benchmarks/.*\.cpp
+          )$
+        args: ["--repository=include", "--extensions=cpp,hpp,tpp"]
+      - id: cpplint
+        name: cpplint-extras
+        alias: cpplint-extras
+        stages: ["pre-push"]
+        files: |
+          (?x)^(
+            tests/.*\.hpp|
+            benchmarks/.*\.hpp
+          )$
+        args: ["--repository=..", "--extensions=hpp"]
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.2
+    hooks:
+      - id: codespell
+        stages: ["pre-push"]

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -184,6 +184,9 @@ source files. To check the whole repository manually, run:
 
   pre-commit run --all-files
 
+If you want to commit something without running the pre-commit hooks, use the
+`--no-verify` flag with `git commit`.
+
 In some cases, it may be desirable to disable automatic formatting; for example,
 if you want to use two lines to construct a vector that represents a 2x2 matrix,
 even though it would fit on one line. Automatic formatting can be disabled using

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -170,6 +170,20 @@ able to run:
 
   apt install clang-format-15
 
+You can also check formatting before every commit by installing
+`pre-commit <https://pre-commit.com/>`_ and running:
+
+.. code-block:: console
+
+  pre-commit install
+
+The pre-commit hook uses ``clang-format-15 --dry-run --Werror`` on staged C++
+source files. To check the whole repository manually, run:
+
+.. code-block:: console
+
+  pre-commit run --all-files
+
 In some cases, it may be desirable to disable automatic formatting; for example,
 if you want to use two lines to construct a vector that represents a 2x2 matrix,
 even though it would fit on one line. Automatic formatting can be disabled using

--- a/Makefile.am
+++ b/Makefile.am
@@ -1128,6 +1128,7 @@ libsemigroups_la_LDFLAGS = -version-info 3:0:0
 ## is required to regenerate these.
 
 EXTRA_DIST =  .clang-format
+EXTRA_DIST += .pre-commit-config.yaml
 EXTRA_DIST += .VERSION
 EXTRA_DIST += CPPLINT.cfg
 EXTRA_DIST += LICENSE

--- a/benchmarks/bench-kambites.cpp
+++ b/benchmarks/bench-kambites.cpp
@@ -544,9 +544,9 @@ namespace libsemigroups {
 
             meter.measure([&]() {
               bool result = true;
-              for (auto wit = words.cbegin(); wit < words.cend() - 1;
-                   wit += 2) {
-                result &= kambites::contains_no_checks(k, *wit, *(wit + 1));
+              for (auto w_it = words.cbegin(); w_it < words.cend() - 1;
+                   w_it += 2) {
+                result &= kambites::contains_no_checks(k, *w_it, *(w_it + 1));
               }
               return result;
             });
@@ -713,9 +713,9 @@ namespace libsemigroups {
 
             bool result = true;
             meter.measure([&]() {
-              for (auto wit = words.cbegin(); wit < words.cend(); ++wit) {
+              for (auto w_it = words.cbegin(); w_it < words.cend(); ++w_it) {
                 result &= kambites::contains_no_checks(
-                    k, kambites::reduce_no_checks(k, *wit), *wit);
+                    k, kambites::reduce_no_checks(k, *w_it), *w_it);
               }
             });
             if (!result) {

--- a/benchmarks/sims/3-manifolds/benchmark.py
+++ b/benchmarks/sims/3-manifolds/benchmark.py
@@ -227,6 +227,7 @@ def translate_to_gap(ex, output):
     for relator in gap_relators:
         output.write('%s,\n'%relator)
     output.write('];\n')
+# codespell:begin-ignore
     output.write("""
 PrintFormatted("{}\\n", info);
 start := NanosecondsSinceEpoch();
@@ -235,6 +236,7 @@ elapsed := Round(Float(NanosecondsSinceEpoch() - start) / 10000000.0)/100;
 PrintFormatted("{} subgroups\\n", ans);
 PrintFormatted("{} secs\\n", ViewString(elapsed));
 """%ex['index'])
+# codespell:end-ignore
 
 def translate_to_magma(ex, output):
     output.write('"%s; index = %d";\n'%(ex['group'], ex['index']))

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - numpy
   - pandas
   - pip
+  - pre-commit
   - rich
   - seaborn
   - pip:

--- a/etc/generate_pybind11.py
+++ b/etc/generate_pybind11.py
@@ -689,18 +689,18 @@ def pybind11_doc(thing, fn, params_t):
     for x in params:
         paramitem = x.find_all("parameteritem")
         for y in paramitem:
-            nam = y.find("parametername").text
-            des = y.find("parameterdescription").find("para")
-            if des is not None:
-                des = des.text
+            param_name = y.find("parametername").text
+            param_des = y.find("parameterdescription").find("para")
+            if param_des is not None:
+                param_des = param_des.text
             else:
-                des = ""
-            doc += f"\n:param {nam}: {des}"
+                param_des = ""
+            doc += f"\n:param {param_name}: {param_des}"
             try:
-                doc += f"\n:type {nam}: {translate_cpp_to_py(params_d[nam])}\n"
+                doc += f"\n:type {param_name}: {translate_cpp_to_py(params_d[param_name])}\n"
             except KeyError:
                 __error(
-                    f'Can\'t find the parameter "{nam}" for "{thing}::{fn}({params_t})" IGNORING!!!'
+                    f'Can\'t find the parameter "{param_name}" for "{thing}::{fn}({params_t})" IGNORING!!!'
                 )
 
     return_ = [

--- a/include/libsemigroups/action.hpp
+++ b/include/libsemigroups/action.hpp
@@ -251,6 +251,7 @@ namespace libsemigroups {
     //!
     //! This member function allows Action objects to be inserted into an
     //! std::ostringstream.
+    // codespell:begin-ignore
     template <typename Elment,
               typename Pint,
               typename Fnc,
@@ -260,6 +261,7 @@ namespace libsemigroups {
     friend std::ostringstream&
     operator<<(std::ostringstream&                                 os,
                Action<Elment, Pint, Fnc, Trits, LftOrRight> const& action);
+    // codespell:end-ignore
 
     //! \brief Insertion operator.
     //!

--- a/src/detail/felsch-tree.cpp
+++ b/src/detail/felsch-tree.cpp
@@ -52,12 +52,12 @@ namespace libsemigroups {
     void FelschTree::add_relations(word_iterator first, word_iterator last) {
       size_t number_of_words = 0;
       LIBSEMIGROUPS_ASSERT(std::distance(first, last) % 2 == 0);
-      for (auto wit = first; wit != last; ++wit) {
-        // For every prefix [wit->cbegin(), last)
-        for (auto suffix = wit->cend(); suffix > wit->cbegin(); --suffix) {
-          // For every suffix [prefix, suffix) of the prefix [wit->cbegin(),
+      for (auto w_it = first; w_it != last; ++w_it) {
+        // For every prefix [w_it->cbegin(), last)
+        for (auto suffix = w_it->cend(); suffix > w_it->cbegin(); --suffix) {
+          // For every suffix [prefix, suffix) of the prefix [w_it->cbegin(),
           // suffix)
-          for (auto prefix = wit->cbegin(); prefix < suffix; ++prefix) {
+          for (auto prefix = w_it->cbegin(); prefix < suffix; ++prefix) {
             // Find the maximal suffix of [prefix, suffix) that corresponds to
             // an existing state . . .
             auto       it = suffix - 1;
@@ -83,10 +83,10 @@ namespace libsemigroups {
               }
             }
           }
-          // Find the state corresponding to the prefix [wit->cbegin(), suffix)
+          // Find the state corresponding to the prefix [w_it->cbegin(), suffix)
           auto       it = suffix - 1;
           state_type s  = initial_state;
-          while (it >= wit->cbegin()) {
+          while (it >= w_it->cbegin()) {
             s = _automata.get(s, *it);
             LIBSEMIGROUPS_ASSERT(s != initial_state);
             --it;

--- a/src/detail/knuth-bendix-impl.cpp
+++ b/src/detail/knuth-bendix-impl.cpp
@@ -25,9 +25,9 @@ namespace libsemigroups {
                          Rule::native_word_type const&                       x,
                          size_t& n) {
       for (auto it = x.cbegin() + 1; it < x.cend(); ++it) {
-        auto w   = Rule::native_word_type(x.cbegin(), it);
-        auto wit = st.find(w);
-        if (wit == st.end()) {
+        auto w    = Rule::native_word_type(x.cbegin(), it);
+        auto w_it = st.find(w);
+        if (w_it == st.end()) {
           st.emplace(w, n);
           n++;
         }

--- a/tests/test-knuth-bendix-string-quick-1.cpp
+++ b/tests/test-knuth-bendix-string-quick-1.cpp
@@ -255,7 +255,7 @@ namespace libsemigroups {
     auto nf = knuth_bendix::normal_forms(kb);
     if constexpr (std::is_same_v<order, ShortLexCompare>) {
       REQUIRE((nf.min(0).max(4) | to_vector())
-              == std::vector<std::string>(  // codespell:end-ignore
+              == std::vector<std::string>(  // codespell:begin-ignore
                   {"",     "a",    "b",    "c",    "d",    "aa",   "ac",
                    "ad",   "bb",   "bc",   "bd",   "cc",   "dd",   "aaa",
                    "aac",  "aad",  "acc",  "add",  "bbb",  "bbc",  "bbd",

--- a/tests/test-knuth-bendix-string-quick-2.cpp
+++ b/tests/test-knuth-bendix-string-quick-2.cpp
@@ -380,6 +380,7 @@ namespace libsemigroups {
 
     presentation::add_inverse_rules(p, "abcdefghijklmno");
 
+    // codespell:begin-ignore
     presentation::add_rule(p, "bab", "aba");
     presentation::add_rule(p, "ca", "ac");
     presentation::add_rule(p, "da", "ad");
@@ -485,6 +486,7 @@ namespace libsemigroups {
     presentation::add_rule(p, "nmn", "mnm");
     presentation::add_rule(p, "om", "mo");
     presentation::add_rule(p, "ono", "non");
+    // codespell:end-ignore
     KnuthBendix<std::string, TestType> kb(twosided, p);
 
     REQUIRE(!kb.rewriting_system().confluent());
@@ -957,6 +959,7 @@ namespace libsemigroups {
     kb.run();
     REQUIRE(kb.rewriting_system().confluent());
 
+    // codespell:begin-ignore
     REQUIRE(knuth_bendix::contains(kb, "aaa", ""));
     REQUIRE(knuth_bendix::contains(kb, "Hb", "H"));
     REQUIRE(knuth_bendix::contains(kb, "HH", "H"));
@@ -971,12 +974,14 @@ namespace libsemigroups {
     REQUIRE(knuth_bendix::contains(kb, "bbaabb", "abba"));
     REQUIRE(knuth_bendix::contains(kb, "aabbaa", "baab"));
     REQUIRE(knuth_bendix::contains(kb, "baabba", "abbaab"));
+    // codespell:end-ignore
 
     using rule_type = typename decltype(kb)::rule_type;
 
     using order = typename TestType::reduction_order;
     if constexpr (std::is_same_v<order, ShortLexCompare>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 14);
+      // codespell:begin-ignore
       REQUIRE((kb.active_rules() | sort(weird_cmp()) | to_vector())
               == std::vector<rule_type>({{{"HH", "H"},
                                           {"Hb", "H"},
@@ -992,8 +997,10 @@ namespace libsemigroups {
                                           {"aabbaa", "baab"},
                                           {"baabba", "abbaab"},
                                           {"bbaabb", "abba"}}}));
+      // codespell:end-ignore
     } else if (std::is_same_v<order, RecursivePathCompare>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 11);
+      // codespell:begin-ignore
       REQUIRE((kb.active_rules() | sort(weird_cmp()) | to_vector())
               == std::vector<rule_type>({{"HH", "H"},
                                          {"Hb", "H"},
@@ -1007,6 +1014,7 @@ namespace libsemigroups {
                                          {"abaab", "bbaa"},
                                          {"abbaab", "bbaabaa"}}));
     }
+    // codespell:end-ignore
   }
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
@@ -1333,11 +1341,13 @@ namespace libsemigroups {
 
     using order = typename TestType::reduction_order;
     if constexpr (std::is_same_v<order, ShortLexCompare>) {
+      // codespell:begin-ignore
       REQUIRE((knuth_bendix::normal_forms(kb) | to_vector())
               == std::vector<std::string>(
                   {"",   "A",   "B",   "C",   "D",   "Y",  "F",  "AB",
                    "AC", "AD",  "AY",  "AF",  "BA",  "BD", "BY", "CY",
                    "DB", "ABA", "ABD", "ABY", "ACY", "ADB"}));
+      // codespell:end-ignore
     } else if (std::is_same_v<order, RecursivePathCompare>) {
       REQUIRE((knuth_bendix::normal_forms(kb) | to_vector())
               == std::vector<std::string>(
@@ -1459,6 +1469,7 @@ namespace libsemigroups {
 
     presentation::add_inverse_rules(p, "abcdefgh");
 
+    // codespell:begin-ignore
     presentation::add_rule(p, "bab", "aba");
     presentation::add_rule(p, "ca", "ac");
     presentation::add_rule(p, "da", "ad");
@@ -1487,6 +1498,7 @@ namespace libsemigroups {
     presentation::add_rule(p, "gfg", "fgf");
     presentation::add_rule(p, "hf", "fh");
     presentation::add_rule(p, "hgh", "ghg");
+    // codespell:end-ignore
 
     KnuthBendix<std::string, TestType> kb(twosided, p);
     REQUIRE(!kb.rewriting_system().confluent());
@@ -1522,6 +1534,7 @@ namespace libsemigroups {
     Presentation<std::string> p;
     p.contains_empty_word(true);
     p.alphabet("abcd");
+    // codespell:begin-ignore
     presentation::add_rule(p, "aa", "a");
     presentation::add_rule(p, "ad", "d");
     presentation::add_rule(p, "bb", "b");
@@ -1543,6 +1556,7 @@ namespace libsemigroups {
     presentation::add_rule(p, "acba", "ac");
     presentation::add_rule(p, "acbd", "cd");
     presentation::add_rule(p, "cbac", "ac");
+    // codespell:end-ignore
     auto it = knuth_bendix::redundant_rule(p, std::chrono::milliseconds(100));
     while (it != p.rules.end()) {
       // std::cout << std::endl

--- a/tests/test-knuth-bendix-string-quick-3.cpp
+++ b/tests/test-knuth-bendix-string-quick-3.cpp
@@ -667,11 +667,13 @@ namespace libsemigroups {
     REQUIRE(knuth_bendix::normal_forms(kb).min(0).max(POSITIVE_INFINITY).count()
             == 22);
     auto nf = knuth_bendix::normal_forms(kb);
+    // codespell:begin-ignore
     REQUIRE((nf.min(0).max(3) | to_vector())
             == std::vector<std::string>({"",    "A",   "B",   "C",  "D",  "Y",
                                          "F",   "AB",  "AC",  "AD", "AY", "AF",
                                          "BA",  "BD",  "BY",  "CY", "DB", "ABA",
                                          "ABD", "ABY", "ACY", "ADB"}));
+    // codespell:end-ignore
   }
 
   // No generators - no anything!


### PR DESCRIPTION
Finally fed up with clang-format ci jobs always failing so taking some proactive steps to avoid that. This PR is generated by Codex, I've checked that this works as intended. It might be tempting to add further things to the pre-commit hooks, like linting. 

Linting with cpplint takes approx. 22s though, so I'm not sure this is a good idea.