### PR TITLE
Add pre-push to default install

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ exclude: |
     m4/.*|
     docs/doxygen-awesome-css/.*
   )$
+default_install_hook_types: [pre-commit, pre-push]
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v15.0.7


### PR DESCRIPTION
This PR updates the default hooks that will be installed by `pre-commit install`.