### PR TITLE
Fix inline code for `operator""_p`

### DIFF
--- a/include/libsemigroups/word-range.hpp
+++ b/include/libsemigroups/word-range.hpp
@@ -2067,11 +2067,11 @@ namespace libsemigroups {
     //! * arbitrarily nested brackets;
     //! * spaces are ignored;
     //! * redundant matched brackets are ignored;
-    //! * \c ^ is treated as the power binary operator;
-    //! * \c , is treated as the commutator binary operator;
-    //! * only the characters in \c "()^, " and in \c a-zA-Z0-9 are allowed.
+    //! * `^` is treated as the power binary operator;
+    //! * `,` is treated as the commutator binary operator;
+    //! * only the characters in `"()^, ` and in \c a-zA-Z0-9 are allowed.
     //!
-    //! When using \c , as the commutator operator, it is not possible to
+    //! When using `,` as the commutator operator, it is not possible to
     //! specify what the inverse of each letter should be. Instead, it is
     //! assumed that the inverse of a lowercase letter is the corresponding
     //! uppercase letter, and the inverse of an uppercase letter is the


### PR DESCRIPTION
This PR updates the doc for `operator""_p` to fix some bad inline code blocks

## Before
<img width="1030" height="326" alt="image" src="https://github.com/user-attachments/assets/237fd82c-55da-439a-bcdd-99d670b952f3" />


## After
<img width="1030" height="326" alt="image" src="https://github.com/user-attachments/assets/7824523a-2dde-44eb-809a-011e5ca2a091" />
(Notice the difference in the fifth bullet point and the first sentence of the paragraph)