### PR TITLE
Assert that the lhs of a rule is not empty when adding rules to a rewriting system

### DIFF
--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -63,6 +63,9 @@ namespace libsemigroups::detail {
       set_cached_confluent(tril::unknown);
       Rule* rule = Rules::add_pending_rule(first1, last1, first2, last2);
       reorder<ReductionOrder>(rule);
+      // The left-hand-side of a rule must not be empty; otherwise, bad things
+      // happen.
+      LIBSEMIGROUPS_ASSERT(!rule->lhs().empty());
       if (!active_rules().empty()
           && pending_rules().size() > settings().reduction_threshold) {
         reduce();


### PR DESCRIPTION
This PR adds an assertion that the lhs of a rule is not empty when adding rules to a rewriting system. If this assertion is violated, bad things happen during rewriting/confluence checking.