### PR TITLE
Add `Presentation` orientation searcher

### DIFF
--- a/include/libsemigroups/knuth-bendix-helpers.hpp
+++ b/include/libsemigroups/knuth-bendix-helpers.hpp
@@ -39,6 +39,8 @@
 #include <utility>        // for move
 #include <vector>         // for vector
 
+#include <iostream>
+
 #include "adapters.hpp"                  // ReturnFalse
 #include "cong-common-helpers.hpp"       // for partition, add_gener...
 #include "constants.hpp"                 // for UNDEFINED, POSITIVE_...
@@ -265,9 +267,9 @@ namespace libsemigroups {
         rewriting_system::add_rule(rewriting_system, lhs, rhs);
       }
 
-      if (rewriting_system.confluent()) {
-        word_type oriented_alphabet = du_narendran_rusinowitch(p);
-        if (!oriented_alphabet.empty()) {
+      word_type oriented_alphabet = du_narendran_rusinowitch(p);
+      if (!oriented_alphabet.empty()) {
+        if (rewriting_system.confluent()) {
           p.alphabet(oriented_alphabet);
           return true;
         }
@@ -299,8 +301,12 @@ namespace libsemigroups {
            orientation_index < num_rule_orientations;
            ++orientation_index) {
         oriented_presentation = p;
-        if (
-
+        if (std::cout << "Checking " << orientation_index + 1 << "/"
+                      << num_rule_orientations << "("
+                      << 100
+                             * (float(orientation_index + 1)
+                                / float(num_rule_orientations))
+                      << "%)" << std::endl;
             detail::orient_and_check(
                 oriented_presentation, rewriting_system, orientation_index)) {
           p = oriented_presentation;

--- a/include/libsemigroups/knuth-bendix-helpers.hpp
+++ b/include/libsemigroups/knuth-bendix-helpers.hpp
@@ -270,7 +270,8 @@ namespace libsemigroups {
         std::cout << "success! Checking confluence ... ";
         p.alphabet(oriented_alphabet);
         kb.init(congruence_kind::twosided, p);
-        if (kb.rewriting_system().confluent()) {
+        kb.run_for(std::chrono::milliseconds(10));
+        if (kb.finished()) {
           std::cout << "success!" << std::endl;
           p.alphabet(oriented_alphabet);
           return true;

--- a/include/libsemigroups/knuth-bendix-helpers.hpp
+++ b/include/libsemigroups/knuth-bendix-helpers.hpp
@@ -287,17 +287,40 @@ namespace libsemigroups {
     // Try all rule orientations, check for confluence, then check to see if
     // there is an alphabet order for which lhs >_rpo rhs for all of the rules
     inline bool order_search(Presentation<word_type>& p) {
-      size_t num_rules = p.rules.size() / 2;
-      if (num_rules > 31) {
+      if (p.rules.empty()) {
+        return true;
+      }
+
+      size_t const num_rules = p.rules.size() / 2;
+      size_t       last      = num_rules;
+
+      for (size_t i = 0; i < last;) {
+        if (p.rules[2 * i + 1].empty()) {
+          --last;
+          std::swap(p.rules[2 * i], p.rules[2 * last]);
+          std::swap(p.rules[2 * i + 1], p.rules[2 * last + 1]);
+        } else {
+          ++i;
+        }
+      }
+
+      if (last == 0) {
+        return false;
+      }
+
+      size_t const num_non_empty_rhs_rules = last;
+
+      if (num_non_empty_rhs_rules > 31) {
         LIBSEMIGROUPS_EXCEPTION(
             "order_search can only be called with presentations that have at "
-            "most 31 rules, found {}",
-            num_rules);
+            "most 31 rules with non-empty right-hand-side, found {}",
+            num_non_empty_rhs_rules);
       }
 
       Presentation<word_type> oriented_presentation;
       KnuthBendix<word_type, detail::RewritingSystemTrie<RPOCmp>> kb;
-      uint32_t const num_rule_orientations = uint32_t{1} << num_rules;
+      uint32_t const num_rule_orientations = uint32_t{1}
+                                             << num_non_empty_rhs_rules;
 
       // The binary representation of each number in [0, num_rule_orientations)
       // specifies which left-hand-sides and right-hand-sides to swap.

--- a/include/libsemigroups/knuth-bendix-helpers.hpp
+++ b/include/libsemigroups/knuth-bendix-helpers.hpp
@@ -304,8 +304,8 @@ namespace libsemigroups {
         if (std::cout << "Checking " << orientation_index + 1 << "/"
                       << num_rule_orientations << "("
                       << 100
-                             * (float(orientation_index + 1)
-                                / float(num_rule_orientations))
+                             * (static_cast<float>(orientation_index + 1)
+                                / static_cast<float>(num_rule_orientations))
                       << "%)" << std::endl;
             detail::orient_and_check(
                 oriented_presentation, rewriting_system, orientation_index)) {

--- a/include/libsemigroups/knuth-bendix-helpers.hpp
+++ b/include/libsemigroups/knuth-bendix-helpers.hpp
@@ -247,12 +247,9 @@ namespace libsemigroups {
 
   namespace detail {
     inline bool
-    orient_and_check(Presentation<word_type>&          p,
-                     RewritingSystemTrie<ReturnFalse>& rewriting_system,
-                     uint32_t                          orientation_index) {
-      rewriting_system.init();
-      rewriting_system.increase_alphabet_size_by(p.alphabet().size());
-
+    orient_and_check(Presentation<word_type>&                             p,
+                     KnuthBendix<word_type, RewritingSystemTrie<RPOCmp>>& kb,
+                     uint32_t orientation_index) {
       for (size_t i = 0; i < p.rules.size() / 2; ++i) {
         // Swap the ith lhs and rhs if the ith bit of rule_orientation_index
         // is a 1.
@@ -262,18 +259,24 @@ namespace libsemigroups {
           std::swap(lhs, rhs);
         }
         if (lhs.size() == 0) {
+          std::cout << "skipping (empty left-hand-side)" << std::endl;
           return false;
         }
-        rewriting_system::add_rule(rewriting_system, lhs, rhs);
       }
 
+      std::cout << "checking alphabet order ... ";
       word_type oriented_alphabet = du_narendran_rusinowitch(p);
       if (!oriented_alphabet.empty()) {
-        if (rewriting_system.confluent()) {
+        std::cout << "success! Checking confluence ... ";
+        p.alphabet(oriented_alphabet);
+        kb.init(congruence_kind::twosided, p);
+        if (kb.rewriting_system().confluent()) {
+          std::cout << "success!" << std::endl;
           p.alphabet(oriented_alphabet);
           return true;
         }
       }
+      std::cout << "failure" << std::endl;
       return false;
     }
   }  // namespace detail
@@ -291,8 +294,8 @@ namespace libsemigroups {
             num_rules);
       }
 
-      Presentation<word_type>                  oriented_presentation;
-      detail::RewritingSystemTrie<ReturnFalse> rewriting_system;
+      Presentation<word_type> oriented_presentation;
+      KnuthBendix<word_type, detail::RewritingSystemTrie<RPOCmp>> kb;
       uint32_t const num_rule_orientations = uint32_t{1} << num_rules;
 
       // The binary representation of each number in [0, num_rule_orientations)
@@ -301,14 +304,14 @@ namespace libsemigroups {
            orientation_index < num_rule_orientations;
            ++orientation_index) {
         oriented_presentation = p;
-        if (std::cout << "Checking " << orientation_index + 1 << "/"
-                      << num_rule_orientations << "("
-                      << 100
-                             * (static_cast<float>(orientation_index + 1)
-                                / static_cast<float>(num_rule_orientations))
-                      << "%)" << std::endl;
-            detail::orient_and_check(
-                oriented_presentation, rewriting_system, orientation_index)) {
+        std::cout << "Checking " << orientation_index + 1 << "/"
+                  << num_rule_orientations << " ("
+                  << 100
+                         * (static_cast<float>(orientation_index + 1)
+                            / static_cast<float>(num_rule_orientations))
+                  << "%): ";
+        if (detail::orient_and_check(
+                oriented_presentation, kb, orientation_index)) {
           p = oriented_presentation;
           return true;
         }

--- a/include/libsemigroups/knuth-bendix-helpers.hpp
+++ b/include/libsemigroups/knuth-bendix-helpers.hpp
@@ -39,18 +39,20 @@
 #include <utility>        // for move
 #include <vector>         // for vector
 
-#include "cong-common-helpers.hpp"  // for partition, add_gener...
-#include "constants.hpp"            // for UNDEFINED, POSITIVE_...
-#include "debug.hpp"                // for LIBSEMIGROUPS_ASSERT
-#include "exception.hpp"            // for LIBSEMIGROUPS_EXCEPTION
-#include "knuth-bendix-class.hpp"   // for KnuthBendix
-#include "paths.hpp"                // for Paths
-#include "presentation.hpp"         // for Presentation
-#include "ranges.hpp"               // for seq, input_range_ite...
-#include "runner.hpp"               // for Runner, delta
-#include "types.hpp"                // for congruence_kind, wor...
-#include "word-graph-helpers.hpp"   // for word_graph
-#include "word-graph.hpp"           // for WordGraph
+#include "adapters.hpp"                  // ReturnFalse
+#include "cong-common-helpers.hpp"       // for partition, add_gener...
+#include "constants.hpp"                 // for UNDEFINED, POSITIVE_...
+#include "debug.hpp"                     // for LIBSEMIGROUPS_ASSERT
+#include "du-narendran-rusinowitch.hpp"  // for du_narendran_narendran
+#include "exception.hpp"                 // for LIBSEMIGROUPS_EXCEPTION
+#include "knuth-bendix-class.hpp"        // for KnuthBendix
+#include "paths.hpp"                     // for Paths
+#include "presentation.hpp"              // for Presentation
+#include "ranges.hpp"                    // for seq, input_range_ite...
+#include "types.hpp"                     // for congruence_kind, wor...
+#include "word-graph-helpers.hpp"        // for word_graph
+#include "word-graph.hpp"                // for WordGraph
+#include "word-range.hpp"                // for ToString
 
 #include "detail/fmt.hpp"               // for format
 #include "detail/knuth-bendix-nf.hpp"   // for KnuthBendix, KnuthBe...
@@ -239,6 +241,74 @@ namespace libsemigroups {
     [[nodiscard]] bool
     is_reduced(KnuthBendix<Word, RewritingSystem, ReductionOrder>& kb);
 #endif
+  }  // namespace knuth_bendix
+
+  namespace detail {
+    inline bool
+    orient_and_check(Presentation<word_type>&          p,
+                     RewritingSystemTrie<ReturnFalse>& rewriting_system,
+                     uint32_t                          orientation_index) {
+      rewriting_system.init();
+      rewriting_system.increase_alphabet_size_by(p.alphabet().size());
+
+      for (size_t i = 0; i < p.rules.size() / 2; ++i) {
+        // Swap the ith lhs and rhs if the ith bit of rule_orientation_index
+        // is a 1.
+        word_type& lhs = p.rules[2 * i];
+        word_type& rhs = p.rules[(2 * i) + 1];
+        if (orientation_index & (1 << i)) {
+          std::swap(lhs, rhs);
+        }
+        if (lhs.size() == 0) {
+          return false;
+        }
+        rewriting_system::add_rule(rewriting_system, lhs, rhs);
+      }
+
+      if (rewriting_system.confluent()) {
+        word_type oriented_alphabet = du_narendran_rusinowitch(p);
+        if (!oriented_alphabet.empty()) {
+          p.alphabet(oriented_alphabet);
+          return true;
+        }
+      }
+      return false;
+    }
+  }  // namespace detail
+
+  namespace knuth_bendix {
+
+    // Try all rule orientations, check for confluence, then check to see if
+    // there is an alphabet order for which lhs >_rpo rhs for all of the rules
+    inline bool order_search(Presentation<word_type>& p) {
+      size_t num_rules = p.rules.size() / 2;
+      if (num_rules > 31) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "order_search can only be called with presentations that have at "
+            "most 31 rules, found {}",
+            num_rules);
+      }
+
+      Presentation<word_type>                  oriented_presentation;
+      detail::RewritingSystemTrie<ReturnFalse> rewriting_system;
+      uint32_t const num_rule_orientations = uint32_t{1} << num_rules;
+
+      // The binary representation of each number in [0, num_rule_orientations)
+      // specifies which left-hand-sides and right-hand-sides to swap.
+      for (uint32_t orientation_index = 0;
+           orientation_index < num_rule_orientations;
+           ++orientation_index) {
+        oriented_presentation = p;
+        if (
+
+            detail::orient_and_check(
+                oriented_presentation, rewriting_system, orientation_index)) {
+          p = oriented_presentation;
+          return true;
+        }
+      }
+      return false;
+    }
 
     ////////////////////////////////////////////////////////////////////////
     // Interface helpers - add_generating_pair

--- a/include/libsemigroups/libsemigroups.hpp
+++ b/include/libsemigroups/libsemigroups.hpp
@@ -131,7 +131,6 @@
 #include "detail/print.hpp"
 #include "detail/race.hpp"
 #include "detail/report.hpp"
-#include "detail/rewriters.hpp"
 #include "detail/rewriting-system.hpp"
 #include "detail/rules.hpp"
 #include "detail/stephen-impl.hpp"

--- a/include/libsemigroups/libsemigroups.hpp
+++ b/include/libsemigroups/libsemigroups.hpp
@@ -131,6 +131,7 @@
 #include "detail/print.hpp"
 #include "detail/race.hpp"
 #include "detail/report.hpp"
+#include "detail/rewriters.hpp"
 #include "detail/rewriting-system.hpp"
 #include "detail/rules.hpp"
 #include "detail/stephen-impl.hpp"

--- a/tests/test-knuth-bendix-extreme.cpp
+++ b/tests/test-knuth-bendix-extreme.cpp
@@ -881,6 +881,54 @@ namespace libsemigroups {
     }
   }
 
+  auto all_relations(std::string const& lhs, std::string const& rhs) {
+    std::unordered_set<std::string> set;
+
+    auto copy_lhs(lhs);
+
+    auto invert = [](auto& letter) {
+      if (std::isupper(letter)) {
+        letter = std::tolower(letter);
+      } else {
+        letter = std::toupper(letter);
+      }
+    };
+    copy_lhs.insert(copy_lhs.end(), rhs.rbegin(), rhs.rend());
+    std::for_each(copy_lhs.begin() + copy_lhs.size() - rhs.size(),
+                  copy_lhs.end(),
+                  invert);
+
+    for (size_t count = 0; count < copy_lhs.size(); ++count) {
+      set.emplace(fmt::format("{}#", copy_lhs));
+      for (size_t prefix_end = 0; prefix_end < copy_lhs.size(); ++prefix_end) {
+        for (size_t suffix_begin = prefix_end; suffix_begin < copy_lhs.size();
+             ++suffix_begin) {
+          std::string next_lhs(copy_lhs.begin() + prefix_end,
+                               copy_lhs.begin() + suffix_begin);
+          std::string next_rhs(copy_lhs.begin(), copy_lhs.begin() + prefix_end);
+          next_rhs.insert(
+              next_rhs.end(), copy_lhs.begin() + suffix_begin, copy_lhs.end());
+
+          std::reverse(next_rhs.begin(), next_rhs.begin() + prefix_end);
+          std::reverse(next_rhs.begin() + prefix_end, next_rhs.end());
+
+          std::for_each(next_rhs.begin(), next_rhs.end(), invert);
+
+          if (lenlex_cmp(next_lhs, next_rhs)) {
+            std::swap(next_lhs, next_rhs);
+          }
+
+          set.emplace(fmt::format("{}#{}", next_lhs, next_rhs));
+        }
+      }
+      auto letter = copy_lhs.front();
+      invert(letter);
+      copy_lhs.erase(0, 1);
+      copy_lhs.push_back(letter);
+    }
+    return set;
+  }
+
   LIBSEMIGROUPS_TEST_CASE("KnuthBendix",
                           "158",
                           "aaa=1, aBBBABAb=1",
@@ -888,15 +936,30 @@ namespace libsemigroups {
     auto                        rg = ReportGuard(true);
     using std::string_literals::operator""s;
     Presentation<std::string>   p;
-    p.alphabet("abB");
+    p.alphabet("aAbB");
     p.contains_empty_word(true);
-    presentation::add_inverse_rules(p, "aBb");
+    presentation::add_rule(p, "Bb", "");
+    presentation::add_rule(p, "bB", "");
     presentation::add_rule(p, "aaa", "");
-    presentation::add_rule(p, "ba", "ababbb");
-    REQUIRE(presentation::index_rule(p, "aa"s, ""s) == 0);
-    p.rules.erase(p.rules.begin(), p.rules.begin() + 2);
+    presentation::add_rule(p, "A", "aa");
 
-    auto new_p = v4::to<Presentation<word_type>>(p);
-    REQUIRE(!knuth_bendix::order_search(new_p));
+    auto all = all_relations("ba"s, "ababbb"s);
+
+    REQUIRE(all.size() == 296);
+
+    for (auto const& rule : all) {
+      size_t pos = rule.find("#");
+      p.add_rule_no_checks(
+          rule.begin(), rule.begin() + pos, rule.begin() + pos + 1, rule.end());
+      auto copy = to<Presentation<word_type>>(p);
+      REQUIRE(!knuth_bendix::order_search(copy));
+      p.rules.erase(p.rules.end() - 2, p.rules.end());
+    }
+
+    //   REQUIRE(presentation::index_rule(p, "aa"s, ""s) == 0);
+    //   p.rules.erase(p.rules.begin(), p.rules.begin() + 2);
+
+    //   auto new_p = v4::to<Presentation<word_type>>(p);
+    //   REQUIRE(!knuth_bendix::order_search(new_p));
   }
 }  // namespace libsemigroups

--- a/tests/test-knuth-bendix-extreme.cpp
+++ b/tests/test-knuth-bendix-extreme.cpp
@@ -19,18 +19,23 @@
 
 #define CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS
 
-#include <algorithm>    // for find, all_of
-#include <chrono>       // for seconds
-#include <complex>      // for operator*, ope...
-#include <cstddef>      // for size_t
-#include <iterator>     // for back_inserter
-#include <list>         // for operator!=
-#include <numeric>      // for accumulate, iota
-#include <string>       // for basic_string
-#include <tuple>        // for get
-#include <type_traits>  // for is_same_v
-#include <utility>      // for pair, forward
-#include <vector>       // for vector, operat...
+#include <algorithm>      // for find, all_of
+#include <chrono>         // for seconds
+#include <complex>        // for operator*, ope...
+#include <cstddef>        // for size_t
+#include <iterator>       // for back_inserter
+#include <iterator>       // for advance
+#include <list>           // for operator!=
+#include <numeric>        // for accumulate, iota
+#include <string>         // for basic_string
+#include <tuple>          // for get
+#include <type_traits>    // for is_same_v
+#include <unordered_set>  // for unordered_set
+#include <utility>        // for pair, forward
+#include <vector>         // for vector, operat...
+
+#include <iostream>
+#include <random>
 
 #include "Catch2-3.14.0/catch_amalgamated.hpp"  // for AssertionHandler, oper...
 #include "test-main.hpp"  // for LIBSEMIGROUPS_TEMPLATE_TEST_CASE
@@ -868,7 +873,7 @@ namespace libsemigroups {
                           "157",
                           "baa(ba)^N=a",
                           "[extreme][order-explorer]") {
-    auto rg = ReportGuard(true);
+    auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
     p.alphabet("ab");
@@ -922,7 +927,6 @@ namespace libsemigroups {
         }
       }
       auto letter = copy_lhs.front();
-      invert(letter);
       copy_lhs.erase(0, 1);
       copy_lhs.push_back(letter);
     }
@@ -933,7 +937,7 @@ namespace libsemigroups {
                           "158",
                           "aaa=1, aBBBABAb=1",
                           "[extreme][order-explorer]") {
-    auto                        rg = ReportGuard(true);
+    auto                        rg = ReportGuard(false);
     using std::string_literals::operator""s;
     Presentation<std::string>   p;
     p.alphabet("aAbB");
@@ -942,18 +946,82 @@ namespace libsemigroups {
     presentation::add_rule(p, "bB", "");
     presentation::add_rule(p, "aaa", "");
     presentation::add_rule(p, "A", "aa");
+    Presentation<word_type> copy;
 
     auto all = all_relations("ba"s, "ababbb"s);
 
-    REQUIRE(all.size() == 296);
+    REQUIRE(all.size() == 72);
 
     for (auto const& rule : all) {
       size_t pos = rule.find("#");
       p.add_rule_no_checks(
           rule.begin(), rule.begin() + pos, rule.begin() + pos + 1, rule.end());
-      auto copy = v4::to<Presentation<word_type>>(p);
+      copy = v4::to<Presentation<word_type>>(p);
       REQUIRE(!knuth_bendix::order_search(copy));
       p.rules.erase(p.rules.end() - 2, p.rules.end());
+    }
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("KnuthBendix",
+                          "159",
+                          "McLaughlin Group",
+                          "[extreme][order-explorer]") {
+    auto                        rg = ReportGuard(false);
+    using literals::            operator""_p;
+    using std::string_literals::operator""s;
+
+    Presentation<std::string> p;
+    p.alphabet("aAbB");
+    p.contains_empty_word(true);
+    std::vector<std::string> const identity_words{
+        "a^2"_p,
+        "b^5"_p,
+        "(ab)^11"_p,
+        "(a,b)^5"_p,
+        "(ab^2)^12"_p,
+        "(a,b^2)^6"_p,
+        "(abaB^2)^7"_p,
+        "(a,B^2ab^2aBab(ab^2)^2abaB)"_p,
+        "(a,b^2ab(ab^2)^2)^2"_p,
+        "abab^2aB^2abaBab^2(aB^2ab)^2(ab^2aB^2ab^2)^2"_p,
+        "(a,b^2ab^2aBab^2)^2"_p,
+        "(a,b^2ab)^4"_p};
+
+    std::vector<std::unordered_set<std::string>> all_rules_all_relations;
+    for (std::string word : identity_words) {
+      all_rules_all_relations.push_back(all_relations(word, ""s));
+    }
+
+    size_t                  N = 100;
+    Presentation<word_type> copy;
+
+    std::random_device rd;
+    std::mt19937       rng(rd());
+
+    for (size_t i = 0; i < N; ++i) {
+      p.init();
+      p.alphabet("aAbB");
+      p.contains_empty_word(true);
+      presentation::add_inverse_rules(p, "AaBb");
+      for (auto const& relation_set : all_rules_all_relations) {
+        std::uniform_int_distribution<size_t> uni(0, relation_set.size() - 1);
+
+        size_t r       = uni(rng);
+        auto   rule_it = relation_set.begin();
+        std::advance(rule_it, r);
+        auto   rule = *rule_it;
+        size_t pos  = rule.find("#");
+        p.add_rule_no_checks(rule.begin(),
+                             rule.begin() + pos,
+                             rule.begin() + pos + 1,
+                             rule.end());
+      }
+      copy = v4::to<Presentation<word_type>>(p);
+      if (knuth_bendix::order_search(copy)) {
+        std::cout << p.alphabet() << std::endl;
+        std::cout << p.rules << std::endl;
+        REQUIRE(false);
+      }
     }
   }
 }  // namespace libsemigroups

--- a/tests/test-knuth-bendix-extreme.cpp
+++ b/tests/test-knuth-bendix-extreme.cpp
@@ -837,4 +837,66 @@ namespace libsemigroups {
     auto result = dora.depth_max(2).number_of_threads(10).result();
     REQUIRE(!result.has_value());
   }
+
+  LIBSEMIGROUPS_TEST_CASE("KnuthBendix",
+                          "156",
+                          "https://math.stackexchange.com/questions/2649807",
+                          "[knuth-bendix][extreme][order-explorer]") {
+    auto        rg    = ReportGuard(true);
+    std::string lphbt = "abcB";
+    std::string invrs = "aBcb";
+
+    Presentation<std::string> p;
+    p.contains_empty_word(true);
+    p.alphabet(lphbt);
+
+    presentation::add_inverse_rules(p, invrs);
+    presentation::add_rule(p, "aa", "");
+    presentation::add_rule(p, "bbbbbbbbbbb", "");
+    presentation::add_rule(p, "cc", "");
+    presentation::add_rule(p, "abababab", "");
+    presentation::add_rule(p, "abbabbabbabbabbabb", "");
+    presentation::add_rule(p, "abbabaBabaBBabbaB", "");
+    presentation::add_rule(p, "acacac", "");
+    presentation::add_rule(p, "bcbc", "");
+
+    auto new_p = v4::to<Presentation<word_type>>(p);
+    REQUIRE(!knuth_bendix::order_search(new_p));
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("KnuthBendix",
+                          "157",
+                          "baa(ba)^N=a",
+                          "[extreme][order-explorer]") {
+    auto rg = ReportGuard(true);
+
+    Presentation<std::string> p;
+    p.alphabet("ab");
+    p.contains_empty_word(true);
+
+    for (auto N = 2; N < 4; ++N) {
+      p.rules    = {words::parse(fmt::format("baa(ba)^{}", N)), "a"};
+      auto new_p = v4::to<Presentation<word_type>>(p);
+      REQUIRE(!knuth_bendix::order_search(new_p));
+    }
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("KnuthBendix",
+                          "158",
+                          "aaa=1, aBBBABAb=1",
+                          "[extreme][order-explorer]") {
+    auto                        rg = ReportGuard(true);
+    using std::string_literals::operator""s;
+    Presentation<std::string>   p;
+    p.alphabet("abB");
+    p.contains_empty_word(true);
+    presentation::add_inverse_rules(p, "aBb");
+    presentation::add_rule(p, "aaa", "");
+    presentation::add_rule(p, "ba", "ababbb");
+    REQUIRE(presentation::index_rule(p, "aa"s, ""s) == 0);
+    p.rules.erase(p.rules.begin(), p.rules.begin() + 2);
+
+    auto new_p = v4::to<Presentation<word_type>>(p);
+    REQUIRE(!knuth_bendix::order_search(new_p));
+  }
 }  // namespace libsemigroups

--- a/tests/test-knuth-bendix-extreme.cpp
+++ b/tests/test-knuth-bendix-extreme.cpp
@@ -951,15 +951,9 @@ namespace libsemigroups {
       size_t pos = rule.find("#");
       p.add_rule_no_checks(
           rule.begin(), rule.begin() + pos, rule.begin() + pos + 1, rule.end());
-      auto copy = to<Presentation<word_type>>(p);
+      auto copy = v4::to<Presentation<word_type>>(p);
       REQUIRE(!knuth_bendix::order_search(copy));
       p.rules.erase(p.rules.end() - 2, p.rules.end());
     }
-
-    //   REQUIRE(presentation::index_rule(p, "aa"s, ""s) == 0);
-    //   p.rules.erase(p.rules.begin(), p.rules.begin() + 2);
-
-    //   auto new_p = v4::to<Presentation<word_type>>(p);
-    //   REQUIRE(!knuth_bendix::order_search(new_p));
   }
 }  // namespace libsemigroups

--- a/tests/test-knuth-bendix-string-quick-1.cpp
+++ b/tests/test-knuth-bendix-string-quick-1.cpp
@@ -33,6 +33,7 @@
 #include "Catch2-3.14.0/catch_amalgamated.hpp"  // for AssertionHandler, ope...
 #include "test-main.hpp"  // for LIBSEMIGROUPS_TEMPLATE_TEST_CASE
 
+#include "libsemigroups/adapters.hpp"            // for ReturnFalse
 #include "libsemigroups/constants.hpp"           // for operator==, operator!=
 #include "libsemigroups/exception.hpp"           // for LibsemigroupsException
 #include "libsemigroups/knuth-bendix.hpp"        // for KnuthBendix, normal_f...
@@ -1371,6 +1372,27 @@ namespace libsemigroups {
     KnuthBendix<std::string, TestType> k(twosided, p);
     k.run();
     REQUIRE(k.number_of_classes() == POSITIVE_INFINITY);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("KnuthBendix",
+                          "147",
+                          "order search",
+                          "[quick][knuth-bendix][order-explorer]") {
+    auto            rg = ReportGuard(false);
+    using literals::operator""_w;
+
+    Presentation<word_type> p;
+    p.contains_empty_word(true);
+    p.alphabet(2);
+    presentation::add_rule(p, "11"_w, "01"_w);
+    KnuthBendix<word_type, detail::RewritingSystemTrie<ReturnFalse>> kb(
+        twosided, p);
+    REQUIRE(!kb.rewriting_system().confluent());
+    REQUIRE(knuth_bendix::order_search(p));
+    REQUIRE(p.rules == std::vector<word_type>{"01"_w, "11"_w});
+    REQUIRE(p.alphabet() == "10"_w);
+    kb.init(twosided, p);
+    REQUIRE(kb.rewriting_system().confluent());
   }
 
 }  // namespace libsemigroups


### PR DESCRIPTION
This PR adds a function that permutes the orientation of the rules in a presentation, and then checks whether an alphabet exists where those rules are correctly oriented with respect to rpo, and then checks confluence. If this is succeeds, then the presentation has a confluent and terminating rewriting system.