### PR TITLE
Improvements to `is_terminating`

### DIFF
--- a/include/libsemigroups/detail/rewriting-system.hpp
+++ b/include/libsemigroups/detail/rewriting-system.hpp
@@ -399,6 +399,15 @@ namespace libsemigroups {
 
       [[nodiscard]] std::pair<size_t, size_t> confluence_ratio();
 
+      // Might never terminate if rws.reduce() doesn't terminate
+      [[nodiscard]] bool is_length_non_increasing() noexcept;
+
+      [[nodiscard]] tril is_length_non_increasing_no_reduce() noexcept;
+
+      [[nodiscard]] tril is_terminating() noexcept;
+
+      [[nodiscard]] tril is_terminating_no_reduce() noexcept;
+
       // Returns true if the system changes as a result of this call (i.e. it
       // wasn't reduced before but now it is)
       bool reduce();
@@ -422,15 +431,6 @@ namespace libsemigroups {
         _use_new_rule_trie = func;
         return *this;
       }
-
-      // Might never terminate if rws.reduce() doesn't terminate
-      [[nodiscard]] bool is_length_non_increasing() noexcept;
-
-      [[nodiscard]] tril is_length_non_increasing_no_reduce() noexcept;
-
-      [[nodiscard]] tril is_terminating() noexcept;
-
-      [[nodiscard]] tril is_terminating_no_reduce() noexcept;
 
      private:
       ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/detail/rewriting-system.hpp
+++ b/include/libsemigroups/detail/rewriting-system.hpp
@@ -423,6 +423,15 @@ namespace libsemigroups {
         return *this;
       }
 
+      // Might never terminate if rws.reduce() doesn't terminate
+      [[nodiscard]] bool is_length_non_increasing() noexcept;
+
+      [[nodiscard]] tril is_length_non_increasing_no_reduce() noexcept;
+
+      [[nodiscard]] tril is_terminating() noexcept;
+
+      [[nodiscard]] tril is_terminating_no_reduce() noexcept;
+
      private:
       ////////////////////////////////////////////////////////////////////////
       // Private member functions
@@ -477,22 +486,6 @@ namespace libsemigroups {
       void add_rule(RewritingSystem& rs, Word const& lhs, Word const& rhs) {
         rs.add_rule(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
       }
-
-      // Might never terminate if rws.reduce() doesn't terminate
-      template <typename RewritingSystem>
-      [[nodiscard]] bool
-      is_length_non_increasing(RewritingSystem& rws) noexcept;
-
-      template <typename RewritingSystem>
-      [[nodiscard]] tril
-      is_length_non_increasing_no_reduce(RewritingSystem const& rws) noexcept;
-
-      template <typename RewritingSystem>
-      [[nodiscard]] tril is_terminating(RewritingSystem& rws) noexcept;
-
-      template <typename RewritingSystem>
-      [[nodiscard]] tril
-      is_terminating_no_reduce(RewritingSystem const& rws) noexcept;
 
     }  // namespace rewriting_system
 

--- a/include/libsemigroups/detail/rewriting-system.hpp
+++ b/include/libsemigroups/detail/rewriting-system.hpp
@@ -343,9 +343,11 @@ namespace libsemigroups {
       // Private data
       ////////////////////////////////////////////////////////////////////////
 
+      mutable bool                                    _cached_terminating;
       Trie                                            _new_rule_trie;
       std::function<bool(RewritingSystemTrie const&)> _use_new_rule_trie;
       Trie                                            _rule_trie;
+      mutable bool                                    _terminating_known;
       bool                                            _ticker_running;
       mutable std::vector<index_type> _trie_nodes_visited_indices;
 
@@ -402,11 +404,11 @@ namespace libsemigroups {
       // Might never terminate if rws.reduce() doesn't terminate
       [[nodiscard]] bool is_length_non_increasing() noexcept;
 
-      [[nodiscard]] tril is_length_non_increasing_no_reduce() noexcept;
+      [[nodiscard]] tril is_length_non_increasing_no_reduce() const noexcept;
 
       [[nodiscard]] tril is_terminating() noexcept;
 
-      [[nodiscard]] tril is_terminating_no_reduce() noexcept;
+      [[nodiscard]] tril is_terminating_no_reduce() const noexcept;
 
       // Returns true if the system changes as a result of this call (i.e. it
       // wasn't reduced before but now it is)
@@ -437,10 +439,17 @@ namespace libsemigroups {
       // Private member functions
       ////////////////////////////////////////////////////////////////////////
 
-      void     add_active_rule(Rule* new_rule);
+      void add_active_rule(Rule* new_rule);
+
+      bool cached_terminating() const noexcept {
+        return _cached_terminating;
+      }
+
       iterator make_active_rule_pending(iterator it);
 
       void rewrite_no_reduce(native_word_type& u) const;
+
+      void set_cached_terminating(tril val) const;
 
       ////////////////////////////////////////////////////////////////////////
       // Confluence

--- a/include/libsemigroups/detail/rewriting-system.hpp
+++ b/include/libsemigroups/detail/rewriting-system.hpp
@@ -409,9 +409,11 @@ namespace libsemigroups {
       // Private data
       ////////////////////////////////////////////////////////////////////////
 
+      mutable bool                                    _cached_terminating;
       Trie                                            _new_rule_trie;
       std::function<bool(RewritingSystemTrie const&)> _use_new_rule_trie;
       Trie                                            _rule_trie;
+      mutable bool                                    _terminating_known;
       bool                                            _ticker_running;
       mutable std::vector<index_type> _trie_nodes_visited_indices;
 
@@ -473,11 +475,11 @@ namespace libsemigroups {
       // Might never terminate if rws.reduce() doesn't terminate
       [[nodiscard]] bool is_length_non_increasing() noexcept;
 
-      [[nodiscard]] tril is_length_non_increasing_no_reduce() noexcept;
+      [[nodiscard]] tril is_length_non_increasing_no_reduce() const noexcept;
 
       [[nodiscard]] tril is_terminating() noexcept;
 
-      [[nodiscard]] tril is_terminating_no_reduce() noexcept;
+      [[nodiscard]] tril is_terminating_no_reduce() const noexcept;
 
       // Returns true if the system changes as a result of this call (i.e. it
       // wasn't reduced before but now it is)
@@ -508,10 +510,17 @@ namespace libsemigroups {
       // Private member functions
       ////////////////////////////////////////////////////////////////////////
 
-      void     add_active_rule(Rule* new_rule);
+      void add_active_rule(Rule* new_rule);
+
+      bool cached_terminating() const noexcept {
+        return _cached_terminating;
+      }
+
       iterator make_active_rule_pending(iterator it);
 
       void rewrite_no_reduce(native_word_type& u) const;
+
+      void set_cached_terminating(tril val) const;
 
       ////////////////////////////////////////////////////////////////////////
       // Confluence

--- a/include/libsemigroups/detail/rewriting-system.hpp
+++ b/include/libsemigroups/detail/rewriting-system.hpp
@@ -470,6 +470,15 @@ namespace libsemigroups {
 
       [[nodiscard]] std::pair<size_t, size_t> confluence_ratio();
 
+      // Might never terminate if rws.reduce() doesn't terminate
+      [[nodiscard]] bool is_length_non_increasing() noexcept;
+
+      [[nodiscard]] tril is_length_non_increasing_no_reduce() noexcept;
+
+      [[nodiscard]] tril is_terminating() noexcept;
+
+      [[nodiscard]] tril is_terminating_no_reduce() noexcept;
+
       // Returns true if the system changes as a result of this call (i.e. it
       // wasn't reduced before but now it is)
       bool reduce();
@@ -493,15 +502,6 @@ namespace libsemigroups {
         _use_new_rule_trie = func;
         return *this;
       }
-
-      // Might never terminate if rws.reduce() doesn't terminate
-      [[nodiscard]] bool is_length_non_increasing() noexcept;
-
-      [[nodiscard]] tril is_length_non_increasing_no_reduce() noexcept;
-
-      [[nodiscard]] tril is_terminating() noexcept;
-
-      [[nodiscard]] tril is_terminating_no_reduce() noexcept;
 
      private:
       ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/detail/rewriting-system.hpp
+++ b/include/libsemigroups/detail/rewriting-system.hpp
@@ -62,9 +62,11 @@ namespace libsemigroups {
       };
 
       mutable std::atomic<bool>                     _cached_confluent;
+      mutable bool                                  _cached_terminating;
       mutable std::atomic<bool>                     _confluence_known;
       Settings                                      _settings;
       std::function<bool(Rule const*, Rule const*)> _pending_rules_comparator;
+      mutable bool                                  _terminating_known;
 
      protected:
       enum class State : uint8_t {
@@ -155,6 +157,10 @@ namespace libsemigroups {
         return _settings;
       }
 
+      [[nodiscard]] bool terminating_known() const {
+        return _terminating_known;
+      }
+
      protected:
       void sort_pending_rules();
 
@@ -165,7 +171,13 @@ namespace libsemigroups {
         return _cached_confluent;
       }
 
+      bool cached_terminating() const noexcept {
+        return _cached_terminating;
+      }
+
       void set_cached_confluent(tril val) const;
+
+      void set_cached_terminating(tril val) const;
 
       ////////////////////////////////////////////////////////////////////////
       // Member functions - protected
@@ -245,6 +257,10 @@ namespace libsemigroups {
           std::swap(rule->lhs(), rule->rhs());
         }
       }
+
+      [[nodiscard]] tril is_length_non_increasing_no_reduce() const noexcept;
+
+      [[nodiscard]] tril is_terminating_no_reduce() const noexcept;
     };  // class RewritingSystemBaseWithOrder
 
     ////////////////////////////////////////////////////////////////////////
@@ -355,6 +371,11 @@ namespace libsemigroups {
 
       [[nodiscard]] std::pair<size_t, size_t> confluence_ratio();
 
+      // Might never terminate if rws.reduce() doesn't terminate
+      [[nodiscard]] bool is_length_non_increasing() noexcept;
+
+      [[nodiscard]] tril is_terminating() noexcept;
+
       // Returns true if the system changes as a result of this call (i.e. it
       // wasn't reduced before but now it is)
       bool reduce();
@@ -409,11 +430,9 @@ namespace libsemigroups {
       // Private data
       ////////////////////////////////////////////////////////////////////////
 
-      mutable bool                                    _cached_terminating;
       Trie                                            _new_rule_trie;
       std::function<bool(RewritingSystemTrie const&)> _use_new_rule_trie;
       Trie                                            _rule_trie;
-      mutable bool                                    _terminating_known;
       bool                                            _ticker_running;
       mutable std::vector<index_type> _trie_nodes_visited_indices;
 
@@ -470,16 +489,12 @@ namespace libsemigroups {
         return *this;
       }
 
-      [[nodiscard]] std::pair<size_t, size_t> confluence_ratio();
-
       // Might never terminate if rws.reduce() doesn't terminate
       [[nodiscard]] bool is_length_non_increasing() noexcept;
 
-      [[nodiscard]] tril is_length_non_increasing_no_reduce() const noexcept;
-
       [[nodiscard]] tril is_terminating() noexcept;
 
-      [[nodiscard]] tril is_terminating_no_reduce() const noexcept;
+      [[nodiscard]] std::pair<size_t, size_t> confluence_ratio();
 
       // Returns true if the system changes as a result of this call (i.e. it
       // wasn't reduced before but now it is)
@@ -512,15 +527,9 @@ namespace libsemigroups {
 
       void add_active_rule(Rule* new_rule);
 
-      bool cached_terminating() const noexcept {
-        return _cached_terminating;
-      }
-
       iterator make_active_rule_pending(iterator it);
 
       void rewrite_no_reduce(native_word_type& u) const;
-
-      void set_cached_terminating(tril val) const;
 
       ////////////////////////////////////////////////////////////////////////
       // Confluence

--- a/include/libsemigroups/detail/rewriting-system.hpp
+++ b/include/libsemigroups/detail/rewriting-system.hpp
@@ -494,6 +494,15 @@ namespace libsemigroups {
         return *this;
       }
 
+      // Might never terminate if rws.reduce() doesn't terminate
+      [[nodiscard]] bool is_length_non_increasing() noexcept;
+
+      [[nodiscard]] tril is_length_non_increasing_no_reduce() noexcept;
+
+      [[nodiscard]] tril is_terminating() noexcept;
+
+      [[nodiscard]] tril is_terminating_no_reduce() noexcept;
+
      private:
       ////////////////////////////////////////////////////////////////////////
       // Private member functions
@@ -548,22 +557,6 @@ namespace libsemigroups {
       void add_rule(RewritingSystem& rs, Word const& lhs, Word const& rhs) {
         rs.add_rule(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
       }
-
-      // Might never terminate if rws.reduce() doesn't terminate
-      template <typename RewritingSystem>
-      [[nodiscard]] bool
-      is_length_non_increasing(RewritingSystem& rws) noexcept;
-
-      template <typename RewritingSystem>
-      [[nodiscard]] tril
-      is_length_non_increasing_no_reduce(RewritingSystem const& rws) noexcept;
-
-      template <typename RewritingSystem>
-      [[nodiscard]] tril is_terminating(RewritingSystem& rws) noexcept;
-
-      template <typename RewritingSystem>
-      [[nodiscard]] tril
-      is_terminating_no_reduce(RewritingSystem const& rws) noexcept;
 
     }  // namespace rewriting_system
 

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -444,6 +444,74 @@ namespace libsemigroups::detail {
   }
 
   template <typename ReductionOrder>
+  void RewritingSystemTrie<ReductionOrder>::rewrite(native_word_type& v) {
+    reduce();
+    rewrite_no_reduce(v);
+  }
+
+  template <typename ReductionOrder>
+  tril RewritingSystemTrie<
+      ReductionOrder>::is_length_non_increasing_no_reduce() noexcept {
+    if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
+      return tril::TRUE;
+    }
+
+    if (is_reduced() != tril::TRUE) {
+      return tril::unknown;
+    }
+
+    for (auto const& rule : rules()) {
+      if (rule.first.size() < rule.second.size()) {
+        return tril::FALSE;
+      }
+    }
+
+    return tril::TRUE;
+  }
+
+  template <typename ReductionOrder>
+  bool
+  RewritingSystemTrie<ReductionOrder>::is_length_non_increasing() noexcept {
+    if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
+      return true;
+    }
+
+    reduce();
+    return is_length_non_increasing_no_reduce() == tril::TRUE;
+  }
+
+  template <typename ReductionOrder>
+  tril
+  RewritingSystemTrie<ReductionOrder>::is_terminating_no_reduce() noexcept {
+    if constexpr (order::is_well_founded_v<ReductionOrder>) {
+      return tril::TRUE;
+    }
+    if (is_length_non_increasing_no_reduce() == tril::TRUE) {
+      return tril::TRUE;
+    }
+    for (auto const& rule : rules()) {
+      if (std::search(rule.second.begin(),
+                      rule.second.end(),
+                      rule.first.begin(),
+                      rule.first.end())
+          != rule.second.end()) {
+        return tril::FALSE;
+      }
+    }
+
+    return tril::unknown;
+  }
+
+  template <typename ReductionOrder>
+  tril RewritingSystemTrie<ReductionOrder>::is_terminating() noexcept {
+    if constexpr (order::is_well_founded_v<ReductionOrder>) {
+      return tril::TRUE;
+    }
+    reduce();
+    return is_terminating_no_reduce();
+  }
+
+  template <typename ReductionOrder>
   bool RewritingSystemTrie<ReductionOrder>::reduce() {
     using aho_corasick_impl::begin_search_no_checks;
     using aho_corasick_impl::end_search_no_checks;
@@ -547,74 +615,6 @@ namespace libsemigroups::detail {
     }
 
     return rules_added;
-  }
-
-  template <typename ReductionOrder>
-  void RewritingSystemTrie<ReductionOrder>::rewrite(native_word_type& v) {
-    reduce();
-    rewrite_no_reduce(v);
-  }
-
-  template <typename ReductionOrder>
-  tril RewritingSystemTrie<
-      ReductionOrder>::is_length_non_increasing_no_reduce() noexcept {
-    if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
-      return tril::TRUE;
-    }
-
-    if (is_reduced() != tril::TRUE) {
-      return tril::unknown;
-    }
-
-    for (auto const& rule : rules()) {
-      if (rule.first.size() < rule.second.size()) {
-        return tril::FALSE;
-      }
-    }
-
-    return tril::TRUE;
-  }
-
-  template <typename ReductionOrder>
-  bool
-  RewritingSystemTrie<ReductionOrder>::is_length_non_increasing() noexcept {
-    if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
-      return true;
-    }
-
-    reduce();
-    return is_length_non_increasing_no_reduce() == tril::TRUE;
-  }
-
-  template <typename ReductionOrder>
-  tril
-  RewritingSystemTrie<ReductionOrder>::is_terminating_no_reduce() noexcept {
-    if constexpr (order::is_well_founded_v<ReductionOrder>) {
-      return tril::TRUE;
-    }
-    if (is_length_non_increasing_no_reduce() == tril::TRUE) {
-      return tril::TRUE;
-    }
-    for (auto const& rule : rules()) {
-      if (std::search(rule.second.begin(),
-                      rule.second.end(),
-                      rule.first.begin(),
-                      rule.first.end())
-          != rule.second.end()) {
-        return tril::FALSE;
-      }
-    }
-
-    return tril::unknown;
-  }
-
-  template <typename ReductionOrder>
-  tril RewritingSystemTrie<ReductionOrder>::is_terminating() noexcept {
-    if constexpr (order::is_well_founded_v<ReductionOrder>) {
-      return tril::TRUE;
-    }
-    reduce();
-    return is_terminating_no_reduce();
   }
 
   ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -528,8 +528,12 @@ namespace libsemigroups::detail {
       set_cached_terminating(tril::TRUE);
       return tril::TRUE;
     }
-    reduce();
-    return is_terminating_no_reduce();
+    tril result = is_terminating_no_reduce();
+    if (result == tril::unknown) {
+      reduce();
+      result = is_terminating_no_reduce();
+    }
+    return result;
   }
 
   template <typename ReductionOrder>

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -595,6 +595,16 @@ namespace libsemigroups::detail {
     if (is_length_non_increasing_no_reduce() == tril::TRUE) {
       return tril::TRUE;
     }
+    for (auto const& rule : rules()) {
+      if (std::search(rule.second.begin(),
+                      rule.second.end(),
+                      rule.first.begin(),
+                      rule.first.end())
+          != rule.second.end()) {
+        return tril::FALSE;
+      }
+    }
+
     return tril::unknown;
   }
 
@@ -603,10 +613,8 @@ namespace libsemigroups::detail {
     if constexpr (order::is_well_founded_v<ReductionOrder>) {
       return tril::TRUE;
     }
-    if (is_length_non_increasing()) {
-      return tril::TRUE;
-    }
-    return tril::unknown;
+    reduce();
+    return is_terminating_no_reduce();
   }
 
   ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -555,6 +555,60 @@ namespace libsemigroups::detail {
     rewrite_no_reduce(v);
   }
 
+  template <typename ReductionOrder>
+  tril RewritingSystemTrie<
+      ReductionOrder>::is_length_non_increasing_no_reduce() noexcept {
+    if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
+      return tril::TRUE;
+    }
+
+    if (is_reduced() != tril::TRUE) {
+      return tril::unknown;
+    }
+
+    for (auto const& rule : rules()) {
+      if (rule.first.size() < rule.second.size()) {
+        return tril::FALSE;
+      }
+    }
+
+    return tril::TRUE;
+  }
+
+  template <typename ReductionOrder>
+  bool
+  RewritingSystemTrie<ReductionOrder>::is_length_non_increasing() noexcept {
+    if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
+      return true;
+    }
+
+    reduce();
+    return is_length_non_increasing_no_reduce() == tril::TRUE;
+  }
+
+  template <typename ReductionOrder>
+  tril
+  RewritingSystemTrie<ReductionOrder>::is_terminating_no_reduce() noexcept {
+    if constexpr (order::is_well_founded_v<ReductionOrder>) {
+      return tril::TRUE;
+    }
+    if (is_length_non_increasing_no_reduce() == tril::TRUE) {
+      return tril::TRUE;
+    }
+    return tril::unknown;
+  }
+
+  template <typename ReductionOrder>
+  tril RewritingSystemTrie<ReductionOrder>::is_terminating() noexcept {
+    if constexpr (order::is_well_founded_v<ReductionOrder>) {
+      return tril::TRUE;
+    }
+    if (is_length_non_increasing()) {
+      return tril::TRUE;
+    }
+    return tril::unknown;
+  }
+
   ////////////////////////////////////////////////////////////////////////
   // RewritingSystemTrie --- Private member functions
   ////////////////////////////////////////////////////////////////////////
@@ -910,66 +964,4 @@ namespace libsemigroups::detail {
     }
   }
 
-  ////////////////////////////////////////////////////////////////////////
-  // Helpers
-  ////////////////////////////////////////////////////////////////////////
-
-  namespace rewriting_system {
-
-    template <typename RewritingSystem>
-    tril
-    is_length_non_increasing_no_reduce(RewritingSystem const& rws) noexcept {
-      if constexpr (order::is_length_non_increasing_v<
-                        typename RewritingSystem::reduction_order>) {
-        return tril::TRUE;
-      }
-
-      if (rws.is_reduced() != tril::TRUE) {
-        return tril::unknown;
-      }
-
-      for (auto const& rule : rws.rules()) {
-        if (rule.first.size() < rule.second.size()) {
-          return tril::FALSE;
-        }
-      }
-
-      return tril::TRUE;
-    }
-
-    template <typename RewritingSystem>
-    bool is_length_non_increasing(RewritingSystem& rws) noexcept {
-      if constexpr (order::is_length_non_increasing_v<
-                        typename RewritingSystem::reduction_order>) {
-        return true;
-      }
-
-      rws.reduce();
-      return is_length_non_increasing_no_reduce(rws) == tril::TRUE;
-    }
-
-    template <typename RewritingSystem>
-    tril is_terminating_no_reduce(RewritingSystem const& rws) noexcept {
-      if constexpr (order::is_well_founded_v<
-                        typename RewritingSystem::reduction_order>) {
-        return tril::TRUE;
-      }
-      if (is_length_non_increasing_no_reduce(rws) == tril::TRUE) {
-        return tril::TRUE;
-      }
-      return tril::unknown;
-    }
-
-    template <typename RewritingSystem>
-    tril is_terminating(RewritingSystem& rws) noexcept {
-      if constexpr (order::is_well_founded_v<
-                        typename RewritingSystem::reduction_order>) {
-        return tril::TRUE;
-      }
-      if (is_length_non_increasing(rws)) {
-        return tril::TRUE;
-      }
-      return tril::unknown;
-    }
-  }  // namespace rewriting_system
 }  // namespace libsemigroups::detail

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -683,10 +683,6 @@ namespace libsemigroups::detail {
       return;
     }
 
-    // If the rewriting system is not terminating, then rewriting may last
-    // forever.
-    LIBSEMIGROUPS_ASSERT(is_terminating_no_reduce() != tril::FALSE);
-
     // OLD VERSION; Assumes length reducing!!
 
     //     _trie_nodes_visited_indices.clear();

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -382,8 +382,10 @@ namespace libsemigroups::detail {
   template <typename ReductionOrder>
   RewritingSystemTrie<ReductionOrder>::RewritingSystemTrie()
       : RewritingSystemBase(),
+        _cached_terminating(false),
         _new_rule_trie(),
         _rule_trie(0),
+        _terminating_known(false),
         _ticker_running(false),
         _trie_nodes_visited_indices() {}
 
@@ -392,8 +394,10 @@ namespace libsemigroups::detail {
   RewritingSystemTrie<ReductionOrder>::init() {
     // Do nothing to _trie_nodes_visited_indices, or _new_rule_trie
     RewritingSystemBase::init();
+    _cached_terminating = false;
     _rule_trie.init();
-    _ticker_running = false;
+    _terminating_known = false;
+    _ticker_running    = false;
     return *this;
   }
 
@@ -410,6 +414,8 @@ namespace libsemigroups::detail {
     for (Rule* rule : Rules::active_rules()) {
       _rule_trie.insert_no_checks(rule->lhs(), rule);
     }
+    _cached_terminating = that._cached_terminating;
+    _terminating_known  = that._terminating_known;
     return *this;
   }
 
@@ -433,6 +439,7 @@ namespace libsemigroups::detail {
       Rule* rule = Rules::add_pending_rule(first1, last1, first2, last2);
       reorder<ReductionOrder>(rule);
       set_cached_confluent(tril::unknown);
+      set_cached_terminating(tril::unknown);
       if (!active_rules().empty()
           && pending_rules().size() > settings().reduction_threshold) {
         // If active_rules().empty(), then we don't process pending rules, to
@@ -450,9 +457,10 @@ namespace libsemigroups::detail {
   }
 
   template <typename ReductionOrder>
-  tril RewritingSystemTrie<
-      ReductionOrder>::is_length_non_increasing_no_reduce() noexcept {
+  tril RewritingSystemTrie<ReductionOrder>::is_length_non_increasing_no_reduce()
+      const noexcept {
     if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
+      set_cached_terminating(tril::TRUE);
       return tril::TRUE;
     }
 
@@ -473,6 +481,7 @@ namespace libsemigroups::detail {
   bool
   RewritingSystemTrie<ReductionOrder>::is_length_non_increasing() noexcept {
     if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
+      set_cached_terminating(tril::TRUE);
       return true;
     }
 
@@ -481,30 +490,42 @@ namespace libsemigroups::detail {
   }
 
   template <typename ReductionOrder>
-  tril
-  RewritingSystemTrie<ReductionOrder>::is_terminating_no_reduce() noexcept {
+  tril RewritingSystemTrie<ReductionOrder>::is_terminating_no_reduce()
+      const noexcept {
+    if (_terminating_known) {
+      if (_cached_terminating == true) {
+        return tril::TRUE;
+      }
+      return tril::FALSE;
+    }
+
+    tril result = tril::unknown;
+
     if constexpr (order::is_well_founded_v<ReductionOrder>) {
-      return tril::TRUE;
-    }
-    if (is_length_non_increasing_no_reduce() == tril::TRUE) {
-      return tril::TRUE;
-    }
-    for (auto const& rule : rules()) {
-      if (std::search(rule.second.begin(),
-                      rule.second.end(),
-                      rule.first.begin(),
-                      rule.first.end())
-          != rule.second.end()) {
-        return tril::FALSE;
+      result = tril::TRUE;
+    } else if (is_length_non_increasing_no_reduce() == tril::TRUE) {
+      result = tril::TRUE;
+    } else {
+      for (auto const& rule : rules()) {
+        if (std::search(rule.second.begin(),
+                        rule.second.end(),
+                        rule.first.begin(),
+                        rule.first.end())
+            != rule.second.end()) {
+          result = tril::FALSE;
+          break;
+        }
       }
     }
 
-    return tril::unknown;
+    set_cached_terminating(result);
+    return result;
   }
 
   template <typename ReductionOrder>
   tril RewritingSystemTrie<ReductionOrder>::is_terminating() noexcept {
     if constexpr (order::is_well_founded_v<ReductionOrder>) {
+      set_cached_terminating(tril::TRUE);
       return tril::TRUE;
     }
     reduce();
@@ -515,6 +536,12 @@ namespace libsemigroups::detail {
   bool RewritingSystemTrie<ReductionOrder>::reduce() {
     using aho_corasick_impl::begin_search_no_checks;
     using aho_corasick_impl::end_search_no_checks;
+
+    // If a system is not terminating, then reduction might make it terminating,
+    // provided it can actually finish!
+    if (_terminating_known && !_cached_terminating) {
+      set_cached_terminating(tril::unknown);
+    }
 
     auto                 start_time = std::chrono::high_resolution_clock::now();
     Ticker               ticker;
@@ -629,6 +656,7 @@ namespace libsemigroups::detail {
     _rule_trie.emplace_no_checks(
         new_rule->lhs().cbegin(), new_rule->lhs().cend(), new_rule);
     set_cached_confluent(tril::unknown);
+    set_cached_terminating(tril::unknown);
   }
 
   template <typename ReductionOrder>
@@ -636,6 +664,9 @@ namespace libsemigroups::detail {
   RewritingSystemTrie<ReductionOrder>::make_active_rule_pending(iterator it) {
     _rule_trie.erase_no_checks((*it)->lhs());
     return Rules::make_active_rule_pending(it);
+    if (_terminating_known && !_cached_terminating) {
+      set_cached_terminating(tril::unknown);
+    }
   }
 
   template <typename ReductionOrder>
@@ -748,6 +779,20 @@ namespace libsemigroups::detail {
       }
     }
     // fmt::print("{}\n", to_printable(v));
+  }
+
+  template <typename ReductionOrder>
+  void
+  RewritingSystemTrie<ReductionOrder>::set_cached_terminating(tril val) const {
+    if (val == tril::TRUE) {
+      _terminating_known  = true;
+      _cached_terminating = true;
+    } else if (val == tril::FALSE) {
+      _terminating_known  = true;
+      _cached_terminating = false;
+    } else {
+      _terminating_known = false;
+    }
   }
 
   ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -678,6 +678,11 @@ namespace libsemigroups::detail {
       // fmt::print("{}\n", to_printable(v));
       return;
     }
+
+    // If the rewriting system is not terminating, then rewriting may last
+    // forever.
+    LIBSEMIGROUPS_ASSERT(is_terminating_no_reduce() != tril::FALSE);
+
     // OLD VERSION; Assumes length reducing!!
 
     //     _trie_nodes_visited_indices.clear();

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -573,6 +573,60 @@ namespace libsemigroups::detail {
     rewrite_no_reduce(v);
   }
 
+  template <typename ReductionOrder>
+  tril RewritingSystemTrie<
+      ReductionOrder>::is_length_non_increasing_no_reduce() noexcept {
+    if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
+      return tril::TRUE;
+    }
+
+    if (is_reduced() != tril::TRUE) {
+      return tril::unknown;
+    }
+
+    for (auto const& rule : rules()) {
+      if (rule.first.size() < rule.second.size()) {
+        return tril::FALSE;
+      }
+    }
+
+    return tril::TRUE;
+  }
+
+  template <typename ReductionOrder>
+  bool
+  RewritingSystemTrie<ReductionOrder>::is_length_non_increasing() noexcept {
+    if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
+      return true;
+    }
+
+    reduce();
+    return is_length_non_increasing_no_reduce() == tril::TRUE;
+  }
+
+  template <typename ReductionOrder>
+  tril
+  RewritingSystemTrie<ReductionOrder>::is_terminating_no_reduce() noexcept {
+    if constexpr (order::is_well_founded_v<ReductionOrder>) {
+      return tril::TRUE;
+    }
+    if (is_length_non_increasing_no_reduce() == tril::TRUE) {
+      return tril::TRUE;
+    }
+    return tril::unknown;
+  }
+
+  template <typename ReductionOrder>
+  tril RewritingSystemTrie<ReductionOrder>::is_terminating() noexcept {
+    if constexpr (order::is_well_founded_v<ReductionOrder>) {
+      return tril::TRUE;
+    }
+    if (is_length_non_increasing()) {
+      return tril::TRUE;
+    }
+    return tril::unknown;
+  }
+
   ////////////////////////////////////////////////////////////////////////
   // RewritingSystemTrie --- Private member functions
   ////////////////////////////////////////////////////////////////////////
@@ -929,66 +983,4 @@ namespace libsemigroups::detail {
     }
   }
 
-  ////////////////////////////////////////////////////////////////////////
-  // Helpers
-  ////////////////////////////////////////////////////////////////////////
-
-  namespace rewriting_system {
-
-    template <typename RewritingSystem>
-    tril
-    is_length_non_increasing_no_reduce(RewritingSystem const& rws) noexcept {
-      if constexpr (order::is_length_non_increasing_v<
-                        typename RewritingSystem::reduction_order>) {
-        return tril::TRUE;
-      }
-
-      if (rws.is_reduced() != tril::TRUE) {
-        return tril::unknown;
-      }
-
-      for (auto const& rule : rws.rules()) {
-        if (rule.first.size() < rule.second.size()) {
-          return tril::FALSE;
-        }
-      }
-
-      return tril::TRUE;
-    }
-
-    template <typename RewritingSystem>
-    bool is_length_non_increasing(RewritingSystem& rws) noexcept {
-      if constexpr (order::is_length_non_increasing_v<
-                        typename RewritingSystem::reduction_order>) {
-        return true;
-      }
-
-      rws.reduce();
-      return is_length_non_increasing_no_reduce(rws) == tril::TRUE;
-    }
-
-    template <typename RewritingSystem>
-    tril is_terminating_no_reduce(RewritingSystem const& rws) noexcept {
-      if constexpr (order::is_well_founded_v<
-                        typename RewritingSystem::reduction_order>) {
-        return tril::TRUE;
-      }
-      if (is_length_non_increasing_no_reduce(rws) == tril::TRUE) {
-        return tril::TRUE;
-      }
-      return tril::unknown;
-    }
-
-    template <typename RewritingSystem>
-    tril is_terminating(RewritingSystem& rws) noexcept {
-      if constexpr (order::is_well_founded_v<
-                        typename RewritingSystem::reduction_order>) {
-        return tril::TRUE;
-      }
-      if (is_length_non_increasing(rws)) {
-        return tril::TRUE;
-      }
-      return tril::unknown;
-    }
-  }  // namespace rewriting_system
 }  // namespace libsemigroups::detail

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -704,10 +704,6 @@ namespace libsemigroups::detail {
       return;
     }
 
-    // If the rewriting system is not terminating, then rewriting may last
-    // forever.
-    LIBSEMIGROUPS_ASSERT(is_terminating_no_reduce() != tril::FALSE);
-
     // OLD VERSION; Assumes length reducing!!
 
     //     _trie_nodes_visited_indices.clear();

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -699,6 +699,11 @@ namespace libsemigroups::detail {
       // fmt::print("{}\n", to_printable(v));
       return;
     }
+
+    // If the rewriting system is not terminating, then rewriting may last
+    // forever.
+    LIBSEMIGROUPS_ASSERT(is_terminating_no_reduce() != tril::FALSE);
+
     // OLD VERSION; Assumes length reducing!!
 
     //     _trie_nodes_visited_indices.clear();

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -540,8 +540,12 @@ namespace libsemigroups::detail {
       set_cached_terminating(tril::TRUE);
       return tril::TRUE;
     }
-    reduce();
-    return is_terminating_no_reduce();
+    tril result = is_terminating_no_reduce();
+    if (result == tril::unknown) {
+      reduce();
+      result = is_terminating_no_reduce();
+    }
+    return result;
   }
 
   template <template <typename, bool> typename ReductionOrder>

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -460,6 +460,68 @@ namespace libsemigroups::detail {
   }
 
   template <template <typename, bool> typename ReductionOrder>
+  tril RewritingSystemTrie<
+      ReductionOrder>::is_length_non_increasing_no_reduce() noexcept {
+    if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
+      return tril::TRUE;
+    }
+
+    if (is_reduced() != tril::TRUE) {
+      return tril::unknown;
+    }
+
+    for (auto const& rule : rules()) {
+      if (rule.first.size() < rule.second.size()) {
+        return tril::FALSE;
+      }
+    }
+
+    return tril::TRUE;
+  }
+
+  template <template <typename, bool> typename ReductionOrder>
+  bool
+  RewritingSystemTrie<ReductionOrder>::is_length_non_increasing() noexcept {
+    if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
+      return true;
+    }
+
+    reduce();
+    return is_length_non_increasing_no_reduce() == tril::TRUE;
+  }
+
+  template <template <typename, bool> typename ReductionOrder>
+  tril
+  RewritingSystemTrie<ReductionOrder>::is_terminating_no_reduce() noexcept {
+    if constexpr (order::is_well_founded_v<ReductionOrder>) {
+      return tril::TRUE;
+    }
+    if (is_length_non_increasing_no_reduce() == tril::TRUE) {
+      return tril::TRUE;
+    }
+    for (auto const& rule : rules()) {
+      if (std::search(rule.second.begin(),
+                      rule.second.end(),
+                      rule.first.begin(),
+                      rule.first.end())
+          != rule.second.end()) {
+        return tril::FALSE;
+      }
+    }
+
+    return tril::unknown;
+  }
+
+  template <template <typename, bool> typename ReductionOrder>
+  tril RewritingSystemTrie<ReductionOrder>::is_terminating() noexcept {
+    if constexpr (order::is_well_founded_v<ReductionOrder>) {
+      return tril::TRUE;
+    }
+    reduce();
+    return is_terminating_no_reduce();
+  }
+
+  template <template <typename, bool> typename ReductionOrder>
   bool RewritingSystemTrie<ReductionOrder>::reduce() {
     using aho_corasick_impl::begin_search_no_checks;
     using aho_corasick_impl::end_search_no_checks;
@@ -571,68 +633,6 @@ namespace libsemigroups::detail {
   void RewritingSystemTrie<ReductionOrder>::rewrite(native_word_type& v) {
     reduce();
     rewrite_no_reduce(v);
-  }
-
-  template <typename ReductionOrder>
-  tril RewritingSystemTrie<
-      ReductionOrder>::is_length_non_increasing_no_reduce() noexcept {
-    if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
-      return tril::TRUE;
-    }
-
-    if (is_reduced() != tril::TRUE) {
-      return tril::unknown;
-    }
-
-    for (auto const& rule : rules()) {
-      if (rule.first.size() < rule.second.size()) {
-        return tril::FALSE;
-      }
-    }
-
-    return tril::TRUE;
-  }
-
-  template <typename ReductionOrder>
-  bool
-  RewritingSystemTrie<ReductionOrder>::is_length_non_increasing() noexcept {
-    if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
-      return true;
-    }
-
-    reduce();
-    return is_length_non_increasing_no_reduce() == tril::TRUE;
-  }
-
-  template <typename ReductionOrder>
-  tril
-  RewritingSystemTrie<ReductionOrder>::is_terminating_no_reduce() noexcept {
-    if constexpr (order::is_well_founded_v<ReductionOrder>) {
-      return tril::TRUE;
-    }
-    if (is_length_non_increasing_no_reduce() == tril::TRUE) {
-      return tril::TRUE;
-    }
-    for (auto const& rule : rules()) {
-      if (std::search(rule.second.begin(),
-                      rule.second.end(),
-                      rule.first.begin(),
-                      rule.first.end())
-          != rule.second.end()) {
-        return tril::FALSE;
-      }
-    }
-
-    return tril::unknown;
-  }
-
-  template <typename ReductionOrder>
-  tril RewritingSystemTrie<ReductionOrder>::is_terminating() noexcept {
-    if constexpr (order::is_well_founded_v<ReductionOrder>) {
-      return tril::TRUE;
-    }
-    reduce();
-    return is_terminating_no_reduce();
   }
 
   ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -613,6 +613,16 @@ namespace libsemigroups::detail {
     if (is_length_non_increasing_no_reduce() == tril::TRUE) {
       return tril::TRUE;
     }
+    for (auto const& rule : rules()) {
+      if (std::search(rule.second.begin(),
+                      rule.second.end(),
+                      rule.first.begin(),
+                      rule.first.end())
+          != rule.second.end()) {
+        return tril::FALSE;
+      }
+    }
+
     return tril::unknown;
   }
 
@@ -621,10 +631,8 @@ namespace libsemigroups::detail {
     if constexpr (order::is_well_founded_v<ReductionOrder>) {
       return tril::TRUE;
     }
-    if (is_length_non_increasing()) {
-      return tril::TRUE;
-    }
-    return tril::unknown;
+    reduce();
+    return is_terminating_no_reduce();
   }
 
   ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -29,6 +29,61 @@ namespace libsemigroups::detail {
     return *this;
   }
 
+  template <template <typename, bool> typename ReductionOrder>
+  tril RewritingSystemBaseWithOrder<
+      ReductionOrder>::is_length_non_increasing_no_reduce() const noexcept {
+    if constexpr (order::is_length_non_increasing_v<
+                      ReductionOrder<Default, true>>) {
+      RewritingSystemBase::set_cached_terminating(tril::TRUE);
+      return tril::TRUE;
+    }
+
+    if (RewritingSystemBase::is_reduced() != tril::TRUE) {
+      return tril::unknown;
+    }
+
+    for (auto const& rule : RewritingSystemBase::rules()) {
+      if (rule.first.size() < rule.second.size()) {
+        return tril::FALSE;
+      }
+    }
+
+    return tril::TRUE;
+  }
+
+  template <template <typename, bool> typename ReductionOrder>
+  tril RewritingSystemBaseWithOrder<ReductionOrder>::is_terminating_no_reduce()
+      const noexcept {
+    if (RewritingSystemBase::terminating_known()) {
+      if (RewritingSystemBase::cached_terminating() == true) {
+        return tril::TRUE;
+      }
+      return tril::FALSE;
+    }
+
+    tril result = tril::unknown;
+
+    if constexpr (order::is_well_founded_v<ReductionOrder<Default, true>>) {
+      result = tril::TRUE;
+    } else if (is_length_non_increasing_no_reduce() == tril::TRUE) {
+      result = tril::TRUE;
+    } else {
+      for (auto const& rule : RewritingSystemBase::rules()) {
+        if (std::search(rule.second.begin(),
+                        rule.second.end(),
+                        rule.first.begin(),
+                        rule.first.end())
+            != rule.second.end()) {
+          result = tril::FALSE;
+          break;
+        }
+      }
+    }
+
+    RewritingSystemBase::set_cached_terminating(result);
+    return result;
+  }
+
   ////////////////////////////////////////////////////////////////////////
   // RewritingSystemSet --- Constructors + initializers
   ////////////////////////////////////////////////////////////////////////
@@ -73,6 +128,7 @@ namespace libsemigroups::detail {
                                                Iterator last2) {
     if (!std::equal(first1, last1, first2, last2)) {
       RewritingSystemBase::set_cached_confluent(tril::unknown);
+      RewritingSystemBase::set_cached_terminating(tril::unknown);
       Rule* rule = Rules::add_pending_rule(first1, last1, first2, last2);
       RewritingSystemBaseWithOrder_::reorder(rule);
       // The left-hand-side of a rule must not be empty; otherwise, bad things
@@ -88,7 +144,41 @@ namespace libsemigroups::detail {
   }
 
   template <template <typename, bool> typename ReductionOrder>
+  bool RewritingSystemSet<ReductionOrder>::is_length_non_increasing() noexcept {
+    if constexpr (order::is_length_non_increasing_v<
+                      ReductionOrder<Default, true>>) {
+      RewritingSystemBase::set_cached_terminating(tril::TRUE);
+      return true;
+    }
+
+    reduce();
+    return RewritingSystemBaseWithOrder_::is_length_non_increasing_no_reduce()
+           == tril::TRUE;
+  }
+
+  template <template <typename, bool> typename ReductionOrder>
+  tril RewritingSystemSet<ReductionOrder>::is_terminating() noexcept {
+    if constexpr (order::is_well_founded_v<ReductionOrder<Default, true>>) {
+      RewritingSystemBase::set_cached_terminating(tril::TRUE);
+      return tril::TRUE;
+    }
+    tril result = RewritingSystemBaseWithOrder_::is_terminating_no_reduce();
+    if (result == tril::unknown) {
+      reduce();
+      result = RewritingSystemBaseWithOrder_::is_terminating_no_reduce();
+    }
+    return result;
+  }
+
+  template <template <typename, bool> typename ReductionOrder>
   bool RewritingSystemSet<ReductionOrder>::reduce() {
+    // If a system is not terminating, then reduction might make it terminating,
+    // provided it can actually finish!
+    if (RewritingSystemBase::terminating_known()
+        && !RewritingSystemBase::cached_terminating()) {
+      RewritingSystemBase::set_cached_terminating(tril::unknown);
+    }
+
     RewritingSystemBase::sort_pending_rules();
 
     auto   start_time = std::chrono::high_resolution_clock::now();
@@ -174,6 +264,7 @@ namespace libsemigroups::detail {
 #endif
     LIBSEMIGROUPS_ASSERT(_set_rules.size() == Rules::active_rules().size());
     RewritingSystemBase::set_cached_confluent(tril::unknown);
+    RewritingSystemBase::set_cached_terminating(tril::unknown);
   }
 
   template <template <typename, bool> typename ReductionOrder>
@@ -258,8 +349,8 @@ namespace libsemigroups::detail {
           }
           // TODO(1): Remove duplication between this and
           // RewritingSystemTrie::overlap_confluent
-          // Find longest common prefix of suffix B of rule1.lhs() defined by it
-          // and R = rule2.lhs()
+          // Find longest common prefix of suffix B of rule1.lhs() defined by
+          // it and R = rule2.lhs()
           auto prefix = maximum_common_prefix(it,
                                               rule1->lhs().cend(),
                                               rule2->lhs().cbegin(),
@@ -397,10 +488,8 @@ namespace libsemigroups::detail {
   template <template <typename, bool> typename ReductionOrder>
   RewritingSystemTrie<ReductionOrder>::RewritingSystemTrie()
       : RewritingSystemBaseWithOrder_(),
-        _cached_terminating(false),
         _new_rule_trie(),
         _rule_trie(0),
-        _terminating_known(false),
         _ticker_running(false),
         _trie_nodes_visited_indices() {}
 
@@ -409,10 +498,8 @@ namespace libsemigroups::detail {
   RewritingSystemTrie<ReductionOrder>::init() {
     // Do nothing to _trie_nodes_visited_indices, or _new_rule_trie
     RewritingSystemBaseWithOrder_::init();
-    _cached_terminating = false;
     _rule_trie.init();
-    _terminating_known = false;
-    _ticker_running    = false;
+    _ticker_running = false;
     return *this;
   }
 
@@ -422,15 +509,13 @@ namespace libsemigroups::detail {
       RewritingSystemTrie const& that) {
     init();
     RewritingSystemBaseWithOrder_::operator=(that);
-    // Cannot just copy the _rule_trie because the values in it are Rule* which
-    // would then point at Rule objects in "that" not "this".
+    // Cannot just copy the _rule_trie because the values in it are Rule*
+    // which would then point at Rule objects in "that" not "this".
     _rule_trie.init().increase_alphabet_size_by(
         that._rule_trie.alphabet_size());
     for (Rule* rule : Rules::active_rules()) {
       _rule_trie.insert_no_checks(rule->lhs(), rule);
     }
-    _cached_terminating = that._cached_terminating;
-    _terminating_known  = that._terminating_known;
     return *this;
   }
 
@@ -454,7 +539,7 @@ namespace libsemigroups::detail {
       Rule* rule = Rules::add_pending_rule(first1, last1, first2, last2);
       RewritingSystemBaseWithOrder_::reorder(rule);
       RewritingSystemBase::set_cached_confluent(tril::unknown);
-      set_cached_terminating(tril::unknown);
+      RewritingSystemBase::set_cached_terminating(tril::unknown);
       if (!RewritingSystemBase::active_rules().empty()
           && RewritingSystemBase::pending_rules().size()
                  > RewritingSystemBase::settings().reduction_threshold) {
@@ -467,83 +552,29 @@ namespace libsemigroups::detail {
   }
 
   template <template <typename, bool> typename ReductionOrder>
-  tril RewritingSystemTrie<ReductionOrder>::is_length_non_increasing_no_reduce()
-      const noexcept {
-    if constexpr (order::is_length_non_increasing_v<
-                      ReductionOrder<Default, true>>) {
-      set_cached_terminating(tril::TRUE);
-      return tril::TRUE;
-    }
-
-    if (RewritingSystemBase::is_reduced() != tril::TRUE) {
-      return tril::unknown;
-    }
-
-    for (auto const& rule : RewritingSystemBase::rules()) {
-      if (rule.first.size() < rule.second.size()) {
-        return tril::FALSE;
-      }
-    }
-
-    return tril::TRUE;
-  }
-
-  template <template <typename, bool> typename ReductionOrder>
   bool
   RewritingSystemTrie<ReductionOrder>::is_length_non_increasing() noexcept {
     if constexpr (order::is_length_non_increasing_v<
                       ReductionOrder<Default, true>>) {
-      set_cached_terminating(tril::TRUE);
+      RewritingSystemBase::set_cached_terminating(tril::TRUE);
       return true;
     }
 
     reduce();
-    return is_length_non_increasing_no_reduce() == tril::TRUE;
-  }
-
-  template <template <typename, bool> typename ReductionOrder>
-  tril RewritingSystemTrie<ReductionOrder>::is_terminating_no_reduce()
-      const noexcept {
-    if (_terminating_known) {
-      if (_cached_terminating == true) {
-        return tril::TRUE;
-      }
-      return tril::FALSE;
-    }
-
-    tril result = tril::unknown;
-
-    if constexpr (order::is_well_founded_v<ReductionOrder<Default, true>>) {
-      result = tril::TRUE;
-    } else if (is_length_non_increasing_no_reduce() == tril::TRUE) {
-      result = tril::TRUE;
-    } else {
-      for (auto const& rule : RewritingSystemBase::rules()) {
-        if (std::search(rule.second.begin(),
-                        rule.second.end(),
-                        rule.first.begin(),
-                        rule.first.end())
-            != rule.second.end()) {
-          result = tril::FALSE;
-          break;
-        }
-      }
-    }
-
-    set_cached_terminating(result);
-    return result;
+    return RewritingSystemBaseWithOrder_::is_length_non_increasing_no_reduce()
+           == tril::TRUE;
   }
 
   template <template <typename, bool> typename ReductionOrder>
   tril RewritingSystemTrie<ReductionOrder>::is_terminating() noexcept {
     if constexpr (order::is_well_founded_v<ReductionOrder<Default, true>>) {
-      set_cached_terminating(tril::TRUE);
+      RewritingSystemBase::set_cached_terminating(tril::TRUE);
       return tril::TRUE;
     }
-    tril result = is_terminating_no_reduce();
+    tril result = RewritingSystemBaseWithOrder_::is_terminating_no_reduce();
     if (result == tril::unknown) {
       reduce();
-      result = is_terminating_no_reduce();
+      result = RewritingSystemBaseWithOrder_::is_terminating_no_reduce();
     }
     return result;
   }
@@ -555,8 +586,9 @@ namespace libsemigroups::detail {
 
     // If a system is not terminating, then reduction might make it terminating,
     // provided it can actually finish!
-    if (_terminating_known && !_cached_terminating) {
-      set_cached_terminating(tril::unknown);
+    if (RewritingSystemBase::terminating_known()
+        && !RewritingSystemBase::cached_terminating()) {
+      RewritingSystemBase::set_cached_terminating(tril::unknown);
     }
 
     auto                 start_time = std::chrono::high_resolution_clock::now();
@@ -681,7 +713,7 @@ namespace libsemigroups::detail {
     _rule_trie.emplace_no_checks(
         new_rule->lhs().cbegin(), new_rule->lhs().cend(), new_rule);
     RewritingSystemBase::set_cached_confluent(tril::unknown);
-    set_cached_terminating(tril::unknown);
+    RewritingSystemBase::set_cached_terminating(tril::unknown);
   }
 
   template <template <typename, bool> typename ReductionOrder>
@@ -689,9 +721,6 @@ namespace libsemigroups::detail {
   RewritingSystemTrie<ReductionOrder>::make_active_rule_pending(iterator it) {
     _rule_trie.erase_no_checks((*it)->lhs());
     return Rules::make_active_rule_pending(it);
-    if (_terminating_known && !_cached_terminating) {
-      set_cached_terminating(tril::unknown);
-    }
   }
 
   template <template <typename, bool> typename ReductionOrder>
@@ -805,20 +834,6 @@ namespace libsemigroups::detail {
       }
     }
     // fmt::print("{}\n", to_printable(v));
-  }
-
-  template <template <typename, bool> typename ReductionOrder>
-  void
-  RewritingSystemTrie<ReductionOrder>::set_cached_terminating(tril val) const {
-    if (val == tril::TRUE) {
-      _terminating_known  = true;
-      _cached_terminating = true;
-    } else if (val == tril::FALSE) {
-      _terminating_known  = true;
-      _cached_terminating = false;
-    } else {
-      _terminating_known = false;
-    }
   }
 
   ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -397,8 +397,10 @@ namespace libsemigroups::detail {
   template <template <typename, bool> typename ReductionOrder>
   RewritingSystemTrie<ReductionOrder>::RewritingSystemTrie()
       : RewritingSystemBaseWithOrder_(),
+        _cached_terminating(false),
         _new_rule_trie(),
         _rule_trie(0),
+        _terminating_known(false),
         _ticker_running(false),
         _trie_nodes_visited_indices() {}
 
@@ -407,8 +409,10 @@ namespace libsemigroups::detail {
   RewritingSystemTrie<ReductionOrder>::init() {
     // Do nothing to _trie_nodes_visited_indices, or _new_rule_trie
     RewritingSystemBaseWithOrder_::init();
+    _cached_terminating = false;
     _rule_trie.init();
-    _ticker_running = false;
+    _terminating_known = false;
+    _ticker_running    = false;
     return *this;
   }
 
@@ -425,6 +429,8 @@ namespace libsemigroups::detail {
     for (Rule* rule : Rules::active_rules()) {
       _rule_trie.insert_no_checks(rule->lhs(), rule);
     }
+    _cached_terminating = that._cached_terminating;
+    _terminating_known  = that._terminating_known;
     return *this;
   }
 
@@ -448,6 +454,7 @@ namespace libsemigroups::detail {
       Rule* rule = Rules::add_pending_rule(first1, last1, first2, last2);
       RewritingSystemBaseWithOrder_::reorder(rule);
       RewritingSystemBase::set_cached_confluent(tril::unknown);
+      set_cached_terminating(tril::unknown);
       if (!RewritingSystemBase::active_rules().empty()
           && RewritingSystemBase::pending_rules().size()
                  > RewritingSystemBase::settings().reduction_threshold) {
@@ -460,17 +467,19 @@ namespace libsemigroups::detail {
   }
 
   template <template <typename, bool> typename ReductionOrder>
-  tril RewritingSystemTrie<
-      ReductionOrder>::is_length_non_increasing_no_reduce() noexcept {
-    if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
+  tril RewritingSystemTrie<ReductionOrder>::is_length_non_increasing_no_reduce()
+      const noexcept {
+    if constexpr (order::is_length_non_increasing_v<
+                      ReductionOrder<Default, true>>) {
+      set_cached_terminating(tril::TRUE);
       return tril::TRUE;
     }
 
-    if (is_reduced() != tril::TRUE) {
+    if (RewritingSystemBase::is_reduced() != tril::TRUE) {
       return tril::unknown;
     }
 
-    for (auto const& rule : rules()) {
+    for (auto const& rule : RewritingSystemBase::rules()) {
       if (rule.first.size() < rule.second.size()) {
         return tril::FALSE;
       }
@@ -482,7 +491,9 @@ namespace libsemigroups::detail {
   template <template <typename, bool> typename ReductionOrder>
   bool
   RewritingSystemTrie<ReductionOrder>::is_length_non_increasing() noexcept {
-    if constexpr (order::is_length_non_increasing_v<ReductionOrder>) {
+    if constexpr (order::is_length_non_increasing_v<
+                      ReductionOrder<Default, true>>) {
+      set_cached_terminating(tril::TRUE);
       return true;
     }
 
@@ -491,30 +502,42 @@ namespace libsemigroups::detail {
   }
 
   template <template <typename, bool> typename ReductionOrder>
-  tril
-  RewritingSystemTrie<ReductionOrder>::is_terminating_no_reduce() noexcept {
-    if constexpr (order::is_well_founded_v<ReductionOrder>) {
-      return tril::TRUE;
+  tril RewritingSystemTrie<ReductionOrder>::is_terminating_no_reduce()
+      const noexcept {
+    if (_terminating_known) {
+      if (_cached_terminating == true) {
+        return tril::TRUE;
+      }
+      return tril::FALSE;
     }
-    if (is_length_non_increasing_no_reduce() == tril::TRUE) {
-      return tril::TRUE;
-    }
-    for (auto const& rule : rules()) {
-      if (std::search(rule.second.begin(),
-                      rule.second.end(),
-                      rule.first.begin(),
-                      rule.first.end())
-          != rule.second.end()) {
-        return tril::FALSE;
+
+    tril result = tril::unknown;
+
+    if constexpr (order::is_well_founded_v<ReductionOrder<Default, true>>) {
+      result = tril::TRUE;
+    } else if (is_length_non_increasing_no_reduce() == tril::TRUE) {
+      result = tril::TRUE;
+    } else {
+      for (auto const& rule : RewritingSystemBase::rules()) {
+        if (std::search(rule.second.begin(),
+                        rule.second.end(),
+                        rule.first.begin(),
+                        rule.first.end())
+            != rule.second.end()) {
+          result = tril::FALSE;
+          break;
+        }
       }
     }
 
-    return tril::unknown;
+    set_cached_terminating(result);
+    return result;
   }
 
   template <template <typename, bool> typename ReductionOrder>
   tril RewritingSystemTrie<ReductionOrder>::is_terminating() noexcept {
-    if constexpr (order::is_well_founded_v<ReductionOrder>) {
+    if constexpr (order::is_well_founded_v<ReductionOrder<Default, true>>) {
+      set_cached_terminating(tril::TRUE);
       return tril::TRUE;
     }
     reduce();
@@ -525,6 +548,12 @@ namespace libsemigroups::detail {
   bool RewritingSystemTrie<ReductionOrder>::reduce() {
     using aho_corasick_impl::begin_search_no_checks;
     using aho_corasick_impl::end_search_no_checks;
+
+    // If a system is not terminating, then reduction might make it terminating,
+    // provided it can actually finish!
+    if (_terminating_known && !_cached_terminating) {
+      set_cached_terminating(tril::unknown);
+    }
 
     auto                 start_time = std::chrono::high_resolution_clock::now();
     Ticker               ticker;
@@ -648,6 +677,7 @@ namespace libsemigroups::detail {
     _rule_trie.emplace_no_checks(
         new_rule->lhs().cbegin(), new_rule->lhs().cend(), new_rule);
     RewritingSystemBase::set_cached_confluent(tril::unknown);
+    set_cached_terminating(tril::unknown);
   }
 
   template <template <typename, bool> typename ReductionOrder>
@@ -655,6 +685,9 @@ namespace libsemigroups::detail {
   RewritingSystemTrie<ReductionOrder>::make_active_rule_pending(iterator it) {
     _rule_trie.erase_no_checks((*it)->lhs());
     return Rules::make_active_rule_pending(it);
+    if (_terminating_known && !_cached_terminating) {
+      set_cached_terminating(tril::unknown);
+    }
   }
 
   template <template <typename, bool> typename ReductionOrder>
@@ -767,6 +800,20 @@ namespace libsemigroups::detail {
       }
     }
     // fmt::print("{}\n", to_printable(v));
+  }
+
+  template <template <typename, bool> typename ReductionOrder>
+  void
+  RewritingSystemTrie<ReductionOrder>::set_cached_terminating(tril val) const {
+    if (val == tril::TRUE) {
+      _terminating_known  = true;
+      _cached_terminating = true;
+    } else if (val == tril::FALSE) {
+      _terminating_known  = true;
+      _cached_terminating = false;
+    } else {
+      _terminating_known = false;
+    }
   }
 
   ////////////////////////////////////////////////////////////////////////

--- a/src/detail/rewriting-system.cpp
+++ b/src/detail/rewriting-system.cpp
@@ -52,17 +52,21 @@ namespace libsemigroups {
 
     RewritingSystemBase::RewritingSystemBase()
         : _cached_confluent(false),
+          _cached_terminating(false),
           _confluence_known(false),
           _pending_rules_comparator(lhs_lex_cmp),
+          _terminating_known(false),
           _state(State::none),
           _ticker_running(false) {}
 
     RewritingSystemBase& RewritingSystemBase::init() {
       Rules::init();
       _cached_confluent         = false;
+      _cached_terminating       = false;
       _confluence_known         = false;
       _pending_rules_comparator = lhs_lex_cmp;
       _state                    = State::none;
+      _terminating_known        = false;
       _ticker_running           = false;
       return *this;
     }
@@ -71,10 +75,12 @@ namespace libsemigroups {
     RewritingSystemBase::operator=(RewritingSystemBase const& that) {
       Rules::operator=(that);
       _cached_confluent         = that._cached_confluent.load();
+      _cached_terminating       = that._cached_terminating;
       _confluence_known         = that._confluence_known.load();
       _pending_rules_comparator = that._pending_rules_comparator;
       _state                    = that._state;
       _ticker_running           = that._ticker_running;
+      _terminating_known        = that._terminating_known;
 
       return *this;
     }
@@ -83,10 +89,12 @@ namespace libsemigroups {
     RewritingSystemBase::operator=(RewritingSystemBase&& that) {
       Rules::operator=(std::move(that));
       _cached_confluent         = that._cached_confluent.load();
+      _cached_terminating       = that._cached_terminating;
       _confluence_known         = that._confluence_known.load();
       _pending_rules_comparator = std::move(that._pending_rules_comparator);
       _state                    = that._state;
       _ticker_running           = std::move(that._ticker_running);
+      _terminating_known        = that._terminating_known;
       return *this;
     }
 
@@ -112,6 +120,18 @@ namespace libsemigroups {
         _cached_confluent = false;
       } else {
         _confluence_known = false;
+      }
+    }
+
+    void RewritingSystemBase::set_cached_terminating(tril val) const {
+      if (val == tril::TRUE) {
+        _terminating_known  = true;
+        _cached_terminating = true;
+      } else if (val == tril::FALSE) {
+        _terminating_known  = true;
+        _cached_terminating = false;
+      } else {
+        _terminating_known = false;
       }
     }
 

--- a/tests/test-rewriting-system.cpp
+++ b/tests/test-rewriting-system.cpp
@@ -353,7 +353,7 @@ namespace libsemigroups {
                                          {{1, 2}, {1}},
                                          {{1, 2}, {2}}}));
       REQUIRE(rws.is_length_non_increasing_no_reduce() == tril::unknown);
-      REQUIRE(rws.is_terminating_no_reduce() == tril::unknown);
+      REQUIRE(rws.is_terminating_no_reduce() == tril::FALSE);
     }
 
     LIBSEMIGROUPS_TEST_CASE("RewritingSystemTrie<ReturnFalse>",
@@ -508,5 +508,21 @@ namespace libsemigroups {
       REQUIRE(rws.confluent_known());
       REQUIRE(!rws.confluent());
     }
+
+    LIBSEMIGROUPS_TEST_CASE("RewritingSystem",
+                            "017",
+                            "is_terminating x2",
+                            "[quick]") {
+      auto                             rg = ReportGuard(false);
+      RewritingSystemTrie<ReturnFalse> rws;
+      rws.increase_alphabet_size_by(3);
+      rewriting_system::add_rule(rws, "aa"_w, "bab"_w);
+      rewriting_system::add_rule(rws, "ab"_w, "aa"_w);
+      REQUIRE(rws.is_terminating_no_reduce() == tril::unknown);
+      // Reduce runs forever, unless running in debug mode, in which case an
+      // assertion is raised.
+      // rws.reduce();
+    }
+
   }  // namespace detail
 }  // namespace libsemigroups

--- a/tests/test-rewriting-system.cpp
+++ b/tests/test-rewriting-system.cpp
@@ -477,6 +477,10 @@ namespace libsemigroups {
       REQUIRE(rws.is_reduced() == tril::unknown);
       REQUIRE(rws.is_terminating() == tril::TRUE);
       REQUIRE(rws.is_reduced() == tril::TRUE);
+
+      rewriting_system::add_rule(rws, "a"_w, "aa"_w);
+      REQUIRE(rws.is_terminating_no_reduce() == tril::FALSE);
+      REQUIRE(rws.is_reduced() == tril::unknown);
     }
 
     LIBSEMIGROUPS_TEMPLATE_TEST_CASE("RewritingSystem",

--- a/tests/test-rewriting-system.cpp
+++ b/tests/test-rewriting-system.cpp
@@ -352,9 +352,8 @@ namespace libsemigroups {
                                          {{0}, {0, 2}},
                                          {{1, 2}, {1}},
                                          {{1, 2}, {2}}}));
-      REQUIRE(rewriting_system::is_length_non_increasing_no_reduce(rws)
-              == tril::unknown);
-      REQUIRE(rewriting_system::is_terminating_no_reduce(rws) == tril::unknown);
+      REQUIRE(rws.is_length_non_increasing_no_reduce() == tril::unknown);
+      REQUIRE(rws.is_terminating_no_reduce() == tril::unknown);
     }
 
     LIBSEMIGROUPS_TEST_CASE("RewritingSystemTrie<ReturnFalse>",
@@ -382,13 +381,13 @@ namespace libsemigroups {
                   {{{0, 0}, {2, 2, 2}}, {{1, 1, 1}, {2, 2, 2}}}));
       REQUIRE(!rws.confluent());
 
-      REQUIRE(!rewriting_system::is_length_non_increasing(rws));
-      REQUIRE(rewriting_system::is_terminating(rws) == tril::unknown);
+      REQUIRE(!rws.is_length_non_increasing());
+      REQUIRE(rws.is_terminating() == tril::unknown);
 
       std::string w({0, 0});
       rws.rewrite(w);
       REQUIRE(w == std::string({2, 2, 2}));
-      REQUIRE(rewriting_system::is_terminating(rws) == tril::unknown);
+      REQUIRE(rws.is_terminating() == tril::unknown);
     }
 
     LIBSEMIGROUPS_TEST_CASE("Rules", "013", "constructors/init", "[quick]") {
@@ -418,8 +417,8 @@ namespace libsemigroups {
       rws.init();
       REQUIRE(rws.number_of_rules() == 0);
       REQUIRE(rws.trie().number_of_nodes() == 1);
-      REQUIRE(rewriting_system::is_length_non_increasing(rws));
-      REQUIRE(rewriting_system::is_terminating(rws) == tril::TRUE);
+      REQUIRE(rws.is_length_non_increasing());
+      REQUIRE(rws.is_terminating() == tril::TRUE);
 
       rws.increase_alphabet_size_by(3);
       rewriting_system::add_rule(rws, "aaa"_w, "c"_w);
@@ -474,9 +473,9 @@ namespace libsemigroups {
       rws.increase_alphabet_size_by(3);
       rewriting_system::add_rule(rws, "bbb"_w, "aa"_w);
       rewriting_system::add_rule(rws, "bbb"_w, "ccc"_w);
-      REQUIRE(rewriting_system::is_terminating_no_reduce(rws) == tril::unknown);
+      REQUIRE(rws.is_terminating_no_reduce() == tril::unknown);
       REQUIRE(rws.is_reduced() == tril::unknown);
-      REQUIRE(rewriting_system::is_terminating(rws) == tril::TRUE);
+      REQUIRE(rws.is_terminating() == tril::TRUE);
       REQUIRE(rws.is_reduced() == tril::TRUE);
     }
 

--- a/tests/test-rewriting-system.cpp
+++ b/tests/test-rewriting-system.cpp
@@ -331,7 +331,7 @@ namespace libsemigroups {
       REQUIRE(!rt.confluent());
     }
 
-    LIBSEMIGROUPS_TEST_CASE("RewritingSystemTrie<ReturnFalse>",
+    LIBSEMIGROUPS_TEST_CASE("RewritingSystemTrie<NoOrder>",
                             "011",
                             "not obviously terminating example",
                             "[quick]") {
@@ -357,10 +357,10 @@ namespace libsemigroups {
                                          {{1, 2}, {1}},
                                          {{1, 2}, {2}}}));
       REQUIRE(rws.is_length_non_increasing_no_reduce() == tril::unknown);
-      REQUIRE(rws.is_terminating_no_reduce() == tril::unknown);
+      REQUIRE(rws.is_terminating_no_reduce() == tril::FALSE);
     }
 
-    LIBSEMIGROUPS_TEST_CASE("RewritingSystemTrie<ReturnFalse>",
+    LIBSEMIGROUPS_TEST_CASE("RewritingSystemTrie<NoOrder>",
                             "012",
                             "not obviously terminating example",
                             "[quick]") {
@@ -563,5 +563,20 @@ namespace libsemigroups {
                | rx::to_vector())
               == std::vector<rule_type>({{{1, 2}, {0, 2}}}));
     }
+    LIBSEMIGROUPS_TEST_CASE("RewritingSystem",
+                            "019",
+                            "is_terminating x2",
+                            "[quick]") {
+      auto                         rg = ReportGuard(false);
+      RewritingSystemTrie<NoOrder> rws;
+      rws.increase_alphabet_size_by(3);
+      rewriting_system::add_rule(rws, "aa"_w, "bab"_w);
+      rewriting_system::add_rule(rws, "ab"_w, "aa"_w);
+      REQUIRE(rws.is_terminating_no_reduce() == tril::unknown);
+      // Reduce runs forever, unless running in debug mode, in which case an
+      // assertion is raised.
+      // rws.reduce();
+    }
+
   }  // namespace detail
 }  // namespace libsemigroups

--- a/tests/test-rewriting-system.cpp
+++ b/tests/test-rewriting-system.cpp
@@ -468,12 +468,14 @@ namespace libsemigroups {
       REQUIRE(other_other_copy.trie().number_of_nodes() == 1);
     }
 
-    LIBSEMIGROUPS_TEST_CASE("RewritingSystem",
-                            "015",
-                            "is_terminating",
-                            "[quick]") {
-      auto                         rg = ReportGuard(false);
-      RewritingSystemTrie<NoOrder> rws;
+    LIBSEMIGROUPS_TEMPLATE_TEST_CASE("RewritingSystem",
+                                     "015",
+                                     "is_terminating",
+                                     "[quick]",
+                                     RewritingSystemSet<NoOrder>,
+                                     RewritingSystemTrie<NoOrder>) {
+      auto     rg = ReportGuard(false);
+      TestType rws;
       rws.increase_alphabet_size_by(3);
       rewriting_system::add_rule(rws, "bbb"_w, "aa"_w);
       rewriting_system::add_rule(rws, "bbb"_w, "ccc"_w);
@@ -563,12 +565,14 @@ namespace libsemigroups {
                | rx::to_vector())
               == std::vector<rule_type>({{{1, 2}, {0, 2}}}));
     }
-    LIBSEMIGROUPS_TEST_CASE("RewritingSystem",
-                            "019",
-                            "is_terminating x2",
-                            "[quick]") {
-      auto                         rg = ReportGuard(false);
-      RewritingSystemTrie<NoOrder> rws;
+    LIBSEMIGROUPS_TEMPLATE_TEST_CASE("RewritingSystem",
+                                     "019",
+                                     "is_terminating x2",
+                                     "[quick]",
+                                     RewritingSystemSet<NoOrder>,
+                                     RewritingSystemTrie<NoOrder>) {
+      auto     rg = ReportGuard(false);
+      TestType rws;
       rws.increase_alphabet_size_by(3);
       rewriting_system::add_rule(rws, "aa"_w, "bab"_w);
       rewriting_system::add_rule(rws, "ab"_w, "aa"_w);

--- a/tests/test-rewriting-system.cpp
+++ b/tests/test-rewriting-system.cpp
@@ -481,6 +481,10 @@ namespace libsemigroups {
       REQUIRE(rws.is_reduced() == tril::unknown);
       REQUIRE(rws.is_terminating() == tril::TRUE);
       REQUIRE(rws.is_reduced() == tril::TRUE);
+
+      rewriting_system::add_rule(rws, "a"_w, "aa"_w);
+      REQUIRE(rws.is_terminating_no_reduce() == tril::FALSE);
+      REQUIRE(rws.is_reduced() == tril::unknown);
     }
 
     LIBSEMIGROUPS_TEMPLATE_TEST_CASE("RewritingSystem",

--- a/tests/test-rewriting-system.cpp
+++ b/tests/test-rewriting-system.cpp
@@ -356,9 +356,8 @@ namespace libsemigroups {
                                          {{0}, {0, 2}},
                                          {{1, 2}, {1}},
                                          {{1, 2}, {2}}}));
-      REQUIRE(rewriting_system::is_length_non_increasing_no_reduce(rws)
-              == tril::unknown);
-      REQUIRE(rewriting_system::is_terminating_no_reduce(rws) == tril::unknown);
+      REQUIRE(rws.is_length_non_increasing_no_reduce() == tril::unknown);
+      REQUIRE(rws.is_terminating_no_reduce() == tril::unknown);
     }
 
     LIBSEMIGROUPS_TEST_CASE("RewritingSystemTrie<ReturnFalse>",
@@ -386,13 +385,13 @@ namespace libsemigroups {
                   {{{0, 0}, {2, 2, 2}}, {{1, 1, 1}, {2, 2, 2}}}));
       REQUIRE(!rws.confluent());
 
-      REQUIRE(!rewriting_system::is_length_non_increasing(rws));
-      REQUIRE(rewriting_system::is_terminating(rws) == tril::unknown);
+      REQUIRE(!rws.is_length_non_increasing());
+      REQUIRE(rws.is_terminating() == tril::unknown);
 
       std::string w({0, 0});
       rws.rewrite(w);
       REQUIRE(w == std::string({2, 2, 2}));
-      REQUIRE(rewriting_system::is_terminating(rws) == tril::unknown);
+      REQUIRE(rws.is_terminating() == tril::unknown);
     }
 
     LIBSEMIGROUPS_TEST_CASE("Rules", "013", "constructors/init", "[quick]") {
@@ -422,8 +421,8 @@ namespace libsemigroups {
       rws.init();
       REQUIRE(rws.number_of_rules() == 0);
       REQUIRE(rws.trie().number_of_nodes() == 1);
-      REQUIRE(rewriting_system::is_length_non_increasing(rws));
-      REQUIRE(rewriting_system::is_terminating(rws) == tril::TRUE);
+      REQUIRE(rws.is_length_non_increasing());
+      REQUIRE(rws.is_terminating() == tril::TRUE);
 
       rws.increase_alphabet_size_by(3);
       rewriting_system::add_rule(rws, "aaa"_w, "c"_w);
@@ -478,9 +477,9 @@ namespace libsemigroups {
       rws.increase_alphabet_size_by(3);
       rewriting_system::add_rule(rws, "bbb"_w, "aa"_w);
       rewriting_system::add_rule(rws, "bbb"_w, "ccc"_w);
-      REQUIRE(rewriting_system::is_terminating_no_reduce(rws) == tril::unknown);
+      REQUIRE(rws.is_terminating_no_reduce() == tril::unknown);
       REQUIRE(rws.is_reduced() == tril::unknown);
-      REQUIRE(rewriting_system::is_terminating(rws) == tril::TRUE);
+      REQUIRE(rws.is_terminating() == tril::TRUE);
       REQUIRE(rws.is_reduced() == tril::TRUE);
     }
 


### PR DESCRIPTION
This PR adds improvements to `is_terminating`, makes it a member function of `RewritingSystemTrie` and uses the function to try and prevent against infinite loops of rewriting. Specifically, if a the left-hand-side of a rule is contained within the right-hand-side of a rule, `is_terminating_no_reduce` will now return `tril::FALSE`.