### PR TITLE
RewritingSystem: Add `confluence_percentage`

### DIFF
--- a/include/libsemigroups/detail/rewriting-system.hpp
+++ b/include/libsemigroups/detail/rewriting-system.hpp
@@ -292,9 +292,7 @@ namespace libsemigroups {
                                    Iterator first2,
                                    Iterator last2);
 
-      [[nodiscard]] std::pair<size_t, size_t> confluence_ratio() override {
-        return {0, 0};
-      }
+      [[nodiscard]] std::pair<size_t, size_t> confluence_ratio() override;
 
       // Returns true if the system changes as a result of this call (i.e. it
       // wasn't reduced before but now it is)

--- a/include/libsemigroups/detail/rewriting-system.hpp
+++ b/include/libsemigroups/detail/rewriting-system.hpp
@@ -395,6 +395,8 @@ namespace libsemigroups {
         return *this;
       }
 
+      [[nodiscard]] std::pair<size_t, size_t> confluence_percentage();
+
       // Returns true if the system changes as a result of this call (i.e. it
       // wasn't reduced before but now it is)
       bool reduce();
@@ -433,9 +435,18 @@ namespace libsemigroups {
       // Confluence
       ////////////////////////////////////////////////////////////////////////
 
+      [[nodiscard]] bool overlap_confluent(Rule const*  rule1,
+                                           Rule const*  rule2,
+                                           size_t const overlap_length) const;
+
       [[nodiscard]] bool descendants_confluent(Rule const* rule1,
                                                index_type  current_node,
                                                size_t backtrack_depth) const;
+
+      [[nodiscard]] std::pair<size_t, size_t>
+      number_descendants_confluent(Rule const* rule1,
+                                   index_type  current_node,
+                                   size_t      overlap_length) const;
 
       [[nodiscard]] bool confluent_impl(std::atomic_uint64_t&) override;
 

--- a/include/libsemigroups/detail/rewriting-system.hpp
+++ b/include/libsemigroups/detail/rewriting-system.hpp
@@ -437,9 +437,11 @@ namespace libsemigroups {
       // Confluence
       ////////////////////////////////////////////////////////////////////////
 
-      [[nodiscard]] bool overlap_confluent(Rule const*  rule1,
-                                           Rule const*  rule2,
-                                           size_t const overlap_length) const;
+      [[nodiscard]] bool overlap_confluent(Rule const*       rule1,
+                                           Rule const*       rule2,
+                                           size_t const      overlap_length,
+                                           native_word_type& word1,
+                                           native_word_type& word2) const;
 
       [[nodiscard]] bool descendants_confluent(Rule const* rule1,
                                                index_type  current_node,

--- a/include/libsemigroups/detail/rewriting-system.hpp
+++ b/include/libsemigroups/detail/rewriting-system.hpp
@@ -137,8 +137,6 @@ namespace libsemigroups {
         return _confluence_known;
       }
 
-      [[nodiscard]] virtual std::pair<size_t, size_t> confluence_ratio() = 0;
-
       // If there are no pending_rules, then the system is reduced. If there
       // are pending rules the system may be reduced or not depending on the
       // pending rules. There doesn't seem to be an easier way of checking if
@@ -292,7 +290,7 @@ namespace libsemigroups {
                                    Iterator first2,
                                    Iterator last2);
 
-      [[nodiscard]] std::pair<size_t, size_t> confluence_ratio() override;
+      [[nodiscard]] std::pair<size_t, size_t> confluence_ratio();
 
       // Returns true if the system changes as a result of this call (i.e. it
       // wasn't reduced before but now it is)
@@ -399,7 +397,7 @@ namespace libsemigroups {
         return *this;
       }
 
-      [[nodiscard]] std::pair<size_t, size_t> confluence_ratio() override;
+      [[nodiscard]] std::pair<size_t, size_t> confluence_ratio();
 
       // Returns true if the system changes as a result of this call (i.e. it
       // wasn't reduced before but now it is)

--- a/include/libsemigroups/detail/rewriting-system.hpp
+++ b/include/libsemigroups/detail/rewriting-system.hpp
@@ -137,6 +137,8 @@ namespace libsemigroups {
         return _confluence_known;
       }
 
+      [[nodiscard]] virtual std::pair<size_t, size_t> confluence_ratio() = 0;
+
       // If there are no pending_rules, then the system is reduced. If there
       // are pending rules the system may be reduced or not depending on the
       // pending rules. There doesn't seem to be an easier way of checking if
@@ -290,6 +292,10 @@ namespace libsemigroups {
                                    Iterator first2,
                                    Iterator last2);
 
+      [[nodiscard]] std::pair<size_t, size_t> confluence_ratio() override {
+        return {0, 0};
+      }
+
       // Returns true if the system changes as a result of this call (i.e. it
       // wasn't reduced before but now it is)
       bool reduce();
@@ -395,7 +401,7 @@ namespace libsemigroups {
         return *this;
       }
 
-      [[nodiscard]] std::pair<size_t, size_t> confluence_percentage();
+      [[nodiscard]] std::pair<size_t, size_t> confluence_ratio() override;
 
       // Returns true if the system changes as a result of this call (i.e. it
       // wasn't reduced before but now it is)

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -692,33 +692,34 @@ namespace libsemigroups::detail {
   // Confluence
   ////////////////////////////////////////////////////////////////////////
 
+  // TODO(1): Consider moving this into RewriterBase so that it can be used by
+  // RewritingSystemSet. This would require making <rewrite_no_reduce> a virtual
+  // function, so maybe we don't want to do this.
   template <typename ReductionOrder>
   bool RewritingSystemTrie<ReductionOrder>::overlap_confluent(
-      Rule const*  rule1,
-      Rule const*  rule2,
-      size_t const overlap_length) const {
-    // Word looks like ABC where the LHS of rule1 corresponds to AB, the LHS of
-    // rule2 corresponds to BC, and |C|= nodes.size() - 1.
-    // AB -> X,
-    // BC -> Y,
-    // ABC gets rewritten to XC and AY
-    // TODO(1) remove allocation, use a MultiView, and check equality,
-    // then copy inside the if-condition
-    native_word_type word1;
-    native_word_type word2;
+      Rule const*       rule1,
+      Rule const*       rule2,
+      size_t const      overlap_length,
+      native_word_type& word1,
+      native_word_type& word2) const {
+    // Overlapped word looks like ABC where the LHS of rule1 corresponds to
+    // AB, the LHS of rule2 corresponds to BC, and |B|= overlap_length.
+    // If AB -> X, BC -> Y, then ABC gets rewritten to XC and AY
+    MultiView<native_word_type> word1_view(rule1->rhs());  // X
+    word1_view.append(rule2->lhs().cbegin() + overlap_length,
+                      rule2->lhs().cend());  // C
 
-    word1.assign(rule1->rhs());  // X
-    word1.append(rule2->lhs().cbegin() + overlap_length,
-                 rule2->lhs().cend());  // C
+    MultiView<native_word_type> word2_view(rule1->lhs().cbegin(),
+                                           rule1->lhs().cend()
+                                               - overlap_length);   // A
+    word2_view.append(rule2->rhs().cbegin(), rule2->rhs().cend());  // Y
 
-    word2.assign(rule1->lhs().cbegin(),
-                 rule1->lhs().cend() - overlap_length);  // A
-    word2.append(rule2->rhs());                          // Y
-
-    if (word1 == word2) {
+    if (word1_view == word2_view) {
       return true;
     }
 
+    word1.assign(word1_view);
+    word2.assign(word2_view);
     rewrite_no_reduce(word1);
     rewrite_no_reduce(word2);
     if (word1 == word2) {
@@ -734,6 +735,8 @@ namespace libsemigroups::detail {
       Rule const* rule1,
       index_type  current_node,
       size_t      overlap_length) const {
+    native_word_type                                word_1;
+    native_word_type                                word_2;
     std::stack<index_type, std::vector<index_type>> stack;
     stack.push(current_node);
 
@@ -743,7 +746,7 @@ namespace libsemigroups::detail {
       LIBSEMIGROUPS_ASSERT(rule1->state() == Rule::State::active);
       if (_rule_trie.node_no_checks(current_node).terminal()) {
         Rule const* rule2 = _rule_trie.node_no_checks(current_node).value();
-        if (!overlap_confluent(rule1, rule2, overlap_length)) {
+        if (!overlap_confluent(rule1, rule2, overlap_length, word_1, word_2)) {
           return false;
         }
       }
@@ -766,6 +769,8 @@ namespace libsemigroups::detail {
       Rule const* rule1,
       index_type  current_node,
       size_t      overlap_length) const {
+    native_word_type                                word_1;
+    native_word_type                                word_2;
     std::pair<size_t, size_t>                       confluence_fraction;
     std::stack<index_type, std::vector<index_type>> stack;
     stack.push(current_node);
@@ -777,7 +782,7 @@ namespace libsemigroups::detail {
       if (_rule_trie.node_no_checks(current_node).terminal()) {
         Rule const* rule2 = _rule_trie.node_no_checks(current_node).value();
         ++confluence_fraction.second;
-        if (overlap_confluent(rule1, rule2, overlap_length)) {
+        if (overlap_confluent(rule1, rule2, overlap_length, word_1, word_2)) {
           ++confluence_fraction.first;
         }
       }

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -626,6 +626,107 @@ namespace libsemigroups::detail {
   ////////////////////////////////////////////////////////////////////////
 
   template <typename ReductionOrder>
+  bool RewritingSystemTrie<ReductionOrder>::overlap_confluent(
+      Rule const*  rule1,
+      Rule const*  rule2,
+      size_t const overlap_length) const {
+    // Word looks like ABC where the LHS of rule1 corresponds to AB, the LHS of
+    // rule2 corresponds to BC, and |C|= nodes.size() - 1.
+    // AB -> X,
+    // BC -> Y,
+    // ABC gets rewritten to XC and AY
+    // TODO(1) remove allocation, use a MultiView, and check equality,
+    // then copy inside the if-condition
+    native_word_type word1;
+    native_word_type word2;
+
+    word1.assign(rule1->rhs());  // X
+    word1.append(rule2->lhs().cbegin() + overlap_length,
+                 rule2->lhs().cend());  // C
+
+    word2.assign(rule1->lhs().cbegin(),
+                 rule1->lhs().cend() - overlap_length);  // A
+    word2.append(rule2->rhs());                          // Y
+
+    if (word1 == word2) {
+      return true;
+    }
+
+    rewrite_no_reduce(word1);
+    rewrite_no_reduce(word2);
+    if (word1 == word2) {
+      return true;
+    }
+
+    set_cached_confluent(tril::FALSE);
+    return false;
+  }
+
+  template <typename ReductionOrder>
+  bool RewritingSystemTrie<ReductionOrder>::descendants_confluent(
+      Rule const* rule1,
+      index_type  current_node,
+      size_t      overlap_length) const {
+    std::stack<index_type, std::vector<index_type>> stack;
+    stack.push(current_node);
+
+    while (!stack.empty()) {
+      current_node = stack.top();
+      stack.pop();
+      LIBSEMIGROUPS_ASSERT(rule1->state() == Rule::State::active);
+      if (_rule_trie.node_no_checks(current_node).terminal()) {
+        Rule const* rule2 = _rule_trie.node_no_checks(current_node).value();
+        if (!overlap_confluent(rule1, rule2, overlap_length)) {
+          return false;
+        }
+      }
+
+      // Read each possible letter and traverse down the trie
+      for (letter_type x = 0; x != _rule_trie.alphabet_size(); ++x) {
+        auto child = _rule_trie.child_no_checks(current_node, x);
+        if (child != UNDEFINED) {
+          stack.push(child);
+        }
+      }
+    }
+    return true;
+  }
+
+  // TODO(1): Remove duplication with descendants_confluent
+  template <typename ReductionOrder>
+  std::pair<size_t, size_t>
+  RewritingSystemTrie<ReductionOrder>::number_descendants_confluent(
+      Rule const* rule1,
+      index_type  current_node,
+      size_t      overlap_length) const {
+    std::pair<size_t, size_t>                       confluence_fraction;
+    std::stack<index_type, std::vector<index_type>> stack;
+    stack.push(current_node);
+
+    while (!stack.empty()) {
+      current_node = stack.top();
+      stack.pop();
+      LIBSEMIGROUPS_ASSERT(rule1->state() == Rule::State::active);
+      if (_rule_trie.node_no_checks(current_node).terminal()) {
+        Rule const* rule2 = _rule_trie.node_no_checks(current_node).value();
+        ++confluence_fraction.second;
+        if (overlap_confluent(rule1, rule2, overlap_length)) {
+          ++confluence_fraction.first;
+        }
+      }
+
+      // Read each possible letter and traverse down the trie
+      for (letter_type x = 0; x != _rule_trie.alphabet_size(); ++x) {
+        auto child = _rule_trie.child_no_checks(current_node, x);
+        if (child != UNDEFINED) {
+          stack.push(child);
+        }
+      }
+    }
+    return confluence_fraction;
+  }
+
+  template <typename ReductionOrder>
   bool RewritingSystemTrie<ReductionOrder>::confluent_impl(
       std::atomic_uint64_t& seen) {
     using std::chrono::time_point;
@@ -661,56 +762,32 @@ namespace libsemigroups::detail {
   }
 
   template <typename ReductionOrder>
-  bool RewritingSystemTrie<ReductionOrder>::descendants_confluent(
-      Rule const* rule1,
-      index_type  current_node,
-      size_t      overlap_length) const {
-    std::stack<index_type, std::vector<index_type>> stack;
-    stack.push(current_node);
+  std::pair<size_t, size_t>
+  RewritingSystemTrie<ReductionOrder>::confluence_percentage() {
+    std::pair<size_t, size_t> confluence_fraction;
+    reduce();
+    index_type link;
 
-    while (!stack.empty()) {
-      current_node = stack.top();
-      stack.pop();
-      LIBSEMIGROUPS_ASSERT(rule1->state() == Rule::State::active);
-      if (_rule_trie.node_no_checks(current_node).terminal()) {
-        Rule const* rule2 = _rule_trie.node_no_checks(current_node).value();
-        // Process overlap
-        // Word looks like ABC where the LHS of rule1 corresponds to AB,
-        // the LHS of rule2 corresponds to BC, and |C|=nodes.size() - 1.
-        // AB -> X, BC -> Y
-        // ABC gets rewritten to XC and AY
-        // TODO(1) remove allocation, use a MultiView, and check equality,
-        // then copy inside the if-condition
-        native_word_type word1;
-        native_word_type word2;
+    // For each rule, count how many descendents of any suffix breaks confluence
+    for (auto node_it = _rule_trie.cbegin_terminal_nodes();
+         node_it != _rule_trie.cend_terminal_nodes();
+         ++node_it) {
+      link = _rule_trie.node_no_checks(*node_it).suffix_link();
+      LIBSEMIGROUPS_ASSERT(*node_it != _rule_trie.root);
+      while (link != _rule_trie.root) {
+        std::pair<size_t, size_t> const descendants_confluence_fraction
+            = number_descendants_confluent(
+                _rule_trie.node_no_checks(*node_it).value(),
+                link,
+                _rule_trie.node_no_checks(link).height());
+        confluence_fraction.first += descendants_confluence_fraction.first;
+        confluence_fraction.second += descendants_confluence_fraction.second;
 
-        word1.assign(rule1->rhs());  // X
-        word1.append(rule2->lhs().cbegin() + overlap_length,
-                     rule2->lhs().cend());  // C
-
-        word2.assign(rule1->lhs().cbegin(),
-                     rule1->lhs().cend() - overlap_length);  // A
-        word2.append(rule2->rhs());                          // Y
-
-        if (word1 != word2) {
-          rewrite_no_reduce(word1);
-          rewrite_no_reduce(word2);
-          if (word1 != word2) {
-            set_cached_confluent(tril::FALSE);
-            return false;
-          }
-        }
-      }
-
-      // Read each possible letter and traverse down the trie
-      for (letter_type x = 0; x != _rule_trie.alphabet_size(); ++x) {
-        auto child = _rule_trie.child_no_checks(current_node, x);
-        if (child != UNDEFINED) {
-          stack.push(child);
-        }
+        link = _rule_trie.node_no_checks(link).suffix_link();
       }
     }
-    return true;
+
+    return confluence_fraction;
   }
 
   ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -763,7 +763,7 @@ namespace libsemigroups::detail {
 
   template <typename ReductionOrder>
   std::pair<size_t, size_t>
-  RewritingSystemTrie<ReductionOrder>::confluence_percentage() {
+  RewritingSystemTrie<ReductionOrder>::confluence_ratio() {
     std::pair<size_t, size_t> confluence_fraction;
     reduce();
     index_type link;

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -238,8 +238,13 @@ namespace libsemigroups::detail {
         Rule const* rule2 = *it2;
         for (auto it = rule1->lhs().cend() - 1; it >= rule1->lhs().cbegin();
              --it) {
-          // Find longest common prefix of suffix B of rule1.lhs() defined
-          // by it and R = rule2.lhs()
+          if (rule1 == rule2 && it == rule1->lhs().cbegin()) {
+            continue;
+          }
+          // TODO(1): Remove duplication between this and
+          // RewritingSystemTrie::overlap_confluent
+          // Find longest common prefix of suffix B of rule1.lhs() defined by it
+          // and R = rule2.lhs()
           auto prefix = maximum_common_prefix(it,
                                               rule1->lhs().cend(),
                                               rule2->lhs().cbegin(),
@@ -277,6 +282,68 @@ namespace libsemigroups::detail {
       report_checking_confluence(seen, start_time);
     }
     return cached_confluent();
+  }
+
+  // TODO(1): Remove duplication between this function and confluent_impl
+  template <typename ReductionOrder>
+  std::pair<size_t, size_t>
+  RewritingSystemSet<ReductionOrder>::confluence_ratio() {
+    reduce();
+    std::pair<size_t, size_t> confluence_ratio{0, 0};
+    native_word_type          word1;
+    native_word_type          word2;
+
+    for (auto it1 = Rules::active_rules().begin();
+         it1 != Rules::active_rules().end();
+         ++it1) {
+      Rule const* rule1 = *it1;
+      // Seems to be much faster to do this in reverse.
+      for (auto it2 = Rules::active_rules().rbegin();
+           it2 != Rules::active_rules().rend();
+           ++it2) {
+        Rule const* rule2 = *it2;
+        for (auto it = rule1->lhs().cend() - 1; it >= rule1->lhs().cbegin();
+             --it) {
+          if (rule1 == rule2 && it == rule1->lhs().cbegin()) {
+            continue;
+          }
+          // Find longest common prefix of a suffix of rule1->lhs() and
+          // rule2->rhs(). If this prefix is also a suffix of either
+          // rule1->lhs() or rule2->lhs(), then there is an overlap that needs
+          // to be checked.
+          auto prefix = maximum_common_prefix(it,
+                                              rule1->lhs().cend(),
+                                              rule2->lhs().cbegin(),
+                                              rule2->lhs().cend());
+          if (prefix.first == rule1->lhs().cend()
+              || prefix.second == rule2->lhs().cend()) {
+            confluence_ratio.first++;
+            confluence_ratio.second++;
+            // Seems that this function isn't called enough to merit using
+            // MSV's here.
+            word1.assign(rule1->lhs().cbegin(),
+                         it);            // A
+            word1.append(rule2->rhs());  // S
+            word1.append(prefix.first,
+                         rule1->lhs().cend());  // D
+
+            word2.assign(rule1->rhs());  // Q
+            word2.append(prefix.second,
+                         rule2->lhs().cend());  // E
+
+            if (word1 != word2) {
+              rewrite_no_reduce(word1);
+              rewrite_no_reduce(word2);
+              if (word1 != word2) {
+                set_cached_confluent(tril::FALSE);
+                confluence_ratio.first--;
+              }
+            }
+          }
+        }
+      }
+    }
+    return confluence_ratio;
   }
 
   ////////////////////////////////////////////////////////////////////////
@@ -764,7 +831,7 @@ namespace libsemigroups::detail {
   template <typename ReductionOrder>
   std::pair<size_t, size_t>
   RewritingSystemTrie<ReductionOrder>::confluence_ratio() {
-    std::pair<size_t, size_t> confluence_fraction;
+    std::pair<size_t, size_t> confluence_fraction{0, 0};
     reduce();
     index_type link;
 

--- a/tests/test-rewriting-system.cpp
+++ b/tests/test-rewriting-system.cpp
@@ -479,5 +479,29 @@ namespace libsemigroups {
       REQUIRE(rewriting_system::is_terminating(rws) == tril::TRUE);
       REQUIRE(rws.is_reduced() == tril::TRUE);
     }
+
+    LIBSEMIGROUPS_TEST_CASE("RewritingSystem",
+                            "016",
+                            "confluence_percentage",
+                            "[quick]") {
+      auto                           rg = ReportGuard(false);
+      RewritingSystemTrie<LenLexCmp> rws;
+      REQUIRE(rws.confluence_percentage() == std::pair<size_t, size_t>{0, 0});
+
+      rws.increase_alphabet_size_by(2);
+      rewriting_system::add_rule(rws, "ab"_w, "b"_w);
+      REQUIRE(rws.confluence_percentage() == std::pair<size_t, size_t>{0, 0});
+
+      rws.increase_alphabet_size_by(1);
+      rewriting_system::add_rule(rws, "ca"_w, "c"_w);
+      REQUIRE(rws.confluence_percentage() == std::pair<size_t, size_t>{1, 1});
+      REQUIRE(rws.confluent());
+
+      rewriting_system::add_rule(rws, "ba"_w, "a"_w);
+      REQUIRE(!rws.confluent_known());
+      REQUIRE(rws.confluence_percentage() == std::pair<size_t, size_t>{1, 3});
+      REQUIRE(rws.confluent_known());
+      REQUIRE(!rws.confluent());
+    }
   }  // namespace detail
 }  // namespace libsemigroups

--- a/tests/test-rewriting-system.cpp
+++ b/tests/test-rewriting-system.cpp
@@ -482,24 +482,24 @@ namespace libsemigroups {
 
     LIBSEMIGROUPS_TEST_CASE("RewritingSystem",
                             "016",
-                            "confluence_percentage",
+                            "confluence_ratio",
                             "[quick]") {
       auto                           rg = ReportGuard(false);
       RewritingSystemTrie<LenLexCmp> rws;
-      REQUIRE(rws.confluence_percentage() == std::pair<size_t, size_t>{0, 0});
+      REQUIRE(rws.confluence_ratio() == std::pair<size_t, size_t>{0, 0});
 
       rws.increase_alphabet_size_by(2);
       rewriting_system::add_rule(rws, "ab"_w, "b"_w);
-      REQUIRE(rws.confluence_percentage() == std::pair<size_t, size_t>{0, 0});
+      REQUIRE(rws.confluence_ratio() == std::pair<size_t, size_t>{0, 0});
 
       rws.increase_alphabet_size_by(1);
       rewriting_system::add_rule(rws, "ca"_w, "c"_w);
-      REQUIRE(rws.confluence_percentage() == std::pair<size_t, size_t>{1, 1});
+      REQUIRE(rws.confluence_ratio() == std::pair<size_t, size_t>{1, 1});
       REQUIRE(rws.confluent());
 
       rewriting_system::add_rule(rws, "ba"_w, "a"_w);
       REQUIRE(!rws.confluent_known());
-      REQUIRE(rws.confluence_percentage() == std::pair<size_t, size_t>{1, 3});
+      REQUIRE(rws.confluence_ratio() == std::pair<size_t, size_t>{1, 3});
       REQUIRE(rws.confluent_known());
       REQUIRE(!rws.confluent());
     }

--- a/tests/test-rewriting-system.cpp
+++ b/tests/test-rewriting-system.cpp
@@ -480,12 +480,14 @@ namespace libsemigroups {
       REQUIRE(rws.is_reduced() == tril::TRUE);
     }
 
-    LIBSEMIGROUPS_TEST_CASE("RewritingSystem",
-                            "016",
-                            "confluence_ratio",
-                            "[quick]") {
-      auto                           rg = ReportGuard(false);
-      RewritingSystemTrie<LenLexCmp> rws;
+    LIBSEMIGROUPS_TEMPLATE_TEST_CASE("RewritingSystem",
+                                     "016",
+                                     "confluence_ratio",
+                                     "[quick]",
+                                     RewritingSystemSet<LenLexCmp>,
+                                     RewritingSystemTrie<LenLexCmp>) {
+      auto     rg = ReportGuard(false);
+      TestType rws;
       REQUIRE(rws.confluence_ratio() == std::pair<size_t, size_t>{0, 0});
 
       rws.increase_alphabet_size_by(2);


### PR DESCRIPTION
This PR adds a function that computes the proportion of critical pairs do not break confluence. There is quite a bit in common with the existing `confluence` functions; I have attempted to reduce duplication where it seemed easy to do so, but it might be worthwhile spending a bit more time to de-duplicate further.