### PR TITLE
Refactor standardize

### DIFF
--- a/include/libsemigroups/detail/containers.hpp
+++ b/include/libsemigroups/detail/containers.hpp
@@ -34,10 +34,12 @@
 #include <utility>           // for forward
 #include <vector>            // for vector, allocator
 
+#include "libsemigroups/adapters.hpp"   // for LIBSEMIGROUPS_ASSERT
+#include "libsemigroups/constants.hpp"  // for UNDEFINED
+#include "libsemigroups/debug.hpp"      // for Hash
+
 #include "iterator.hpp"  // for ConstIteratorStateful, ConstItera...
-#include "libsemigroups/adapters.hpp"  // for LIBSEMIGROUPS_ASSERT
-#include "libsemigroups/debug.hpp"     // for Hash
-#include "string.hpp"                  // for to_string
+#include "string.hpp"    // for to_string
 
 namespace libsemigroups {
   namespace detail {
@@ -799,19 +801,28 @@ namespace libsemigroups {
       // The following is adapted from http://bit.ly/2X4xPlK
       // TODO(1): a checks version
       // Not noexcept because std::vector::operator[] isn't
+      // p represents a partial permutation of the form old -> new. That is, if
+      // the input vector is [a, b, c], and p is [1, 2, 0], then permuted vector
+      // will be [c, a, b]. Values set to UNDEFINED are ignored.
+      // In previous versions of this function, the input permutation was of the
+      // form new -> old, so the permuted vector would have been [b, c, a].
       template <typename T, typename... Args>
-      void apply_row_permutation_no_checks(std::vector<T> p, Args&&... args) {
-        for (size_t start = 0; start < p.size(); ++start) {
-          size_t current = start;
-          while (start != p[current]) {
-            size_t next = p[current];
+      void apply_row_permutation_no_copy_no_checks(std::vector<T>& p,
+                                                   Args&&... args) {
+        for (size_t current = 0; current < p.size(); ++current) {
+          while (current != p[current] && p[current] != UNDEFINED) {
+            size_t const next = p[current];
             (std::forward<Args>(args).swap_rows(next, current), ...);
-            p[current] = current;
-            current    = next;
+            std::swap(p[next], p[current]);
           }
-          p[current] = current;
         }
       }
+
+      template <typename T, typename... Args>
+      void apply_row_permutation_no_checks(std::vector<T> p, Args&&... args) {
+        apply_row_permutation_no_copy_no_checks(p, std::forward<Args>(args)...);
+      }
+
     }  // namespace dynamic_array2
 
     // StaticVector1 wraps an array, providing it with some of the syntax of

--- a/include/libsemigroups/detail/node-managed-graph.hpp
+++ b/include/libsemigroups/detail/node-managed-graph.hpp
@@ -219,7 +219,7 @@ namespace libsemigroups {
       bool process_coincidences(Functor&& = Noop{});
 
       void standardize(std::vector<node_type> const& p,
-                       std::vector<node_type> const& q) {
+                       std::vector<node_type>&       q) {
         auto& c = lookahead_cursor();
         if (c < q.size()) {
           c = q[c];
@@ -230,7 +230,7 @@ namespace libsemigroups {
       }
 
       void permute_nodes_no_checks(std::vector<node_type> const& p,
-                                   std::vector<node_type> const& q) {
+                                   std::vector<node_type>&       q) {
         BaseGraph::permute_nodes_no_checks(
             p, q, NodeManager<node_type>::number_of_nodes_active());
         NodeManager<node_type>::apply_permutation(p);

--- a/include/libsemigroups/detail/node-managed-graph.hpp
+++ b/include/libsemigroups/detail/node-managed-graph.hpp
@@ -218,6 +218,8 @@ namespace libsemigroups {
       template <typename Functor = Noop>
       bool process_coincidences(Functor&& = Noop{});
 
+      // q is not not const here because permute_nodes_no_checks changes q in
+      // place.
       void standardize(std::vector<node_type> const& p,
                        std::vector<node_type>&       q) {
         auto& c = lookahead_cursor();

--- a/include/libsemigroups/detail/node-managed-graph.hpp
+++ b/include/libsemigroups/detail/node-managed-graph.hpp
@@ -220,8 +220,8 @@ namespace libsemigroups {
 
       // q is not not const here because permute_nodes_no_checks changes q in
       // place.
-      void standardize(std::vector<node_type> const& p,
-                       std::vector<node_type>&       q) {
+      void standardize_no_checks(std::vector<node_type> const& p,
+                                 std::vector<node_type>&       q) {
         auto& c = lookahead_cursor();
         if (c < q.size()) {
           c = q[c];

--- a/include/libsemigroups/detail/stephen-impl.hpp
+++ b/include/libsemigroups/detail/stephen-impl.hpp
@@ -197,7 +197,7 @@ namespace libsemigroups {
       }
 
       void standardize() {
-        v4::word_graph::standardize(_word_graph);
+        v4::word_graph::standardize_no_checks(_word_graph);
         _word_graph.induced_subgraph_no_checks(
             0, _word_graph.number_of_nodes_active());
       }

--- a/include/libsemigroups/detail/stephen-impl.tpp
+++ b/include/libsemigroups/detail/stephen-impl.tpp
@@ -99,7 +99,7 @@ namespace libsemigroups {
       }
 
       void disjoint_union_inplace_no_checks(StephenGraph& that) {
-        v4::word_graph::standardize(that);
+        v4::word_graph::standardize_no_checks(that);
         LIBSEMIGROUPS_ASSERT(v4::word_graph::is_standardized(that));
         size_t const N = number_of_nodes_active();
         // TODO(2): the following 2 lines are a bit awkward

--- a/include/libsemigroups/detail/stephen-impl.tpp
+++ b/include/libsemigroups/detail/stephen-impl.tpp
@@ -228,9 +228,14 @@ namespace libsemigroups {
       // NodeManager) and number_active_nodes (in WordGraph), this is super
       // confusing!
       size_t const N = _word_graph.number_of_nodes_active();
+
+      // accept_state() may call run, so we get the value before attempting to
+      // modify the graph
+      StephenImpl<PresentationType>::node_type const accept_state
+          = StephenImpl<PresentationType>::accept_state();
+
       _word_graph.disjoint_union_inplace_no_checks(that._word_graph);
-      _word_graph.merge_nodes_no_checks(accept_state(),
-                                        that.initial_state() + N);
+      _word_graph.merge_nodes_no_checks(accept_state, that.initial_state() + N);
       _word_graph.process_coincidences();
       _accept_state = UNDEFINED;
       _finished     = false;

--- a/include/libsemigroups/detail/todd-coxeter-impl.hpp
+++ b/include/libsemigroups/detail/todd-coxeter-impl.hpp
@@ -369,7 +369,7 @@ namespace libsemigroups {
         ////////////////////////////////////////////////////////////////////////
 
         using FelschGraph_::presentation;
-        using FelschGraph_::standardize;
+        using FelschGraph_::standardize_no_checks;
         using FelschGraph_::target_no_checks;
 
         ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/detail/word-graph-with-sources.hpp
+++ b/include/libsemigroups/detail/word-graph-with-sources.hpp
@@ -157,7 +157,7 @@ namespace libsemigroups {
       // The permutation q must map the valid nodes to the [0, .. , n), where
       // n is the number of valid nodes, and p = q ^ -1.
       void permute_nodes_no_checks(std::vector<node_type> const& p,
-                                   std::vector<node_type> const& q,
+                                   std::vector<node_type>&       q,
                                    size_t                        n);
 
       // Swaps valid nodes c and d, if c or d is not valid, then this will

--- a/include/libsemigroups/detail/word-graph-with-sources.hpp
+++ b/include/libsemigroups/detail/word-graph-with-sources.hpp
@@ -155,7 +155,8 @@ namespace libsemigroups {
       void induced_subgraph_no_checks(node_type first, node_type last);
 
       // The permutation q must map the valid nodes to the [0, .. , n), where
-      // n is the number of valid nodes, and p = q ^ -1.
+      // n is the number of valid nodes, and p = q ^ -1. The vector q is not
+      // const because it is modified in-place.
       void permute_nodes_no_checks(std::vector<node_type> const& p,
                                    std::vector<node_type>&       q,
                                    size_t                        n);

--- a/include/libsemigroups/detail/word-graph-with-sources.tpp
+++ b/include/libsemigroups/detail/word-graph-with-sources.tpp
@@ -109,7 +109,7 @@ namespace libsemigroups {
     template <typename Node>
     void WordGraphWithSources<Node>::permute_nodes_no_checks(
         std::vector<node_type> const& p,
-        std::vector<node_type> const& q,
+        std::vector<node_type>&       q,
         size_t                        m) {
       // p : new -> old, q = p ^ -1
       // Permute all the values in the _table, and pre-images, that relate
@@ -127,7 +127,7 @@ namespace libsemigroups {
         }
       }
       // Permute the rows themselves
-      detail::dynamic_array2::apply_row_permutation_no_checks(
+      detail::dynamic_array2::apply_row_permutation_no_copy_no_checks(
           q, this->_dynamic_array_2, _preim_init, _preim_next);
     }
 

--- a/include/libsemigroups/detail/word-graph-with-sources.tpp
+++ b/include/libsemigroups/detail/word-graph-with-sources.tpp
@@ -111,6 +111,7 @@ namespace libsemigroups {
         std::vector<node_type> const& p,
         std::vector<node_type>&       q,
         size_t                        m) {
+      LIBSEMIGROUPS_ASSERT(m <= p.size());
       // p : new -> old, q = p ^ -1
       // Permute all the values in the _table, and pre-images, that relate
       // to active nodes

--- a/include/libsemigroups/detail/word-graph-with-sources.tpp
+++ b/include/libsemigroups/detail/word-graph-with-sources.tpp
@@ -128,7 +128,7 @@ namespace libsemigroups {
       }
       // Permute the rows themselves
       detail::dynamic_array2::apply_row_permutation_no_checks(
-          p, this->_dynamic_array_2, _preim_init, _preim_next);
+          q, this->_dynamic_array_2, _preim_init, _preim_next);
     }
 
     template <typename Node>

--- a/include/libsemigroups/detail/word-graph-with-sources.tpp
+++ b/include/libsemigroups/detail/word-graph-with-sources.tpp
@@ -106,6 +106,9 @@ namespace libsemigroups {
       }
     }
 
+    // The vector q is not const because apply_row_permutation_no_copy_no_checks
+    // modifies q in order to permute the array in-place without allocating
+    // additional memory.
     template <typename Node>
     void WordGraphWithSources<Node>::permute_nodes_no_checks(
         std::vector<node_type> const& p,

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -84,11 +84,7 @@ namespace libsemigroups {
     //! (Definition 1.2.14, page 24).
     //!
     //! \deprecated_warning{value} Use \ref Order::rpo instead.
-    recursive [[deprecated("Use rpo instead!")]] = rev_rpo,
-
-    //! The wreath ordering, as described in \cite Sims1994aa
-    //! (Section 3.8, page 138)
-    wreath
+    recursive [[deprecated("Use rpo instead!")]] = rev_rpo
   };
 
   //! \defgroup orders_group Orders

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -84,9 +84,11 @@ namespace libsemigroups {
     //! (Definition 1.2.14, page 24).
     //!
     //! \deprecated_warning{value} Use \ref Order::rpo instead.
-    recursive [[deprecated("Use rpo instead!")]] = rev_rpo
+    recursive [[deprecated("Use rpo instead!")]] = rev_rpo,
 
-    // wreath TODO(later)
+    //! The wreath ordering, as described in \cite Sims1994aa
+    //! (Section 3.8, page 138)
+    wreath
   };
 
   //! \defgroup orders_group Orders

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -84,11 +84,7 @@ namespace libsemigroups {
     //! (Definition 1.2.14, page 24).
     //!
     //! \deprecated_warning{value} Use \ref Order::rpo instead.
-    recursive [[deprecated("Use rpo instead!")]] = rev_rpo,
-
-    //! The wreath ordering, as described in \cite Sims1994aa
-    //! (Section 3.8, page 138)
-    wreath
+    recursive [[deprecated("Use rpo instead!")]] = rpo
   };
 
   //! \defgroup orders_group Orders

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -2643,6 +2643,11 @@ namespace libsemigroups {
       //! \exceptions
       //! \no_libsemigroups_except
       //!
+      //! \warning It is only guaranteed that the sub-word-graph induced by the
+      //! nodes reachable from 0 will be isomorphic before and after this
+      //! operation is performed. It is possible that other parts of the word
+      //! graph will not be isomorphic before and after standardization.
+      //!
       //! \note If any target of any edge in the word graph \p wg that is out of
       //! bounds, then this is ignored by this function.
       // Not nodiscard because sometimes we just don't want the output
@@ -2671,6 +2676,11 @@ namespace libsemigroups {
       //! \exceptions
       //! \no_libsemigroups_except
       //!
+      //! \warning It is only guaranteed that the sub-word-graph induced by the
+      //! nodes reachable from 0 will be isomorphic before and after this
+      //! operation is performed. It is possible that other parts of the word
+      //! graph will not be isomorphic before and after standardization.
+      //!
       //! \note If any target of any edge in the word graph \p wg that is out of
       //! bounds, then this is ignored by this function.
       // Not nodiscard because sometimes we just don't want the output
@@ -2689,7 +2699,7 @@ namespace libsemigroups {
       //! Order::lenlex).
       //!
       //! \throws LibsemigroupsException if \p val is not one of: Order::none,
-      //! Order::lenlex, Order::lex or Order::rpo.
+      //! Order::lenlex, Order::lex, Order::rpo, or Order::rev_rpo.
       //!
       //! \sa
       //! standardize.
@@ -2709,7 +2719,7 @@ namespace libsemigroups {
       //! Order::lenlex).
       //!
       //! \throws LibsemigroupsException if \p val is not one of: Order::none,
-      //! Order::lenlex, Order::lex or Order::rpo.
+      //! Order::lenlex, Order::lex, Order::rpo or Order::rev_rpo.
       //!
       //! \sa
       //! standardize.

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -39,17 +39,18 @@
 #include <utility>           // for pair, move, make_pair
 #include <vector>            // for vector, swap
 
-#include "libsemigroups/adapters.hpp"         // for Hash
-#include "libsemigroups/config.hpp"           // for LIBSEMIGROUPS_EIGEN_...
-#include "libsemigroups/constants.hpp"        // for UNDEFINED
-#include "libsemigroups/debug.hpp"            // for LIBSEMIGROUPS_ASSERT
-#include "libsemigroups/dot.hpp"              // for Dot
-#include "libsemigroups/exception.hpp"        // for LIBSEMIGROUPS_EXCEPTION
-#include "libsemigroups/forest.hpp"           // for Forest
-#include "libsemigroups/order.hpp"            // for Order
-#include "libsemigroups/types.hpp"            // for word_type, letter_type
-#include "libsemigroups/word-graph-view.hpp"  // for WordGraphView
-#include "libsemigroups/word-graph.hpp"       // for WordGraph
+#include "libsemigroups/adapters.hpp"   // for Hash
+#include "libsemigroups/config.hpp"     // for LIBSEMIGROUPS_EIGEN_...
+#include "libsemigroups/constants.hpp"  // for UNDEFINED
+#include "libsemigroups/debug.hpp"      // for LIBSEMIGROUPS_ASSERT
+#include "libsemigroups/dot.hpp"        // for Dot
+#include "libsemigroups/exception.hpp"  // for LIBSEMIGROUPS_EXCEPTION
+#include "libsemigroups/forest.hpp"     // for Forest
+#include "libsemigroups/is_specialization_of.hpp"  // for is_specialization_of
+#include "libsemigroups/order.hpp"                 // for Order
+#include "libsemigroups/types.hpp"                 // for word_type, letter_type
+#include "libsemigroups/word-graph-view.hpp"       // for WordGraphView
+#include "libsemigroups/word-graph.hpp"            // for WordGraph
 
 #include "libsemigroups/detail/fmt.hpp"     // for fmt::format
 #include "libsemigroups/detail/stl.hpp"     // for HasLessEqual

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -2771,6 +2771,7 @@ namespace libsemigroups {
       //!
       //! \sa
       //! standardize.
+      // TODO(1): Add is_standardized_no_checks?
       template <typename Node>
       bool is_standardized(WordGraphView<Node> const& wg,
                            Order                      val = Order::lenlex);

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -2643,14 +2643,14 @@ namespace libsemigroups {
       //! \exceptions
       //! \no_libsemigroups_except
       //!
+      //! \note If any target of any edge in the word graph \p wg that is out of
+      //! bounds, then this is ignored by this function.
+      // Not nodiscard because sometimes we just don't want the output
+      //!
       //! \warning If there are nodes in the \p wg that are not reachable from
       //! the node \c 0, then this function may not preserve \p wg up to
       //! isomorphism. However, the isomorphism type of the sub-word-graph
       //! consisting of those nodes reachable from the node \c 0 is preserved.
-      //!
-      //! \note If any target of any edge in the word graph \p wg that is out of
-      //! bounds, then this is ignored by this function.
-      // Not nodiscard because sometimes we just don't want the output
       template <typename Graph>
       bool standardize_no_checks(Graph& wg, Forest& f, Order val);
 
@@ -2709,14 +2709,14 @@ namespace libsemigroups {
       //! \exceptions
       //! \no_libsemigroups_except
       //!
+      //! \note If any target of any edge in the word graph \p wg that is out of
+      //! bounds, then this is ignored by this function.
+      // Not nodiscard because sometimes we just don't want the output
+      //!
       //! \warning If there are nodes in the \p wg that are not reachable from
       //! the node \c 0, then this function may not preserve \p wg up to
       //! isomorphism. However, the isomorphism type of the sub-word-graph
       //! consisting of those nodes reachable from the node \c 0 is preserved.
-      //!
-      //! \note If any target of any edge in the word graph \p wg that is out of
-      //! bounds, then this is ignored by this function.
-      // Not nodiscard because sometimes we just don't want the output
       template <typename Graph>
       std::pair<bool, Forest> standardize_no_checks(Graph& wg,
                                                     Order  val = Order::lenlex);

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -2767,7 +2767,7 @@ namespace libsemigroups {
       //! Order::lenlex).
       //!
       //! \throws LibsemigroupsException if \p val is not one of: Order::none,
-      //! Order::lenlex, Order::lex, Order::rpo, or Order::rev_rpo.
+      //! Order::lenlex, or Order::rpo.
       //!
       //! \sa
       //! standardize.
@@ -2787,7 +2787,7 @@ namespace libsemigroups {
       //! Order::lenlex).
       //!
       //! \throws LibsemigroupsException if \p val is not one of: Order::none,
-      //! Order::lenlex, Order::lex, Order::rpo or Order::rev_rpo.
+      //! Order::lenlex or Order::rpo.
       //!
       //! \sa
       //! standardize.

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -2652,7 +2652,40 @@ namespace libsemigroups {
       //! bounds, then this is ignored by this function.
       // Not nodiscard because sometimes we just don't want the output
       template <typename Graph>
-      bool standardize(Graph& wg, Forest& f, Order val);
+      bool standardize_no_checks(Graph& wg, Forest& f, Order val);
+
+      //! \brief Standardizes a word graph in-place.
+      //!
+      //! This function standardizes the word graph \p wg according to the
+      //! reduction order specified by \p val, and replaces the contents of the
+      //! Forest \p f with a spanning tree rooted at \c 0 for the node reachable
+      //! from \c 0. The spanning tree corresponds to the order \p val.
+      //!
+      //! \tparam Graph the type of the word graph \p wg.
+      //!
+      //! \param wg the word graph.
+      //! \param f the Forest object to store the spanning tree.
+      //! \param val the order to use for standardization.
+      //!
+      //! \returns
+      //! This function returns \c true if the word graph \p wg is modified by
+      //! this function (i.e. it was not standardized already), and \c false
+      //! otherwise.
+      //!
+      //! \throws LibsemigroupsException if any target or any label of \p wg is
+      //! out of bounds.
+      //!
+      //! \warning If there are nodes in the \p wg that are not reachable from
+      //! the node \c 0, then this function may not preserve \p wg up to
+      //! isomorphism. However, the isomorphism type of the sub-word-graph
+      //! consisting of those nodes reachable from the node \c 0 is preserved.
+      //!
+      // Not nodiscard because sometimes we just don't want the output
+      template <typename Graph>
+      bool standardize(Graph& wg, Forest& f, Order val) {
+        libsemigroups::word_graph::throw_if_any_target_out_of_bounds(wg);
+        return standardize_no_checks(wg, f, val);
+      }
 
       //! \brief Standardizes a word graph in-place.
       //!
@@ -2685,7 +2718,42 @@ namespace libsemigroups {
       //! bounds, then this is ignored by this function.
       // Not nodiscard because sometimes we just don't want the output
       template <typename Graph>
-      std::pair<bool, Forest> standardize(Graph& wg, Order val = Order::lenlex);
+      std::pair<bool, Forest> standardize_no_checks(Graph& wg,
+                                                    Order  val = Order::lenlex);
+
+      //! \brief Standardizes a word graph in-place.
+      //!
+      //! This function standardizes the word graph \p wg according to the
+      //! reduction order specified by \p val, and returns a Forest object
+      //! containing a spanning tree rooted at \c 0 for the node reachable from
+      //! \c 0. The spanning tree corresponds to the order \p val.
+      //!
+      //! \tparam Graph the type of the word graph \p wg.
+      //!
+      //! \param wg the word graph.
+      //! \param val the order to use for standardization.
+      //!
+      //! \returns
+      //! A std::pair the first entry of which is \c true if the word graph
+      //! \p wg is modified by this function (i.e. it was not standardized
+      //! already), and
+      //! \c false otherwise. The second entry is a Forest object containing a
+      //! spanning tree for \p wg.
+      //!
+      //! \throws LibsemigroupsException if any target or any label of \p wg is
+      //! out of bounds.
+      //!
+      //! \warning If there are nodes in the \p wg that are not reachable from
+      //! the node \c 0, then this function may not preserve \p wg up to
+      //! isomorphism. However, the isomorphism type of the sub-word-graph
+      //! consisting of those nodes reachable from the node \c 0 is preserved.
+      // Not nodiscard because sometimes we just don't want the output
+      template <typename Graph>
+      std::pair<bool, Forest> standardize(Graph& wg,
+                                          Order  val = Order::lenlex) {
+        libsemigroups::word_graph::throw_if_any_target_out_of_bounds(wg);
+        return standardize_no_checks(wg, val);
+      }
 
       //! \brief Check if a word graph is standardized.
       //!

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -2643,10 +2643,10 @@ namespace libsemigroups {
       //! \exceptions
       //! \no_libsemigroups_except
       //!
-      //! \warning It is only guaranteed that the sub-word-graph induced by the
-      //! nodes reachable from 0 will be isomorphic before and after this
-      //! operation is performed. It is possible that other parts of the word
-      //! graph will not be isomorphic before and after standardization.
+      //! \warning If there are nodes in the \p wg that are not reachable from
+      //! the node \c 0, then this function may not preserve \p wg up to
+      //! isomorphism. However, the isomorphism type of the sub-word-graph
+      //! consisting of those nodes reachable from the node \c 0 is preserved.
       //!
       //! \note If any target of any edge in the word graph \p wg that is out of
       //! bounds, then this is ignored by this function.
@@ -2676,10 +2676,10 @@ namespace libsemigroups {
       //! \exceptions
       //! \no_libsemigroups_except
       //!
-      //! \warning It is only guaranteed that the sub-word-graph induced by the
-      //! nodes reachable from 0 will be isomorphic before and after this
-      //! operation is performed. It is possible that other parts of the word
-      //! graph will not be isomorphic before and after standardization.
+      //! \warning If there are nodes in the \p wg that are not reachable from
+      //! the node \c 0, then this function may not preserve \p wg up to
+      //! isomorphism. However, the isomorphism type of the sub-word-graph
+      //! consisting of those nodes reachable from the node \c 0 is preserved.
       //!
       //! \note If any target of any edge in the word graph \p wg that is out of
       //! bounds, then this is ignored by this function.

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -127,47 +127,52 @@ namespace libsemigroups {
           return static_cast<size_t>(max_seen + 1) == nr_reachable;
         }
 
+        template <typename Node>
+        class NodeManagedGraph;
+
         template <typename Graph>
         class Standardizer {
-         public:
           using node_type  = typename Graph::node_type;
           using label_type = typename Graph::label_type;
 
+          static node_type init_max_nodes(Graph& wg) {
+            if constexpr (is_specialization_of_v<Graph, NodeManagedGraph>) {
+              return wg.number_of_nodes_active() - 1;
+            } else {
+              return wg.number_of_nodes() - 1;
+            }
+          }
+
+         public:
           Standardizer(Graph& wg, Forest& f)
               : _f(f),
                 _largest_used_node(0),
-                _max_node(number_of_nodes_reachable_from(wg, 0) - 1),
-                _p(wg.number_of_nodes()),
-                _p_inverse(wg.number_of_nodes()),
+                _max_node(init_max_nodes(wg)),
+                _p(_max_node + 1),
+                _p_inverse(wg.number_of_nodes(), UNDEFINED),
                 _swapped(false),
                 _wg(wg) {
-            std::iota(_p.begin(), _p.end(), 0);
-            _p_inverse = _p;
+            _p_inverse[0] = 0;
           }
 
           // Follow the edge labelled <x> out of the node currently occupying
           // position <s>. If that edge leads to a node that is larger than
           // <_largest_used_node>, then <_largest_used_node> is incremented and
-          // p is updated to represent the swap that should take place.
+          // p[_largest_used_node] is set to the newly discovered node.
           //
           // Returns true if a previously-unseen node was discovered.
           bool try_set_next_smallest(node_type const s, label_type const x) {
-            node_type target = _wg.target_no_checks(_p[s], x);
-            if (target == UNDEFINED) {
-              return false;
-            }
-            target = _p_inverse[target];
-            if (target <= _largest_used_node) {
+            node_type const target = _wg.target_no_checks(_p[s], x);
+            if (target == UNDEFINED || _p_inverse[target] != UNDEFINED) {
               return false;
             }
             ++_largest_used_node;
             if (_largest_used_node >= _f.number_of_nodes()) {
               _f.add_nodes(1);
             }
-            if (target > _largest_used_node) {
-              std::swap(_p[target], _p[_largest_used_node]);
-              std::swap(_p_inverse[_p[target]],
-                        _p_inverse[_p[_largest_used_node]]);
+            _p[_largest_used_node] = target;
+            _p_inverse[target]     = _largest_used_node;
+            if (target != _largest_used_node) {
               _swapped = true;
             }
             _f.set_parent_and_label_no_checks(
@@ -185,8 +190,7 @@ namespace libsemigroups {
 
           bool standardize() {
             if (_swapped) {
-              _wg.permute_nodes_no_checks(
-                  _p, _p_inverse, _largest_used_node + 1);
+              _wg.standardize(_p, _p_inverse);
             }
             return _swapped;
           }

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -84,6 +84,49 @@ namespace libsemigroups {
           return true;
         }
 
+        template <typename Node>
+        bool is_wreath_standardized(WordGraphView<Node> const& wg) {
+          using node_type = typename WordGraphView<Node>::node_type;
+
+          auto const N = wg.number_of_nodes_no_checks();
+          if (N == 0) {
+            return true;
+          }
+
+          auto const nr_reachable = number_of_nodes_reachable_from(wg, 0);
+          if (nr_reachable <= 1) {
+            return true;
+          }
+
+          std::vector<bool>      seen(N, false);
+          std::vector<node_type> next_node(wg.out_degree_no_checks(), 0);
+          node_type              max_seen = 0;
+
+          seen[0] = true;
+
+        restart:
+          for (letter_type x = 0; x < wg.out_degree_no_checks(); ++x) {
+            while (next_node[x] <= max_seen) {
+              node_type const s = next_node[x];
+              ++next_node[x];
+
+              node_type const t = wg.target_no_checks(s, x);
+              if (t < N && !seen[t]) {
+                if (t != max_seen + 1) {
+                  return false;
+                }
+                seen[t] = true;
+                ++max_seen;
+                if (static_cast<size_t>(max_seen + 1) == nr_reachable) {
+                  return true;
+                }
+                goto restart;
+              }
+            }
+          }
+          return static_cast<size_t>(max_seen + 1) == nr_reachable;
+        }
+
         // For best performance ensure that <f> has the correct number of nodes
         // when calling this function.
         template <typename Graph>
@@ -288,6 +331,77 @@ namespace libsemigroups {
           return result;
         }
 
+        template <typename Graph>
+        bool wreath_standardize(Graph& wg, Forest& f) {
+          LIBSEMIGROUPS_ASSERT(wg.number_of_nodes() != 0);
+          LIBSEMIGROUPS_ASSERT(f.number_of_nodes() != 0);
+
+          using node_type = typename Graph::node_type;
+
+          auto const N          = wg.number_of_nodes();
+          auto const nr_letters = wg.out_degree();
+          auto const max_t      = static_cast<node_type>(
+              number_of_nodes_reachable_from(wg, 0) - 1);
+
+          std::vector<node_type> p(N, 0);
+          std::iota(p.begin(), p.end(), 0);
+          std::vector<node_type> q(p);
+          std::vector<node_type> next_node(nr_letters, 0);
+
+          node_type max_seen = 0;
+          bool      result   = false;
+
+          auto swap_if_necessary
+              = [&wg, &f, &p, &q, &result](
+                    node_type const s, node_type& t, letter_type const x) {
+                  node_type r = wg.target_no_checks(p[s], x);
+                  if (r < wg.number_of_nodes()) {
+                    r = q[r];
+                    if (r > t) {
+                      ++t;
+                      if (t >= f.number_of_nodes()) {
+                        f.add_nodes(1);
+                      }
+                      if (r > t) {
+                        std::swap(p[t], p[r]);
+                        std::swap(q[p[t]], q[p[r]]);
+                        result = true;
+                      }
+                      f.set_parent_and_label_no_checks(t, (s == t ? r : s), x);
+                      return true;
+                    }
+                  }
+                  return false;
+                };
+
+          if (max_seen < max_t) {
+            // Follow Sims' WREATH_STND literally: each letter keeps its own
+            // cursor, and every discovery restarts the sweep from the first
+            // letter so earlier frontier words are handled first.
+          restart:
+            for (letter_type x = 0; x < nr_letters; ++x) {
+              while (next_node[x] <= max_seen) {
+                node_type const s = next_node[x];
+                ++next_node[x];
+
+                if (swap_if_necessary(s, max_seen, x)) {
+                  if (max_seen == max_t) {
+                    goto done;
+                  }
+                  goto restart;
+                }
+              }
+            }
+          }
+
+        done:
+          LIBSEMIGROUPS_ASSERT(max_seen == max_t);
+          if (result) {
+            wg.standardize(p, q);
+          }
+          return result;
+        }
+
         // Helper function for the two versions of is_acyclic below.
         // Not noexcept because std::stack::emplace isn't
         // This function does not really need to exist any longer, since
@@ -464,6 +578,8 @@ namespace libsemigroups {
             return detail::lex_standardize(wg, f);
           case Order::rpo:
             return detail::recursive_standardize(wg, f);
+          case Order::wreath:
+            return detail::wreath_standardize(wg, f);
           case Order::rev_rpo:
             // Intentional fall-through
           default:
@@ -478,9 +594,12 @@ namespace libsemigroups {
             return true;
           case Order::lenlex:
             return detail::is_shortlex_standardized(wg);
+          case Order::wreath:
+            return detail::is_wreath_standardized(wg);
           case Order::lex:
           case Order::rpo:
           case Order::rev_rpo:
+          case Order::wreath:
           default:
             LIBSEMIGROUPS_EXCEPTION("not yet implemented")
         }

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -127,6 +127,80 @@ namespace libsemigroups {
           return static_cast<size_t>(max_seen + 1) == nr_reachable;
         }
 
+        template <typename Graph>
+        class Standardizer {
+         public:
+          using node_type  = typename Graph::node_type;
+          using label_type = typename Graph::label_type;
+
+          Standardizer(Graph& wg, Forest& f)
+              : _f(f),
+                _largest_used_node(0),
+                _max_node(number_of_nodes_reachable_from(wg, 0) - 1),
+                _p(wg.number_of_nodes()),
+                _p_inverse(wg.number_of_nodes()),
+                _swapped(false),
+                _wg(wg) {
+            std::iota(_p.begin(), _p.end(), 0);
+            _p_inverse = _p;
+          }
+
+          // Follow the edge labelled <x> out of the node currently occupying
+          // position <s>. If that edge leads to a node that is larger than
+          // <_largest_used_node>, then <_largest_used_node> is incremented and
+          // p is updated to represent the swap that should take place.
+          //
+          // Returns true if a previously-unseen node was discovered.
+          bool try_set_next_smallest(node_type const s, label_type const x) {
+            node_type target = _wg.target_no_checks(_p[s], x);
+            if (target == UNDEFINED) {
+              return false;
+            }
+            target = _p_inverse[target];
+            if (target <= _largest_used_node) {
+              return false;
+            }
+            ++_largest_used_node;
+            if (_largest_used_node >= _f.number_of_nodes()) {
+              _f.add_nodes(1);
+            }
+            if (target > _largest_used_node) {
+              std::swap(_p[target], _p[_largest_used_node]);
+              std::swap(_p_inverse[_p[target]],
+                        _p_inverse[_p[_largest_used_node]]);
+              _swapped = true;
+            }
+            _f.set_parent_and_label_no_checks(
+                _largest_used_node, (s == _largest_used_node ? target : s), x);
+            return true;
+          }
+
+          node_type largest_used_node() {
+            return _largest_used_node;
+          }
+
+          bool stop_early() {
+            return _largest_used_node >= _max_node;
+          }
+
+          bool standardize() {
+            if (_swapped) {
+              _wg.permute_nodes_no_checks(
+                  _p, _p_inverse, _largest_used_node + 1);
+            }
+            return _swapped;
+          }
+
+         private:
+          Forest&                _f;
+          node_type              _largest_used_node;
+          node_type const        _max_node;
+          std::vector<node_type> _p;
+          std::vector<node_type> _p_inverse;
+          bool                   _swapped;
+          Graph&                 _wg;
+        };
+
         // For best performance ensure that <f> has the correct number of nodes
         // when calling this function.
         template <typename Graph>
@@ -134,41 +208,22 @@ namespace libsemigroups {
           LIBSEMIGROUPS_ASSERT(wg.number_of_nodes() != 0);
           LIBSEMIGROUPS_ASSERT(f.number_of_nodes() != 0);
 
-          using node_type = typename Graph::node_type;
+          using node_type  = typename Graph::node_type;
+          using label_type = typename Graph::label_type;
 
-          node_type    t      = 0;
-          size_t const n      = wg.out_degree();
-          bool         result = false;
+          size_t const        n = wg.out_degree();
+          Standardizer<Graph> standardizer(wg, f);
 
-          // p : new -> old and q : old -> new
-          std::vector<node_type> p(wg.number_of_nodes(), 0);
-          std::iota(p.begin(), p.end(), 0);
-          std::vector<node_type> q(p);
-
-          for (node_type s = 0; s <= t; ++s) {
-            for (letter_type x = 0; x < n; ++x) {
-              node_type r = wg.target_no_checks(p[s], x);
-              if (r < wg.number_of_nodes()) {
-                r = q[r];  // new
-                if (r > t) {
-                  t++;
-                  if (r > t) {
-                    std::swap(p[t], p[r]);
-                    std::swap(q[p[t]], q[p[r]]);
-                    result = true;
-                  }
-                  if (t >= f.number_of_nodes()) {
-                    f.add_nodes(1);
-                  }
-                  f.set_parent_and_label_no_checks(t, (s == t ? r : s), x);
-                }
+          for (node_type s = 0; s <= standardizer.largest_used_node(); ++s) {
+            for (label_type x = 0; x < n; ++x) {
+              standardizer.try_set_next_smallest(s, x);
+              if (standardizer.stop_early()) {
+                return standardizer.standardize();
               }
             }
           }
-          if (result) {
-            wg.standardize(p, q);
-          }
-          return result;
+
+          return standardizer.standardize();
         }
 
         template <typename Graph>
@@ -179,36 +234,19 @@ namespace libsemigroups {
           using node_type  = typename Graph::node_type;
           using label_type = typename Graph::label_type;
 
-          node_type  s = 0, t = 0;
-          label_type x      = 0;
-          auto const n      = wg.out_degree();
-          bool       result = false;
+          node_type    s = 0;
+          label_type   x = 0;
+          size_t const n = wg.out_degree();
 
-          // p : new -> old and q : old -> new
-          std::vector<node_type> p(wg.number_of_nodes(), 0);
-          std::iota(p.begin(), p.end(), 0);
-          std::vector<node_type> q(p);
+          Standardizer<Graph> standardizer(wg, f);
 
           // Perform a DFS through wg
-          while (s <= t) {
-            node_type r = wg.target_no_checks(p[s], x);
-            if (r < wg.number_of_nodes()) {
-              r = q[r];  // new
-              if (r > t) {
-                t++;
-                if (t >= f.number_of_nodes()) {
-                  f.add_nodes(1);
-                }
-                if (r > t) {
-                  std::swap(p[t], p[r]);
-                  std::swap(q[p[t]], q[p[r]]);
-                  result = true;
-                }
-                f.set_parent_and_label_no_checks(t, (s == t ? r : s), x);
-                s = t;
-                x = 0;
-                continue;
-              }
+          while (s <= standardizer.largest_used_node()
+                 && !standardizer.stop_early()) {
+            if (standardizer.try_set_next_smallest(s, x)) {
+              s = standardizer.largest_used_node();
+              x = 0;
+              continue;
             }
             x++;
             if (x == n) {  // backtrack
@@ -216,119 +254,7 @@ namespace libsemigroups {
               s = f.parent(s);
             }
           }
-          if (result) {
-            wg.standardize(p, q);
-          }
-          return result;
-        }
-
-        template <typename Graph>
-        bool recursive_standardize(Graph& wg, Forest& f) {
-          LIBSEMIGROUPS_ASSERT(wg.number_of_nodes() != 0);
-          LIBSEMIGROUPS_ASSERT(f.number_of_nodes() != 0);
-
-          using node_type = typename Graph::node_type;
-
-          std::vector<word_type> words;
-          size_t const           n = wg.out_degree();
-          letter_type            a = 0;
-          node_type              s = 0, t = 0;
-
-          std::vector<node_type> p(wg.number_of_nodes(), 0);
-          std::iota(p.begin(), p.end(), 0);
-          std::vector<node_type> q(p);
-
-          size_t max_t = number_of_nodes_reachable_from(wg, 0) - 1;
-
-          // TODO(1) move this out of here and use it in the other standardize
-          // functions
-          auto swap_if_necessary = [&wg, &f, &p, &q](node_type const   ss,
-                                                     node_type&        tt,
-                                                     letter_type const x) {
-            node_type r      = wg.target_no_checks(p[ss], x);
-            bool      result = false;
-            if (r < wg.number_of_nodes()) {
-              r = q[r];  // new
-              if (r > tt) {
-                tt++;
-                if (tt >= f.number_of_nodes()) {
-                  f.add_nodes(1);
-                }
-                if (r > tt) {
-                  std::swap(p[tt], p[r]);
-                  std::swap(q[p[tt]], q[p[r]]);
-                }
-                result = true;
-                f.set_parent_and_label_no_checks(tt, (ss == tt ? r : ss), x);
-              }
-            }
-            return result;
-          };
-
-          bool result = false;
-
-          while (s <= t) {
-            if (swap_if_necessary(s, t, 0)) {
-              words.push_back(word_type(t, a));
-              result = true;
-            }
-            s++;
-          }
-          a++;
-          bool new_generator = true;
-          int  x, u, w;
-          while (a < n && t < max_t) {
-            if (new_generator) {
-              w = -1;  // -1 is the empty word
-              if (swap_if_necessary(0, t, a)) {
-                result = true;
-                words.push_back({a});
-              }
-              x             = words.size() - 1;
-              u             = words.size() - 1;
-              new_generator = false;
-            }
-
-            node_type const uu = word_graph::follow_path_no_checks(
-                wg, 0, words[u].begin(), words[u].end());
-            if (uu != UNDEFINED) {
-              for (int v = 0; v < x; v++) {
-                node_type const uuv = word_graph::follow_path_no_checks(
-                    wg, uu, words[v].begin(), words[v].end() - 1);
-                if (uuv != UNDEFINED) {
-                  s = q[uuv];
-                  if (swap_if_necessary(s, t, words[v].back())) {
-                    result        = true;
-                    word_type nxt = words[u];
-                    nxt.insert(nxt.end(), words[v].begin(), words[v].end());
-                    words.push_back(std::move(nxt));
-                  }
-                }
-              }
-            }
-            w++;
-            if (static_cast<size_t>(w) < words.size()) {
-              node_type const ww = word_graph::follow_path_no_checks(
-                  wg, 0, words[w].begin(), words[w].end());
-              if (ww != UNDEFINED) {
-                s = q[ww];
-                if (swap_if_necessary(s, t, a)) {
-                  result        = true;
-                  u             = words.size();
-                  word_type nxt = words[w];
-                  nxt.push_back(a);
-                  words.push_back(std::move(nxt));
-                }
-              }
-            } else {
-              a++;
-              new_generator = true;
-            }
-          }
-          if (result) {
-            wg.standardize(p, q);
-          }
-          return result;
+          return standardizer.standardize();
         }
 
         template <typename Graph>
@@ -336,70 +262,70 @@ namespace libsemigroups {
           LIBSEMIGROUPS_ASSERT(wg.number_of_nodes() != 0);
           LIBSEMIGROUPS_ASSERT(f.number_of_nodes() != 0);
 
-          using node_type = typename Graph::node_type;
+          using node_type  = typename Graph::node_type;
+          using label_type = typename Graph::label_type;
 
-          auto const N          = wg.number_of_nodes();
-          auto const nr_letters = wg.out_degree();
-          auto const max_t      = static_cast<node_type>(
-              number_of_nodes_reachable_from(wg, 0) - 1);
+          Standardizer<Graph> standardizer(wg, f);
+          size_t const        n = wg.out_degree();
 
-          std::vector<node_type> p(N, 0);
-          std::iota(p.begin(), p.end(), 0);
-          std::vector<node_type> q(p);
-          std::vector<node_type> next_node(nr_letters, 0);
+          std::vector<node_type> next_node(n, 0);
 
-          node_type max_seen = 0;
-          bool      result   = false;
+        // Follow Sims' WREATH_STND literally: each letter keeps its own
+        // cursor, and every discovery restarts the sweep from the first
+        // letter so earlier frontier words are handled first.
+        start_wreath_standardize_search:
+          for (label_type x = 0; x < n; ++x) {
+            while (next_node[x] <= standardizer.largest_used_node()) {
+              node_type const s = next_node[x];
+              ++next_node[x];
 
-          auto swap_if_necessary
-              = [&wg, &f, &p, &q, &result](
-                    node_type const s, node_type& t, letter_type const x) {
-                  node_type r = wg.target_no_checks(p[s], x);
-                  if (r < wg.number_of_nodes()) {
-                    r = q[r];
-                    if (r > t) {
-                      ++t;
-                      if (t >= f.number_of_nodes()) {
-                        f.add_nodes(1);
-                      }
-                      if (r > t) {
-                        std::swap(p[t], p[r]);
-                        std::swap(q[p[t]], q[p[r]]);
-                        result = true;
-                      }
-                      f.set_parent_and_label_no_checks(t, (s == t ? r : s), x);
-                      return true;
-                    }
-                  }
-                  return false;
-                };
-
-          if (max_seen < max_t) {
-            // Follow Sims' WREATH_STND literally: each letter keeps its own
-            // cursor, and every discovery restarts the sweep from the first
-            // letter so earlier frontier words are handled first.
-          restart:
-            for (letter_type x = 0; x < nr_letters; ++x) {
-              while (next_node[x] <= max_seen) {
-                node_type const s = next_node[x];
-                ++next_node[x];
-
-                if (swap_if_necessary(s, max_seen, x)) {
-                  if (max_seen == max_t) {
-                    goto done;
-                  }
-                  goto restart;
+              if (standardizer.try_set_next_smallest(s, x)) {
+                if (standardizer.stop_early()) {
+                  return standardizer.standardize();
                 }
+                goto start_wreath_standardize_search;
               }
             }
           }
 
-        done:
-          LIBSEMIGROUPS_ASSERT(max_seen == max_t);
-          if (result) {
-            wg.standardize(p, q);
+          return standardizer.standardize();
+        }
+
+        template <typename Graph>
+        bool recursive_standardize(Graph& wg, Forest& f) {
+          LIBSEMIGROUPS_ASSERT(wg.number_of_nodes() != 0);
+          LIBSEMIGROUPS_ASSERT(f.number_of_nodes() != 0);
+
+          using node_type  = typename Graph::node_type;
+          using label_type = typename Graph::label_type;
+
+          Standardizer<Graph>    standardizer(wg, f);
+          size_t const           n = wg.out_degree();
+          label_type             x = 0;
+          std::vector<node_type> next_node(n, 0);
+
+          while (x < n) {
+            bool            changed = false;
+            node_type const largest_this_pass
+                = standardizer.largest_used_node();
+            while (next_node[x] <= largest_this_pass) {
+              node_type const s = next_node[x];
+              ++next_node[x];
+              if (standardizer.try_set_next_smallest(s, x)) {
+                if (standardizer.stop_early()) {
+                  return standardizer.standardize();
+                }
+                changed = true;
+              }
+            }
+            if (changed) {
+              x = 0;
+            } else {
+              ++x;
+            }
           }
-          return result;
+
+          return standardizer.standardize();
         }
 
         // Helper function for the two versions of is_acyclic below.
@@ -599,7 +525,6 @@ namespace libsemigroups {
           case Order::lex:
           case Order::rpo:
           case Order::rev_rpo:
-          case Order::wreath:
           default:
             LIBSEMIGROUPS_EXCEPTION("not yet implemented")
         }

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -65,7 +65,7 @@ namespace libsemigroups {
       namespace detail {
         template <typename Node>
         // TODO rename to _no_checks and add a checks version?
-        bool is_shortlex_standardized(WordGraphView<Node> const& wg) {
+        bool is_lenlex_standardized(WordGraphView<Node> const& wg) {
           Node current_max_node = 0;
 
           for (auto s : wg.nodes_no_checks()) {
@@ -85,7 +85,7 @@ namespace libsemigroups {
         }
 
         template <typename Node>
-        bool is_wreath_standardized(WordGraphView<Node> const& wg) {
+        bool is_rev_rpo_standardized(WordGraphView<Node> const& wg) {
           using node_type = typename WordGraphView<Node>::node_type;
 
           auto const N = wg.number_of_nodes_no_checks();
@@ -208,7 +208,7 @@ namespace libsemigroups {
         // For best performance ensure that <f> has the correct number of nodes
         // when calling this function.
         template <typename Graph>
-        bool shortlex_standardize(Graph& wg, Forest& f) {
+        bool lenlex_standardize(Graph& wg, Forest& f) {
           LIBSEMIGROUPS_ASSERT(wg.number_of_nodes() != 0);
           LIBSEMIGROUPS_ASSERT(f.number_of_nodes() != 0);
 
@@ -262,7 +262,7 @@ namespace libsemigroups {
         }
 
         template <typename Graph>
-        bool wreath_standardize(Graph& wg, Forest& f) {
+        bool rev_rpo_standardize(Graph& wg, Forest& f) {
           LIBSEMIGROUPS_ASSERT(wg.number_of_nodes() != 0);
           LIBSEMIGROUPS_ASSERT(f.number_of_nodes() != 0);
 
@@ -277,7 +277,7 @@ namespace libsemigroups {
         // Follow Sims' WREATH_STND literally: each letter keeps its own
         // cursor, and every discovery restarts the sweep from the first
         // letter so earlier frontier words are handled first.
-        start_wreath_standardize_search:
+        start_rev_rpo_standardize_search:
           for (label_type x = 0; x < n; ++x) {
             while (next_node[x] <= standardizer.largest_used_node()) {
               node_type const s = next_node[x];
@@ -287,7 +287,7 @@ namespace libsemigroups {
                 if (standardizer.stop_early()) {
                   return standardizer.standardize();
                 }
-                goto start_wreath_standardize_search;
+                goto start_rev_rpo_standardize_search;
               }
             }
           }
@@ -296,7 +296,7 @@ namespace libsemigroups {
         }
 
         template <typename Graph>
-        bool recursive_standardize(Graph& wg, Forest& f) {
+        bool rpo_standardize(Graph& wg, Forest& f) {
           LIBSEMIGROUPS_ASSERT(wg.number_of_nodes() != 0);
           LIBSEMIGROUPS_ASSERT(f.number_of_nodes() != 0);
 
@@ -503,14 +503,13 @@ namespace libsemigroups {
           case Order::none:
             return false;
           case Order::lenlex:
-            return detail::shortlex_standardize(wg, f);
+            return detail::lenlex_standardize(wg, f);
           case Order::lex:
             return detail::lex_standardize(wg, f);
           case Order::rpo:
-            return detail::recursive_standardize(wg, f);
-          case Order::wreath:
-            return detail::wreath_standardize(wg, f);
+            return detail::rpo_standardize(wg, f);
           case Order::rev_rpo:
+            return detail::rev_rpo_standardize(wg, f);
             // Intentional fall-through
           default:
             return false;
@@ -523,12 +522,11 @@ namespace libsemigroups {
           case Order::none:
             return true;
           case Order::lenlex:
-            return detail::is_shortlex_standardized(wg);
-          case Order::wreath:
-            return detail::is_wreath_standardized(wg);
+            return detail::is_lenlex_standardized(wg);
+          case Order::rev_rpo:
+            return detail::is_rev_rpo_standardized(wg);
           case Order::lex:
           case Order::rpo:
-          case Order::rev_rpo:
           default:
             LIBSEMIGROUPS_EXCEPTION("not yet implemented")
         }

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -152,6 +152,7 @@ namespace libsemigroups {
                 _p_inverse(wg.number_of_nodes(), UNDEFINED),
                 _swapped(false),
                 _wg(wg) {
+            _p[0]         = 0;
             _p_inverse[0] = 0;
           }
 
@@ -190,6 +191,7 @@ namespace libsemigroups {
 
           bool standardize() {
             if (_swapped) {
+              _p.resize(_largest_used_node + 1);
               _wg.standardize(_p, _p_inverse);
             }
             return _swapped;

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -65,7 +65,7 @@ namespace libsemigroups {
       namespace detail {
         template <typename Node>
         // TODO rename to _no_checks and add a checks version?
-        bool is_shortlex_standardized(WordGraphView<Node> const& wg) {
+        bool is_lenlex_standardized(WordGraphView<Node> const& wg) {
           Node current_max_node = 0;
 
           for (auto s : wg.nodes_no_checks()) {
@@ -85,7 +85,7 @@ namespace libsemigroups {
         }
 
         template <typename Node>
-        bool is_wreath_standardized(WordGraphView<Node> const& wg) {
+        bool is_rpo_standardized(WordGraphView<Node> const& wg) {
           using node_type = typename WordGraphView<Node>::node_type;
 
           auto const N = wg.number_of_nodes_no_checks();
@@ -208,7 +208,7 @@ namespace libsemigroups {
         // For best performance ensure that <f> has the correct number of nodes
         // when calling this function.
         template <typename Graph>
-        bool shortlex_standardize(Graph& wg, Forest& f) {
+        bool lenlex_standardize(Graph& wg, Forest& f) {
           LIBSEMIGROUPS_ASSERT(wg.number_of_nodes() != 0);
           LIBSEMIGROUPS_ASSERT(f.number_of_nodes() != 0);
 
@@ -262,7 +262,7 @@ namespace libsemigroups {
         }
 
         template <typename Graph>
-        bool wreath_standardize(Graph& wg, Forest& f) {
+        bool rpo_standardize(Graph& wg, Forest& f) {
           LIBSEMIGROUPS_ASSERT(wg.number_of_nodes() != 0);
           LIBSEMIGROUPS_ASSERT(f.number_of_nodes() != 0);
 
@@ -277,7 +277,7 @@ namespace libsemigroups {
         // Follow Sims' WREATH_STND literally: each letter keeps its own
         // cursor, and every discovery restarts the sweep from the first
         // letter so earlier frontier words are handled first.
-        start_wreath_standardize_search:
+        start_rpo_standardize_search:
           for (label_type x = 0; x < n; ++x) {
             while (next_node[x] <= standardizer.largest_used_node()) {
               node_type const s = next_node[x];
@@ -287,7 +287,7 @@ namespace libsemigroups {
                 if (standardizer.stop_early()) {
                   return standardizer.standardize();
                 }
-                goto start_wreath_standardize_search;
+                goto start_rpo_standardize_search;
               }
             }
           }
@@ -296,7 +296,7 @@ namespace libsemigroups {
         }
 
         template <typename Graph>
-        bool recursive_standardize(Graph& wg, Forest& f) {
+        bool rev_rpo_standardize(Graph& wg, Forest& f) {
           LIBSEMIGROUPS_ASSERT(wg.number_of_nodes() != 0);
           LIBSEMIGROUPS_ASSERT(f.number_of_nodes() != 0);
 
@@ -503,14 +503,13 @@ namespace libsemigroups {
           case Order::none:
             return false;
           case Order::lenlex:
-            return detail::shortlex_standardize(wg, f);
+            return detail::lenlex_standardize(wg, f);
           case Order::lex:
             return detail::lex_standardize(wg, f);
           case Order::rpo:
-            return detail::recursive_standardize(wg, f);
-          case Order::wreath:
-            return detail::wreath_standardize(wg, f);
+            return detail::rpo_standardize(wg, f);
           case Order::rev_rpo:
+            return detail::rev_rpo_standardize(wg, f);
             // Intentional fall-through
           default:
             return false;
@@ -523,12 +522,11 @@ namespace libsemigroups {
           case Order::none:
             return true;
           case Order::lenlex:
-            return detail::is_shortlex_standardized(wg);
-          case Order::wreath:
-            return detail::is_wreath_standardized(wg);
-          case Order::lex:
+            return detail::is_lenlex_standardized(wg);
           case Order::rpo:
+            return detail::is_rpo_standardized(wg);
           case Order::rev_rpo:
+          case Order::lex:
           default:
             LIBSEMIGROUPS_EXCEPTION("not yet implemented")
         }

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -137,11 +137,11 @@ namespace libsemigroups {
 
          public:
           Standardizer(Graph& wg, Forest& f)
-              : _f(f),
+              : _forest(f),
                 _largest_used_node(0),
                 _p(),
                 _p_inverse(wg.number_of_nodes(), UNDEFINED),
-                _swapped(false),
+                _is_non_trivial_permutation(false),
                 _wg(wg) {
             _p.resize(max_node() + 1);
             _p[0]         = 0;
@@ -160,15 +160,15 @@ namespace libsemigroups {
               return false;
             }
             ++_largest_used_node;
-            if (_largest_used_node >= _f.number_of_nodes()) {
-              _f.add_nodes(1);
+            if (_largest_used_node >= _forest.number_of_nodes()) {
+              _forest.add_nodes(1);
             }
             _p[_largest_used_node] = target;
             _p_inverse[target]     = _largest_used_node;
             if (target != _largest_used_node) {
-              _swapped = true;
+              _is_non_trivial_permutation = true;
             }
-            _f.set_parent_and_label_no_checks(
+            _forest.set_parent_and_label_no_checks(
                 _largest_used_node, (s == _largest_used_node ? target : s), x);
             return true;
           }
@@ -182,11 +182,11 @@ namespace libsemigroups {
           }
 
           bool standardize() {
-            if (_swapped) {
+            if (_is_non_trivial_permutation) {
               _p.resize(_largest_used_node + 1);
               _wg.standardize(_p, _p_inverse);
             }
-            return _swapped;
+            return _is_non_trivial_permutation;
           }
 
          private:
@@ -198,11 +198,11 @@ namespace libsemigroups {
             }
           }
 
-          Forest&                _f;
+          Forest&                _forest;
           node_type              _largest_used_node;
           std::vector<node_type> _p;
           std::vector<node_type> _p_inverse;
-          bool                   _swapped;
+          bool                   _is_non_trivial_permutation;
           Graph&                 _wg;
         };
 

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -19,6 +19,13 @@
 // This file contains helper functions for word graphs and word graph views
 
 namespace libsemigroups {
+  namespace detail {
+    // Forward decl
+    template <typename Node>
+    class NodeManagedGraph;
+
+  }  // namespace detail
+
   namespace v4 {
     //////////////////////////////////////////////////////////////////////////////
     // Helper namespace
@@ -127,11 +134,10 @@ namespace libsemigroups {
           return static_cast<size_t>(max_seen + 1) == nr_reachable;
         }
 
-        template <typename Node>
-        class NodeManagedGraph;
-
         template <typename Graph>
         class Standardizer {
+          static_assert(std::is_same_v<std::decay_t<Graph>, Graph>);
+
           using node_type  = typename Graph::node_type;
           using label_type = typename Graph::label_type;
 
@@ -190,8 +196,10 @@ namespace libsemigroups {
           }
 
          private:
-          node_type max_node() const noexcept {
-            if constexpr (is_specialization_of_v<Graph, NodeManagedGraph>) {
+          inline node_type max_node() const noexcept {
+            if constexpr (std::is_base_of_v<libsemigroups::detail::
+                                                NodeManagedGraph<node_type>,
+                                            Graph>) {
               return _wg.number_of_nodes_active() - 1;
             } else {
               return _wg.number_of_nodes() - 1;

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -154,7 +154,7 @@ namespace libsemigroups {
           // p[_largest_used_node] is set to the newly discovered node.
           //
           // Returns true if a previously-unseen node was discovered.
-          bool try_set_next_smallest(node_type const s, label_type const x) {
+          bool try_set_next_smallest(node_type s, label_type x) {
             node_type const target = _wg.target_no_checks(_p[s], x);
             if (target == UNDEFINED || _p_inverse[target] != UNDEFINED) {
               return false;

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -184,7 +184,7 @@ namespace libsemigroups {
           bool standardize() {
             if (_is_non_trivial_permutation) {
               _p.resize(_largest_used_node + 1);
-              _wg.standardize(_p, _p_inverse);
+              _wg.standardize_no_checks(_p, _p_inverse);
             }
             return _is_non_trivial_permutation;
           }
@@ -484,14 +484,14 @@ namespace libsemigroups {
       }  // namespace detail
 
       template <typename Graph>
-      std::pair<bool, Forest> standardize(Graph& wg, Order val) {
+      std::pair<bool, Forest> standardize_no_checks(Graph& wg, Order val) {
         Forest f;
-        bool   result = standardize(wg, f, val);
+        bool   result = standardize_no_checks(wg, f, val);
         return std::make_pair(result, f);
       }
 
       template <typename Graph>
-      bool standardize(Graph& wg, Forest& f, Order val) {
+      bool standardize_no_checks(Graph& wg, Forest& f, Order val) {
         if (wg.number_of_nodes() == 0) {
           return false;
         }

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -135,23 +135,15 @@ namespace libsemigroups {
           using node_type  = typename Graph::node_type;
           using label_type = typename Graph::label_type;
 
-          static node_type init_max_nodes(Graph& wg) {
-            if constexpr (is_specialization_of_v<Graph, NodeManagedGraph>) {
-              return wg.number_of_nodes_active() - 1;
-            } else {
-              return wg.number_of_nodes() - 1;
-            }
-          }
-
          public:
           Standardizer(Graph& wg, Forest& f)
               : _f(f),
                 _largest_used_node(0),
-                _max_node(init_max_nodes(wg)),
-                _p(_max_node + 1),
+                _p(),
                 _p_inverse(wg.number_of_nodes(), UNDEFINED),
                 _swapped(false),
                 _wg(wg) {
+            _p.resize(max_node() + 1);
             _p[0]         = 0;
             _p_inverse[0] = 0;
           }
@@ -186,7 +178,7 @@ namespace libsemigroups {
           }
 
           bool stop_early() {
-            return _largest_used_node >= _max_node;
+            return _largest_used_node >= max_node();
           }
 
           bool standardize() {
@@ -198,9 +190,16 @@ namespace libsemigroups {
           }
 
          private:
+          node_type max_node() const noexcept {
+            if constexpr (is_specialization_of_v<Graph, NodeManagedGraph>) {
+              return _wg.number_of_nodes_active() - 1;
+            } else {
+              return _wg.number_of_nodes() - 1;
+            }
+          }
+
           Forest&                _f;
           node_type              _largest_used_node;
-          node_type const        _max_node;
           std::vector<node_type> _p;
           std::vector<node_type> _p_inverse;
           bool                   _swapped;

--- a/include/libsemigroups/word-graph.hpp
+++ b/include/libsemigroups/word-graph.hpp
@@ -2605,7 +2605,7 @@ namespace libsemigroups {
     //!
     //! This function standardizes the word graph \p wg according to the
     //! reduction order specified by \p val, and replaces the contents of the
-    //! Forest \p f with a spanning tree rooted at \c 0 for the node reachable
+    //! Forest \p f with a spanning tree rooted at \c 0 for the nodes reachable
     //! from \c 0. The spanning tree corresponds to the order \p val.
     //!
     //! \tparam Graph the type of the word graph \p wg.

--- a/include/libsemigroups/word-graph.hpp
+++ b/include/libsemigroups/word-graph.hpp
@@ -58,6 +58,10 @@
 #include "matrix.hpp"
 #endif
 
+// TODO(1): Add a comment to the relevant places in the doc that says a properly
+// formed WordGraph never has any target that is >= number_of_nodes() and !=
+// UNDEFINED.
+
 namespace libsemigroups {
 
   //! \defgroup word_graph_group Word graphs and related functionality

--- a/include/libsemigroups/word-graph.hpp
+++ b/include/libsemigroups/word-graph.hpp
@@ -1212,8 +1212,8 @@ namespace libsemigroups {
       return permute_nodes_no_checks(p, q, p.size());
     }
 
-    WordGraph& standardize(std::vector<node_type> const& p,
-                           std::vector<node_type> const& q) {
+    WordGraph& standardize_no_checks(std::vector<node_type> const& p,
+                                     std::vector<node_type> const& q) {
       return permute_nodes_no_checks(p, q, p.size());
     }
 #endif

--- a/include/libsemigroups/word-graph.tpp
+++ b/include/libsemigroups/word-graph.tpp
@@ -1341,7 +1341,7 @@ namespace libsemigroups {
       }
     }
     // Permute the rows themselves
-    detail::dynamic_array2::apply_row_permutation_no_checks(p,
+    detail::dynamic_array2::apply_row_permutation_no_checks(q,
                                                             _dynamic_array_2);
     return *this;
   }

--- a/include/libsemigroups/word-graph.tpp
+++ b/include/libsemigroups/word-graph.tpp
@@ -31,7 +31,7 @@ namespace libsemigroups {
 
     namespace detail {
       template <typename Node>
-      bool is_shortlex_standardized(WordGraph<Node> const& wg) {
+      bool is_lenlex_standardized(WordGraph<Node> const& wg) {
         Node current_max_node = 0;
 
         for (auto s : wg.nodes()) {
@@ -53,7 +53,7 @@ namespace libsemigroups {
       // For best performance ensure that <f> has the correct number of nodes
       // when calling this function.
       template <typename Graph>
-      bool shortlex_standardize(Graph& wg, Forest& f) {
+      bool lenlex_standardize(Graph& wg, Forest& f) {
         LIBSEMIGROUPS_ASSERT(wg.number_of_nodes() != 0);
         LIBSEMIGROUPS_ASSERT(f.number_of_nodes() != 0);
 
@@ -146,7 +146,7 @@ namespace libsemigroups {
       }
 
       template <typename Graph>
-      bool recursive_standardize(Graph& wg, Forest& f) {
+      bool rpo_standardize(Graph& wg, Forest& f) {
         LIBSEMIGROUPS_ASSERT(wg.number_of_nodes() != 0);
         LIBSEMIGROUPS_ASSERT(f.number_of_nodes() != 0);
 
@@ -488,11 +488,11 @@ namespace libsemigroups {
         case Order::none:
           return false;
         case Order::lenlex:
-          return detail::shortlex_standardize(wg, f);
+          return detail::lenlex_standardize(wg, f);
         case Order::lex:
           return detail::lex_standardize(wg, f);
         case Order::rpo:
-          return detail::recursive_standardize(wg, f);
+          return detail::rpo_standardize(wg, f);
         case Order::rev_rpo:
           // Intentional fall-through
         default:
@@ -506,7 +506,7 @@ namespace libsemigroups {
         case Order::none:
           return true;
         case Order::lenlex:
-          return detail::is_shortlex_standardized(wg);
+          return detail::is_lenlex_standardized(wg);
         case Order::lex:
         case Order::rpo:
         case Order::rev_rpo:

--- a/include/libsemigroups/word-graph.tpp
+++ b/include/libsemigroups/word-graph.tpp
@@ -1334,6 +1334,7 @@ namespace libsemigroups {
   WordGraph<Node>::permute_nodes_no_checks(std::vector<node_type> const& p,
                                            std::vector<node_type> const& q,
                                            size_t                        m) {
+    LIBSEMIGROUPS_ASSERT(m <= p.size());
     // p : new -> old, q = p ^ -1: old -> new
     for (node_type s = 0; s < m; ++s) {
       for (auto [a, t] : labels_and_targets_no_checks(p[s])) {

--- a/include/libsemigroups/word-graph.tpp
+++ b/include/libsemigroups/word-graph.tpp
@@ -89,7 +89,7 @@ namespace libsemigroups {
           }
         }
         if (result) {
-          wg.standardize(p, q);
+          wg.standardize_no_checks(p, q);
         }
         return result;
       }
@@ -140,7 +140,7 @@ namespace libsemigroups {
           }
         }
         if (result) {
-          wg.standardize(p, q);
+          wg.standardize_no_checks(p, q);
         }
         return result;
       }
@@ -249,7 +249,7 @@ namespace libsemigroups {
           }
         }
         if (result) {
-          wg.standardize(p, q);
+          wg.standardize_no_checks(p, q);
         }
         return result;
       }

--- a/tests/test-containers.cpp
+++ b/tests/test-containers.cpp
@@ -1522,9 +1522,9 @@ namespace libsemigroups {
       dynamic_array2::apply_row_permutation_no_checks(p, rv);
 
       for (size_t i = 0; i < 10; i++) {
-        REQUIRE(std::all_of(rv.begin_row(i), rv.end_row(i), [&p, &i](size_t x) {
-          return x == p[i];
-        }));
+        REQUIRE(std::all_of(rv.begin_row(p[i]),
+                            rv.end_row(p[i]),
+                            [&i](size_t x) { return x == i; }));
       }
     }
 

--- a/tests/test-to-todd-coxeter.cpp
+++ b/tests/test-to-todd-coxeter.cpp
@@ -60,7 +60,7 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 21);
     tc.shrink_to_fit();
     REQUIRE(tc.number_of_classes() == 21);
-    tc.standardize(Order::rpo);
+    tc.standardize(Order::rev_rpo);
     auto w = (todd_coxeter::normal_forms(tc) | rx::to_vector());
     REQUIRE(w.size() == 21);
     REQUIRE(w
@@ -108,7 +108,7 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 21);
     tc.shrink_to_fit();
     REQUIRE(tc.number_of_classes() == 21);
-    tc.standardize(Order::rpo);
+    tc.standardize(Order::rev_rpo);
     auto w = (todd_coxeter::normal_forms(tc) | rx::to_vector());
     REQUIRE(w.size() == 21);
     REQUIRE(w

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -186,7 +186,7 @@ namespace libsemigroups {
       Order old_val   = tc.current_word_graph().standardization_order();
 
       tc.run();
-      for (auto val : {Order::lenlex, Order::lex, Order::rpo}) {
+      for (auto val : {Order::lenlex, Order::lex, Order::rpo, Order::rev_rpo}) {
         tc.standardize(val);
         REQUIRE(tc.current_word_graph().is_standardized(val));
         REQUIRE(tc.current_word_graph().is_standardized());
@@ -431,9 +431,9 @@ namespace libsemigroups {
     REQUIRE(word_of(tc, 0) == 0_w);
     REQUIRE(word_of(tc, 1) == 00_w);
     REQUIRE(word_of(tc, 2) == 1_w);
-    REQUIRE(word_of(tc, 3) == 10_w);
-    REQUIRE(word_of(tc, 4) == 100_w);
-    REQUIRE(is_sorted(normal_forms(tc), RevRPOCmp{}));
+    REQUIRE(word_of(tc, 3) == 01_w);
+    REQUIRE(word_of(tc, 4) == 001_w);
+    REQUIRE(is_sorted(normal_forms(tc), RPOCmp{}));
 
     check_normal_forms(tc, tc.number_of_classes());
   }
@@ -474,7 +474,7 @@ namespace libsemigroups {
 
     REQUIRE(tc.finished());
 
-    tc.standardize(Order::rpo);
+    tc.standardize(Order::rev_rpo);
     REQUIRE(is_sorted(normal_forms(tc), RevRPOCmp{}));
     REQUIRE(
         (normal_forms(tc) | take(10) | to_vector())
@@ -2604,6 +2604,8 @@ namespace libsemigroups {
     REQUIRE(!tc.finished());
     tc.standardize(Order::rpo);
     REQUIRE(!tc.finished());
+    tc.standardize(Order::rev_rpo);
+    REQUIRE(!tc.finished());
 
     section_hlt(tc);
     section_felsch(tc);
@@ -2618,6 +2620,8 @@ namespace libsemigroups {
     tc.standardize(Order::lex);
     REQUIRE(is_sorted(normal_forms(tc), LexCmp()));
     tc.standardize(Order::rpo);
+    REQUIRE(is_sorted(normal_forms(tc), RPOCmp()));
+    tc.standardize(Order::rev_rpo);
     REQUIRE(is_sorted(normal_forms(tc), RevRPOCmp()));
   }
 

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -5515,4 +5515,33 @@ namespace libsemigroups {
       }
     }
   }
+
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "135",
+                          "From FroidurePin",
+                          "[todd-coxeter][quick]") {
+    using Transf          = LeastTransf<5>;
+    FroidurePin<Transf> S = make<FroidurePin>(
+        {make<Transf>({1, 3, 4, 2, 3}), make<Transf>({3, 2, 1, 3, 3})});
+    ToddCoxeter<word_type> tc
+        = to<ToddCoxeter<word_type>>(onesided, S, S.right_cayley_graph());
+    todd_coxeter::add_generating_pair(
+        tc,
+        froidure_pin::factorisation(S, make<Transf>({3, 4, 4, 4, 4})),
+        froidure_pin::factorisation(S, make<Transf>({3, 1, 3, 3, 3})));
+    WordRange words;
+    words.alphabet_size(2).min(1).max(5);
+    tc.run();
+    REQUIRE(v4::word_graph::number_of_nodes_reachable_from(
+                tc.current_word_graph(), 0)
+            == tc.current_word_graph().number_of_nodes_active());
+    std::vector<std::vector<word_type>> const classes
+        = congruence_common::non_trivial_classes(tc, words);
+    REQUIRE(classes
+            == std::vector<std::vector<word_type>>{{{1}, {1, 1, 1}},
+                                                   {{0, 1}, {0, 1, 1, 1}},
+                                                   {{1, 0}, {1, 1, 1, 0}},
+                                                   {{1, 1}, {1, 1, 1, 1}},
+                                                   {{1, 0, 1}, {1, 1, 0, 1}}});
+  }
 }  // namespace libsemigroups

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -5085,7 +5085,7 @@ namespace libsemigroups {
                           "[todd-coxeter][extreme]") {
     ReportGuard               rg(true);
     Presentation<std::string> p;
-    p.alphabet("ab");
+    p.alphabet("ba");
     ToddCoxeter tc(twosided, p);
     tc.strategy(options::strategy::felsch);
     tc.run_until([&tc]() {
@@ -5452,5 +5452,67 @@ namespace libsemigroups {
                       LibsemigroupsException);
     REQUIRE_THROWS_AS(tc.run_for(std::chrono::microseconds(1)),
                       LibsemigroupsException);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",
+                          "134",
+                          "Higman-Sims",
+                          "[todd-coxeter][fail]") {
+    using literals::            operator""_p;
+    using std::string_literals::operator""s;
+
+    Presentation<std::string> p;
+    p.alphabet("abAB");
+    p.contains_empty_word(true);
+    presentation::add_inverse_rules(p, "ABab");
+
+    presentation::add_rule(p, "a^2"_p, "");
+    presentation::add_rule(p, "b^5"_p, "");
+    presentation::add_rule(p, "(ab)^11"_p, "");
+    presentation::add_rule(p, "(ab^2)^10"_p, "");
+    presentation::add_rule(p, "(a,b)^5"_p, "");
+    presentation::add_rule(p, "(a,bab)^3"_p, "");
+    presentation::add_rule(p, "(a,b^2)^6"_p, "");
+    presentation::add_rule(p, "ababab^2aBaB^2aBab^2abab(aB^2)^4"_p, "");
+    presentation::add_rule(p, "ab(ab^2(aB^2)^2)^2ab^2abab^2(aBab^2)^2"_p, "");
+    presentation::add_rule(
+        p, "abab(ab^2)^2ab(aB)^2ab(ab^2)^2ababaB^2aBaB^2"_p, "");
+    presentation::add_rule(p, "(ababab^2aBaB^2ababaB)^2"_p, "");
+    presentation::add_rule(p, "(ababab^2)^2ababaBabab(ab^2)^3ababaB"_p, "");
+    presentation::add_rule(p, "ab(abab^2)^3ababab^2aBabaB^2abaBab^2"_p, "");
+
+    presentation::balance(p, "abAB"s, "ABab"s);
+    presentation::replace_subword(p, "A"s, "a"s);
+    presentation::replace_subword(p, "B"s, "bbbb"s);
+    p.alphabet("ab");
+
+    KnuthBendix kb(congruence_kind::twosided, p);
+    kb.run_for(std::chrono::microseconds(1));
+
+    ToddCoxeter tc(twosided, to<Presentation>(kb));
+    tc.lookahead_extent(options::lookahead_extent::full);
+    size_t limit = 100000000;
+
+    while (!tc.finished()) {
+      tc.run_until([&tc, &limit]() {
+        return tc.current_word_graph().number_of_nodes_active() >= limit;
+      });
+      size_t num_lookaheads = 0;
+      while (true) {
+        num_lookaheads++;
+        size_t num_nodes = tc.current_word_graph().number_of_nodes_active();
+        tc.perform_lookahead();
+        size_t diff
+            = num_nodes - tc.current_word_graph().number_of_nodes_active();
+        if (diff <= 1000000) {
+          break;
+        }
+        if (num_lookaheads == 1) {
+          tc.standardize(Order::lenlex);
+          tc.perform_lookbehind();
+          limit *= 1.1;
+        }
+      }
+    }
   }
 }  // namespace libsemigroups

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -186,7 +186,7 @@ namespace libsemigroups {
       Order old_val   = tc.current_word_graph().standardization_order();
 
       tc.run();
-      for (auto val : {Order::lenlex, Order::lex, Order::rpo}) {
+      for (auto val : {Order::lenlex, Order::lex, Order::rpo, Order::rev_rpo}) {
         tc.standardize(val);
         REQUIRE(tc.current_word_graph().is_standardized(val));
         REQUIRE(tc.current_word_graph().is_standardized());
@@ -2604,6 +2604,8 @@ namespace libsemigroups {
     REQUIRE(!tc.finished());
     tc.standardize(Order::rpo);
     REQUIRE(!tc.finished());
+    tc.standardize(Order::rev_rpo);
+    REQUIRE(!tc.finished());
 
     section_hlt(tc);
     section_felsch(tc);
@@ -2619,6 +2621,8 @@ namespace libsemigroups {
     REQUIRE(is_sorted(normal_forms(tc), LexCmp()));
     tc.standardize(Order::rpo);
     REQUIRE(is_sorted(normal_forms(tc), RPOCmp()));
+    tc.standardize(Order::rev_rpo);
+    REQUIRE(is_sorted(normal_forms(tc), RevRPOCmp()));
   }
 
   // The following example is a good one for using the lookahead.

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <algorithm>      // for min_element, reverse, sort
+#include <cmath>          // for pow
 #include <cstddef>        // for ptrdiff_t, size_t
 #include <numeric>        // for iota
 #include <stdexcept>      // for runtime_error
@@ -1080,6 +1081,8 @@ namespace libsemigroups {
     Forest f;
     REQUIRE(!v4::word_graph::standardize(wg, f, Order::rev_rpo));
     REQUIRE(v4::word_graph::is_standardized(wg, Order::rev_rpo));
+    REQUIRE(std::is_sorted(
+        expected_words.begin(), expected_words.end(), RevRPOCmp()));
     REQUIRE(words_from_forest(f) == expected_words);
   }
 
@@ -1091,12 +1094,20 @@ namespace libsemigroups {
         6, {{1, 3}, {2}, {0, 5}, {4}, {UNDEFINED, 2}, {0}});
     auto permuted = canonical;
 
-    std::vector<size_t> p({0, 3, 5, 1, 4, 2});
+    // old -> new
+    std::vector<size_t> p({0, 2, 3, 4, 5, 1});
+
+    // new -> old
     std::vector<size_t> q(p.size(), 0);
     for (size_t i = 0; i < p.size(); ++i) {
       q[p[i]] = i;
     }
-    permuted.standardize(p, q);
+    permuted.standardize(q, p);
+
+    REQUIRE(v4::word_graph::is_standardized(canonical, Order::rev_rpo));
+    REQUIRE(permuted
+            == v4::make<WordGraph<size_t>>(
+                6, {{2, 4}, {0}, {3}, {0, 1}, {5}, {UNDEFINED, 3}}));
 
     REQUIRE(!v4::word_graph::is_standardized(permuted, Order::rev_rpo));
 
@@ -1105,6 +1116,8 @@ namespace libsemigroups {
     REQUIRE(permuted == canonical);
     REQUIRE(v4::word_graph::is_standardized(permuted, Order::rev_rpo));
     REQUIRE(words_from_forest(f) == minimal_rev_rpo_words(canonical));
+    auto const words = words_from_forest(f);
+    REQUIRE(std::is_sorted(words.begin(), words.end(), RevRPOCmp()));
   }
 
   LIBSEMIGROUPS_TEST_CASE(
@@ -1127,5 +1140,98 @@ namespace libsemigroups {
     REQUIRE(
         expected.second
         == std::vector<word_type>({{}, {0}, {0, 0}, {1}, {1, 0}, {0, 1}, {2}}));
+    REQUIRE(std::is_sorted(
+        expected.second.begin(), expected.second.end(), RevRPOCmp()));
   }
+
+  LIBSEMIGROUPS_TEST_CASE("WordGraph",
+                          "051",
+                          "random standardization",
+                          "[quick][word-graph]") {
+    WordGraph wg = WordGraph<size_t>::random(5000, 8);
+    REQUIRE(wg.number_of_nodes() == 5000);
+    REQUIRE(wg.number_of_edges() == 40000);
+    WordGraph<size_t> wg1 = wg;
+    WordGraph<size_t> wg2 = wg;
+    WordGraph<size_t> wg3 = wg;
+    WordGraph<size_t> wg4 = wg;
+
+    SECTION("LenLex") {
+      Forest const f = v4::word_graph::standardize(wg1, Order::lenlex).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(std::is_sorted(
+          sorted_words.begin(), sorted_words.end(), LenLexCmp()));
+    }
+    SECTION("Lex") {
+      Forest const f = v4::word_graph::standardize(wg2, Order::lex).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(
+          std::is_sorted(sorted_words.begin(), sorted_words.end(), LexCmp()));
+    }
+    SECTION("RPO") {
+      Forest const f = v4::word_graph::standardize(wg3, Order::rpo).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(
+          std::is_sorted(sorted_words.begin(), sorted_words.end(), RPOCmp()));
+    }
+    SECTION("RevRPO") {
+      Forest const f = v4::word_graph::standardize(wg4, Order::rev_rpo).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(std::is_sorted(
+          sorted_words.begin(), sorted_words.end(), RevRPOCmp()));
+    }
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("WordGraph",
+                          "052",
+                          "all words standardization",
+                          "[quick][word-graph]") {
+    // Construct the WordGraph such that the paths from 0 are labelled by the
+    // words with length in [0, max_depth), consisting of letters in
+    // [0, num_letters).
+    size_t const max_depth   = 8;
+    size_t const num_letters = 5;
+    size_t const num_nodes
+        = (std::pow(num_letters, max_depth) - 1) / (num_letters - 1);
+    size_t const num_sources
+        = (std::pow(num_letters, max_depth - 1) - 1) / (num_letters - 1);
+    WordGraph<size_t> wg(num_nodes, num_letters);
+
+    for (size_t s = 0; s < num_sources; s++) {
+      size_t t = s * num_letters + 1;
+      for (size_t letter = 0; letter < num_letters; letter++) {
+        wg.target(s, letter, t + letter);
+      }
+    }
+    WordGraph<size_t> wg1 = wg;
+    WordGraph<size_t> wg2 = wg;
+    WordGraph<size_t> wg3 = wg;
+    WordGraph<size_t> wg4 = wg;
+
+    SECTION("LenLex") {
+      Forest const f = v4::word_graph::standardize(wg1, Order::lenlex).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(std::is_sorted(
+          sorted_words.begin(), sorted_words.end(), LenLexCmp()));
+    }
+    SECTION("Lex") {
+      Forest const f = v4::word_graph::standardize(wg2, Order::lex).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(
+          std::is_sorted(sorted_words.begin(), sorted_words.end(), LexCmp()));
+    }
+    SECTION("RPO") {
+      Forest const f = v4::word_graph::standardize(wg3, Order::rpo).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(
+          std::is_sorted(sorted_words.begin(), sorted_words.end(), RPOCmp()));
+    }
+    SECTION("RevRPO") {
+      Forest const f = v4::word_graph::standardize(wg4, Order::rev_rpo).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(std::is_sorted(
+          sorted_words.begin(), sorted_words.end(), RevRPOCmp()));
+    }
+  }
+
 }  // namespace libsemigroups

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -42,8 +42,8 @@ namespace libsemigroups {
   struct LibsemigroupsException;  // forward decl
 
   namespace {
-    std::vector<word_type> wreath_blocks(word_type const& word,
-                                         letter_type      largest_letter) {
+    std::vector<word_type> rev_rpo_blocks(word_type const& word,
+                                          letter_type      largest_letter) {
       std::vector<word_type> result(1);
       for (auto letter : word) {
         if (letter == largest_letter) {
@@ -55,26 +55,26 @@ namespace libsemigroups {
       return result;
     }
 
-    bool wreath_less(word_type const& lhs,
-                     word_type const& rhs,
-                     size_t           alphabet_size) {
+    bool rev_rpo_less(word_type const& lhs,
+                      word_type const& rhs,
+                      size_t           alphabet_size) {
       if (alphabet_size <= 1) {
         return lhs.size() < rhs.size();
       }
 
       auto const largest_letter = static_cast<letter_type>(alphabet_size - 1);
-      auto const lhs_blocks     = wreath_blocks(lhs, largest_letter);
-      auto const rhs_blocks     = wreath_blocks(rhs, largest_letter);
+      auto const lhs_blocks     = rev_rpo_blocks(lhs, largest_letter);
+      auto const rhs_blocks     = rev_rpo_blocks(rhs, largest_letter);
 
       if (lhs_blocks.size() != rhs_blocks.size()) {
         return lhs_blocks.size() < rhs_blocks.size();
       }
 
       for (size_t i = 0; i < lhs_blocks.size(); ++i) {
-        if (wreath_less(lhs_blocks[i], rhs_blocks[i], alphabet_size - 1)) {
+        if (rev_rpo_less(lhs_blocks[i], rhs_blocks[i], alphabet_size - 1)) {
           return true;
         }
-        if (wreath_less(rhs_blocks[i], lhs_blocks[i], alphabet_size - 1)) {
+        if (rev_rpo_less(rhs_blocks[i], lhs_blocks[i], alphabet_size - 1)) {
           return false;
         }
       }
@@ -82,14 +82,14 @@ namespace libsemigroups {
     }
 
     template <typename Node>
-    std::vector<word_type> minimal_wreath_words(WordGraph<Node> const& wg) {
+    std::vector<word_type> minimal_rev_rpo_words(WordGraph<Node> const& wg) {
       struct Candidate {
         word_type word;
         Node      node;
       };
 
       // This best-first search computes the true minimal word of each
-      // reachable state directly from the wreath order, independently of the
+      // reachable state directly from the rev_rpo order, independently of the
       // standardization routine under test.
       auto const nr_reachable
           = v4::word_graph::number_of_nodes_reachable_from(wg, 0);
@@ -103,10 +103,10 @@ namespace libsemigroups {
             frontier.cbegin(),
             frontier.cend(),
             [&wg](Candidate const& lhs, Candidate const& rhs) {
-              if (wreath_less(lhs.word, rhs.word, wg.out_degree())) {
+              if (rev_rpo_less(lhs.word, rhs.word, wg.out_degree())) {
                 return true;
               }
-              if (wreath_less(rhs.word, lhs.word, wg.out_degree())) {
+              if (rev_rpo_less(rhs.word, lhs.word, wg.out_degree())) {
                 return false;
               }
               return lhs.node < rhs.node;
@@ -137,17 +137,17 @@ namespace libsemigroups {
 
     template <typename Node>
     std::pair<WordGraph<Node>, std::vector<word_type>>
-    canonical_wreath_standardization(WordGraph<Node> const& wg) {
-      auto const minimal_words = minimal_wreath_words(wg);
+    canonical_rev_rpo_standardization(WordGraph<Node> const& wg) {
+      auto const minimal_words = minimal_rev_rpo_words(wg);
 
       std::vector<Node> p(wg.number_of_nodes());
       std::iota(p.begin(), p.end(), static_cast<Node>(0));
       std::sort(p.begin(), p.end(), [&minimal_words, &wg](Node lhs, Node rhs) {
-        if (wreath_less(
+        if (rev_rpo_less(
                 minimal_words[lhs], minimal_words[rhs], wg.out_degree())) {
           return true;
         }
-        if (wreath_less(
+        if (rev_rpo_less(
                 minimal_words[rhs], minimal_words[lhs], wg.out_degree())) {
           return false;
         }
@@ -1067,25 +1067,25 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
                           "048",
-                          "wreath standardization | textbook example",
+                          "rev_rpo standardization | textbook example",
                           "[quick][word-graph]") {
     auto wg = v4::make<WordGraph<size_t>>(
         6, {{1, 3}, {2}, {0, 5}, {4}, {UNDEFINED, 2}, {0}});
 
     auto const expected_words
         = std::vector<word_type>({{}, {0}, {0, 0}, {1}, {1, 0}, {0, 0, 1}});
-    REQUIRE(minimal_wreath_words(wg) == expected_words);
-    REQUIRE(v4::word_graph::is_standardized(wg, Order::wreath));
+    REQUIRE(minimal_rev_rpo_words(wg) == expected_words);
+    REQUIRE(v4::word_graph::is_standardized(wg, Order::rev_rpo));
 
     Forest f;
-    REQUIRE(!v4::word_graph::standardize(wg, f, Order::wreath));
-    REQUIRE(v4::word_graph::is_standardized(wg, Order::wreath));
+    REQUIRE(!v4::word_graph::standardize(wg, f, Order::rev_rpo));
+    REQUIRE(v4::word_graph::is_standardized(wg, Order::rev_rpo));
     REQUIRE(words_from_forest(f) == expected_words);
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
                           "049",
-                          "wreath standardization | permuted textbook example",
+                          "rev_rpo standardization | permuted textbook example",
                           "[quick][word-graph]") {
     auto canonical = v4::make<WordGraph<size_t>>(
         6, {{1, 3}, {2}, {0, 5}, {4}, {UNDEFINED, 2}, {0}});
@@ -1098,31 +1098,31 @@ namespace libsemigroups {
     }
     permuted.standardize(p, q);
 
-    REQUIRE(!v4::word_graph::is_standardized(permuted, Order::wreath));
+    REQUIRE(!v4::word_graph::is_standardized(permuted, Order::rev_rpo));
 
     Forest f;
-    REQUIRE(v4::word_graph::standardize(permuted, f, Order::wreath));
+    REQUIRE(v4::word_graph::standardize(permuted, f, Order::rev_rpo));
     REQUIRE(permuted == canonical);
-    REQUIRE(v4::word_graph::is_standardized(permuted, Order::wreath));
-    REQUIRE(words_from_forest(f) == minimal_wreath_words(canonical));
+    REQUIRE(v4::word_graph::is_standardized(permuted, Order::rev_rpo));
+    REQUIRE(words_from_forest(f) == minimal_rev_rpo_words(canonical));
   }
 
   LIBSEMIGROUPS_TEST_CASE(
       "WordGraph",
       "050",
-      "wreath standardization | recursive three-letter case",
+      "rev_rpo standardization | recursive three-letter case",
       "[quick][word-graph]") {
     auto wg = v4::make<WordGraph<size_t>>(
         7, {{1, 3, 5}, {2, 4}, {}, {6}, {}, {4}, {}});
 
-    auto const expected = canonical_wreath_standardization(wg);
+    auto const expected = canonical_rev_rpo_standardization(wg);
 
-    REQUIRE(!v4::word_graph::is_standardized(wg, Order::wreath));
+    REQUIRE(!v4::word_graph::is_standardized(wg, Order::rev_rpo));
 
     Forest f;
-    REQUIRE(v4::word_graph::standardize(wg, f, Order::wreath));
+    REQUIRE(v4::word_graph::standardize(wg, f, Order::rev_rpo));
     REQUIRE(wg == expected.first);
-    REQUIRE(v4::word_graph::is_standardized(wg, Order::wreath));
+    REQUIRE(v4::word_graph::is_standardized(wg, Order::rev_rpo));
     REQUIRE(words_from_forest(f) == expected.second);
     REQUIRE(
         expected.second

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -16,7 +16,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <cstddef>        // for size_t
+#include <algorithm>      // for min_element, reverse, sort
+#include <cstddef>        // for ptrdiff_t, size_t
+#include <numeric>        // for iota
 #include <stdexcept>      // for runtime_error
 #include <unordered_set>  // for unordered_set
 #include <vector>         // for vector
@@ -38,6 +40,150 @@ namespace libsemigroups {
   using namespace literals;
 
   struct LibsemigroupsException;  // forward decl
+
+  namespace {
+    std::vector<word_type> wreath_blocks(word_type const& word,
+                                         letter_type      largest_letter) {
+      std::vector<word_type> result(1);
+      for (auto letter : word) {
+        if (letter == largest_letter) {
+          result.emplace_back();
+        } else {
+          result.back().push_back(letter);
+        }
+      }
+      return result;
+    }
+
+    bool wreath_less(word_type const& lhs,
+                     word_type const& rhs,
+                     size_t           alphabet_size) {
+      if (alphabet_size <= 1) {
+        return lhs.size() < rhs.size();
+      }
+
+      auto const largest_letter = static_cast<letter_type>(alphabet_size - 1);
+      auto const lhs_blocks     = wreath_blocks(lhs, largest_letter);
+      auto const rhs_blocks     = wreath_blocks(rhs, largest_letter);
+
+      if (lhs_blocks.size() != rhs_blocks.size()) {
+        return lhs_blocks.size() < rhs_blocks.size();
+      }
+
+      for (size_t i = 0; i < lhs_blocks.size(); ++i) {
+        if (wreath_less(lhs_blocks[i], rhs_blocks[i], alphabet_size - 1)) {
+          return true;
+        }
+        if (wreath_less(rhs_blocks[i], lhs_blocks[i], alphabet_size - 1)) {
+          return false;
+        }
+      }
+      return false;
+    }
+
+    template <typename Node>
+    std::vector<word_type> minimal_wreath_words(WordGraph<Node> const& wg) {
+      struct Candidate {
+        word_type word;
+        Node      node;
+      };
+
+      // This best-first search computes the true minimal word of each
+      // reachable state directly from the wreath order, independently of the
+      // standardization routine under test.
+      auto const nr_reachable
+          = v4::word_graph::number_of_nodes_reachable_from(wg, 0);
+      std::vector<bool>      seen(wg.number_of_nodes(), false);
+      std::vector<word_type> result(wg.number_of_nodes());
+      std::vector<Candidate> frontier = {{{}, 0}};
+      size_t                 done     = 0;
+
+      while (done < nr_reachable) {
+        auto const it = std::min_element(
+            frontier.cbegin(),
+            frontier.cend(),
+            [&wg](Candidate const& lhs, Candidate const& rhs) {
+              if (wreath_less(lhs.word, rhs.word, wg.out_degree())) {
+                return true;
+              }
+              if (wreath_less(rhs.word, lhs.word, wg.out_degree())) {
+                return false;
+              }
+              return lhs.node < rhs.node;
+            });
+        REQUIRE(it != frontier.cend());
+
+        auto current = *it;
+        frontier.erase(frontier.begin()
+                       + static_cast<std::ptrdiff_t>(it - frontier.cbegin()));
+        if (seen[current.node]) {
+          continue;
+        }
+        seen[current.node]   = true;
+        result[current.node] = current.word;
+        ++done;
+
+        for (letter_type x = 0; x < wg.out_degree(); ++x) {
+          auto const next = wg.target_no_checks(current.node, x);
+          if (next != UNDEFINED && !seen[next]) {
+            auto word = current.word;
+            word.push_back(x);
+            frontier.push_back({std::move(word), next});
+          }
+        }
+      }
+      return result;
+    }
+
+    template <typename Node>
+    std::pair<WordGraph<Node>, std::vector<word_type>>
+    canonical_wreath_standardization(WordGraph<Node> const& wg) {
+      auto const minimal_words = minimal_wreath_words(wg);
+
+      std::vector<Node> p(wg.number_of_nodes());
+      std::iota(p.begin(), p.end(), static_cast<Node>(0));
+      std::sort(p.begin(), p.end(), [&minimal_words, &wg](Node lhs, Node rhs) {
+        if (wreath_less(
+                minimal_words[lhs], minimal_words[rhs], wg.out_degree())) {
+          return true;
+        }
+        if (wreath_less(
+                minimal_words[rhs], minimal_words[lhs], wg.out_degree())) {
+          return false;
+        }
+        return lhs < rhs;
+      });
+
+      std::vector<Node> q(wg.number_of_nodes());
+      for (Node i = 0; i < wg.number_of_nodes(); ++i) {
+        q[p[i]] = i;
+      }
+
+      WordGraph<Node> result = wg;
+      result.standardize(p, q);
+
+      std::vector<word_type> ordered_words;
+      ordered_words.reserve(p.size());
+      for (auto node : p) {
+        ordered_words.push_back(minimal_words[node]);
+      }
+      return {std::move(result), std::move(ordered_words)};
+    }
+
+    std::vector<word_type> words_from_forest(Forest const& f) {
+      std::vector<word_type> result(f.number_of_nodes());
+      for (Forest::node_type node = 1; node < f.number_of_nodes(); ++node) {
+        auto current = node;
+        while (current != UNDEFINED
+               && f.parent_no_checks(current) != UNDEFINED) {
+          result[node].push_back(f.label_no_checks(current));
+          current = f.parent_no_checks(current);
+        }
+        std::reverse(result[node].begin(), result[node].end());
+      }
+      return result;
+    }
+  }  // namespace
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
                           "000",
@@ -917,5 +1063,69 @@ namespace libsemigroups {
         std::ignore = v4::word_graph::dot(wg, node_labels, {"a"}),
         "expected the 3rd argument (edge labels) to have size 2, the "
         "out-degree of the 1st argument (word graph), but found 1");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("WordGraph",
+                          "048",
+                          "wreath standardization | textbook example",
+                          "[quick][word-graph]") {
+    auto wg = v4::make<WordGraph<size_t>>(
+        6, {{1, 3}, {2}, {0, 5}, {4}, {UNDEFINED, 2}, {0}});
+
+    auto const expected_words
+        = std::vector<word_type>({{}, {0}, {0, 0}, {1}, {1, 0}, {0, 0, 1}});
+    REQUIRE(minimal_wreath_words(wg) == expected_words);
+    REQUIRE(v4::word_graph::is_standardized(wg, Order::wreath));
+
+    Forest f;
+    REQUIRE(!v4::word_graph::standardize(wg, f, Order::wreath));
+    REQUIRE(v4::word_graph::is_standardized(wg, Order::wreath));
+    REQUIRE(words_from_forest(f) == expected_words);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("WordGraph",
+                          "049",
+                          "wreath standardization | permuted textbook example",
+                          "[quick][word-graph]") {
+    auto canonical = v4::make<WordGraph<size_t>>(
+        6, {{1, 3}, {2}, {0, 5}, {4}, {UNDEFINED, 2}, {0}});
+    auto permuted = canonical;
+
+    std::vector<size_t> p({0, 3, 5, 1, 4, 2});
+    std::vector<size_t> q(p.size(), 0);
+    for (size_t i = 0; i < p.size(); ++i) {
+      q[p[i]] = i;
+    }
+    permuted.standardize(p, q);
+
+    REQUIRE(!v4::word_graph::is_standardized(permuted, Order::wreath));
+
+    Forest f;
+    REQUIRE(v4::word_graph::standardize(permuted, f, Order::wreath));
+    REQUIRE(permuted == canonical);
+    REQUIRE(v4::word_graph::is_standardized(permuted, Order::wreath));
+    REQUIRE(words_from_forest(f) == minimal_wreath_words(canonical));
+  }
+
+  LIBSEMIGROUPS_TEST_CASE(
+      "WordGraph",
+      "050",
+      "wreath standardization | recursive three-letter case",
+      "[quick][word-graph]") {
+    auto wg = v4::make<WordGraph<size_t>>(
+        7, {{1, 3, 5}, {2, 4}, {}, {6}, {}, {4}, {}});
+
+    auto const expected = canonical_wreath_standardization(wg);
+
+    REQUIRE(!v4::word_graph::is_standardized(wg, Order::wreath));
+
+    Forest f;
+    REQUIRE(v4::word_graph::standardize(wg, f, Order::wreath));
+    REQUIRE(wg == expected.first);
+    REQUIRE(v4::word_graph::is_standardized(wg, Order::wreath));
+    REQUIRE(words_from_forest(f) == expected.second);
+    REQUIRE(
+        expected.second
+        == std::vector<word_type>({{}, {0}, {0, 0}, {1}, {1, 0}, {0, 1}, {2}}));
   }
 }  // namespace libsemigroups

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -1068,6 +1068,8 @@ namespace libsemigroups {
                           "048",
                           "rpo standardization | textbook example",
                           "[quick][word-graph]") {
+    auto rg = ReportGuard(false);
+
     auto wg = v4::make<WordGraph<size_t>>(
         6, {{1, 3}, {2}, {0, 5}, {4}, {UNDEFINED, 2}, {0}});
 
@@ -1088,6 +1090,8 @@ namespace libsemigroups {
                           "049",
                           "rpo standardization | permuted textbook example",
                           "[quick][word-graph]") {
+    auto rg = ReportGuard(false);
+
     auto canonical = v4::make<WordGraph<size_t>>(
         6, {{1, 3}, {2}, {0, 5}, {4}, {UNDEFINED, 2}, {0}});
     auto permuted = canonical;
@@ -1122,6 +1126,8 @@ namespace libsemigroups {
                           "050",
                           "rpo standardization | recursive three-letter case",
                           "[quick][word-graph]") {
+    auto rg = ReportGuard(false);
+
     auto wg = v4::make<WordGraph<size_t>>(
         7, {{1, 3, 5}, {2, 4}, {}, {6}, {}, {4}, {}});
 
@@ -1145,6 +1151,8 @@ namespace libsemigroups {
                           "051",
                           "random standardization",
                           "[quick][word-graph]") {
+    auto rg = ReportGuard(false);
+
     WordGraph wg = WordGraph<size_t>::random(5000, 8);
     REQUIRE(wg.number_of_nodes() == 5000);
     REQUIRE(wg.number_of_edges() == 40000);
@@ -1183,6 +1191,8 @@ namespace libsemigroups {
                           "052",
                           "all words standardization",
                           "[quick][word-graph]") {
+    auto rg = ReportGuard(false);
+
     // Construct the WordGraph such that the paths from 0 are labelled by the
     // words with length in [0, max_depth), consisting of letters in
     // [0, num_letters).

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -42,8 +42,8 @@ namespace libsemigroups {
   struct LibsemigroupsException;  // forward decl
 
   namespace {
-    std::vector<word_type> wreath_blocks(word_type const& word,
-                                         letter_type      largest_letter) {
+    std::vector<word_type> rpo_blocks(word_type const& word,
+                                      letter_type      largest_letter) {
       std::vector<word_type> result(1);
       for (auto letter : word) {
         if (letter == largest_letter) {
@@ -55,26 +55,26 @@ namespace libsemigroups {
       return result;
     }
 
-    bool wreath_less(word_type const& lhs,
-                     word_type const& rhs,
-                     size_t           alphabet_size) {
+    bool rpo_less(word_type const& lhs,
+                  word_type const& rhs,
+                  size_t           alphabet_size) {
       if (alphabet_size <= 1) {
         return lhs.size() < rhs.size();
       }
 
       auto const largest_letter = static_cast<letter_type>(alphabet_size - 1);
-      auto const lhs_blocks     = wreath_blocks(lhs, largest_letter);
-      auto const rhs_blocks     = wreath_blocks(rhs, largest_letter);
+      auto const lhs_blocks     = rpo_blocks(lhs, largest_letter);
+      auto const rhs_blocks     = rpo_blocks(rhs, largest_letter);
 
       if (lhs_blocks.size() != rhs_blocks.size()) {
         return lhs_blocks.size() < rhs_blocks.size();
       }
 
       for (size_t i = 0; i < lhs_blocks.size(); ++i) {
-        if (wreath_less(lhs_blocks[i], rhs_blocks[i], alphabet_size - 1)) {
+        if (rpo_less(lhs_blocks[i], rhs_blocks[i], alphabet_size - 1)) {
           return true;
         }
-        if (wreath_less(rhs_blocks[i], lhs_blocks[i], alphabet_size - 1)) {
+        if (rpo_less(rhs_blocks[i], lhs_blocks[i], alphabet_size - 1)) {
           return false;
         }
       }
@@ -82,14 +82,14 @@ namespace libsemigroups {
     }
 
     template <typename Node>
-    std::vector<word_type> minimal_wreath_words(WordGraph<Node> const& wg) {
+    std::vector<word_type> minimal_rpo_words(WordGraph<Node> const& wg) {
       struct Candidate {
         word_type word;
         Node      node;
       };
 
       // This best-first search computes the true minimal word of each
-      // reachable state directly from the wreath order, independently of the
+      // reachable state directly from the rpo order, independently of the
       // standardization routine under test.
       auto const nr_reachable
           = v4::word_graph::number_of_nodes_reachable_from(wg, 0);
@@ -103,10 +103,10 @@ namespace libsemigroups {
             frontier.cbegin(),
             frontier.cend(),
             [&wg](Candidate const& lhs, Candidate const& rhs) {
-              if (wreath_less(lhs.word, rhs.word, wg.out_degree())) {
+              if (rpo_less(lhs.word, rhs.word, wg.out_degree())) {
                 return true;
               }
-              if (wreath_less(rhs.word, lhs.word, wg.out_degree())) {
+              if (rpo_less(rhs.word, lhs.word, wg.out_degree())) {
                 return false;
               }
               return lhs.node < rhs.node;
@@ -137,18 +137,16 @@ namespace libsemigroups {
 
     template <typename Node>
     std::pair<WordGraph<Node>, std::vector<word_type>>
-    canonical_wreath_standardization(WordGraph<Node> const& wg) {
-      auto const minimal_words = minimal_wreath_words(wg);
+    canonical_rpo_standardization(WordGraph<Node> const& wg) {
+      auto const minimal_words = minimal_rpo_words(wg);
 
       std::vector<Node> p(wg.number_of_nodes());
       std::iota(p.begin(), p.end(), static_cast<Node>(0));
       std::sort(p.begin(), p.end(), [&minimal_words, &wg](Node lhs, Node rhs) {
-        if (wreath_less(
-                minimal_words[lhs], minimal_words[rhs], wg.out_degree())) {
+        if (rpo_less(minimal_words[lhs], minimal_words[rhs], wg.out_degree())) {
           return true;
         }
-        if (wreath_less(
-                minimal_words[rhs], minimal_words[lhs], wg.out_degree())) {
+        if (rpo_less(minimal_words[rhs], minimal_words[lhs], wg.out_degree())) {
           return false;
         }
         return lhs < rhs;
@@ -1067,25 +1065,27 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
                           "048",
-                          "wreath standardization | textbook example",
+                          "rpo standardization | textbook example",
                           "[quick][word-graph]") {
     auto wg = v4::make<WordGraph<size_t>>(
         6, {{1, 3}, {2}, {0, 5}, {4}, {UNDEFINED, 2}, {0}});
 
     auto const expected_words
         = std::vector<word_type>({{}, {0}, {0, 0}, {1}, {1, 0}, {0, 0, 1}});
-    REQUIRE(minimal_wreath_words(wg) == expected_words);
-    REQUIRE(v4::word_graph::is_standardized(wg, Order::wreath));
+    REQUIRE(minimal_rpo_words(wg) == expected_words);
+    REQUIRE(v4::word_graph::is_standardized(wg, Order::rpo));
 
     Forest f;
-    REQUIRE(!v4::word_graph::standardize(wg, f, Order::wreath));
-    REQUIRE(v4::word_graph::is_standardized(wg, Order::wreath));
+    REQUIRE(!v4::word_graph::standardize(wg, f, Order::rpo));
+    REQUIRE(v4::word_graph::is_standardized(wg, Order::rpo));
+    REQUIRE(
+        std::is_sorted(expected_words.begin(), expected_words.end(), RPOCmp()));
     REQUIRE(words_from_forest(f) == expected_words);
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
                           "049",
-                          "wreath standardization | permuted textbook example",
+                          "rpo standardization | permuted textbook example",
                           "[quick][word-graph]") {
     auto canonical = v4::make<WordGraph<size_t>>(
         6, {{1, 3}, {2}, {0, 5}, {4}, {UNDEFINED, 2}, {0}});
@@ -1096,36 +1096,44 @@ namespace libsemigroups {
     for (size_t i = 0; i < p.size(); ++i) {
       q[p[i]] = i;
     }
-    permuted.standardize(p, q);
+    permuted.standardize(q, p);
 
-    REQUIRE(!v4::word_graph::is_standardized(permuted, Order::wreath));
+    REQUIRE(v4::word_graph::is_standardized(canonical, Order::rpo));
+    REQUIRE(permuted
+            == v4::make<WordGraph<size_t>>(
+                6, {{2, 4}, {0}, {3}, {0, 1}, {5}, {UNDEFINED, 3}}));
+
+    REQUIRE(!v4::word_graph::is_standardized(permuted, Order::rpo));
 
     Forest f;
-    REQUIRE(v4::word_graph::standardize(permuted, f, Order::wreath));
+    REQUIRE(v4::word_graph::standardize(permuted, f, Order::rpo));
     REQUIRE(permuted == canonical);
-    REQUIRE(v4::word_graph::is_standardized(permuted, Order::wreath));
-    REQUIRE(words_from_forest(f) == minimal_wreath_words(canonical));
+    REQUIRE(v4::word_graph::is_standardized(permuted, Order::rpo));
+    REQUIRE(words_from_forest(f) == minimal_rpo_words(canonical));
+    auto const words = words_from_forest(f);
+    REQUIRE(std::is_sorted(words.begin(), words.end(), RPOCmp()));
   }
 
-  LIBSEMIGROUPS_TEST_CASE(
-      "WordGraph",
-      "050",
-      "wreath standardization | recursive three-letter case",
-      "[quick][word-graph]") {
+  LIBSEMIGROUPS_TEST_CASE("WordGraph",
+                          "050",
+                          "rpo standardization | recursive three-letter case",
+                          "[quick][word-graph]") {
     auto wg = v4::make<WordGraph<size_t>>(
         7, {{1, 3, 5}, {2, 4}, {}, {6}, {}, {4}, {}});
 
-    auto const expected = canonical_wreath_standardization(wg);
+    auto const expected = canonical_rpo_standardization(wg);
 
-    REQUIRE(!v4::word_graph::is_standardized(wg, Order::wreath));
+    REQUIRE(!v4::word_graph::is_standardized(wg, Order::rpo));
 
     Forest f;
-    REQUIRE(v4::word_graph::standardize(wg, f, Order::wreath));
+    REQUIRE(v4::word_graph::standardize(wg, f, Order::rpo));
     REQUIRE(wg == expected.first);
-    REQUIRE(v4::word_graph::is_standardized(wg, Order::wreath));
+    REQUIRE(v4::word_graph::is_standardized(wg, Order::rpo));
     REQUIRE(words_from_forest(f) == expected.second);
     REQUIRE(
         expected.second
         == std::vector<word_type>({{}, {0}, {0, 0}, {1}, {1, 0}, {0, 1}, {2}}));
+    REQUIRE(std::is_sorted(
+        expected.second.begin(), expected.second.end(), RPOCmp()));
   }
 }  // namespace libsemigroups

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <algorithm>      // for min_element, reverse, sort
+#include <cmath>          // for pow
 #include <cstddef>        // for ptrdiff_t, size_t
 #include <numeric>        // for iota
 #include <stdexcept>      // for runtime_error
@@ -1091,7 +1092,10 @@ namespace libsemigroups {
         6, {{1, 3}, {2}, {0, 5}, {4}, {UNDEFINED, 2}, {0}});
     auto permuted = canonical;
 
-    std::vector<size_t> p({0, 3, 5, 1, 4, 2});
+    // old -> new
+    std::vector<size_t> p({0, 2, 3, 4, 5, 1});
+
+    // new -> old
     std::vector<size_t> q(p.size(), 0);
     for (size_t i = 0; i < p.size(); ++i) {
       q[p[i]] = i;
@@ -1136,4 +1140,95 @@ namespace libsemigroups {
     REQUIRE(std::is_sorted(
         expected.second.begin(), expected.second.end(), RPOCmp()));
   }
+
+  LIBSEMIGROUPS_TEST_CASE("WordGraph",
+                          "051",
+                          "random standardization",
+                          "[quick][word-graph]") {
+    WordGraph wg = WordGraph<size_t>::random(5000, 8);
+    REQUIRE(wg.number_of_nodes() == 5000);
+    REQUIRE(wg.number_of_edges() == 40000);
+    WordGraph<size_t> wg1 = wg;
+    WordGraph<size_t> wg2 = wg;
+    WordGraph<size_t> wg3 = wg;
+    WordGraph<size_t> wg4 = wg;
+
+    SECTION("LenLex") {
+      Forest const f = v4::word_graph::standardize(wg1, Order::lenlex).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(std::is_sorted(
+          sorted_words.begin(), sorted_words.end(), LenLexCmp()));
+    }
+    SECTION("Lex") {
+      Forest const f = v4::word_graph::standardize(wg2, Order::lex).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(
+          std::is_sorted(sorted_words.begin(), sorted_words.end(), LexCmp()));
+    }
+    SECTION("RPO") {
+      Forest const f = v4::word_graph::standardize(wg3, Order::rpo).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(
+          std::is_sorted(sorted_words.begin(), sorted_words.end(), RPOCmp()));
+    }
+    SECTION("RevRPO") {
+      Forest const f = v4::word_graph::standardize(wg4, Order::rev_rpo).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(std::is_sorted(
+          sorted_words.begin(), sorted_words.end(), RevRPOCmp()));
+    }
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("WordGraph",
+                          "052",
+                          "all words standardization",
+                          "[quick][word-graph]") {
+    // Construct the WordGraph such that the paths from 0 are labelled by the
+    // words with length in [0, max_depth), consisting of letters in
+    // [0, num_letters).
+    size_t const max_depth   = 8;
+    size_t const num_letters = 5;
+    size_t const num_nodes
+        = (std::pow(num_letters, max_depth) - 1) / (num_letters - 1);
+    size_t const num_sources
+        = (std::pow(num_letters, max_depth - 1) - 1) / (num_letters - 1);
+    WordGraph<size_t> wg(num_nodes, num_letters);
+
+    for (size_t s = 0; s < num_sources; s++) {
+      size_t t = s * num_letters + 1;
+      for (size_t letter = 0; letter < num_letters; letter++) {
+        wg.target(s, letter, t + letter);
+      }
+    }
+    WordGraph<size_t> wg1 = wg;
+    WordGraph<size_t> wg2 = wg;
+    WordGraph<size_t> wg3 = wg;
+    WordGraph<size_t> wg4 = wg;
+
+    SECTION("LenLex") {
+      Forest const f = v4::word_graph::standardize(wg1, Order::lenlex).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(std::is_sorted(
+          sorted_words.begin(), sorted_words.end(), LenLexCmp()));
+    }
+    SECTION("Lex") {
+      Forest const f = v4::word_graph::standardize(wg2, Order::lex).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(
+          std::is_sorted(sorted_words.begin(), sorted_words.end(), LexCmp()));
+    }
+    SECTION("RPO") {
+      Forest const f = v4::word_graph::standardize(wg3, Order::rpo).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(
+          std::is_sorted(sorted_words.begin(), sorted_words.end(), RPOCmp()));
+    }
+    SECTION("RevRPO") {
+      Forest const f = v4::word_graph::standardize(wg4, Order::rev_rpo).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(std::is_sorted(
+          sorted_words.begin(), sorted_words.end(), RevRPOCmp()));
+    }
+  }
+
 }  // namespace libsemigroups

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -159,7 +159,7 @@ namespace libsemigroups {
       }
 
       WordGraph<Node> result = wg;
-      result.standardize(p, q);
+      result.standardize_no_checks(p, q);
 
       std::vector<word_type> ordered_words;
       ordered_words.reserve(p.size());
@@ -1100,7 +1100,7 @@ namespace libsemigroups {
     for (size_t i = 0; i < p.size(); ++i) {
       q[p[i]] = i;
     }
-    permuted.standardize(q, p);
+    permuted.standardize_no_checks(q, p);
 
     REQUIRE(v4::word_graph::is_standardized(canonical, Order::rpo));
     REQUIRE(permuted


### PR DESCRIPTION
This builds on the work done by @jswent in #964 and closes #809. In particular, this PR adds a reverse-rpo standardisation for WordGraphs, and also homogenises the implementations of the four standardisation functions. Note that we don't call this function `wreath_standardize` because there is no specification of different levels for generators. 