### PR TITLE
Add maximum rewriting depth

### DIFF
--- a/include/libsemigroups/detail/rewriting-system.hpp
+++ b/include/libsemigroups/detail/rewriting-system.hpp
@@ -59,8 +59,23 @@ namespace libsemigroups {
 
      private:
       struct Settings {
-        size_t reduction_threshold = 128;
-        size_t max_rewriting_depth = POSITIVE_INFINITY;
+        size_t reduction_threshold;
+        size_t max_rewriting_depth;
+
+        Settings() : reduction_threshold(), max_rewriting_depth() {
+          init();
+        }
+
+        Settings(Settings const&)            = default;
+        Settings& operator=(Settings const&) = default;
+        Settings(Settings&&)                 = default;
+        Settings& operator=(Settings&&)      = default;
+
+        Settings& init() noexcept {
+          reduction_threshold = 128;
+          max_rewriting_depth = POSITIVE_INFINITY;
+          return *this;
+        }
       };
 
       mutable std::atomic<bool>                     _cached_confluent;

--- a/include/libsemigroups/detail/rewriting-system.hpp
+++ b/include/libsemigroups/detail/rewriting-system.hpp
@@ -31,11 +31,12 @@
 #include <type_traits>    // for enable_if_t, is_same_v
 #include <unordered_map>  // for unordered_map
 
-#include "libsemigroups/config.hpp"  // for LIBSEMIGROUPS_DEBUG
-#include "libsemigroups/debug.hpp"   // for LIBSEMIGROUPS_ASSERT
-#include "libsemigroups/order.hpp"   // for lenlex_cmp
-#include "libsemigroups/runner.hpp"  // for delta
-#include "libsemigroups/types.hpp"   // for u8string
+#include "libsemigroups/config.hpp"     // for LIBSEMIGROUPS_DEBUG
+#include "libsemigroups/debug.hpp"      // for LIBSEMIGROUPS_ASSERT
+#include "libsemigroups/exception.hpp"  // for LIBSEMIGRUOPS_EXCEPTION
+#include "libsemigroups/order.hpp"      // for lenlex_cmp
+#include "libsemigroups/runner.hpp"     // for delta
+#include "libsemigroups/types.hpp"      // for u8string
 
 #include "aho-corasick-impl.hpp"  // for AhoCorasickImpl
 #include "multi-view.hpp"         // for MultiView
@@ -59,6 +60,7 @@ namespace libsemigroups {
      private:
       struct Settings {
         size_t reduction_threshold = 128;
+        size_t max_rewriting_depth = POSITIVE_INFINITY;
       };
 
       mutable std::atomic<bool>                     _cached_confluent;

--- a/include/libsemigroups/detail/rewriting-system.hpp
+++ b/include/libsemigroups/detail/rewriting-system.hpp
@@ -194,6 +194,8 @@ namespace libsemigroups {
         report_progress_from_thread(0, start_time);
       }
 
+      void throw_if_rewiting_depth_exceeded(size_t num_rewrites) const;
+
      private:
       [[nodiscard]] virtual bool confluent_impl(std::atomic_uint64_t& seen) = 0;
 

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -290,7 +290,8 @@ namespace libsemigroups::detail {
     }
 
     // position of the start of the unread suffix of the input word
-    size_t pos = n - 1;
+    size_t pos                = n - 1;
+    size_t number_of_rewrites = 0;
 
     RuleLookup lookup;
 
@@ -303,6 +304,13 @@ namespace libsemigroups::detail {
         // lookup in _set_rules doesn't necessarily mean that we have found a
         // rule whose lhs is contained in [v.begin(), v.begin() + pos), that's
         // why we do the second check in the if-condition above.
+        ++number_of_rewrites;
+        if (number_of_rewrites
+            > RewritingSystemBase::settings().max_rewriting_depth) {
+          LIBSEMIGROUPS_EXCEPTION(
+              "rewriting has exceeded the maximum rewrite depth, {}",
+              RewritingSystemBase::settings().max_rewriting_depth);
+        }
         Rule const* rule = (*it).rule();
         LIBSEMIGROUPS_ASSERT(is_suffix(v.begin(),
                                        v.begin() + pos,
@@ -804,6 +812,7 @@ namespace libsemigroups::detail {
     //    }
 
     // NEW VERSION
+    size_t number_of_rewrites = 0;
     _trie_nodes_visited_indices.clear();
     index_type current = _rule_trie.root;
     _trie_nodes_visited_indices.push_back(current);
@@ -820,6 +829,13 @@ namespace libsemigroups::detail {
         _trie_nodes_visited_indices.push_back(current);
         pos++;
       } else {
+        ++number_of_rewrites;
+        if (number_of_rewrites
+            > RewritingSystemBase::settings().max_rewriting_depth) {
+          LIBSEMIGROUPS_EXCEPTION(
+              "rewriting has exceeded the maximum rewrite depth, {}",
+              RewritingSystemBase::settings().max_rewriting_depth);
+        }
         // Everything here is off by one because we read everything up to and
         // including the pos-th character in "v"
         Rule const* rule = _rule_trie.node_no_checks(current).value();

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -305,12 +305,8 @@ namespace libsemigroups::detail {
         // rule whose lhs is contained in [v.begin(), v.begin() + pos), that's
         // why we do the second check in the if-condition above.
         ++number_of_rewrites;
-        if (number_of_rewrites
-            > RewritingSystemBase::settings().max_rewriting_depth) {
-          LIBSEMIGROUPS_EXCEPTION(
-              "rewriting has exceeded the maximum rewrite depth, {}",
-              RewritingSystemBase::settings().max_rewriting_depth);
-        }
+        RewritingSystemBase::throw_if_rewiting_depth_exceeded(
+            number_of_rewrites);
         Rule const* rule = (*it).rule();
         LIBSEMIGROUPS_ASSERT(is_suffix(v.begin(),
                                        v.begin() + pos,
@@ -830,12 +826,8 @@ namespace libsemigroups::detail {
         pos++;
       } else {
         ++number_of_rewrites;
-        if (number_of_rewrites
-            > RewritingSystemBase::settings().max_rewriting_depth) {
-          LIBSEMIGROUPS_EXCEPTION(
-              "rewriting has exceeded the maximum rewrite depth, {}",
-              RewritingSystemBase::settings().max_rewriting_depth);
-        }
+        RewritingSystemBase::throw_if_rewiting_depth_exceeded(
+            number_of_rewrites);
         // Everything here is off by one because we read everything up to and
         // including the pos-th character in "v"
         Rule const* rule = _rule_trie.node_no_checks(current).value();

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -192,8 +192,15 @@ namespace libsemigroups::detail {
       LIBSEMIGROUPS_ASSERT(rule1->state() == Rule::State::pending);
       LIBSEMIGROUPS_ASSERT(rule1->lhs() != rule1->rhs());
 
-      rewrite_no_reduce(rule1->lhs());
-      rewrite_no_reduce(rule1->rhs());
+      try {
+        rewrite_no_reduce(rule1->lhs());
+        rewrite_no_reduce(rule1->rhs());
+      } catch (LibsemigroupsException const&) {
+        // We do this so that the memory allocated for rule1 actually gets freed
+        // at some point.
+        Rules::pending_rules().push_back(rule1);
+        throw;
+      }
 
       // Check rule is non-trivial
       if (rule1->lhs() != rule1->rhs()) {
@@ -294,7 +301,6 @@ namespace libsemigroups::detail {
     size_t number_of_rewrites = 0;
 
     RuleLookup lookup;
-
     while (pos < v.size()) {
       LIBSEMIGROUPS_ASSERT(pos >= n - 1);
       ++pos;
@@ -618,8 +624,15 @@ namespace libsemigroups::detail {
         Rule* rule = Rules::pop_pending_rule();
         LIBSEMIGROUPS_ASSERT(rule->state() == Rule::State::pending);
         LIBSEMIGROUPS_ASSERT(rule->lhs() != rule->rhs());
-        rewrite_no_reduce(rule->lhs());
-        rewrite_no_reduce(rule->rhs());
+        try {
+          rewrite_no_reduce(rule->lhs());
+          rewrite_no_reduce(rule->rhs());
+        } catch (LibsemigroupsException const&) {
+          // We do this so that the memory allocated for rule1 actually gets
+          // freed at some point.
+          Rules::pending_rules().push_back(rule);
+          throw;
+        }
 
         if (rule->lhs() != rule->rhs()) {
           RewritingSystemBaseWithOrder_::reorder(rule);

--- a/include/libsemigroups/detail/rewriting-system.tpp
+++ b/include/libsemigroups/detail/rewriting-system.tpp
@@ -199,7 +199,8 @@ namespace libsemigroups::detail {
     }
 
     // position of the start of the unread suffix of the input word
-    size_t pos = n - 1;
+    size_t pos                = n - 1;
+    size_t number_of_rewrites = 0;
 
     RuleLookup lookup;
 
@@ -212,6 +213,13 @@ namespace libsemigroups::detail {
         // lookup in _set_rules doesn't necessarily mean that we have found a
         // rule whose lhs is contained in [v.begin(), v.begin() + pos), that's
         // why we do the second check in the if-condition above.
+        ++number_of_rewrites;
+        if (number_of_rewrites
+            > RewritingSystemBase::settings().max_rewriting_depth) {
+          LIBSEMIGROUPS_EXCEPTION(
+              "rewriting has exceeded the maximum rewrite depth, {}",
+              RewritingSystemBase::settings().max_rewriting_depth);
+        }
         Rule const* rule = (*it).rule();
         LIBSEMIGROUPS_ASSERT(is_suffix(v.begin(),
                                        v.begin() + pos,
@@ -675,6 +683,7 @@ namespace libsemigroups::detail {
     //    }
 
     // NEW VERSION
+    size_t number_of_rewrites = 0;
     _trie_nodes_visited_indices.clear();
     index_type current = _rule_trie.root;
     _trie_nodes_visited_indices.push_back(current);
@@ -691,6 +700,13 @@ namespace libsemigroups::detail {
         _trie_nodes_visited_indices.push_back(current);
         pos++;
       } else {
+        ++number_of_rewrites;
+        if (number_of_rewrites
+            > RewritingSystemBase::settings().max_rewriting_depth) {
+          LIBSEMIGROUPS_EXCEPTION(
+              "rewriting has exceeded the maximum rewrite depth, {}",
+              RewritingSystemBase::settings().max_rewriting_depth);
+        }
         // Everything here is off by one because we read everything up to and
         // including the pos-th character in "v"
         Rule const* rule = _rule_trie.node_no_checks(current).value();

--- a/src/detail/rewriting-system.cpp
+++ b/src/detail/rewriting-system.cpp
@@ -61,13 +61,15 @@ namespace libsemigroups {
 
     RewritingSystemBase& RewritingSystemBase::init() {
       Rules::init();
-      _cached_confluent         = false;
-      _cached_terminating       = false;
-      _confluence_known         = false;
-      _pending_rules_comparator = lhs_lex_cmp;
-      _state                    = State::none;
-      _terminating_known        = false;
-      _ticker_running           = false;
+      _cached_confluent             = false;
+      _cached_terminating           = false;
+      _confluence_known             = false;
+      _settings.reduction_threshold = 128;
+      _settings.max_rewriting_depth = POSITIVE_INFINITY;
+      _pending_rules_comparator     = lhs_lex_cmp;
+      _terminating_known            = false;
+      _state                        = State::none;
+      _ticker_running               = false;
       return *this;
     }
 
@@ -78,9 +80,10 @@ namespace libsemigroups {
       _cached_terminating       = that._cached_terminating;
       _confluence_known         = that._confluence_known.load();
       _pending_rules_comparator = that._pending_rules_comparator;
+      _settings                 = that._settings;
+      _terminating_known        = that._terminating_known;
       _state                    = that._state;
       _ticker_running           = that._ticker_running;
-      _terminating_known        = that._terminating_known;
 
       return *this;
     }
@@ -92,9 +95,10 @@ namespace libsemigroups {
       _cached_terminating       = that._cached_terminating;
       _confluence_known         = that._confluence_known.load();
       _pending_rules_comparator = std::move(that._pending_rules_comparator);
+      _settings                 = that._settings;
+      _terminating_known        = that._terminating_known;
       _state                    = that._state;
       _ticker_running           = std::move(that._ticker_running);
-      _terminating_known        = that._terminating_known;
       return *this;
     }
 

--- a/src/detail/rewriting-system.cpp
+++ b/src/detail/rewriting-system.cpp
@@ -61,15 +61,14 @@ namespace libsemigroups {
 
     RewritingSystemBase& RewritingSystemBase::init() {
       Rules::init();
-      _cached_confluent             = false;
-      _cached_terminating           = false;
-      _confluence_known             = false;
-      _settings.reduction_threshold = 128;
-      _settings.max_rewriting_depth = POSITIVE_INFINITY;
-      _pending_rules_comparator     = lhs_lex_cmp;
-      _terminating_known            = false;
-      _state                        = State::none;
-      _ticker_running               = false;
+      _cached_confluent   = false;
+      _cached_terminating = false;
+      _confluence_known   = false;
+      _settings.init();
+      _pending_rules_comparator = lhs_lex_cmp;
+      _terminating_known        = false;
+      _state                    = State::none;
+      _ticker_running           = false;
       return *this;
     }
 

--- a/src/detail/rewriting-system.cpp
+++ b/src/detail/rewriting-system.cpp
@@ -185,5 +185,18 @@ namespace libsemigroups {
       }
     }
 
+    ////////////////////////////////////////////////////////////////////////
+    // RewritingSystemBase - private mem fns
+    ////////////////////////////////////////////////////////////////////////
+    void RewritingSystemBase::throw_if_rewiting_depth_exceeded(
+        size_t num_rewrites) const {
+      if (num_rewrites > settings().max_rewriting_depth) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "rewriting has exceeded the maximum rewrite depth, "
+            "settings().max_rewriting_depth = {}",
+            RewritingSystemBase::settings().max_rewriting_depth);
+      }
+    }
+
   }  // namespace detail
 }  // namespace libsemigroups

--- a/tests/test-knuth-bendix-string-quick-2.cpp
+++ b/tests/test-knuth-bendix-string-quick-2.cpp
@@ -856,7 +856,9 @@ namespace libsemigroups {
                                    "kbmag/standalone/kb_data/237",
                                    "[quick][knuth-bendix][kbmag]",
                                    LenLexSet,
-                                   LenLexTrie) {
+                                   LenLexTrie,
+                                   RPOSet,
+                                   RPOTrie) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("aAbBc"s);
@@ -870,45 +872,53 @@ namespace libsemigroups {
 
     KnuthBendix<std::string, TestType> kb(twosided, p);
     REQUIRE(!kb.rewriting_system().confluent());
+    // This number can be set as low as seven and the LenLex tests will still
+    // pass
+    kb.rewriting_system().settings().max_rewriting_depth = 50;
 
-    kb.run();
-    REQUIRE(kb.rewriting_system().confluent());
-    REQUIRE(kb.rewriting_system().number_of_rules() == 32);
-    using rule_type = typename decltype(kb)::rule_type;
-    REQUIRE((kb.active_rules() | sort(weird_cmp()) | to_vector())
-            == std::vector<rule_type>({{"Aa", ""},
-                                       {"Ac", "b"},
-                                       {"BA", "c"},
-                                       {"BB", "b"},
-                                       {"Bb", ""},
-                                       {"Bc", "bA"},
-                                       {"aA", ""},
-                                       {"ab", "c"},
-                                       {"bB", ""},
-                                       {"ba", "AB"},
-                                       {"bb", "B"},
-                                       {"bc", "A"},
-                                       {"cB", "a"},
-                                       {"ca", "B"},
-                                       {"cb", "aB"},
-                                       {"cc", ""},
-                                       {"BaB", "bAb"},
-                                       {"bAB", "Ba"},
-                                       {"cAB", "aBa"},
-                                       {"AAAA", "aaa"},
-                                       {"AAAb", "aaac"},
-                                       {"aaaa", "AAA"},
-                                       {"bAbA", "Bac"},
-                                       {"cAAA", "Baaa"},
-                                       {"cAbA", "aBac"},
-                                       {"ABaaa", "bAAA"},
-                                       {"Baaac", "cAAb"},
-                                       {"bAABaac", "BacAAb"},
-                                       {"cAABaac", "aBacAAb"},
-                                       {"BaaaBaaa", "cAAbAAA"},
-                                       {"bAABaaBaaa", "BacAAbAAA"},
-                                       {"cAABaaBaaa", "aBacAAbAAA"}}));
-    REQUIRE(kb.number_of_classes() == POSITIVE_INFINITY);
+    if constexpr (std::is_same_v<TestType, RPOSet>
+                  || std::is_same_v<TestType, RPOTrie>) {
+      REQUIRE_THROWS_AS(kb.run(), LibsemigroupsException);
+    } else {
+      kb.run();
+      REQUIRE(kb.rewriting_system().confluent());
+      REQUIRE(kb.rewriting_system().number_of_rules() == 32);
+      using rule_type = typename decltype(kb)::rule_type;
+      REQUIRE((kb.active_rules() | sort(weird_cmp()) | to_vector())
+              == std::vector<rule_type>({{"Aa", ""},
+                                         {"Ac", "b"},
+                                         {"BA", "c"},
+                                         {"BB", "b"},
+                                         {"Bb", ""},
+                                         {"Bc", "bA"},
+                                         {"aA", ""},
+                                         {"ab", "c"},
+                                         {"bB", ""},
+                                         {"ba", "AB"},
+                                         {"bb", "B"},
+                                         {"bc", "A"},
+                                         {"cB", "a"},
+                                         {"ca", "B"},
+                                         {"cb", "aB"},
+                                         {"cc", ""},
+                                         {"BaB", "bAb"},
+                                         {"bAB", "Ba"},
+                                         {"cAB", "aBa"},
+                                         {"AAAA", "aaa"},
+                                         {"AAAb", "aaac"},
+                                         {"aaaa", "AAA"},
+                                         {"bAbA", "Bac"},
+                                         {"cAAA", "Baaa"},
+                                         {"cAbA", "aBac"},
+                                         {"ABaaa", "bAAA"},
+                                         {"Baaac", "cAAb"},
+                                         {"bAABaac", "BacAAb"},
+                                         {"cAABaac", "aBacAAb"},
+                                         {"BaaaBaaa", "cAAbAAA"},
+                                         {"bAABaaBaaa", "BacAAbAAA"},
+                                         {"cAABaaBaaa", "aBacAAbAAA"}}));
+      REQUIRE(kb.number_of_classes() == POSITIVE_INFINITY);
+    }
   }
 
   // Cyclic group of order 2.
@@ -1430,7 +1440,8 @@ namespace libsemigroups {
     REQUIRE(kb3.presentation().rules.size() / 2 == 1);
   }
 
-  // RevRPO very slow here
+  // RPO very slow here. RPOTrie seems to be spending most of its time doing
+  // SearchIterator things
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "054",
                                    "small overlap 1",

--- a/tests/test-rewriting-system.cpp
+++ b/tests/test-rewriting-system.cpp
@@ -582,5 +582,38 @@ namespace libsemigroups {
       // rws.reduce();
     }
 
+    LIBSEMIGROUPS_TEMPLATE_TEST_CASE("RewritingSystem",
+                                     "020",
+                                     "max_rewriting_depth",
+                                     "[quick]",
+                                     RewritingSystemSet<LenLexCmp>,
+                                     RewritingSystemTrie<LenLexCmp>) {
+      auto     rg = ReportGuard(false);
+      TestType rws;
+      REQUIRE(rws.settings().max_rewriting_depth == POSITIVE_INFINITY);
+      rws.increase_alphabet_size_by(1);
+      rewriting_system::add_rule(rws, "aa"_w, "a"_w);
+
+      // words that require 9 rewrite steps
+      string_type word1{0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+      string_type word2(word1);
+      string_type word3(word1);
+      string_type word4(word1);
+
+      // word that requires 8 rewrite steps
+      string_type word5{0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+      REQUIRE_NOTHROW(rws.rewrite(word1));
+
+      rws.settings().max_rewriting_depth = 10;
+      REQUIRE_NOTHROW(rws.rewrite(word2));
+
+      rws.settings().max_rewriting_depth = 9;
+      REQUIRE_NOTHROW(rws.rewrite(word3));
+
+      rws.settings().max_rewriting_depth = 8;
+      REQUIRE_THROWS_AS(rws.rewrite(word4), LibsemigroupsException);
+      REQUIRE_NOTHROW(rws.rewrite(word5));
+    }
   }  // namespace detail
 }  // namespace libsemigroups

--- a/tests/test-rewriting-system.cpp
+++ b/tests/test-rewriting-system.cpp
@@ -560,5 +560,39 @@ namespace libsemigroups {
                | rx::to_vector())
               == std::vector<rule_type>({{{1, 2}, {0, 2}}}));
     }
+
+    LIBSEMIGROUPS_TEMPLATE_TEST_CASE("RewritingSystem",
+                                     "019",
+                                     "max_rewriting_depth",
+                                     "[quick]",
+                                     RewritingSystemSet<LenLexCmp>,
+                                     RewritingSystemTrie<LenLexCmp>) {
+      auto     rg = ReportGuard(false);
+      TestType rws;
+      REQUIRE(rws.settings().max_rewriting_depth == POSITIVE_INFINITY);
+      rws.increase_alphabet_size_by(1);
+      rewriting_system::add_rule(rws, "aa"_w, "a"_w);
+
+      // words that require 9 rewrite steps
+      string_type word1{0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+      string_type word2(word1);
+      string_type word3(word1);
+      string_type word4(word1);
+
+      // word that requires 8 rewrite steps
+      string_type word5{0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+      REQUIRE_NOTHROW(rws.rewrite(word1));
+
+      rws.settings().max_rewriting_depth = 10;
+      REQUIRE_NOTHROW(rws.rewrite(word2));
+
+      rws.settings().max_rewriting_depth = 9;
+      REQUIRE_NOTHROW(rws.rewrite(word3));
+
+      rws.settings().max_rewriting_depth = 8;
+      REQUIRE_THROWS_AS(rws.rewrite(word4), LibsemigroupsException);
+      REQUIRE_NOTHROW(rws.rewrite(word5));
+    }
   }  // namespace detail
 }  // namespace libsemigroups


### PR DESCRIPTION
This PR adds a setting to the rewriting systems that can be used to limit how many individual rewriting steps are allowed to occur before an exception is thrown. The default value is `POSITIVE_INFINITY`, so this should have no impact on existing test cases.