### PR TITLE
Add `to_human_readable_repr` overloads for structs/classes

### DIFF
--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -5178,6 +5178,39 @@ namespace libsemigroups {
     }
   };  // class RevWtLexCmp<Default, check>
 
+  //! \relates RevWtLexCmp
+  //!
+  //! \brief Return a human readable representation of a reversed weighted
+  //! lexicographic comparison functor with an alphabet.
+  //!
+  //! \tparam Word the word type associated with the alphabet.
+  //! \tparam check whether to check that letters belong to the alphabet.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <typename Word, bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RevWtLexCmp<Word, check> const& cmp);
+
+  //! \relates RevWtLexCmp
+  //!
+  //! \brief Return a human readable representation of a reversed weighted
+  //! lexicographic comparison functor on index words.
+  //!
+  //! \tparam check whether to check arguments.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RevWtLexCmp<Default, check> const& cmp);
+
   //! \brief Deduction guide from a weights vector.
   RevWtLexCmp(std::vector<size_t> const&)->RevWtLexCmp<>;
 

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -516,6 +516,39 @@ namespace libsemigroups {
     }
   };  // struct LexCmp<Default, false>
 
+  //! \relates LexCmp
+  //!
+  //! \brief Return a human readable representation of a stateful
+  //! lexicographic comparison functor.
+  //!
+  //! \tparam Word the word type associated with the alphabet.
+  //! \tparam check whether to check that letters belong to the alphabet.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <typename Word, bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(LexCmp<Word, check> const& cmp);
+
+  //! \relates LexCmp
+  //!
+  //! \brief Return a human readable representation of a stateless
+  //! lexicographic comparison functor.
+  //!
+  //! \tparam check whether to check arguments.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(LexCmp<Default, check> const& cmp);
+
   //////////////////////////////////////////////////////////////////////
   // Reversed lex
   //////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -741,6 +741,39 @@ namespace libsemigroups {
     }
   };  // struct RevLexCmp<Default, false>
 
+  //! \relates RevLexCmp
+  //!
+  //! \brief Return a human readable representation of a stateful reversed
+  //! lexicographic comparison functor.
+  //!
+  //! \tparam Word the word type associated with the alphabet.
+  //! \tparam check whether to check that letters belong to the alphabet.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <typename Word, bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RevLexCmp<Word, check> const& cmp);
+
+  //! \relates RevLexCmp
+  //!
+  //! \brief Return a human readable representation of a stateless reversed
+  //! lexicographic comparison functor.
+  //!
+  //! \tparam check whether to check arguments.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RevLexCmp<Default, check> const& cmp);
+
   //////////////////////////////////////////////////////////////////////
   // Len-lex
   //////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -2247,6 +2247,39 @@ namespace libsemigroups {
     }
   };  // struct RevRPOCmp<Default, false>
 
+  //! \relates RevRPOCmp
+  //!
+  //! \brief Return a human readable representation of a stateful reversed
+  //! recursive path order comparison functor.
+  //!
+  //! \tparam Word the word type associated with the alphabet.
+  //! \tparam check whether to check that letters belong to the alphabet.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <typename Word, bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RevRPOCmp<Word, check> const& cmp);
+
+  //! \relates RevRPOCmp
+  //!
+  //! \brief Return a human readable representation of a stateless reversed
+  //! recursive path order comparison functor.
+  //!
+  //! \tparam check whether to check arguments.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RevRPOCmp<Default, check> const& cmp);
+
   //////////////////////////////////////////////////////////////////////
   // Wreath-product
   //////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -3183,6 +3183,39 @@ namespace libsemigroups {
     }
   };  // class RevWrCmp<Default, check>
 
+  //! \relates RevWrCmp
+  //!
+  //! \brief Return a human readable representation of a reversed
+  //! wreath-product comparison functor with an alphabet.
+  //!
+  //! \tparam Word the word type associated with the alphabet.
+  //! \tparam check whether to check that letters belong to the alphabet.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <typename Word, bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RevWrCmp<Word, check> const& cmp);
+
+  //! \relates RevWrCmp
+  //!
+  //! \brief Return a human readable representation of a reversed
+  //! wreath-product comparison functor on index words.
+  //!
+  //! \tparam check whether to check arguments.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RevWrCmp<Default, check> const& cmp);
+
   //! \brief Deduction guide from a levels vector.
   RevWrCmp(std::vector<size_t> const&)->RevWrCmp<>;
 

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -5825,6 +5825,39 @@ namespace libsemigroups {
     }
   };  // class RevLenWtLexCmp<Default, check>
 
+  //! \relates RevLenWtLexCmp
+  //!
+  //! \brief Return a human readable representation of a reversed
+  //! length-then-weighted lexicographic comparison functor with an alphabet.
+  //!
+  //! \tparam Word the word type associated with the alphabet.
+  //! \tparam check whether to check that letters belong to the alphabet.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <typename Word, bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RevLenWtLexCmp<Word, check> const& cmp);
+
+  //! \relates RevLenWtLexCmp
+  //!
+  //! \brief Return a human readable representation of a reversed
+  //! length-then-weighted lexicographic comparison functor on index words.
+  //!
+  //! \tparam check whether to check arguments.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RevLenWtLexCmp<Default, check> const& cmp);
+
   //! \brief Deduction guide from a weights vector.
   RevLenWtLexCmp(std::vector<size_t> const&)->RevLenWtLexCmp<>;
 

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -1821,6 +1821,39 @@ namespace libsemigroups {
     }
   };  // struct RPOCmp<Default, false>
 
+  //! \relates RPOCmp
+  //!
+  //! \brief Return a human readable representation of a stateful recursive
+  //! path order comparison functor.
+  //!
+  //! \tparam Word the word type associated with the alphabet.
+  //! \tparam check whether to check that letters belong to the alphabet.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <typename Word, bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RPOCmp<Word, check> const& cmp);
+
+  //! \relates RPOCmp
+  //!
+  //! \brief Return a human readable representation of a stateless recursive
+  //! path order comparison functor.
+  //!
+  //! \tparam check whether to check arguments.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RPOCmp<Default, check> const& cmp);
+
   //////////////////////////////////////////////////////////////////////
   // Reversed recursive path order (RPO)
   //////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -5495,6 +5495,39 @@ namespace libsemigroups {
     }
   };  // class LenWtLexCmp<Default, check>
 
+  //! \relates LenWtLexCmp
+  //!
+  //! \brief Return a human readable representation of a length-then-weighted
+  //! lexicographic comparison functor with an alphabet.
+  //!
+  //! \tparam Word the word type associated with the alphabet.
+  //! \tparam check whether to check that letters belong to the alphabet.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <typename Word, bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(LenWtLexCmp<Word, check> const& cmp);
+
+  //! \relates LenWtLexCmp
+  //!
+  //! \brief Return a human readable representation of a length-then-weighted
+  //! lexicographic comparison functor on index words.
+  //!
+  //! \tparam check whether to check arguments.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(LenWtLexCmp<Default, check> const& cmp);
+
   //! \brief Deduction guide from a weights vector.
   LenWtLexCmp(std::vector<size_t> const&)->LenWtLexCmp<>;
 

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -2874,6 +2874,39 @@ namespace libsemigroups {
     }
   };  // class WrCmp<Default, check>
 
+  //! \relates WrCmp
+  //!
+  //! \brief Return a human readable representation of a wreath-product
+  //! comparison functor with an alphabet.
+  //!
+  //! \tparam Word the word type associated with the alphabet.
+  //! \tparam check whether to check that letters belong to the alphabet.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <typename Word, bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(WrCmp<Word, check> const& cmp);
+
+  //! \relates WrCmp
+  //!
+  //! \brief Return a human readable representation of a wreath-product
+  //! comparison functor on index words.
+  //!
+  //! \tparam check whether to check arguments.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(WrCmp<Default, check> const& cmp);
+
   //! \brief Deduction guide from a levels vector reference.
   WrCmp(std::vector<size_t> const&)->WrCmp<>;
 

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -1111,6 +1111,39 @@ namespace libsemigroups {
     }
   };  // struct LenLexCmp<Default, false>
 
+  //! \relates LenLexCmp
+  //!
+  //! \brief Return a human readable representation of a stateful len-lex
+  //! comparison functor.
+  //!
+  //! \tparam Word the word type associated with the alphabet.
+  //! \tparam check whether to check that letters belong to the alphabet.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <typename Word, bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(LenLexCmp<Word, check> const& cmp);
+
+  //! \relates LenLexCmp
+  //!
+  //! \brief Return a human readable representation of a stateless len-lex
+  //! comparison functor.
+  //!
+  //! \tparam check whether to check arguments.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(LenLexCmp<Default, check> const& cmp);
+
   //////////////////////////////////////////////////////////////////////
   // Reversed len-lex
   //////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -4863,6 +4863,39 @@ namespace libsemigroups {
     }
   };  // class WtLexCmp<Default, check>
 
+  //! \relates WtLexCmp
+  //!
+  //! \brief Return a human readable representation of a weighted
+  //! lexicographic comparison functor with an alphabet.
+  //!
+  //! \tparam Word the word type associated with the alphabet.
+  //! \tparam check whether to check that letters belong to the alphabet.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <typename Word, bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(WtLexCmp<Word, check> const& cmp);
+
+  //! \relates WtLexCmp
+  //!
+  //! \brief Return a human readable representation of a weighted
+  //! lexicographic comparison functor on index words.
+  //!
+  //! \tparam check whether to check arguments.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(WtLexCmp<Default, check> const& cmp);
+
   //! \brief Deduction guide for constructing \ref WtLexCmp from weights.
   WtLexCmp(std::vector<size_t> const&)->WtLexCmp<>;
 

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -3875,6 +3875,39 @@ namespace libsemigroups {
     }
   };  // class WtLenLexCmp<Default, check>
 
+  //! \relates WtLenLexCmp
+  //!
+  //! \brief Return a human readable representation of a weighted len-lex
+  //! comparison functor with an alphabet.
+  //!
+  //! \tparam Word the word type associated with the alphabet.
+  //! \tparam check whether to check that letters belong to the alphabet.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <typename Word, bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(WtLenLexCmp<Word, check> const& cmp);
+
+  //! \relates WtLenLexCmp
+  //!
+  //! \brief Return a human readable representation of a weighted len-lex
+  //! comparison functor on index words.
+  //!
+  //! \tparam check whether to check arguments.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(WtLenLexCmp<Default, check> const& cmp);
+
   //! \brief Deduction guide for constructing \ref WtLenLexCmp from weights.
   WtLenLexCmp(std::vector<size_t> const&)->WtLenLexCmp<>;
 

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -1403,6 +1403,39 @@ namespace libsemigroups {
     }
   };  // struct RevLenLexCmp<Default, false>
 
+  //! \relates RevLenLexCmp
+  //!
+  //! \brief Return a human readable representation of a stateful reversed
+  //! len-lex comparison functor.
+  //!
+  //! \tparam Word the word type associated with the alphabet.
+  //! \tparam check whether to check that letters belong to the alphabet.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <typename Word, bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RevLenLexCmp<Word, check> const& cmp);
+
+  //! \relates RevLenLexCmp
+  //!
+  //! \brief Return a human readable representation of a stateless reversed
+  //! len-lex comparison functor.
+  //!
+  //! \tparam check whether to check arguments.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RevLenLexCmp<Default, check> const& cmp);
+
   //////////////////////////////////////////////////////////////////////
   // Recursive path order (RPO)
   //////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -4195,6 +4195,39 @@ namespace libsemigroups {
     }
   };  // class RevWtLenLexCmp<Default, check>
 
+  //! \relates RevWtLenLexCmp
+  //!
+  //! \brief Return a human readable representation of a reversed weighted
+  //! len-lex comparison functor with an alphabet.
+  //!
+  //! \tparam Word the word type associated with the alphabet.
+  //! \tparam check whether to check that letters belong to the alphabet.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <typename Word, bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RevWtLenLexCmp<Word, check> const& cmp);
+
+  //! \relates RevWtLenLexCmp
+  //!
+  //! \brief Return a human readable representation of a reversed weighted
+  //! len-lex comparison functor on index words.
+  //!
+  //! \tparam check whether to check arguments.
+  //! \param cmp the comparison functor.
+  //!
+  //! \returns A string containing the representation.
+  //!
+  //! \exceptions
+  //! \no_libsemigroups_except
+  template <bool check>
+  [[nodiscard]] std::string
+  to_human_readable_repr(RevWtLenLexCmp<Default, check> const& cmp);
+
   //! \brief Deduction guide from a weights vector.
   RevWtLenLexCmp(std::vector<size_t> const&)->RevWtLenLexCmp<>;
 

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -545,6 +545,17 @@ namespace libsemigroups {
   }
 
   template <typename Word, bool check>
+  std::string to_human_readable_repr(LexCmp<Word, check> const& cmp) {
+    return fmt::format("<LexCmp object over {}>",
+                       to_human_readable_repr(cmp.alphabet()));
+  }
+
+  template <bool check>
+  std::string to_human_readable_repr(LexCmp<Default, check> const&) {
+    return "<LexCmp object>";
+  }
+
+  template <typename Word, bool check>
   LenLexCmp<Word, check>&
   LenLexCmp<Word, check>::init(Alphabet<Word> const& alphabet) {
     if (&alphabet != &_alphabet) {

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -563,6 +563,17 @@ namespace libsemigroups {
   }
 
   template <typename Word, bool check>
+  std::string to_human_readable_repr(LenLexCmp<Word, check> const& cmp) {
+    return fmt::format("<LenLexCmp object over {}>",
+                       to_human_readable_repr(cmp.alphabet()));
+  }
+
+  template <bool check>
+  std::string to_human_readable_repr(LenLexCmp<Default, check> const&) {
+    return "<LenLexCmp object>";
+  }
+
+  template <typename Word, bool check>
   RPOCmp<Word, check>&
   RPOCmp<Word, check>::init(Alphabet<Word> const& alphabet) {
     if (&alphabet != &_alphabet) {

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -783,6 +783,29 @@ namespace libsemigroups {
   }
 
   template <typename Word, bool check>
+  std::string to_human_readable_repr(RevWtLenLexCmp<Word, check> const& cmp) {
+    if (cmp.weights().size() < 10) {
+      return fmt::format("<RevWtLenLexCmp object over {} with weights {}>",
+                         to_human_readable_repr(cmp.alphabet()),
+                         detail::to_printable(cmp.weights()));
+    }
+    return fmt::format("<RevWtLenLexCmp object over {} with {} weights>",
+                       to_human_readable_repr(cmp.alphabet()),
+                       cmp.weights().size());
+  }
+
+  template <bool check>
+  std::string
+  to_human_readable_repr(RevWtLenLexCmp<Default, check> const& cmp) {
+    if (cmp.weights().size() < 10) {
+      return fmt::format("<RevWtLenLexCmp object with weights {}>",
+                         detail::to_printable(cmp.weights()));
+    }
+    return fmt::format("<RevWtLenLexCmp object with {} weights>",
+                       cmp.weights().size());
+  }
+
+  template <typename Word, bool check>
   WtLexCmp<Word, check>&
   WtLexCmp<Word, check>::init(Alphabet<Word> const&      alphabet,
                               std::vector<size_t> const& weights) {

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -833,4 +833,26 @@ namespace libsemigroups {
     return *this;
   }
 
+  template <typename Word, bool check>
+  std::string to_human_readable_repr(WtLexCmp<Word, check> const& cmp) {
+    if (cmp.weights().size() < 10) {
+      return fmt::format("<WtLexCmp object over {} with weights {}>",
+                         to_human_readable_repr(cmp.alphabet()),
+                         detail::to_printable(cmp.weights()));
+    }
+    return fmt::format("<WtLexCmp object over {} with {} weights>",
+                       to_human_readable_repr(cmp.alphabet()),
+                       cmp.weights().size());
+  }
+
+  template <bool check>
+  std::string to_human_readable_repr(WtLexCmp<Default, check> const& cmp) {
+    if (cmp.weights().size() < 10) {
+      return fmt::format("<WtLexCmp object with weights {}>",
+                         detail::to_printable(cmp.weights()));
+    }
+    return fmt::format("<WtLexCmp object with {} weights>",
+                       cmp.weights().size());
+  }
+
 }  // namespace libsemigroups

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -624,6 +624,17 @@ namespace libsemigroups {
   }
 
   template <typename Word, bool check>
+  std::string to_human_readable_repr(RPOCmp<Word, check> const& cmp) {
+    return fmt::format("<RPOCmp object over {}>",
+                       to_human_readable_repr(cmp.alphabet()));
+  }
+
+  template <bool check>
+  std::string to_human_readable_repr(RPOCmp<Default, check> const&) {
+    return "<RPOCmp object>";
+  }
+
+  template <typename Word, bool check>
   RevRPOCmp<Word, check>&
   RevRPOCmp<Word, check>::init(Alphabet<Word> const& alphabet) {
     if (&alphabet != &_alphabet) {

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -596,6 +596,17 @@ namespace libsemigroups {
   }
 
   template <typename Word, bool check>
+  std::string to_human_readable_repr(RevLenLexCmp<Word, check> const& cmp) {
+    return fmt::format("<RevLenLexCmp object over {}>",
+                       to_human_readable_repr(cmp.alphabet()));
+  }
+
+  template <bool check>
+  std::string to_human_readable_repr(RevLenLexCmp<Default, check> const&) {
+    return "<RevLenLexCmp object>";
+  }
+
+  template <typename Word, bool check>
   RPOCmp<Word, check>&
   RPOCmp<Word, check>::init(Alphabet<Word> const& alphabet) {
     if (&alphabet != &_alphabet) {

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -691,6 +691,27 @@ namespace libsemigroups {
   }
 
   template <typename Word, bool check>
+  std::string to_human_readable_repr(WrCmp<Word, check> const& cmp) {
+    if (cmp.levels().size() < 10) {
+      return fmt::format("<WrCmp object over {} with levels {}>",
+                         to_human_readable_repr(cmp.alphabet()),
+                         detail::to_printable(cmp.levels()));
+    }
+    return fmt::format("<WrCmp object over {} with {} levels>",
+                       to_human_readable_repr(cmp.alphabet()),
+                       cmp.levels().size());
+  }
+
+  template <bool check>
+  std::string to_human_readable_repr(WrCmp<Default, check> const& cmp) {
+    if (cmp.levels().size() < 10) {
+      return fmt::format("<WrCmp object with levels {}>",
+                         detail::to_printable(cmp.levels()));
+    }
+    return fmt::format("<WrCmp object with {} levels>", cmp.levels().size());
+  }
+
+  template <typename Word, bool check>
   WtLenLexCmp<Word, check>&
   WtLenLexCmp<Word, check>::init(Alphabet<Word> const&      alphabet,
                                  std::vector<size_t> const& weights) {

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -556,6 +556,17 @@ namespace libsemigroups {
   }
 
   template <typename Word, bool check>
+  std::string to_human_readable_repr(RevLexCmp<Word, check> const& cmp) {
+    return fmt::format("<RevLexCmp object over {}>",
+                       to_human_readable_repr(cmp.alphabet()));
+  }
+
+  template <bool check>
+  std::string to_human_readable_repr(RevLexCmp<Default, check> const&) {
+    return "<RevLexCmp object>";
+  }
+
+  template <typename Word, bool check>
   LenLexCmp<Word, check>&
   LenLexCmp<Word, check>::init(Alphabet<Word> const& alphabet) {
     if (&alphabet != &_alphabet) {

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -877,4 +877,26 @@ namespace libsemigroups {
                        cmp.weights().size());
   }
 
+  template <typename Word, bool check>
+  std::string to_human_readable_repr(LenWtLexCmp<Word, check> const& cmp) {
+    if (cmp.weights().size() < 10) {
+      return fmt::format("<LenWtLexCmp object over {} with weights {}>",
+                         to_human_readable_repr(cmp.alphabet()),
+                         detail::to_printable(cmp.weights()));
+    }
+    return fmt::format("<LenWtLexCmp object over {} with {} weights>",
+                       to_human_readable_repr(cmp.alphabet()),
+                       cmp.weights().size());
+  }
+
+  template <bool check>
+  std::string to_human_readable_repr(LenWtLexCmp<Default, check> const& cmp) {
+    if (cmp.weights().size() < 10) {
+      return fmt::format("<LenWtLexCmp object with weights {}>",
+                         detail::to_printable(cmp.weights()));
+    }
+    return fmt::format("<LenWtLexCmp object with {} weights>",
+                       cmp.weights().size());
+  }
+
 }  // namespace libsemigroups

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -899,4 +899,27 @@ namespace libsemigroups {
                        cmp.weights().size());
   }
 
+  template <typename Word, bool check>
+  std::string to_human_readable_repr(RevLenWtLexCmp<Word, check> const& cmp) {
+    if (cmp.weights().size() < 10) {
+      return fmt::format("<RevLenWtLexCmp object over {} with weights {}>",
+                         to_human_readable_repr(cmp.alphabet()),
+                         detail::to_printable(cmp.weights()));
+    }
+    return fmt::format("<RevLenWtLexCmp object over {} with {} weights>",
+                       to_human_readable_repr(cmp.alphabet()),
+                       cmp.weights().size());
+  }
+
+  template <bool check>
+  std::string
+  to_human_readable_repr(RevLenWtLexCmp<Default, check> const& cmp) {
+    if (cmp.weights().size() < 10) {
+      return fmt::format("<RevLenWtLexCmp object with weights {}>",
+                         detail::to_printable(cmp.weights()));
+    }
+    return fmt::format("<RevLenWtLexCmp object with {} weights>",
+                       cmp.weights().size());
+  }
+
 }  // namespace libsemigroups

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -712,6 +712,27 @@ namespace libsemigroups {
   }
 
   template <typename Word, bool check>
+  std::string to_human_readable_repr(RevWrCmp<Word, check> const& cmp) {
+    if (cmp.levels().size() < 10) {
+      return fmt::format("<RevWrCmp object over {} with levels {}>",
+                         to_human_readable_repr(cmp.alphabet()),
+                         detail::to_printable(cmp.levels()));
+    }
+    return fmt::format("<RevWrCmp object over {} with {} levels>",
+                       to_human_readable_repr(cmp.alphabet()),
+                       cmp.levels().size());
+  }
+
+  template <bool check>
+  std::string to_human_readable_repr(RevWrCmp<Default, check> const& cmp) {
+    if (cmp.levels().size() < 10) {
+      return fmt::format("<RevWrCmp object with levels {}>",
+                         detail::to_printable(cmp.levels()));
+    }
+    return fmt::format("<RevWrCmp object with {} levels>", cmp.levels().size());
+  }
+
+  template <typename Word, bool check>
   WtLenLexCmp<Word, check>&
   WtLenLexCmp<Word, check>::init(Alphabet<Word> const&      alphabet,
                                  std::vector<size_t> const& weights) {

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -761,6 +761,28 @@ namespace libsemigroups {
   }
 
   template <typename Word, bool check>
+  std::string to_human_readable_repr(WtLenLexCmp<Word, check> const& cmp) {
+    if (cmp.weights().size() < 10) {
+      return fmt::format("<WtLenLexCmp object over {} with weights {}>",
+                         to_human_readable_repr(cmp.alphabet()),
+                         detail::to_printable(cmp.weights()));
+    }
+    return fmt::format("<WtLenLexCmp object over {} with {} weights>",
+                       to_human_readable_repr(cmp.alphabet()),
+                       cmp.weights().size());
+  }
+
+  template <bool check>
+  std::string to_human_readable_repr(WtLenLexCmp<Default, check> const& cmp) {
+    if (cmp.weights().size() < 10) {
+      return fmt::format("<WtLenLexCmp object with weights {}>",
+                         detail::to_printable(cmp.weights()));
+    }
+    return fmt::format("<WtLenLexCmp object with {} weights>",
+                       cmp.weights().size());
+  }
+
+  template <typename Word, bool check>
   WtLexCmp<Word, check>&
   WtLexCmp<Word, check>::init(Alphabet<Word> const&      alphabet,
                               std::vector<size_t> const& weights) {

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -855,4 +855,26 @@ namespace libsemigroups {
                        cmp.weights().size());
   }
 
+  template <typename Word, bool check>
+  std::string to_human_readable_repr(RevWtLexCmp<Word, check> const& cmp) {
+    if (cmp.weights().size() < 10) {
+      return fmt::format("<RevWtLexCmp object over {} with weights {}>",
+                         to_human_readable_repr(cmp.alphabet()),
+                         detail::to_printable(cmp.weights()));
+    }
+    return fmt::format("<RevWtLexCmp object over {} with {} weights>",
+                       to_human_readable_repr(cmp.alphabet()),
+                       cmp.weights().size());
+  }
+
+  template <bool check>
+  std::string to_human_readable_repr(RevWtLexCmp<Default, check> const& cmp) {
+    if (cmp.weights().size() < 10) {
+      return fmt::format("<RevWtLexCmp object with weights {}>",
+                         detail::to_printable(cmp.weights()));
+    }
+    return fmt::format("<RevWtLexCmp object with {} weights>",
+                       cmp.weights().size());
+  }
+
 }  // namespace libsemigroups

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -653,6 +653,17 @@ namespace libsemigroups {
   }
 
   template <typename Word, bool check>
+  std::string to_human_readable_repr(RevRPOCmp<Word, check> const& cmp) {
+    return fmt::format("<RevRPOCmp object over {}>",
+                       to_human_readable_repr(cmp.alphabet()));
+  }
+
+  template <bool check>
+  std::string to_human_readable_repr(RevRPOCmp<Default, check> const&) {
+    return "<RevRPOCmp object>";
+  }
+
+  template <typename Word, bool check>
   WrCmp<Word, check>&
   WrCmp<Word, check>::init(Alphabet<Word> const&      alphabet,
                            std::vector<size_t> const& levels) {

--- a/tests/test-order.cpp
+++ b/tests/test-order.cpp
@@ -2410,6 +2410,38 @@ namespace libsemigroups {
     static_assert(order::is_well_founded_v<RevWtLenLexCmp<>>);
   }
 
+  LIBSEMIGROUPS_TEST_CASE("WtLexCmp",
+                          "082",
+                          "to_human_readable_repr",
+                          "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    auto                rg      = ReportGuard(false);
+    std::vector<size_t> weights = {2, 1};
+
+    REQUIRE(to_human_readable_repr(WtLexCmp(weights))
+            == "<WtLexCmp object with weights [2, 1]>");
+    REQUIRE(to_human_readable_repr(WtLexCmp<Default, false>(weights))
+            == "<WtLexCmp object with weights [2, 1]>");
+
+    Alphabet alphabet("ba"s);
+    REQUIRE(to_human_readable_repr(WtLexCmp(alphabet, weights))
+            == "<WtLexCmp object over <alphabet \"ba\"> with weights [2, "
+               "1]>");
+    REQUIRE(
+        to_human_readable_repr(WtLexCmp<std::string, false>(alphabet, weights))
+        == "<WtLexCmp object over <alphabet \"ba\"> with weights [2, "
+           "1]>");
+
+    std::vector<size_t> large_weights(10, 1);
+    REQUIRE(to_human_readable_repr(WtLexCmp(large_weights))
+            == "<WtLexCmp object with 10 weights>");
+    REQUIRE(
+        to_human_readable_repr(WtLexCmp(Alphabet<word_type>(10), large_weights))
+        == "<WtLexCmp object over <alphabet with 10 letters> with 10 "
+           "weights>");
+  }
+
   LIBSEMIGROUPS_TEST_CASE("RevWtLexCmp",
                           "070",
                           "functions and functors",

--- a/tests/test-order.cpp
+++ b/tests/test-order.cpp
@@ -2095,6 +2095,29 @@ namespace libsemigroups {
     REQUIRE(std::is_sorted(strings.begin(), strings.end(), RPOCmp(alphabet)));
   }
 
+  LIBSEMIGROUPS_TEST_CASE("RevRPOCmp",
+                          "077",
+                          "to_human_readable_repr",
+                          "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    auto rg = ReportGuard(false);
+
+    REQUIRE(to_human_readable_repr(RevRPOCmp<>()) == "<RevRPOCmp object>");
+    REQUIRE(to_human_readable_repr(RevRPOCmp<Default, false>())
+            == "<RevRPOCmp object>");
+
+    Alphabet alphabet("ba"s);
+    REQUIRE(to_human_readable_repr(RevRPOCmp(alphabet))
+            == "<RevRPOCmp object over <alphabet \"ba\">>");
+    REQUIRE(to_human_readable_repr(RevRPOCmp<std::string, false>(alphabet))
+            == "<RevRPOCmp object over <alphabet \"ba\">>");
+
+    Alphabet<word_type> large_alphabet(10);
+    REQUIRE(to_human_readable_repr(RevRPOCmp(large_alphabet))
+            == "<RevRPOCmp object over <alphabet with 10 letters>>");
+  }
+
   LIBSEMIGROUPS_TEST_CASE("RPOCmp",
                           "076",
                           "to_human_readable_repr",

--- a/tests/test-order.cpp
+++ b/tests/test-order.cpp
@@ -2443,6 +2443,38 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("RevWtLexCmp",
+                          "083",
+                          "to_human_readable_repr",
+                          "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    auto                rg      = ReportGuard(false);
+    std::vector<size_t> weights = {2, 1};
+
+    REQUIRE(to_human_readable_repr(RevWtLexCmp(weights))
+            == "<RevWtLexCmp object with weights [2, 1]>");
+    REQUIRE(to_human_readable_repr(RevWtLexCmp<Default, false>(weights))
+            == "<RevWtLexCmp object with weights [2, 1]>");
+
+    Alphabet alphabet("ba"s);
+    REQUIRE(to_human_readable_repr(RevWtLexCmp(alphabet, weights))
+            == "<RevWtLexCmp object over <alphabet \"ba\"> with weights [2, "
+               "1]>");
+    REQUIRE(to_human_readable_repr(
+                RevWtLexCmp<std::string, false>(alphabet, weights))
+            == "<RevWtLexCmp object over <alphabet \"ba\"> with weights [2, "
+               "1]>");
+
+    std::vector<size_t> large_weights(10, 1);
+    REQUIRE(to_human_readable_repr(RevWtLexCmp(large_weights))
+            == "<RevWtLexCmp object with 10 weights>");
+    REQUIRE(to_human_readable_repr(
+                RevWtLexCmp(Alphabet<word_type>(10), large_weights))
+            == "<RevWtLexCmp object over <alphabet with 10 letters> with 10 "
+               "weights>");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("RevWtLexCmp",
                           "070",
                           "functions and functors",
                           "[quick][order]") {

--- a/tests/test-order.cpp
+++ b/tests/test-order.cpp
@@ -2321,6 +2321,38 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("RevWtLenLexCmp",
+                          "081",
+                          "to_human_readable_repr",
+                          "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    auto                rg      = ReportGuard(false);
+    std::vector<size_t> weights = {2, 1};
+
+    REQUIRE(to_human_readable_repr(RevWtLenLexCmp(weights))
+            == "<RevWtLenLexCmp object with weights [2, 1]>");
+    REQUIRE(to_human_readable_repr(RevWtLenLexCmp<Default, false>(weights))
+            == "<RevWtLenLexCmp object with weights [2, 1]>");
+
+    Alphabet alphabet("ba"s);
+    REQUIRE(to_human_readable_repr(RevWtLenLexCmp(alphabet, weights))
+            == "<RevWtLenLexCmp object over <alphabet \"ba\"> with weights "
+               "[2, 1]>");
+    REQUIRE(to_human_readable_repr(
+                RevWtLenLexCmp<std::string, false>(alphabet, weights))
+            == "<RevWtLenLexCmp object over <alphabet \"ba\"> with weights "
+               "[2, 1]>");
+
+    std::vector<size_t> large_weights(10, 1);
+    REQUIRE(to_human_readable_repr(RevWtLenLexCmp(large_weights))
+            == "<RevWtLenLexCmp object with 10 weights>");
+    REQUIRE(to_human_readable_repr(
+                RevWtLenLexCmp(Alphabet<word_type>(10), large_weights))
+            == "<RevWtLenLexCmp object over <alphabet with 10 letters> with "
+               "10 weights>");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("RevWtLenLexCmp",
                           "069",
                           "functions and functors",
                           "[quick][order]") {

--- a/tests/test-order.cpp
+++ b/tests/test-order.cpp
@@ -2403,6 +2403,36 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("RevWrCmp",
+                          "079",
+                          "to_human_readable_repr",
+                          "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    auto                rg     = ReportGuard(false);
+    std::vector<size_t> levels = {0, 1};
+
+    REQUIRE(to_human_readable_repr(RevWrCmp(levels))
+            == "<RevWrCmp object with levels [0, 1]>");
+    REQUIRE(to_human_readable_repr(RevWrCmp<Default, false>(levels))
+            == "<RevWrCmp object with levels [0, 1]>");
+
+    Alphabet alphabet("ba"s);
+    REQUIRE(to_human_readable_repr(RevWrCmp(alphabet, levels))
+            == "<RevWrCmp object over <alphabet \"ba\"> with levels [0, 1]>");
+    REQUIRE(
+        to_human_readable_repr(RevWrCmp<std::string, false>(alphabet, levels))
+        == "<RevWrCmp object over <alphabet \"ba\"> with levels [0, 1]>");
+
+    std::vector<size_t> large_levels(10, 0);
+    REQUIRE(to_human_readable_repr(RevWrCmp(large_levels))
+            == "<RevWrCmp object with 10 levels>");
+    REQUIRE(
+        to_human_readable_repr(RevWrCmp(Alphabet<word_type>(10), large_levels))
+        == "<RevWrCmp object over <alphabet with 10 letters> with 10 "
+           "levels>");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("RevWrCmp",
                           "071",
                           "functions and functors",
                           "[quick][order]") {

--- a/tests/test-order.cpp
+++ b/tests/test-order.cpp
@@ -2096,6 +2096,30 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("RevLenLexCmp",
+                          "075",
+                          "to_human_readable_repr",
+                          "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    auto rg = ReportGuard(false);
+
+    REQUIRE(to_human_readable_repr(RevLenLexCmp<>())
+            == "<RevLenLexCmp object>");
+    REQUIRE(to_human_readable_repr(RevLenLexCmp<Default, false>())
+            == "<RevLenLexCmp object>");
+
+    Alphabet alphabet("ba"s);
+    REQUIRE(to_human_readable_repr(RevLenLexCmp(alphabet))
+            == "<RevLenLexCmp object over <alphabet \"ba\">>");
+    REQUIRE(to_human_readable_repr(RevLenLexCmp<std::string, false>(alphabet))
+            == "<RevLenLexCmp object over <alphabet \"ba\">>");
+
+    Alphabet<word_type> large_alphabet(10);
+    REQUIRE(to_human_readable_repr(RevLenLexCmp(large_alphabet))
+            == "<RevLenLexCmp object over <alphabet with 10 letters>>");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("RevLenLexCmp",
                           "067",
                           "functions and functors",
                           "[quick][order]") {

--- a/tests/test-order.cpp
+++ b/tests/test-order.cpp
@@ -1002,6 +1002,29 @@ namespace libsemigroups {
   // lenlex_cmp with alphabet
   // =========================================================================
 
+  LIBSEMIGROUPS_TEST_CASE("LexCmp",
+                          "033",
+                          "to_human_readable_repr",
+                          "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    auto rg = ReportGuard(false);
+
+    REQUIRE(to_human_readable_repr(LexCmp<>()) == "<LexCmp object>");
+    REQUIRE(to_human_readable_repr(LexCmp<Default, false>())
+            == "<LexCmp object>");
+
+    Alphabet alphabet("ba"s);
+    REQUIRE(to_human_readable_repr(LexCmp(alphabet))
+            == "<LexCmp object over <alphabet \"ba\">>");
+    REQUIRE(to_human_readable_repr(LexCmp<std::string, false>(alphabet))
+            == "<LexCmp object over <alphabet \"ba\">>");
+
+    Alphabet<word_type> large_alphabet(10);
+    REQUIRE(to_human_readable_repr(LexCmp(large_alphabet))
+            == "<LexCmp object over <alphabet with 10 letters>>");
+  }
+
   LIBSEMIGROUPS_TEST_CASE("lenlex_cmp",
                           "043",
                           "with alphabet",

--- a/tests/test-order.cpp
+++ b/tests/test-order.cpp
@@ -2609,6 +2609,38 @@ namespace libsemigroups {
     static_assert(order::is_well_founded_v<RevWrCmp<>>);
   }
 
+  LIBSEMIGROUPS_TEST_CASE("LenWtLexCmp",
+                          "084",
+                          "to_human_readable_repr",
+                          "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    auto                rg      = ReportGuard(false);
+    std::vector<size_t> weights = {2, 1};
+
+    REQUIRE(to_human_readable_repr(LenWtLexCmp(weights))
+            == "<LenWtLexCmp object with weights [2, 1]>");
+    REQUIRE(to_human_readable_repr(LenWtLexCmp<Default, false>(weights))
+            == "<LenWtLexCmp object with weights [2, 1]>");
+
+    Alphabet alphabet("ba"s);
+    REQUIRE(to_human_readable_repr(LenWtLexCmp(alphabet, weights))
+            == "<LenWtLexCmp object over <alphabet \"ba\"> with weights [2, "
+               "1]>");
+    REQUIRE(to_human_readable_repr(
+                LenWtLexCmp<std::string, false>(alphabet, weights))
+            == "<LenWtLexCmp object over <alphabet \"ba\"> with weights [2, "
+               "1]>");
+
+    std::vector<size_t> large_weights(10, 1);
+    REQUIRE(to_human_readable_repr(LenWtLexCmp(large_weights))
+            == "<LenWtLexCmp object with 10 weights>");
+    REQUIRE(to_human_readable_repr(
+                LenWtLexCmp(Alphabet<word_type>(10), large_weights))
+            == "<LenWtLexCmp object over <alphabet with 10 letters> with 10 "
+               "weights>");
+  }
+
   LIBSEMIGROUPS_TEST_CASE("len_wt_lex_cmp",
                           "072",
                           "length before weighted lex",

--- a/tests/test-order.cpp
+++ b/tests/test-order.cpp
@@ -1959,6 +1959,33 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WrCmp",
+                          "078",
+                          "to_human_readable_repr",
+                          "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    auto                rg     = ReportGuard(false);
+    std::vector<size_t> levels = {0, 1};
+
+    REQUIRE(to_human_readable_repr(WrCmp(levels))
+            == "<WrCmp object with levels [0, 1]>");
+    REQUIRE(to_human_readable_repr(WrCmp<Default, false>(levels))
+            == "<WrCmp object with levels [0, 1]>");
+
+    Alphabet alphabet("ba"s);
+    REQUIRE(to_human_readable_repr(WrCmp(alphabet, levels))
+            == "<WrCmp object over <alphabet \"ba\"> with levels [0, 1]>");
+    REQUIRE(to_human_readable_repr(WrCmp<std::string, false>(alphabet, levels))
+            == "<WrCmp object over <alphabet \"ba\"> with levels [0, 1]>");
+
+    std::vector<size_t> large_levels(10, 0);
+    REQUIRE(to_human_readable_repr(WrCmp(large_levels))
+            == "<WrCmp object with 10 levels>");
+    REQUIRE(to_human_readable_repr(WrCmp(Alphabet<word_type>(10), large_levels))
+            == "<WrCmp object over <alphabet with 10 letters> with 10 levels>");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("WrCmp",
                           "063",
                           "deduction guides and checks",
                           "[quick][order]") {

--- a/tests/test-order.cpp
+++ b/tests/test-order.cpp
@@ -570,6 +570,38 @@ namespace libsemigroups {
   // =========================================================================
 
   LIBSEMIGROUPS_TEST_CASE("WtLenLexCmp",
+                          "080",
+                          "to_human_readable_repr",
+                          "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    auto                rg      = ReportGuard(false);
+    std::vector<size_t> weights = {2, 1};
+
+    REQUIRE(to_human_readable_repr(WtLenLexCmp(weights))
+            == "<WtLenLexCmp object with weights [2, 1]>");
+    REQUIRE(to_human_readable_repr(WtLenLexCmp<Default, false>(weights))
+            == "<WtLenLexCmp object with weights [2, 1]>");
+
+    Alphabet alphabet("ba"s);
+    REQUIRE(to_human_readable_repr(WtLenLexCmp(alphabet, weights))
+            == "<WtLenLexCmp object over <alphabet \"ba\"> with weights [2, "
+               "1]>");
+    REQUIRE(to_human_readable_repr(
+                WtLenLexCmp<std::string, false>(alphabet, weights))
+            == "<WtLenLexCmp object over <alphabet \"ba\"> with weights [2, "
+               "1]>");
+
+    std::vector<size_t> large_weights(10, 1);
+    REQUIRE(to_human_readable_repr(WtLenLexCmp(large_weights))
+            == "<WtLenLexCmp object with 10 weights>");
+    REQUIRE(to_human_readable_repr(
+                WtLenLexCmp(Alphabet<word_type>(10), large_weights))
+            == "<WtLenLexCmp object over <alphabet with 10 letters> with 10 "
+               "weights>");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("WtLenLexCmp",
                           "034",
                           "use in std::set",
                           "[quick][order]") {

--- a/tests/test-order.cpp
+++ b/tests/test-order.cpp
@@ -2095,6 +2095,29 @@ namespace libsemigroups {
     REQUIRE(std::is_sorted(strings.begin(), strings.end(), RPOCmp(alphabet)));
   }
 
+  LIBSEMIGROUPS_TEST_CASE("RPOCmp",
+                          "076",
+                          "to_human_readable_repr",
+                          "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    auto rg = ReportGuard(false);
+
+    REQUIRE(to_human_readable_repr(RPOCmp<>()) == "<RPOCmp object>");
+    REQUIRE(to_human_readable_repr(RPOCmp<Default, false>())
+            == "<RPOCmp object>");
+
+    Alphabet alphabet("ba"s);
+    REQUIRE(to_human_readable_repr(RPOCmp(alphabet))
+            == "<RPOCmp object over <alphabet \"ba\">>");
+    REQUIRE(to_human_readable_repr(RPOCmp<std::string, false>(alphabet))
+            == "<RPOCmp object over <alphabet \"ba\">>");
+
+    Alphabet<word_type> large_alphabet(10);
+    REQUIRE(to_human_readable_repr(RPOCmp(large_alphabet))
+            == "<RPOCmp object over <alphabet with 10 letters>>");
+  }
+
   LIBSEMIGROUPS_TEST_CASE("RevLenLexCmp",
                           "075",
                           "to_human_readable_repr",

--- a/tests/test-order.cpp
+++ b/tests/test-order.cpp
@@ -2710,6 +2710,38 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("RevLenWtLexCmp",
+                          "085",
+                          "to_human_readable_repr",
+                          "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    auto                rg      = ReportGuard(false);
+    std::vector<size_t> weights = {2, 1};
+
+    REQUIRE(to_human_readable_repr(RevLenWtLexCmp(weights))
+            == "<RevLenWtLexCmp object with weights [2, 1]>");
+    REQUIRE(to_human_readable_repr(RevLenWtLexCmp<Default, false>(weights))
+            == "<RevLenWtLexCmp object with weights [2, 1]>");
+
+    Alphabet alphabet("ba"s);
+    REQUIRE(to_human_readable_repr(RevLenWtLexCmp(alphabet, weights))
+            == "<RevLenWtLexCmp object over <alphabet \"ba\"> with weights "
+               "[2, 1]>");
+    REQUIRE(to_human_readable_repr(
+                RevLenWtLexCmp<std::string, false>(alphabet, weights))
+            == "<RevLenWtLexCmp object over <alphabet \"ba\"> with weights "
+               "[2, 1]>");
+
+    std::vector<size_t> large_weights(10, 1);
+    REQUIRE(to_human_readable_repr(RevLenWtLexCmp(large_weights))
+            == "<RevLenWtLexCmp object with 10 weights>");
+    REQUIRE(to_human_readable_repr(
+                RevLenWtLexCmp(Alphabet<word_type>(10), large_weights))
+            == "<RevLenWtLexCmp object over <alphabet with 10 letters> with "
+               "10 weights>");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("RevLenWtLexCmp",
                           "073",
                           "functions and functors",
                           "[quick][order]") {

--- a/tests/test-order.cpp
+++ b/tests/test-order.cpp
@@ -2133,6 +2133,29 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("RevLexCmp",
+                          "074",
+                          "to_human_readable_repr",
+                          "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    auto rg = ReportGuard(false);
+
+    REQUIRE(to_human_readable_repr(RevLexCmp<>()) == "<RevLexCmp object>");
+    REQUIRE(to_human_readable_repr(RevLexCmp<Default, false>())
+            == "<RevLexCmp object>");
+
+    Alphabet alphabet("ba"s);
+    REQUIRE(to_human_readable_repr(RevLexCmp(alphabet))
+            == "<RevLexCmp object over <alphabet \"ba\">>");
+    REQUIRE(to_human_readable_repr(RevLexCmp<std::string, false>(alphabet))
+            == "<RevLexCmp object over <alphabet \"ba\">>");
+
+    Alphabet<word_type> large_alphabet(10);
+    REQUIRE(to_human_readable_repr(RevLexCmp(large_alphabet))
+            == "<RevLexCmp object over <alphabet with 10 letters>>");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("RevLexCmp",
                           "068",
                           "functions and functors",
                           "[quick][order]") {

--- a/tests/test-order.cpp
+++ b/tests/test-order.cpp
@@ -1072,6 +1072,29 @@ namespace libsemigroups {
                           "invalid letter 'b', valid letters are \"cd\"");
   }
 
+  LIBSEMIGROUPS_TEST_CASE("LenLexCmp",
+                          "032",
+                          "to_human_readable_repr",
+                          "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    auto rg = ReportGuard(false);
+
+    REQUIRE(to_human_readable_repr(LenLexCmp<>()) == "<LenLexCmp object>");
+    REQUIRE(to_human_readable_repr(LenLexCmp<Default, false>())
+            == "<LenLexCmp object>");
+
+    Alphabet alphabet("ba"s);
+    REQUIRE(to_human_readable_repr(LenLexCmp(alphabet))
+            == "<LenLexCmp object over <alphabet \"ba\">>");
+    REQUIRE(to_human_readable_repr(LenLexCmp<std::string, false>(alphabet))
+            == "<LenLexCmp object over <alphabet \"ba\">>");
+
+    Alphabet<word_type> large_alphabet(10);
+    REQUIRE(to_human_readable_repr(LenLexCmp(large_alphabet))
+            == "<LenLexCmp object over <alphabet with 10 letters>>");
+  }
+
   // =========================================================================
   // rev_rpo_cmp with alphabet
   // =========================================================================


### PR DESCRIPTION
This PR adds overloads of `to_human_readable_repr` for the various structs/classes in `order.hpp`, i.e. `LenLexCmp` etc.