### PR TITLE
Swap the meaning of `rpo_cmp` and `rev_rpo_cmp` ... again

### DIFF
--- a/docs/libsemigroups.bib
+++ b/docs/libsemigroups.bib
@@ -836,3 +836,16 @@
   author   = {Wei Du and Paliath Narendran and Michael Rusinowitch},
   keywords = {Recursive path ordering, String rewriting systems, NP-complete},
 }
+
+@article{Dershowitz1982aa,
+  title = {Orderings for term-rewriting systems},
+  journal = {Theoretical Computer Science},
+  volume = {17},
+  number = {3},
+  pages = {279-301},
+  year = {1982},
+  issn = {0304-3975},
+  doi = {https://doi.org/10.1016/0304-3975(82)90026-3},
+  url = {https://www.sciencedirect.com/science/article/pii/0304397582900263},
+  author = {Nachum Dershowitz},
+}

--- a/include/libsemigroups/alphabet-class.hpp
+++ b/include/libsemigroups/alphabet-class.hpp
@@ -449,6 +449,16 @@ namespace libsemigroups {
     void throw_if_duplicate_letters(decltype(_letters_map)& letters_map) const;
   };  // class Alphabet
 
+  //! \relates Alphabet
+  //!
+  //! \brief Deduction guide.
+  //!
+  //! Defined in `alphabet-class.hpp`.
+  //!
+  //! Deduction guide to construct a `Alphabet<Word>` from Word const reference.
+  template <typename Word>
+  Alphabet(Word&) -> Alphabet<Word>;
+
   ////////////////////////////////////////////////////////////////////////
   // Validation
   ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/alphabet-class.hpp
+++ b/include/libsemigroups/alphabet-class.hpp
@@ -455,7 +455,7 @@ namespace libsemigroups {
   //!
   //! Defined in `alphabet-class.hpp`.
   //!
-  //! Deduction guide to construct a `Alphabet<Word>` from Word const reference.
+  //! Deduction guide to construct a `Alphabet<Word>` from a \c Word reference.
   template <typename Word>
   Alphabet(Word&) -> Alphabet<Word>;
 

--- a/include/libsemigroups/du-narendran-rusinowitch.hpp
+++ b/include/libsemigroups/du-narendran-rusinowitch.hpp
@@ -88,7 +88,7 @@ namespace libsemigroups {
   //! \ingroup du_narendran_rusinowitch_group
   //!
   //! \brief Return an ordered alphabet such that the rules are oriented with
-  //! respect to recursive path order.
+  //! respect to recursive path order; see \ref rpo_cmp.
   //!
   //! This function returns the alphabet of \p p ordered so that the rules of
   //! \p p satisfy \f$x_i \to y_i \f$ and \f$x_i > y_i\f$ with respect to

--- a/include/libsemigroups/du-narendran-rusinowitch.hpp
+++ b/include/libsemigroups/du-narendran-rusinowitch.hpp
@@ -23,6 +23,11 @@
 // Narendran and Rusinowitch's article "Inferring RPO symbol orderings"
 // (https://doi.org/10.1016/j.jlamp.2026.101126).
 
+// TODO(1): Turn this into an iterator over all possible alphabets
+// TODO(1): Add a function that infers the an alphabet order for rev RPO by
+// looking at longest prefixes without a letter, rather than suffixes.
+// TODO(1): Add a function that infers an alphabet order for wreath order.
+
 #ifndef LIBSEMIGROUPS_DU_NARENDRAN_RUSINOWITCH_HPP_
 #define LIBSEMIGROUPS_DU_NARENDRAN_RUSINOWITCH_HPP_
 
@@ -75,19 +80,19 @@ namespace libsemigroups {
 
   //! \defgroup du_narendran_rusinowitch_group Du-Narendran-Rusinowitch
   //!
-  //! This file contains documentation for a function that finds on ordering on
+  //! This file contains documentation for a function that finds an ordering on
   //! a presentation's alphabet such that the rules are oriented with respect to
-  //! the reverse recursive path ordering. The implementation is based on the
-  //! algorithm provided in Section 4 of \cite Du2026aa.
+  //! the recursive path ordering. The implementation is based on the algorithm
+  //! provided in Section 4 of \cite Du2026aa.
 
   //! \ingroup du_narendran_rusinowitch_group
   //!
   //! \brief Return an ordered alphabet such that the rules are oriented with
-  //! respect to reverse recursive path order.
+  //! respect to recursive path order.
   //!
   //! This function returns the alphabet of \p p ordered so that the rules of
   //! \p p satisfy \f$x_i \to y_i \f$ and \f$x_i > y_i\f$ with respect to
-  //! reverse recursive path order and the returned alphabet order. The returned
+  //! recursive path order and the returned alphabet order. The returned
   //! alphabet is empty if this fails, or if the alphabet was empty to begin
   //! with.
   //!
@@ -102,7 +107,7 @@ namespace libsemigroups {
   //! \ref Presentation::throw_if_bad_alphabet_or_rules throws.
   //!
   //! \sa
-  //! \ref rev_rpo_cmp
+  //! \ref rpo_cmp
   template <typename Word>
   Word du_narendran_rusinowitch(Presentation<Word> const& p);
 

--- a/include/libsemigroups/order-deprecated.hpp
+++ b/include/libsemigroups/order-deprecated.hpp
@@ -273,91 +273,23 @@ using ShortLexCompare [[deprecated("Use LenLexCmp instead!")]] = LenLexCmp<>;
 // Recursive path order (RPO) - deprecated
 //////////////////////////////////////////////////////////////////////
 
-//! \brief Compare two objects of the same type using the reversed recursive
-//! path comparison.
-//!
-//! Defined in `order-deprecated.hpp`.
-//!
-//! This function compares two objects of the same type using the reversed
-//! recursive path comparison. This is the same as applying the recursive path
-//! comparison described in \cite Jantzen2012aa (Definition 1.2.14, page 24)
-//! to the reversed words in `[first1, last1)`, `[first2, last2)`.
-//!
-//! If \f$u, v\in X ^ {*}\f$, then
-//! \f$u < v\f$ if and only if one of the following conditions holds:
-//! 1. \f$u\f$ is empty and \f$v\f$ is not empty; or
-//! 2. \f$u = u'a\f$ and \f$v = v'b\f$ for some \f$a,b \in X\f$, \f$u',v'\in
-//!    X ^ {*}\f$ and:
-//!   1. \f$a = b\f$ and \f$u' < v'\f$; or
-//!   2. \f$a < b\f$ and \f$u  < v'\f$; or
-//!   3. \f$a > b\f$ and \f$u' < v\f$.
-//!
-//! This documentation and the implementation of
-//! \ref libsemigroups::recursive_path_compare is based on the source code of
-//! \cite Holt2018aa, specifically the function `rt_rec_compare`.
-//!
-//! \tparam Iterator the type of iterators that are the arguments.
-//!
-//! \param first1 beginning iterator of first object for comparison.
-//! \param last1 ending iterator of first object for comparison.
-//! \param first2 beginning iterator of second object for comparison.
-//! \param last2 ending iterator of second object for comparison.
-//!
-//! \returns The boolean value \c true if the range `[first1, last1)` is less
-//! than the range `[first2, last2)` with respect to the reversed recursive
-//! path ordering, and \c false otherwise.
-//!
-//! \exceptions
-//! \noexcept
-//!
-//! \warning
-//! This function has significantly worse performance than all
-//! the variants of \ref libsemigroups::lenlex_cmp and
-//! std::lexicographical_compare.
-//!
-//! \deprecated_warning{function} Use \ref libsemigroups::rpo_cmp instead.
+//! \copydoc libsemigroups::rev_rpo_cmp(Iterator, Iterator, Iterator, Iterator)
+//! \deprecated_warning{function} Use \ref libsemigroups::rev_rpo_cmp instead.
 template <typename Iterator>
-[[nodiscard]] [[deprecated("Use rpo_cmp instead!")]] bool
+[[nodiscard]] [[deprecated("Use rev_rpo_cmp instead!")]] bool
 recursive_path_compare(Iterator first1,
                        Iterator last1,
                        Iterator first2,
                        Iterator last2) noexcept {
-  return rpo_cmp(first1, last1, first2, last2);
+  return rev_rpo_cmp(first1, last1, first2, last2);
 }
 
-//! \brief Compare two objects of the same type using
-//! \ref libsemigroups::recursive_path_compare.
-//!
-//! Defined in `order-deprecated.hpp`.
-//!
-//! This function compares two objects of the same type using
-//! \ref libsemigroups::recursive_path_compare.
-//!
-//! \tparam Word the type of the objects to be compared.
-//!
-//! \param x const reference to the first object for comparison.
-//! \param y const reference to the second object for comparison.
-//!
-//! \returns The boolean value \c true if \p x is less than \p y with respect
-//! to the recursive path ordering, and \c false otherwise.
-//!
-//! \exceptions
-//! \noexcept
-//!
-//! \par Possible Implementation
-//! \code_no_test
-//! recursive_path_compare(
-//!   x.cbegin(), x.cend(), y.cbegin(), y.cend());
-//! \end_code_no_test
-//!
-//! \sa
-//! recursive_path_compare(Iterator, Iterator, Iterator, Iterator)
-//!
-//! \deprecated_warning{function} Use \ref libsemigroups::rpo_cmp instead.
+//! \copydoc libsemigroups::rev_rpo_cmp(Word const&, Word const&)
+//! \deprecated_warning{function} Use \ref libsemigroups::rev_rpo_cmp instead.
 template <typename Word>
-[[nodiscard]] [[deprecated("Use rpo_cmp instead!")]] bool
+[[nodiscard]] [[deprecated("Use rev_rpo_cmp instead!")]] bool
 recursive_path_compare(Word const& x, Word const& y) noexcept {
-  return rpo_cmp(x, y);
+  return rev_rpo_cmp(x, y);
 }
 
 //! \brief Compare two objects via their pointers using
@@ -389,31 +321,19 @@ recursive_path_compare(Word const& x, Word const& y) noexcept {
 //! \sa
 //! recursive_path_compare(Iterator, Iterator, Iterator, Iterator)
 //!
-//! \deprecated_warning{function} Use \ref libsemigroups::rpo_cmp instead.
+//! \deprecated_warning{function}.
 template <typename Word>
 [[nodiscard]] [[deprecated(
     "This function will be removed in v4, and no alternative "
     "provided.")]] bool
 recursive_path_compare(Word* const x, Word* const y) noexcept {
-  return rpo_cmp(*x, *y);
+  return rev_rpo_cmp(*x, *y);
 }
 
-//! \brief A stateless struct with binary call operator using
-//! \ref libsemigroups::recursive_path_compare.
-//!
-//! Defined in `order-deprecated.hpp`.
-//!
-//! A stateless struct with binary call operator using
-//! \ref libsemigroups::recursive_path_compare.
-//!
-//! This only exists to be used as a template parameter, and has no
-//! advantages over using \ref libsemigroups::recursive_path_compare otherwise.
-//!
-//! \sa
-//! recursive_path_compare(Iterator, Iterator, Iterator, Iterator)
-//!
+//! \copydoc libsemigroups::RevRpoCmp
 //! \deprecated_warning{struct} Use \ref libsemigroups::RPOCmp instead.
-using RecursivePathCompare [[deprecated("Use RPOCmp instead!")]] = RPOCmp<>;
+using RecursivePathCompare [[deprecated("Use RevRPOCmp instead!")]]
+= RevRPOCmp<>;
 
 //////////////////////////////////////////////////////////////////////
 // Weighted short-lex - deprecated

--- a/include/libsemigroups/order-deprecated.hpp
+++ b/include/libsemigroups/order-deprecated.hpp
@@ -320,7 +320,6 @@ recursive_path_compare(Word const& x, Word const& y) noexcept {
 //!
 //! \sa
 //! recursive_path_compare(Iterator, Iterator, Iterator, Iterator)
-//!
 //! \deprecated_warning{function}.
 template <typename Word>
 [[nodiscard]] [[deprecated(

--- a/include/libsemigroups/order-deprecated.hpp
+++ b/include/libsemigroups/order-deprecated.hpp
@@ -329,8 +329,8 @@ recursive_path_compare(Word* const x, Word* const y) noexcept {
   return rev_rpo_cmp(*x, *y);
 }
 
-//! \copydoc libsemigroups::RevRpoCmp
-//! \deprecated_warning{struct} Use \ref libsemigroups::RPOCmp instead.
+//! \copydoc libsemigroups::RevRPOCmp
+//! \deprecated_warning{struct} Use \ref libsemigroups::RevRPOCmp instead.
 using RecursivePathCompare [[deprecated("Use RevRPOCmp instead!")]]
 = RevRPOCmp<>;
 

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -91,10 +91,27 @@ namespace libsemigroups {
   //! \defgroup orders_group Orders
   //! This page contains the documentation for several class and function
   //! templates for comparing words or strings with respect to certain reduction
-  //! orderings.
+  //! orderings. Those orders with prefix `Rev` or `rev_` read words from right
+  //! to left, whereas those without this prefix read from left to right.
   //!
-  //! \note Those orders with prefix `Rev` or `rev_` read words from right to
-  //! left, whereas those without this prefix read from left to right.
+  //! Some of the orders are generalisations of others. In particular,
+  //! when the weight of every generator is the same:
+  //! - \ref len_wt_lex_cmp is a generalisation of \ref lenlex_cmp;
+  //! - \ref rev_len_wt_lex_cmp is a generalisation of \ref rev_lenlex_cmp;
+  //! - \ref wt_lenlex_cmp is a generalisation of \ref lenlex_cmp; and
+  //! - \ref rev_wt_lenlex_cmp is a generalisation of \ref rev_lenlex_cmp;
+  //! - \ref wt_lex_cmp is a generalisation of \ref lex_cmp; and
+  //! - \ref rev_wt_lex_cmp is a generalisation of \ref rev_lex_cmp.
+  //!
+  //! Additionally:
+  //! - \ref wr_cmp is a generalisation of \ref lenlex_cmp when all
+  //!   of the generators have the same level;
+  //! - \ref rev_wr_cmp is a generalisation of \ref rev_lenlex_cmp when all
+  //!   of the generators have the same level;
+  //! - \ref wr_cmp is a generalisation of \ref rev_rpo_cmp when all
+  //!   of the generators have a different level; and
+  //! - \ref rev_wr_cmp is a generalisation of \ref rpo_cmp when all
+  //!   of the generators have a different level.
   //!
   //! \sa \ref Order
   //!

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -56,7 +56,7 @@ namespace libsemigroups {
     //! No ordering.
     none = 0,
 
-    //! The len-lex ordering. Words are first ordered by length, and then
+    //! The lenlex ordering. Words are first ordered by length, and then
     //! lexicographically.
     lenlex,
 
@@ -774,15 +774,15 @@ namespace libsemigroups {
   to_human_readable_repr(RevLexCmp<Default, check> const& cmp);
 
   //////////////////////////////////////////////////////////////////////
-  // Len-lex
+  // Lenlex
   //////////////////////////////////////////////////////////////////////
 
-  //! \brief Compare two objects of the same type using the len-lex reduction
+  //! \brief Compare two objects of the same type using the lenlex reduction
   //! ordering.
   //!
   //! Defined in `order.hpp`.
   //!
-  //! This function compares two objects of the same type using the len-lex
+  //! This function compares two objects of the same type using the lenlex
   //! reduction ordering.
   //!
   //! \tparam Iterator the type of iterators that are the parameters.
@@ -793,7 +793,7 @@ namespace libsemigroups {
   //! \param last2 ending iterator of second object for comparison.
   //!
   //! \returns The boolean value \c true if the range `[first1, last1)` is
-  //! len-lex less than the range `[first2, last2)`, and \c false
+  //! lenlex less than the range `[first2, last2)`, and \c false
   //! otherwise.
   //!
   //! \exceptions
@@ -826,7 +826,7 @@ namespace libsemigroups {
                && std::lexicographical_compare(first1, last1, first2, last2));
   }
 
-  //! \brief Compare two ranges using len-lex without checking an alphabet.
+  //! \brief Compare two ranges using lenlex without checking an alphabet.
   //!
   //! This overload orders first by length and then lexicographically using
   //! \p alphabet to map letters to indices. It does not check that the
@@ -838,7 +838,7 @@ namespace libsemigroups {
   //! \param first2 beginning iterator of second object for comparison.
   //! \param last2 ending iterator of second object for comparison.
   //!
-  //! \returns The boolean value \c true if the first range is len-lex less
+  //! \returns The boolean value \c true if the first range is lenlex less
   //! than the second range, and \c false otherwise.
   template <typename Word, typename Iterator>
   [[nodiscard]] bool lenlex_cmp_no_checks(Alphabet<Word> const& alphabet,
@@ -851,7 +851,7 @@ namespace libsemigroups {
                && lex_cmp_no_checks(alphabet, first1, last1, first2, last2));
   }
 
-  //! \brief Compare two ranges using len-lex with respect to an alphabet.
+  //! \brief Compare two ranges using lenlex with respect to an alphabet.
   //!
   //! This overload checks that both ranges contain only letters belonging to
   //! \p alphabet, then orders first by length and then lexicographically using
@@ -863,7 +863,7 @@ namespace libsemigroups {
   //! \param first2 beginning iterator of second object for comparison.
   //! \param last2 ending iterator of second object for comparison.
   //!
-  //! \returns The boolean value \c true if the first range is len-lex less
+  //! \returns The boolean value \c true if the first range is lenlex less
   //! than the second range, and \c false otherwise.
   //!
   //! \throws LibsemigroupsException if any letter in either range does not
@@ -891,7 +891,7 @@ namespace libsemigroups {
   //! \param x const reference to the first object for comparison.
   //! \param y const reference to the second object for comparison.
   //!
-  //! \returns The boolean value \c true if \p x is len-lex less than \p y,
+  //! \returns The boolean value \c true if \p x is lenlex less than \p y,
   //! and \c false otherwise.
   //!
   //! \exceptions
@@ -916,7 +916,7 @@ namespace libsemigroups {
 
   // TODO there's no no_checks version of lenlex_cmp for two objects
 
-  //! \brief Compare two objects using len-lex with respect to an alphabet.
+  //! \brief Compare two objects using lenlex with respect to an alphabet.
   //!
   //! This overload checks that both objects contain only letters belonging to
   //! \p alphabet, then orders first by length and then lexicographically using
@@ -926,7 +926,7 @@ namespace libsemigroups {
   //! \param x const reference to the first object for comparison.
   //! \param y const reference to the second object for comparison.
   //!
-  //! \returns The boolean value \c true if \p x is len-lex less than \p y
+  //! \returns The boolean value \c true if \p x is lenlex less than \p y
   //! with respect to \p alphabet, and \c false otherwise.
   //!
   //! \throws LibsemigroupsException if any letter in either object does not
@@ -938,7 +938,7 @@ namespace libsemigroups {
     return lenlex_cmp(alphabet, x.cbegin(), x.cend(), y.cbegin(), y.cend());
   }
 
-  //! \brief Compare two objects using len-lex without checking an alphabet.
+  //! \brief Compare two objects using lenlex without checking an alphabet.
   //!
   //! This overload orders first by length and then lexicographically using
   //! \p alphabet to map letters to indices. It does not check that the
@@ -948,7 +948,7 @@ namespace libsemigroups {
   //! \param x const reference to the first object for comparison.
   //! \param y const reference to the second object for comparison.
   //!
-  //! \returns The boolean value \c true if \p x is len-lex less than \p y
+  //! \returns The boolean value \c true if \p x is lenlex less than \p y
   //! with respect to \p alphabet, and \c false otherwise.
   template <typename Word>
   [[nodiscard]] bool lenlex_cmp_no_checks(Alphabet<Word> const& alphabet,
@@ -961,9 +961,9 @@ namespace libsemigroups {
   template <typename Word = Default, bool check = true>
   class LenLexCmp;
 
-  //! \brief Stateful len-lex comparison functor.
+  //! \brief Stateful lenlex comparison functor.
   //!
-  //! This class stores an alphabet and compares words in len-lex order with
+  //! This class stores an alphabet and compares words in lenlex order with
   //! respect to that alphabet.
   //!
   //! \tparam Word the word type associated with the alphabet.
@@ -1039,7 +1039,7 @@ namespace libsemigroups {
     //! \param x const reference to the first object for comparison.
     //! \param y const reference to the second object for comparison.
     //!
-    //! \returns The boolean value \c true if \p x is len-lex less than \p y,
+    //! \returns The boolean value \c true if \p x is lenlex less than \p y,
     //! and \c false otherwise.
     //!
     //! \exceptions
@@ -1129,7 +1129,7 @@ namespace libsemigroups {
     //! \param x const reference to the first object for comparison.
     //! \param y const reference to the second object for comparison.
     //!
-    //! \returns The boolean value \c true if \p x is len-lex less than \p y,
+    //! \returns The boolean value \c true if \p x is lenlex less than \p y,
     //! and \c false otherwise.
     //!
     //! \exceptions
@@ -1178,7 +1178,7 @@ namespace libsemigroups {
 
   //! \relates LenLexCmp
   //!
-  //! \brief Return a human readable representation of a stateful len-lex
+  //! \brief Return a human readable representation of a stateful lenlex
   //! comparison functor.
   //!
   //! \tparam Word the word type associated with the alphabet.
@@ -1195,7 +1195,7 @@ namespace libsemigroups {
 
   //! \relates LenLexCmp
   //!
-  //! \brief Return a human readable representation of a stateless len-lex
+  //! \brief Return a human readable representation of a stateless lenlex
   //! comparison functor.
   //!
   //! \tparam check whether to check arguments.
@@ -1210,10 +1210,10 @@ namespace libsemigroups {
   to_human_readable_repr(LenLexCmp<Default, check> const& cmp);
 
   //////////////////////////////////////////////////////////////////////
-  // Reversed len-lex
+  // Reversed lenlex
   //////////////////////////////////////////////////////////////////////
 
-  //! \brief Compare two ranges using reversed len-lex.
+  //! \brief Compare two ranges using reversed lenlex.
   //!
   //! This function applies \ref lenlex_cmp to the ranges read from right to
   //! left.
@@ -1224,7 +1224,7 @@ namespace libsemigroups {
   //! \param last2 ending iterator of second object for comparison.
   //!
   //! \returns The boolean value \c true if the first range is reversed
-  //! len-lex less than the second range, and \c false otherwise.
+  //! lenlex less than the second range, and \c false otherwise.
   template <typename Iterator>
   [[nodiscard]] bool rev_lenlex_cmp(Iterator first1,
                                     Iterator last1,
@@ -1236,7 +1236,7 @@ namespace libsemigroups {
                       std::make_reverse_iterator(first2));
   }
 
-  //! \brief Compare two ranges using reversed len-lex without checking an
+  //! \brief Compare two ranges using reversed lenlex without checking an
   //! alphabet.
   //!
   //! This function applies \ref lenlex_cmp_no_checks to the ranges read from
@@ -1254,7 +1254,7 @@ namespace libsemigroups {
                                 std::make_reverse_iterator(first2));
   }
 
-  //! \brief Compare two ranges using reversed len-lex with respect to an
+  //! \brief Compare two ranges using reversed lenlex with respect to an
   //! alphabet.
   //!
   //! This function applies \ref lenlex_cmp to the ranges read from right to
@@ -1272,14 +1272,14 @@ namespace libsemigroups {
                       std::make_reverse_iterator(first2));
   }
 
-  //! \brief Compare two objects using reversed len-lex.
+  //! \brief Compare two objects using reversed lenlex.
   template <typename Word,
             typename = std::enable_if_t<!rx::is_input_or_sink_v<Word>>>
   [[nodiscard]] bool rev_lenlex_cmp(Word const& x, Word const& y) {
     return rev_lenlex_cmp(x.cbegin(), x.cend(), y.cbegin(), y.cend());
   }
 
-  //! \brief Compare two objects using reversed len-lex without checking an
+  //! \brief Compare two objects using reversed lenlex without checking an
   //! alphabet.
   template <typename Word>
   [[nodiscard]] bool rev_lenlex_cmp_no_checks(Alphabet<Word> const& alphabet,
@@ -1289,7 +1289,7 @@ namespace libsemigroups {
         alphabet, x.cbegin(), x.cend(), y.cbegin(), y.cend());
   }
 
-  //! \brief Compare two objects using reversed len-lex with respect to an
+  //! \brief Compare two objects using reversed lenlex with respect to an
   //! alphabet.
   template <typename Word>
   [[nodiscard]] bool rev_lenlex_cmp(Alphabet<Word> const& alphabet,
@@ -1301,7 +1301,7 @@ namespace libsemigroups {
   template <typename Word = Default, bool check = true>
   class RevLenLexCmp;
 
-  //! \brief Stateful reversed len-lex comparison functor.
+  //! \brief Stateful reversed lenlex comparison functor.
   template <typename Word, bool check>
   class RevLenLexCmp {
     LenLexCmp<Word, check> _lenlex;
@@ -1344,12 +1344,12 @@ namespace libsemigroups {
       return *this;
     }
 
-    //! \brief Compare two words using reversed len-lex.
+    //! \brief Compare two words using reversed lenlex.
     [[nodiscard]] bool operator()(Word const& x, Word const& y) const {
       return operator()(x.cbegin(), x.cend(), y.cbegin(), y.cend());
     }
 
-    //! \brief Compare two iterator ranges using reversed len-lex.
+    //! \brief Compare two iterator ranges using reversed lenlex.
     template <typename Iterator>
     [[nodiscard]] bool operator()(Iterator first1,
                                   Iterator last1,
@@ -1367,7 +1367,7 @@ namespace libsemigroups {
     }
   };  // class RevLenLexCmp
 
-  //! \brief Stateless reversed len-lex comparison functor.
+  //! \brief Stateless reversed lenlex comparison functor.
   template <>
   struct RevLenLexCmp<Default, true> {
     //! \brief Reinitialize the comparison object.
@@ -1375,13 +1375,13 @@ namespace libsemigroups {
       return *this;
     }
 
-    //! \brief Compare two words using reversed len-lex.
+    //! \brief Compare two words using reversed lenlex.
     template <typename Word>
     [[nodiscard]] bool operator()(Word const& x, Word const& y) const {
       return operator()(x.cbegin(), x.cend(), y.cbegin(), y.cend());
     }
 
-    //! \brief Compare two iterator ranges using reversed len-lex.
+    //! \brief Compare two iterator ranges using reversed lenlex.
     template <typename Iterator>
     [[nodiscard]] bool operator()(Iterator first1,
                                   Iterator last1,
@@ -1405,7 +1405,7 @@ namespace libsemigroups {
   //! \relates RevLenLexCmp
   //!
   //! \brief Return a human readable representation of a stateful reversed
-  //! len-lex comparison functor.
+  //! lenlex comparison functor.
   //!
   //! \tparam Word the word type associated with the alphabet.
   //! \tparam check whether to check that letters belong to the alphabet.
@@ -1422,7 +1422,7 @@ namespace libsemigroups {
   //! \relates RevLenLexCmp
   //!
   //! \brief Return a human readable representation of a stateless reversed
-  //! len-lex comparison functor.
+  //! lenlex comparison functor.
   //!
   //! \tparam check whether to check arguments.
   //! \param cmp the comparison functor.
@@ -2250,14 +2250,14 @@ namespace libsemigroups {
   //! Defined in `order.hpp`.
   //!
   //! This function compares two objects of the same type using a
-  //! wreath-product of len-lex comparisons as described in \cite Sims1994aa
+  //! wreath-product of lenlex comparisons as described in \cite Sims1994aa
   //! (Chapter 2.1). Generators are assigned levels. Differences between
   //! generators at higher levels dominate differences at lower levels.
-  //! Differences within the same level are determined by len-lex.
+  //! Differences within the same level are determined by lenlex.
   //!
   //! Suppose that \f$X\f$ is the disjoint union of non-empty sets
   //! \f$X_1, \dots, X_n\f$ referred to as levels, and for \f$1 \leq i \leq
-  //! n\f$, let \f$<_i\f$ be a len-lex ordering of \f$X_i\f$. We define \f$<\f$
+  //! n\f$, let \f$<_i\f$ be a lenlex ordering of \f$X_i\f$. We define \f$<\f$
   //! to be \f$<_1 \wr \dots \wr <_n\f$. Next suppose that \f$U, V\in X ^
   //! {*}\f$. If \f$U\f$ and \f$V\f$ have a common prefix, that is \f$U = AB\f$
   //! and \f$V = AC\f$, then \f$U < V\f$ if and only if \f$B < C\f$. Therefore,
@@ -3191,20 +3191,20 @@ namespace libsemigroups {
   RevWrCmp(Alphabet<Word>&&, std::vector<size_t>&&) -> RevWrCmp<Word>;
 
   //////////////////////////////////////////////////////////////////////
-  // Weighted len-lex
+  // Weighted lenlex
   //////////////////////////////////////////////////////////////////////
 
-  //! \brief Compare two objects of the same type using the weighted len-lex
+  //! \brief Compare two objects of the same type using the weighted lenlex
   //! ordering without checks.
   //!
   //! Defined in `order.hpp`.
   //!
   //! This function compares two objects of the same type using the weighted
-  //! len-lex ordering. The weight of a word is computed by adding up the
+  //! lenlex ordering. The weight of a word is computed by adding up the
   //! weights of the letters in the word, where the `i`th index of the weights
   //! vector corresponds to the weight of the `i`th letter in the alphabet.
   //! Heavier words come later in the ordering than all lighter words. Amongst
-  //! words of equal weight, len-lex ordering is used.
+  //! words of equal weight, lenlex ordering is used.
   //!
   //! \tparam Iterator the type of iterators that are the arguments.
   //!
@@ -3215,7 +3215,7 @@ namespace libsemigroups {
   //! \param last2 ending iterator of second object for comparison.
   //!
   //! \returns The boolean value \c true if the range `[first1, last1)` is
-  //! weighted len-lex less than the range `[first2, last2)`, and \c false
+  //! weighted lenlex less than the range `[first2, last2)`, and \c false
   //! otherwise.
   //!
   //! \exceptions
@@ -3240,7 +3240,7 @@ namespace libsemigroups {
                                              Iterator                   first2,
                                              Iterator                   last2);
 
-  //! \brief Compare two ranges using the weighted len-lex ordering without
+  //! \brief Compare two ranges using the weighted lenlex ordering without
   //! checks and with a specified alphabet.
   //!
   //! This overload is the same as
@@ -3259,7 +3259,7 @@ namespace libsemigroups {
   //! \param last2 ending iterator of second object for comparison.
   //!
   //! \returns The boolean value \c true if the range `[first1, last1)` is
-  //! weighted len-lex less than the range `[first2, last2)`, and \c false
+  //! weighted lenlex less than the range `[first2, last2)`, and \c false
   //! otherwise.
   //!
   //! \warning
@@ -3288,7 +3288,7 @@ namespace libsemigroups {
   //! \param x const reference to the first object for comparison.
   //! \param y const reference to the second object for comparison.
   //!
-  //! \returns The boolean value \c true if \p x is weighted len-lex less
+  //! \returns The boolean value \c true if \p x is weighted lenlex less
   //! than \p y, and \c false otherwise.
   //!
   //! \exceptions
@@ -3331,7 +3331,7 @@ namespace libsemigroups {
   //! \param x const reference to the first object for comparison.
   //! \param y const reference to the second object for comparison.
   //!
-  //! \returns The boolean value \c true if \p x is weighted len-lex less than
+  //! \returns The boolean value \c true if \p x is weighted lenlex less than
   //! \p y, and \c false otherwise.
   //!
   //! \warning
@@ -3346,17 +3346,17 @@ namespace libsemigroups {
         alphabet, weights, x.cbegin(), x.cend(), y.cbegin(), y.cend());
   }
 
-  //! \brief Compare two objects of the same type using the weighted len-lex
+  //! \brief Compare two objects of the same type using the weighted lenlex
   //! ordering and check validity.
   //!
   //! Defined in `order.hpp`.
   //!
   //! This function compares two objects of the same type using the weighted
-  //! len-lex ordering. The weight of a word is computed by adding up the
+  //! lenlex ordering. The weight of a word is computed by adding up the
   //! weights of the letters in the word, where the `i`th index of the weights
   //! vector corresponds to the weight of the `i`th letter in the alphabet.
   //! Heavier words come later in the ordering than all lighter words. Amongst
-  //! words of equal weight, len-lex ordering is used.
+  //! words of equal weight, lenlex ordering is used.
   //!
   //! After checking that all letters in both ranges are valid indices into
   //! the weights vector, this function performs the same as
@@ -3371,7 +3371,7 @@ namespace libsemigroups {
   //! \param last2 ending iterator of second object for comparison.
   //!
   //! \returns The boolean value \c true if the range `[first1, last1)` is
-  //! weighted len-lex less than the range `[first2, last2)`, and \c false
+  //! weighted lenlex less than the range `[first2, last2)`, and \c false
   //! otherwise.
   //!
   //! \throws LibsemigroupsException if any letter in either range is not a
@@ -3393,7 +3393,7 @@ namespace libsemigroups {
                                    Iterator                   first2,
                                    Iterator                   last2);
 
-  //! \brief Compare two ranges using the weighted len-lex ordering and with a
+  //! \brief Compare two ranges using the weighted lenlex ordering and with a
   //! specified alphabet.
   //!
   //! This overload is the same as
@@ -3412,7 +3412,7 @@ namespace libsemigroups {
   //! \param last2 ending iterator of second object for comparison.
   //!
   //! \returns The boolean value \c true if the range `[first1, last1)` is
-  //! weighted len-lex less than the range `[first2, last2)`, and \c false
+  //! weighted lenlex less than the range `[first2, last2)`, and \c false
   //! otherwise.
   //!
   //! \throws LibsemigroupsException if any letter in either range has an index
@@ -3444,7 +3444,7 @@ namespace libsemigroups {
   //! \param x const reference to the first object for comparison.
   //! \param y const reference to the second object for comparison.
   //!
-  //! \returns The boolean value \c true if \p x is weighted len-lex less
+  //! \returns The boolean value \c true if \p x is weighted lenlex less
   //! than \p y, and \c false otherwise.
   //!
   //! \throws LibsemigroupsException if any letter in \p x or \p y is not a
@@ -3480,7 +3480,7 @@ namespace libsemigroups {
   //! \param x const reference to the first object for comparison.
   //! \param y const reference to the second object for comparison.
   //!
-  //! \returns The boolean value \c true if \p x is weighted len-lex less than
+  //! \returns The boolean value \c true if \p x is weighted lenlex less than
   //! \p y, and \c false otherwise.
   //!
   //! \throws LibsemigroupsException if any letter in \p x or \p y has an
@@ -3498,7 +3498,7 @@ namespace libsemigroups {
   template <typename Word = Default, bool check = true>
   class WtLenLexCmp;
 
-  //! \brief Stateful weighted len-lex comparison functor.
+  //! \brief Stateful weighted lenlex comparison functor.
   //!
   //! This class stores an alphabet and a weights vector and compares words by
   //! applying \ref wt_lenlex_cmp with that alphabet and weights vector. The
@@ -3597,7 +3597,7 @@ namespace libsemigroups {
     //! \param x const reference to the first word for comparison.
     //! \param y const reference to the second word for comparison.
     //!
-    //! \returns The boolean value \c true if \p x is weighted len-lex less
+    //! \returns The boolean value \c true if \p x is weighted lenlex less
     //! than \p y, and \c false otherwise.
     //!
     //! \throws LibsemigroupsException if \c check is \c true and a letter in
@@ -3614,7 +3614,7 @@ namespace libsemigroups {
     //! \param last2 ending iterator of second object for comparison.
     //!
     //! \returns The boolean value \c true if the first range is weighted
-    //! len-lex less than the second range, and \c false otherwise.
+    //! lenlex less than the second range, and \c false otherwise.
     //!
     //! \throws LibsemigroupsException if \c check is \c true and a letter in
     //! either range does not belong to the stored alphabet.
@@ -3655,7 +3655,7 @@ namespace libsemigroups {
     }
   };  // class WtLenLexCmp
 
-  //! \brief Stateful weighted len-lex comparison functor.
+  //! \brief Stateful weighted lenlex comparison functor.
   //!
   //! Defined in `order.hpp`.
   //!
@@ -3775,7 +3775,7 @@ namespace libsemigroups {
     //! \param x const reference to the first object for comparison.
     //! \param y const reference to the second object for comparison.
     //!
-    //! \returns The boolean value \c true if \p x is weighted len-lex less
+    //! \returns The boolean value \c true if \p x is weighted lenlex less
     //! than \p y, and \c false otherwise.
     //!
     //! \throws LibsemigroupsException if \c check is \c true and a letter is
@@ -3805,7 +3805,7 @@ namespace libsemigroups {
     //! \param last2 ending iterator of second object for comparison.
     //!
     //! \returns The boolean value \c true if the first range is weighted
-    //! len-lex less than the second range, and \c false otherwise.
+    //! lenlex less than the second range, and \c false otherwise.
     //!
     //! \throws LibsemigroupsException if \c check is \c true and a letter is
     //! not a valid index into the weights vector.
@@ -3837,7 +3837,7 @@ namespace libsemigroups {
 
   //! \relates WtLenLexCmp
   //!
-  //! \brief Return a human readable representation of a weighted len-lex
+  //! \brief Return a human readable representation of a weighted lenlex
   //! comparison functor with an alphabet.
   //!
   //! \tparam Word the word type associated with the alphabet.
@@ -3854,7 +3854,7 @@ namespace libsemigroups {
 
   //! \relates WtLenLexCmp
   //!
-  //! \brief Return a human readable representation of a weighted len-lex
+  //! \brief Return a human readable representation of a weighted lenlex
   //! comparison functor on index words.
   //!
   //! \tparam check whether to check arguments.
@@ -3886,10 +3886,10 @@ namespace libsemigroups {
   WtLenLexCmp(Alphabet<Word>&&, std::vector<size_t>&&) -> WtLenLexCmp<Word>;
 
   //////////////////////////////////////////////////////////////////////
-  // Reversed weighted len-lex
+  // Reversed weighted lenlex
   //////////////////////////////////////////////////////////////////////
 
-  //! \brief Compare two ranges using reversed weighted len-lex without
+  //! \brief Compare two ranges using reversed weighted lenlex without
   //! checks.
   //!
   //! This function applies \ref wt_lenlex_cmp_no_checks to the ranges read
@@ -3908,7 +3908,7 @@ namespace libsemigroups {
                                    std::make_reverse_iterator(first2));
   }
 
-  //! \brief Compare two ranges using reversed weighted len-lex without
+  //! \brief Compare two ranges using reversed weighted lenlex without
   //! checks and with a specified alphabet.
   template <typename Word, typename Iterator>
   [[nodiscard]] bool
@@ -3926,7 +3926,7 @@ namespace libsemigroups {
                                    std::make_reverse_iterator(first2));
   }
 
-  //! \brief Compare two objects using reversed weighted len-lex without
+  //! \brief Compare two objects using reversed weighted lenlex without
   //! checks.
   template <typename Word>
   [[nodiscard]] bool
@@ -3937,7 +3937,7 @@ namespace libsemigroups {
         weights, x.cbegin(), x.cend(), y.cbegin(), y.cend());
   }
 
-  //! \brief Compare two objects using reversed weighted len-lex without
+  //! \brief Compare two objects using reversed weighted lenlex without
   //! checks and with a specified alphabet.
   template <typename Word>
   [[nodiscard]] bool
@@ -3949,7 +3949,7 @@ namespace libsemigroups {
         alphabet, weights, x.cbegin(), x.cend(), y.cbegin(), y.cend());
   }
 
-  //! \brief Compare two ranges using reversed weighted len-lex and check
+  //! \brief Compare two ranges using reversed weighted lenlex and check
   //! validity.
   template <typename Iterator>
   [[nodiscard]] bool rev_wt_lenlex_cmp(std::vector<size_t> const& weights,
@@ -3964,7 +3964,7 @@ namespace libsemigroups {
                          std::make_reverse_iterator(first2));
   }
 
-  //! \brief Compare two ranges using reversed weighted len-lex and a
+  //! \brief Compare two ranges using reversed weighted lenlex and a
   //! specified alphabet.
   template <typename Word, typename Iterator>
   [[nodiscard]] bool rev_wt_lenlex_cmp(Alphabet<Word> const&      alphabet,
@@ -3981,7 +3981,7 @@ namespace libsemigroups {
                          std::make_reverse_iterator(first2));
   }
 
-  //! \brief Compare two objects using reversed weighted len-lex and check
+  //! \brief Compare two objects using reversed weighted lenlex and check
   //! validity.
   template <typename Word>
   [[nodiscard]] bool rev_wt_lenlex_cmp(std::vector<size_t> const& weights,
@@ -3991,7 +3991,7 @@ namespace libsemigroups {
         weights, x.cbegin(), x.cend(), y.cbegin(), y.cend());
   }
 
-  //! \brief Compare two objects using reversed weighted len-lex and a
+  //! \brief Compare two objects using reversed weighted lenlex and a
   //! specified alphabet.
   template <typename Word>
   [[nodiscard]] bool rev_wt_lenlex_cmp(Alphabet<Word> const&      alphabet,
@@ -4006,7 +4006,7 @@ namespace libsemigroups {
   template <typename Word = Default, bool check = true>
   class RevWtLenLexCmp;
 
-  //! \brief Stateful reversed weighted len-lex comparison functor.
+  //! \brief Stateful reversed weighted lenlex comparison functor.
   template <typename Word, bool check>
   class RevWtLenLexCmp {
     WtLenLexCmp<Word, check> _wt_lenlex;
@@ -4053,12 +4053,12 @@ namespace libsemigroups {
       return *this;
     }
 
-    //! \brief Compare two words using reversed weighted len-lex.
+    //! \brief Compare two words using reversed weighted lenlex.
     [[nodiscard]] bool operator()(Word const& x, Word const& y) const {
       return operator()(x.cbegin(), x.cend(), y.cbegin(), y.cend());
     }
 
-    //! \brief Compare two iterator ranges using reversed weighted len-lex.
+    //! \brief Compare two iterator ranges using reversed weighted lenlex.
     template <typename Iterator>
     [[nodiscard]] bool operator()(Iterator first1,
                                   Iterator last1,
@@ -4081,7 +4081,7 @@ namespace libsemigroups {
     }
   };  // class RevWtLenLexCmp
 
-  //! \brief Reversed weighted len-lex comparison functor using index words.
+  //! \brief Reversed weighted lenlex comparison functor using index words.
   template <bool check>
   class RevWtLenLexCmp<Default, check> {
     WtLenLexCmp<Default, check> _wt_lenlex;
@@ -4131,13 +4131,13 @@ namespace libsemigroups {
       return *this;
     }
 
-    //! \brief Compare two words using reversed weighted len-lex.
+    //! \brief Compare two words using reversed weighted lenlex.
     template <typename Word>
     [[nodiscard]] bool operator()(Word const& x, Word const& y) const {
       return operator()(x.cbegin(), x.cend(), y.cbegin(), y.cend());
     }
 
-    //! \brief Compare two iterator ranges using reversed weighted len-lex.
+    //! \brief Compare two iterator ranges using reversed weighted lenlex.
     template <typename Iterator>
     [[nodiscard]] bool operator()(Iterator first1,
                                   Iterator last1,
@@ -4158,7 +4158,7 @@ namespace libsemigroups {
   //! \relates RevWtLenLexCmp
   //!
   //! \brief Return a human readable representation of a reversed weighted
-  //! len-lex comparison functor with an alphabet.
+  //! lenlex comparison functor with an alphabet.
   //!
   //! \tparam Word the word type associated with the alphabet.
   //! \tparam check whether to check that letters belong to the alphabet.
@@ -4175,7 +4175,7 @@ namespace libsemigroups {
   //! \relates RevWtLenLexCmp
   //!
   //! \brief Return a human readable representation of a reversed weighted
-  //! len-lex comparison functor on index words.
+  //! lenlex comparison functor on index words.
   //!
   //! \tparam check whether to check arguments.
   //! \param cmp the comparison functor.
@@ -5862,7 +5862,7 @@ namespace libsemigroups {
     template <typename Thing>
     struct is_length_non_increasing : std::false_type {};
 
-    //! \brief len-lex order is length non-increasing.
+    //! \brief lenlex order is length non-increasing.
     //!
     //! Specialization of \ref is_length_non_increasing for
     //! \ref LenLexCmp.
@@ -5870,7 +5870,7 @@ namespace libsemigroups {
     struct is_length_non_increasing<LenLexCmp<Default, check>>
         : std::true_type {};
 
-    //! \brief Reversed len-lex order is length non-increasing.
+    //! \brief Reversed lenlex order is length non-increasing.
     template <bool check>
     struct is_length_non_increasing<RevLenLexCmp<Default, check>>
         : std::true_type {};
@@ -5906,13 +5906,13 @@ namespace libsemigroups {
     template <typename Thing>
     struct is_well_founded : std::false_type {};
 
-    //! \brief len-lex order is well-founded.
+    //! \brief lenlex order is well-founded.
     //!
     //! Specialization of \ref is_well_founded for \ref LenLexCmp.
     template <bool check>
     struct is_well_founded<LenLexCmp<Default, check>> : std::true_type {};
 
-    //! \brief Reversed len-lex order is well-founded.
+    //! \brief Reversed lenlex order is well-founded.
     template <bool check>
     struct is_well_founded<RevLenLexCmp<Default, check>> : std::true_type {};
 
@@ -5944,7 +5944,7 @@ namespace libsemigroups {
     template <bool check>
     struct is_well_founded<WtLenLexCmp<Default, check>> : std::true_type {};
 
-    //! \brief Reversed weighted len-lex order is well-founded.
+    //! \brief Reversed weighted lenlex order is well-founded.
     template <bool check>
     struct is_well_founded<RevWtLenLexCmp<Default, check>> : std::true_type {};
 

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -2276,10 +2276,10 @@ namespace libsemigroups {
   //! \f$A_0 < B_0\f$.
   //!
   //! The implementation of this function is inspired by the source code of
-  //! \cite Holt2018aa, specifically the function `wr_compare`.
+  //! \cite Holt2018aa, specifically the function `wreath_compare`.
   //!
   //! In the case where each generator has a unique level, this function
-  //! produces the same output as \ref rpo_cmp. In the case where each
+  //! produces the same output as \ref rev_rpo_cmp. In the case where each
   //! generator has the same level, this function produces the same output as
   //! \ref lenlex_cmp.
   //!

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -1446,27 +1446,20 @@ namespace libsemigroups {
   //!
   //! This function compares two objects of the same type using the recursive
   //! path comparison, based on the description in \cite Jantzen2012aa
-  //! (Definition 1.2.14, page 24).
-  //!
-  //! In the literature, recursive path order is sometimes defined in the way
-  //! that `libsemigroups` defines reversed recursive path order. This
-  //! distinction is so that, in `libsemigroups`, recursive path order is a
-  //! special case of wreath-product order, and reverse recursive path order is
-  //! a special case of reverse wreath-product order. The following definition
-  //! is used in `libsemigroups` for recursive path order.
+  //! (Definition 1.2.14, page 24) and \cite Dershowitz1982aa (Definition 5,
+  //! page 289). The following definition is used in `libsemigroups`.
   //!
   //! If \f$u, v\in X ^ {*}\f$, then
   //! \f$u < v\f$ if and only if one of the following conditions holds:
   //! 1. \f$u\f$ is empty and \f$v\f$ is not empty; or
-  //! 2. \f$u = u'a\f$ and \f$v = v'b\f$ for some \f$a,b \in X\f$, \f$u',v'\in
+  //! 2. \f$u = au'\f$ and \f$v = bv'\f$ for some \f$a,b \in X\f$, \f$u',v'\in
   //!    X ^ {*}\f$ and:
   //!   1. \f$a = b\f$ and \f$u' < v'\f$; or
-  //!   2. \f$a < b\f$ and \f$u'  < v\f$; or
-  //!   3. \f$a > b\f$ and \f$u < v'\f$.
+  //!   2. \f$a < b\f$ and \f$u' < v\f$; or
+  //!   3. \f$a > b\f$ and \f$u  \leq v'\f$.
   //!
-  //! This documentation and the implementation of \ref rpo_cmp
-  //! is based on the source code of \cite Holt2018aa, specifically the function
-  //! `rec_compare`.
+  //! The implementation of \ref rpo_cmp is based on the source code of
+  //! \cite Holt2018aa, specifically the function `rt_rec_compare`.
   //!
   //! \tparam Iterator the type of iterators that are the arguments.
   //!
@@ -1481,10 +1474,6 @@ namespace libsemigroups {
   //!
   //! \exceptions
   //! \noexcept
-  //!
-  //! \warning
-  //! This function has significantly worse performance than all
-  //! the variants of \ref lenlex_cmp and std::lexicographical_compare.
   template <typename Iterator>
   [[nodiscard]] bool rpo_cmp(Iterator first1,
                              Iterator last1,
@@ -1857,35 +1846,10 @@ namespace libsemigroups {
   // Reversed recursive path order (RPO)
   //////////////////////////////////////////////////////////////////////
 
-  //! \brief Compare two objects of the same type using the reversed recursive
-  //! path comparison.
+  //! \brief Compare two ranges using reversed recursive path compare.
   //!
-  //! Defined in `order.hpp`.
-  //!
-  //! This function compares two objects of the same type using the reversed
-  //! recursive path comparison. This is the same as applying the recursive path
-  //! comparison to the reversed words in `[first1, last1)`, `[first2, last2)`.
-  //!
-  //! In the literature, recursive path order is sometimes defined in the way
-  //! that `libsemigroups` defines reversed recursive path order. This
-  //! distinction is so that, in `libsemigroups`, recursive path order is a
-  //! special case of wreath-product order, and reverse recursive path order is
-  //! a special case of reverse wreath-product order. The following definition
-  //! is used in `libsemigroups` for reversed recursive path order, and is taken
-  //! from \cite Jantzen2012aa (Definition 1.2.14, page 24).
-  //!
-  //! If \f$u, v\in X ^ {*}\f$, then
-  //! \f$u < v\f$ if and only if one of the following conditions holds:
-  //! 1. \f$u\f$ is empty and \f$v\f$ is not empty; or
-  //! 2. \f$u = au'\f$ and \f$v = bv'\f$ for some \f$a,b \in X\f$, \f$u',v'\in
-  //!    X ^ {*}\f$ and:
-  //!   1. \f$a = b\f$ and \f$u' < v'\f$; or
-  //!   2. \f$a < b\f$ and \f$u'  < v\f$; or
-  //!   3. \f$a > b\f$ and \f$u < v'\f$.
-  //!
-  //! This documentation and the implementation of \ref rev_rpo_cmp
-  //! is based on the source code of \cite Holt2018aa, specifically the function
-  //! `rt_rec_compare`.
+  //! This function applies \ref libsemigroups::rpo_cmp to the ranges read from
+  //! right to left.
   //!
   //! \tparam Iterator the type of iterators that are the arguments.
   //!
@@ -1894,16 +1858,12 @@ namespace libsemigroups {
   //! \param first2 beginning iterator of second object for comparison.
   //! \param last2 ending iterator of second object for comparison.
   //!
-  //! \returns The boolean value \c true if the range `[first1, last1)` is less
-  //! than the range `[first2, last2)` with respect to the reversed recursive
-  //! path ordering, and \c false otherwise.
+  //! \returns The boolean value \c true if the first range is less than the
+  //! second range with respect to reversed recursive path order, and \c false
+  //! otherwise.
   //!
   //! \exceptions
   //! \noexcept
-  //!
-  //! \warning
-  //! This function has significantly worse performance than all
-  //! the variants of \ref lenlex_cmp and std::lexicographical_compare.
   template <typename Iterator>
   [[nodiscard]] bool rev_rpo_cmp(Iterator first1,
                                  Iterator last1,
@@ -1959,12 +1919,13 @@ namespace libsemigroups {
                                  Iterator              first2,
                                  Iterator              last2);
 
-  //! \brief Compare two objects of the same type using \ref rev_rpo_cmp.
+  //! \brief Compare two objects of the same type using
+  //! \ref libsemigroups::rev_rpo_cmp.
   //!
   //! Defined in `order.hpp`.
   //!
   //! This function compares two objects of the same type using
-  //! \ref rev_rpo_cmp.
+  //! \ref libsemigroups::rev_rpo_cmp.
   //!
   //! \tparam Word the type of the objects to be compared.
   //!
@@ -5957,15 +5918,15 @@ namespace libsemigroups {
 
     //! \brief Recursive path order is well-founded.
     //!
-    //! Specialization of \ref is_well_founded for \ref RevRPOCmp.
-    template <bool check>
-    struct is_well_founded<RevRPOCmp<Default, check>> : std::true_type {};
-
-    //! \brief Reverse recursive path order is well-founded.
-    //!
     //! Specialization of \ref is_well_founded for \ref RPOCmp.
     template <bool check>
     struct is_well_founded<RPOCmp<Default, check>> : std::true_type {};
+
+    //! \brief Reverse recursive path order is well-founded.
+    //!
+    //! Specialization of \ref is_well_founded for \ref RevRPOCmp.
+    template <bool check>
+    struct is_well_founded<RevRPOCmp<Default, check>> : std::true_type {};
 
     //! \brief Wreath-product order is well-founded.
     //!

--- a/include/libsemigroups/order.hpp
+++ b/include/libsemigroups/order.hpp
@@ -80,11 +80,12 @@ namespace libsemigroups {
     //! right-to-left before ordering.
     rev_rpo,
 
-    //! The recursive path ordering, as described in \cite Jantzen2012aa
-    //! (Definition 1.2.14, page 24).
+    //! The reversed recursive path ordering, based on the description in
+    //! \cite Jantzen2012aa (Definition 1.2.14, page 24), where words are read
+    //! right-to-left before ordering.
     //!
-    //! \deprecated_warning{value} Use \ref Order::rpo instead.
-    recursive [[deprecated("Use rpo instead!")]] = rpo
+    //! \deprecated_warning{value} Use \ref Order::rev_rpo instead.
+    recursive [[deprecated("Use rev_rpo instead!")]] = rev_rpo
   };
 
   //! \defgroup orders_group Orders

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -75,41 +75,6 @@ namespace libsemigroups {
                Iterator last1,
                Iterator first2,
                Iterator last2) noexcept {
-    return rev_rpo_cmp(std::make_reverse_iterator(last1),
-                       std::make_reverse_iterator(first1),
-                       std::make_reverse_iterator(last2),
-                       std::make_reverse_iterator(first2));
-  }
-
-  template <typename Word, typename Iterator>
-  bool rpo_cmp_no_checks(Alphabet<Word> const& alphabet,
-                         Iterator              first1,
-                         Iterator              last1,
-                         Iterator              first2,
-                         Iterator              last2) {
-    return rev_rpo_cmp_no_checks(alphabet,
-                                 std::make_reverse_iterator(last1),
-                                 std::make_reverse_iterator(first1),
-                                 std::make_reverse_iterator(last2),
-                                 std::make_reverse_iterator(first2));
-  }
-
-  template <typename Word, typename Iterator>
-  bool rpo_cmp(Alphabet<Word> const& alphabet,
-               Iterator              first1,
-               Iterator              last1,
-               Iterator              first2,
-               Iterator              last2) {
-    alphabet.throw_if_letter_not_in_alphabet(first1, last1);
-    alphabet.throw_if_letter_not_in_alphabet(first2, last2);
-    return rpo_cmp_no_checks(alphabet, first1, last1, first2, last2);
-  }
-
-  template <typename Iterator>
-  bool rev_rpo_cmp(Iterator first1,
-                   Iterator last1,
-                   Iterator first2,
-                   Iterator last2) noexcept {
     int lastmoved = 0;
 
     while (true) {
@@ -137,15 +102,50 @@ namespace libsemigroups {
   }
 
   template <typename Word, typename Iterator>
+  bool rpo_cmp_no_checks(Alphabet<Word> const& alphabet,
+                         Iterator              first1,
+                         Iterator              last1,
+                         Iterator              first2,
+                         Iterator              last2) {
+    return rpo_cmp(detail::citow(alphabet, first1),
+                   detail::citow(alphabet, last1),
+                   detail::citow(alphabet, first2),
+                   detail::citow(alphabet, last2));
+  }
+
+  template <typename Word, typename Iterator>
+  bool rpo_cmp(Alphabet<Word> const& alphabet,
+               Iterator              first1,
+               Iterator              last1,
+               Iterator              first2,
+               Iterator              last2) {
+    alphabet.throw_if_letter_not_in_alphabet(first1, last1);
+    alphabet.throw_if_letter_not_in_alphabet(first2, last2);
+    return rpo_cmp_no_checks(alphabet, first1, last1, first2, last2);
+  }
+
+  template <typename Iterator>
+  bool rev_rpo_cmp(Iterator first1,
+                   Iterator last1,
+                   Iterator first2,
+                   Iterator last2) noexcept {
+    return rpo_cmp(std::make_reverse_iterator(last1),
+                   std::make_reverse_iterator(first1),
+                   std::make_reverse_iterator(last2),
+                   std::make_reverse_iterator(first2));
+  }
+
+  template <typename Word, typename Iterator>
   bool rev_rpo_cmp_no_checks(Alphabet<Word> const& alphabet,
                              Iterator              first1,
                              Iterator              last1,
                              Iterator              first2,
                              Iterator              last2) {
-    return rev_rpo_cmp(detail::citow(alphabet, first1),
-                       detail::citow(alphabet, last1),
-                       detail::citow(alphabet, first2),
-                       detail::citow(alphabet, last2));
+    return rpo_cmp_no_checks(alphabet,
+                             std::make_reverse_iterator(last1),
+                             std::make_reverse_iterator(first1),
+                             std::make_reverse_iterator(last2),
+                             std::make_reverse_iterator(first2));
   }
 
   template <typename Word, typename Iterator>

--- a/include/libsemigroups/order.tpp
+++ b/include/libsemigroups/order.tpp
@@ -163,7 +163,7 @@ namespace libsemigroups {
   // smaller than the second sequence (word 2) with respect to a wreath-product
   // order. Generators are assigned levels. Differences between generators at
   // higher levels dominate differences at lower levels. Differences within the
-  // same level are determined by len-lex.
+  // same level are determined by lenlex.
   //
   // The words are read from right to left, and the dominant level is stored in
   // the variable <relevant_level>. This level is the highest level that is

--- a/include/libsemigroups/todd-coxeter-class.hpp
+++ b/include/libsemigroups/todd-coxeter-class.hpp
@@ -119,13 +119,13 @@ namespace libsemigroups {
   //! // {0_w,
   //! //  1_w,
   //! //  2_w,
-  //! //  21_w,
   //! //  12_w,
+  //! //  21_w,
   //! //  121_w,
   //! //  22_w,
-  //! //  221_w,
+  //! //  122_w,
   //! //  212_w,
-  //! //  2121_w}
+  //! //  1212_w};
   //! tc.standardize(Order::lex);
   //! todd_coxeter::normal_forms(tc) | rx::take(10) | rx::to_vector();
   //! // {0_w,

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -2884,7 +2884,7 @@ namespace libsemigroups {
       //! Order::lenlex).
       //!
       //! \throws LibsemigroupsException if \p val is not one of: Order::none,
-      //! Order::lenlex, or Order::rpo.
+      //! Order::lenlex, or Order::rev_rpo.
       //!
       //! \sa
       //! standardize.
@@ -2905,7 +2905,7 @@ namespace libsemigroups {
       //! Order::lenlex).
       //!
       //! \throws LibsemigroupsException if \p val is not one of: Order::none,
-      //! Order::lenlex or Order::rpo.
+      //! Order::lenlex or Order::rev_rpo.
       //!
       //! \sa
       //! standardize.

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -92,7 +92,7 @@ namespace libsemigroups {
         }
 
         template <typename Node>
-        bool is_rpo_standardized(WordGraphView<Node> const& wg) {
+        bool is_rev_rpo_standardized(WordGraphView<Node> const& wg) {
           using node_type = typename WordGraphView<Node>::node_type;
 
           auto const N = wg.number_of_nodes_no_checks();
@@ -111,7 +111,7 @@ namespace libsemigroups {
 
           seen[0] = true;
 
-        restart:
+        start_is_rev_rpo_standardized:
           for (letter_type x = 0; x < wg.out_degree_no_checks(); ++x) {
             while (next_node[x] <= max_seen) {
               node_type const s = next_node[x];
@@ -127,7 +127,7 @@ namespace libsemigroups {
                 if (static_cast<size_t>(max_seen + 1) == nr_reachable) {
                   return true;
                 }
-                goto restart;
+                goto start_is_rev_rpo_standardized;
               }
             }
           }
@@ -278,40 +278,6 @@ namespace libsemigroups {
           using node_type  = typename Graph::node_type;
           using label_type = typename Graph::label_type;
 
-          Standardizer<Graph> standardizer(wg, f);
-          size_t const        n = wg.out_degree();
-
-          std::vector<node_type> next_node(n, 0);
-
-        // Follow Sims' WREATH_STND literally: each letter keeps its own
-        // cursor, and every discovery restarts the sweep from the first
-        // letter so earlier frontier words are handled first.
-        start_rpo_standardize_search:
-          for (label_type x = 0; x < n; ++x) {
-            while (next_node[x] <= standardizer.largest_used_node()) {
-              node_type const s = next_node[x];
-              ++next_node[x];
-
-              if (standardizer.try_set_next_smallest(s, x)) {
-                if (standardizer.stop_early()) {
-                  return standardizer.standardize();
-                }
-                goto start_rpo_standardize_search;
-              }
-            }
-          }
-
-          return standardizer.standardize();
-        }
-
-        template <typename Graph>
-        bool rev_rpo_standardize(Graph& wg, Forest& f) {
-          LIBSEMIGROUPS_ASSERT(wg.number_of_nodes() != 0);
-          LIBSEMIGROUPS_ASSERT(f.number_of_nodes() != 0);
-
-          using node_type  = typename Graph::node_type;
-          using label_type = typename Graph::label_type;
-
           Standardizer<Graph>    standardizer(wg, f);
           size_t const           n = wg.out_degree();
           label_type             x = 0;
@@ -335,6 +301,40 @@ namespace libsemigroups {
               x = 0;
             } else {
               ++x;
+            }
+          }
+
+          return standardizer.standardize();
+        }
+
+        template <typename Graph>
+        bool rev_rpo_standardize(Graph& wg, Forest& f) {
+          LIBSEMIGROUPS_ASSERT(wg.number_of_nodes() != 0);
+          LIBSEMIGROUPS_ASSERT(f.number_of_nodes() != 0);
+
+          using node_type  = typename Graph::node_type;
+          using label_type = typename Graph::label_type;
+
+          Standardizer<Graph> standardizer(wg, f);
+          size_t const        n = wg.out_degree();
+
+          std::vector<node_type> next_node(n, 0);
+
+        // Follow Sims' WREATH_STND literally: each letter keeps its own
+        // cursor, and every discovery restarts the sweep from the first
+        // letter so earlier frontier words are handled first.
+        start_rev_rpo_standardize_search:
+          for (label_type x = 0; x < n; ++x) {
+            while (next_node[x] <= standardizer.largest_used_node()) {
+              node_type const s = next_node[x];
+              ++next_node[x];
+
+              if (standardizer.try_set_next_smallest(s, x)) {
+                if (standardizer.stop_early()) {
+                  return standardizer.standardize();
+                }
+                goto start_rev_rpo_standardize_search;
+              }
             }
           }
 
@@ -532,9 +532,9 @@ namespace libsemigroups {
             return true;
           case Order::lenlex:
             return detail::is_lenlex_standardized(wg);
-          case Order::rpo:
-            return detail::is_rpo_standardized(wg);
           case Order::rev_rpo:
+            return detail::is_rev_rpo_standardized(wg);
+          case Order::rpo:
           case Order::lex:
           default:
             LIBSEMIGROUPS_EXCEPTION("not yet implemented")

--- a/include/libsemigroups/word-graph.hpp
+++ b/include/libsemigroups/word-graph.hpp
@@ -2631,6 +2631,10 @@ namespace libsemigroups {
     //!
     //! \note This function will be moved from the header `word-graph.hpp`
     //! to `word-graph-helpers.hpp` in v4 of libsemigroups.
+    //!
+    //! \warning Passing Order::rpo as \p val will result in \p wg being
+    //! standardized with respect to reverse rpo. This inconsistency will be
+    //! fixed in v4.
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph>
     [[deprecated]] bool standardize(Graph& wg, Forest& f, Order val);
@@ -2661,6 +2665,10 @@ namespace libsemigroups {
     //!
     //! \note This function will be moved from the header `word-graph.hpp`
     //! to `word-graph-helpers.hpp` in v4 of libsemigroups.
+    //!
+    //! \warning Passing Order::rpo as \p val will result in \p wg being
+    //! standardized with respect to reverse rpo. This inconsistency will be
+    //! fixed in v4.
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph>
     [[deprecated]] std::pair<bool, Forest> standardize(Graph& wg,

--- a/include/libsemigroups/word-graph.hpp
+++ b/include/libsemigroups/word-graph.hpp
@@ -2679,7 +2679,7 @@ namespace libsemigroups {
     //! Order::lenlex).
     //!
     //! \throws LibsemigroupsException if \p val is not one of: Order::none,
-    //! Order::lenlex, Order::lex or Order::rpo.
+    //! Order::lenlex.
     //!
     //! \note This function will be moved from the header `word-graph.hpp`
     //! to `word-graph-helpers.hpp` in v4 of libsemigroups.

--- a/tests/test-docs-code-examples.cpp
+++ b/tests/test-docs-code-examples.cpp
@@ -500,13 +500,13 @@ namespace libsemigroups {
     // {0_w,
     //  1_w,
     //  2_w,
-    //  21_w,
     //  12_w,
+    //  21_w,
     //  121_w,
     //  22_w,
-    //  221_w,
+    //  122_w,
     //  212_w,
-    //  2121_w}
+    //  1212_w};
     tc.standardize(Order::lex);
     todd_coxeter::normal_forms(tc) | rx::take(10) | rx::to_vector();
     // {0_w,
@@ -521,10 +521,10 @@ namespace libsemigroups {
     //  0121212121_w};
   }
 
-  // word-graph.hpp: Line 1581
+  // word-graph.hpp: Line 1585
   LIBSEMIGROUPS_TEST_CASE("docs",
                           "029",
-                          "./include/libsemigroups/word-graph.hpp:1581",
+                          "./include/libsemigroups/word-graph.hpp:1585",
                           "[docs][quick]") {
     WordGraph<size_t> wg;
     wg.add_nodes(2);
@@ -534,10 +534,10 @@ namespace libsemigroups {
     REQUIRE(word_graph::is_acyclic(wg) == false);
   }
 
-  // word-graph.hpp: Line 1629
+  // word-graph.hpp: Line 1633
   LIBSEMIGROUPS_TEST_CASE("docs",
                           "030",
-                          "./include/libsemigroups/word-graph.hpp:1629",
+                          "./include/libsemigroups/word-graph.hpp:1633",
                           "[docs][quick]") {
     WordGraph<size_t> wg;
     wg.add_nodes(4);
@@ -552,10 +552,10 @@ namespace libsemigroups {
     REQUIRE(word_graph::is_acyclic(wg, 3) == true);
   }
 
-  // word-graph.hpp: Line 2066
+  // word-graph.hpp: Line 2070
   LIBSEMIGROUPS_TEST_CASE("docs",
                           "031",
-                          "./include/libsemigroups/word-graph.hpp:2066",
+                          "./include/libsemigroups/word-graph.hpp:2070",
                           "[docs][quick]") {
     WordGraph<size_t> wg;
     wg.add_nodes(4);
@@ -570,19 +570,19 @@ namespace libsemigroups {
     REQUIRE(word_graph::is_reachable_no_checks(wg, 3, 2) == false);
   }
 
-  // word-graph.hpp: Line 2150
+  // word-graph.hpp: Line 2154
   LIBSEMIGROUPS_TEST_CASE("docs",
                           "032",
-                          "./include/libsemigroups/word-graph.hpp:2150",
+                          "./include/libsemigroups/word-graph.hpp:2154",
                           "[docs][quick]") {
     auto wg = make<WordGraph<uint8_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
     REQUIRE(word_graph::is_strictly_cyclic(wg) == false);
   }
 
-  // word-graph.hpp: Line 2964
+  // word-graph.hpp: Line 2968
   LIBSEMIGROUPS_TEST_CASE("docs",
                           "033",
-                          "./include/libsemigroups/word-graph.hpp:2964",
+                          "./include/libsemigroups/word-graph.hpp:2968",
                           "[docs][quick]") {
     // Construct a word graph with 5 nodes and 10 edges (7 specified)
     auto wg = make<WordGraph<uint8_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});

--- a/tests/test-du-narendran-rusinowitch.cpp
+++ b/tests/test-du-narendran-rusinowitch.cpp
@@ -19,6 +19,7 @@
 #include "test-main.hpp"  // for LIBSEMIGROUPS_TEST_CASE
 
 #include "libsemigroups/du-narendran-rusinowitch.hpp"  // for du_...
+#include "libsemigroups/presentation.hpp"              // for Presentation, p...
 
 #include "libsemigroups/detail/report.hpp"  // for ReportGuard
 
@@ -31,9 +32,13 @@ namespace libsemigroups {
                           "[quick]") {
     Presentation<std::string> p;
     p.alphabet("abcde"s);
-    p.rules = {"dbcbace", "cbbaec", "bcbad", "badbc"};
+    p.rules              = {"dbcbace", "cbbaec", "bcbad", "badbc"};
+    std::string alphabet = du_narendran_rusinowitch(p);
 
-    REQUIRE(du_narendran_rusinowitch(p) == "edcab");
+    REQUIRE(du_narendran_rusinowitch(p) == alphabet);
+    Presentation<std::string> copy(p);
+    presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
+    REQUIRE(copy == p);
   }
 
   LIBSEMIGROUPS_TEST_CASE("du_narendran_rusinowitch",
@@ -44,7 +49,12 @@ namespace libsemigroups {
     p.alphabet("abcd"s);
     p.rules = {"a", "cc", "d", "bcc", "bccb", "c", "cccb", "bccc"};
 
-    REQUIRE(du_narendran_rusinowitch(p) == "bcda");
+    std::string alphabet = du_narendran_rusinowitch(p);
+
+    REQUIRE(du_narendran_rusinowitch(p) == alphabet);
+    Presentation<std::string> copy(p);
+    presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
+    REQUIRE(copy == p);
   }
 
   LIBSEMIGROUPS_TEST_CASE("du_narendran_rusinowitch",
@@ -58,7 +68,12 @@ namespace libsemigroups {
                "a",  "cbA",    "AB",  "bbAb", "cc", "BB",  "cbb", "bbc",
                "Ac", "bbcbAb", "Abb", "BBA",  "cB", "BBcb"};
 
-    REQUIRE(du_narendran_rusinowitch(p) == "bBcAa");
+    std::string alphabet = du_narendran_rusinowitch(p);
+
+    REQUIRE(du_narendran_rusinowitch(p) == alphabet);
+    Presentation<std::string> copy(p);
+    presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
+    REQUIRE(copy == p);
   }
 
   LIBSEMIGROUPS_TEST_CASE("du_narendran_rusinowitch",
@@ -167,7 +182,12 @@ namespace libsemigroups {
                "cadaadadddaadadadad",
                "cadaadadddaadadddaa"};
 
-    REQUIRE(du_narendran_rusinowitch(p) == "dcab");
+    std::string alphabet = du_narendran_rusinowitch(p);
+
+    REQUIRE(du_narendran_rusinowitch(p) == alphabet);
+    Presentation<std::string> copy(p);
+    presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
+    REQUIRE(copy == p);
   }
 
   LIBSEMIGROUPS_TEST_CASE("du_narendran_rusinowitch",
@@ -180,7 +200,12 @@ namespace libsemigroups {
     p.rules = {
         "c", "bdad", "ab", "d", "ddad", "a", "adad", "ddaa", "aad", "ddddaa"};
 
-    REQUIRE(du_narendran_rusinowitch(p) == "dbac");
+    std::string alphabet = du_narendran_rusinowitch(p);
+
+    REQUIRE(du_narendran_rusinowitch(p) == alphabet);
+    Presentation<std::string> copy(p);
+    presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
+    REQUIRE(copy == p);
   }
 
   LIBSEMIGROUPS_TEST_CASE("du_narendran_rusinowitch",
@@ -196,7 +221,12 @@ namespace libsemigroups {
            "a",     "ddaabb", "d",    "dddad",    "a",   "aaabb",      "ddda",
            "addad", "dddaa",  "adad", "ddddddaa", "aad", "dddddddddaa"};
     // codespell:end-ignore
-    REQUIRE(du_narendran_rusinowitch(p) == "dabc");
+    std::string alphabet = du_narendran_rusinowitch(p);
+
+    REQUIRE(du_narendran_rusinowitch(p) == alphabet);
+    Presentation<std::string> copy(p);
+    presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
+    REQUIRE(copy == p);
   }
 
   LIBSEMIGROUPS_TEST_CASE("du_narendran_rusinowitch",
@@ -206,56 +236,61 @@ namespace libsemigroups {
     Presentation<std::string> p;
     p.alphabet("abcd"s);
     p.contains_empty_word(true);
-    p.rules = {"ac",       "a",
-               "dc",       "d",
-               "bad",      "dba",
-               "baba",     "ddab",
-               "cadabd",   "caddab",
-               "dadabb",   "d",
-               "cadabb",   "c",
-               "aadabb",   "a",
-               "ddabba",   "d",
-               "ddabc",    "ddab",
-               "ddabd",    "dddab",
-               "cadabc",   "cadab",
-               "aadabd",   "aaddab",
-               "dadabd",   "daddab",
-               "dddabab",  "ba",
-               "caddabab", "ddddaba",
-               "ddddad",   "ca",
-               "aadabc",   "aadab",
-               "dadabc",   "dadab",
-               "caabb",    "dddd",
-               "aaddabab", "addddaba",
-               "daddabab", "dddddaba",
-               "baa",      "dddaddab",
-               "caabd",    "cadab",
-               "cadddad",  "ddddaa",
-               "aaabb",    "adddd",
-               "daabb",    "ddddd",
-               "cadabab",  "ddddddddaba",
-               "aaabd",    "aadab",
-               "daabd",    "dadab",
-               "aadddad",  "addddaa",
-               "dadddad",  "dddddaa",
-               "caabc",    "caab",
-               "aadabab",  "addddddddaba",
-               "dadabab",  "dddddddddaba",
-               "cadad",    "ddddddddddddaa",
-               "caabab",   "ddddddddddddaba",
-               "aadad",    "addddddddddddaa",
-               "caddad",   "ddddddddaa",
-               "aaabc",    "aaab",
-               "daabc",    "daab",
-               "dadad",    "dddddddddddddaa",
-               "aaabab",   "addddddddddddaba",
-               "daabab",   "dddddddddddddaba",
-               "caad",     "ddddddddddddddddaa",
-               "aaddad",   "addddddddaa",
-               "daddad",   "dddddddddaa",
-               "aaad",     "addddddddddddddddaa",
-               "daad",     "dddddddddddddddddaa"};
-    REQUIRE(du_narendran_rusinowitch(p) == "dcab");
+    p.rules              = {"ac",       "a",
+                            "dc",       "d",
+                            "bad",      "dba",
+                            "baba",     "ddab",
+                            "cadabd",   "caddab",
+                            "dadabb",   "d",
+                            "cadabb",   "c",
+                            "aadabb",   "a",
+                            "ddabba",   "d",
+                            "ddabc",    "ddab",
+                            "ddabd",    "dddab",
+                            "cadabc",   "cadab",
+                            "aadabd",   "aaddab",
+                            "dadabd",   "daddab",
+                            "dddabab",  "ba",
+                            "caddabab", "ddddaba",
+                            "ddddad",   "ca",
+                            "aadabc",   "aadab",
+                            "dadabc",   "dadab",
+                            "caabb",    "dddd",
+                            "aaddabab", "addddaba",
+                            "daddabab", "dddddaba",
+                            "baa",      "dddaddab",
+                            "caabd",    "cadab",
+                            "cadddad",  "ddddaa",
+                            "aaabb",    "adddd",
+                            "daabb",    "ddddd",
+                            "cadabab",  "ddddddddaba",
+                            "aaabd",    "aadab",
+                            "daabd",    "dadab",
+                            "aadddad",  "addddaa",
+                            "dadddad",  "dddddaa",
+                            "caabc",    "caab",
+                            "aadabab",  "addddddddaba",
+                            "dadabab",  "dddddddddaba",
+                            "cadad",    "ddddddddddddaa",
+                            "caabab",   "ddddddddddddaba",
+                            "aadad",    "addddddddddddaa",
+                            "caddad",   "ddddddddaa",
+                            "aaabc",    "aaab",
+                            "daabc",    "daab",
+                            "dadad",    "dddddddddddddaa",
+                            "aaabab",   "addddddddddddaba",
+                            "daabab",   "dddddddddddddaba",
+                            "caad",     "ddddddddddddddddaa",
+                            "aaddad",   "addddddddaa",
+                            "daddad",   "dddddddddaa",
+                            "aaad",     "addddddddddddddddaa",
+                            "daad",     "dddddddddddddddddaa"};
+    std::string alphabet = du_narendran_rusinowitch(p);
+
+    REQUIRE(du_narendran_rusinowitch(p) == alphabet);
+    Presentation<std::string> copy(p);
+    presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
+    REQUIRE(copy == p);
   }
 
   LIBSEMIGROUPS_TEST_CASE("du_narendran_rusinowitch",
@@ -348,7 +383,12 @@ namespace libsemigroups {
                "daad",
                "ddddddddddddddddddddddddddaa"};
 
-    REQUIRE(du_narendran_rusinowitch(p) == "dabc");
+    std::string alphabet = du_narendran_rusinowitch(p);
+
+    REQUIRE(du_narendran_rusinowitch(p) == alphabet);
+    Presentation<std::string> copy(p);
+    presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
+    REQUIRE(copy == p);
   }
 
   LIBSEMIGROUPS_TEST_CASE("du_narendran_rusinowitch",
@@ -463,7 +503,12 @@ namespace libsemigroups {
                "daad",
                "dddddddddddddddddddddddddddddddddddddaa"};
 
-    REQUIRE(du_narendran_rusinowitch(p) == "dabc");
+    std::string alphabet = du_narendran_rusinowitch(p);
+
+    REQUIRE(du_narendran_rusinowitch(p) == alphabet);
+    Presentation<std::string> copy(p);
+    presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
+    REQUIRE(copy == p);
   }
 
   LIBSEMIGROUPS_TEST_CASE("du_narendran_rusinowitch",

--- a/tests/test-du-narendran-rusinowitch.cpp
+++ b/tests/test-du-narendran-rusinowitch.cpp
@@ -36,7 +36,7 @@ namespace libsemigroups {
     std::string alphabet = du_narendran_rusinowitch(p);
 
     REQUIRE(du_narendran_rusinowitch(p) == alphabet);
-    Presentation<std::string> copy(p);
+    Presentation copy(p);
     presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
     REQUIRE(copy == p);
   }
@@ -52,7 +52,7 @@ namespace libsemigroups {
     std::string alphabet = du_narendran_rusinowitch(p);
 
     REQUIRE(du_narendran_rusinowitch(p) == alphabet);
-    Presentation<std::string> copy(p);
+    Presentation copy(p);
     presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
     REQUIRE(copy == p);
   }
@@ -71,7 +71,7 @@ namespace libsemigroups {
     std::string alphabet = du_narendran_rusinowitch(p);
 
     REQUIRE(du_narendran_rusinowitch(p) == alphabet);
-    Presentation<std::string> copy(p);
+    Presentation copy(p);
     presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
     REQUIRE(copy == p);
   }
@@ -185,7 +185,7 @@ namespace libsemigroups {
     std::string alphabet = du_narendran_rusinowitch(p);
 
     REQUIRE(du_narendran_rusinowitch(p) == alphabet);
-    Presentation<std::string> copy(p);
+    Presentation copy(p);
     presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
     REQUIRE(copy == p);
   }
@@ -203,7 +203,7 @@ namespace libsemigroups {
     std::string alphabet = du_narendran_rusinowitch(p);
 
     REQUIRE(du_narendran_rusinowitch(p) == alphabet);
-    Presentation<std::string> copy(p);
+    Presentation copy(p);
     presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
     REQUIRE(copy == p);
   }
@@ -224,7 +224,7 @@ namespace libsemigroups {
     std::string alphabet = du_narendran_rusinowitch(p);
 
     REQUIRE(du_narendran_rusinowitch(p) == alphabet);
-    Presentation<std::string> copy(p);
+    Presentation copy(p);
     presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
     REQUIRE(copy == p);
   }
@@ -288,7 +288,7 @@ namespace libsemigroups {
     std::string alphabet = du_narendran_rusinowitch(p);
 
     REQUIRE(du_narendran_rusinowitch(p) == alphabet);
-    Presentation<std::string> copy(p);
+    Presentation copy(p);
     presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
     REQUIRE(copy == p);
   }
@@ -386,7 +386,7 @@ namespace libsemigroups {
     std::string alphabet = du_narendran_rusinowitch(p);
 
     REQUIRE(du_narendran_rusinowitch(p) == alphabet);
-    Presentation<std::string> copy(p);
+    Presentation copy(p);
     presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
     REQUIRE(copy == p);
   }
@@ -506,7 +506,7 @@ namespace libsemigroups {
     std::string alphabet = du_narendran_rusinowitch(p);
 
     REQUIRE(du_narendran_rusinowitch(p) == alphabet);
-    Presentation<std::string> copy(p);
+    Presentation copy(p);
     presentation::sort_each_rule(copy, RPOCmp(Alphabet(alphabet)));
     REQUIRE(copy == p);
   }

--- a/tests/test-knuth-bendix-extreme.cpp
+++ b/tests/test-knuth-bendix-extreme.cpp
@@ -80,17 +80,21 @@ namespace libsemigroups {
 
   using LenLexTrie = detail::RewritingSystemTrie<LenLexCmp>;
   using LenLexSet  = detail::RewritingSystemSet<LenLexCmp>;
-  using RPOTrie    = detail::RewritingSystemTrie<RPOCmp>;
-  using RPOSet     = detail::RewritingSystemSet<RPOCmp>;
 
-#define REWRITING_SYSTEM_TYPES LenLexTrie, RPOTrie
+  using RPOTrie = detail::RewritingSystemTrie<RPOCmp>;
+  using RPOSet  = detail::RewritingSystemSet<RPOCmp>;
+
+  using RevRPOTrie = detail::RewritingSystemTrie<RevRPOCmp>;
+  using RevRPOSet  = detail::RewritingSystemSet<RevRPOCmp>;
+
+#define REWRITING_SYSTEM_TYPES LenLexTrie, RevRPOTrie
 
   ////////////////////////////////////////////////////////////////////////
   // Extreme tests
   ////////////////////////////////////////////////////////////////////////
 
   // Fibonacci group F(2,7) - order 29 - works better with largish tidyint
-  // [102]: KnuthBendix: kbmag/standalone/kb_data/f27 - RPOTrie
+  // [102]: KnuthBendix: kbmag/standalone/kb_data/f27 - RevRPOTrie
   // -- plain Knuth-Bendix ......4.681s
   // -- by_overlap_length ......5.677s
   // [102]: KnuthBendix: kbmag/standalone/kb_data/f27 - LenLexTrie
@@ -130,7 +134,7 @@ namespace libsemigroups {
     REQUIRE(kb.finished());
     REQUIRE(kb.rewriting_system().confluent());
 
-    if constexpr (std::is_same_v<TestType, RPOTrie>) {
+    if constexpr (std::is_same_v<TestType, RevRPOTrie>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 14);
     } else {
       REQUIRE(kb.rewriting_system().number_of_rules() == 194);
@@ -141,7 +145,7 @@ namespace libsemigroups {
 
   // Mathieu group M_11
   // [103]: KnuthBendix: kbmag/standalone/kb_data/m11 - LenLexTrie ......6.062s
-  // [103]: KnuthBendix: kbmag/standalone/kb_data/m11 - RPOTrie ......2.913s
+  // [103]: KnuthBendix: kbmag/standalone/kb_data/m11 - RevRPOTrie ......2.913s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "103",
                                    "kbmag/standalone/kb_data/m11",
@@ -164,7 +168,7 @@ namespace libsemigroups {
 
     knuth_bendix::by_overlap_length(kb);
     REQUIRE(kb.rewriting_system().confluent());
-    if constexpr (std::is_same_v<TestType, RPOTrie>) {
+    if constexpr (std::is_same_v<TestType, RevRPOTrie>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 741);
     } else {
       REQUIRE(kb.rewriting_system().number_of_rules() == 1'731);
@@ -194,7 +198,7 @@ namespace libsemigroups {
   // Works quickest with large value of tidyint
   // [105]: KnuthBendix: kbmag/standalone/kb_data/degen4b - LenLexTrie
   // ......2.600s
-  // [105]: KnuthBendix: kbmag/standalone/kb_data/degen4b - RPOTrie
+  // [105]: KnuthBendix: kbmag/standalone/kb_data/degen4b - RevRPOTrie
   // .......790ms
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "105",
@@ -224,7 +228,7 @@ namespace libsemigroups {
   // value of tidyint works better.
   // [106]: KnuthBendix: kbmag/standalone/kb_data/f27_2gen - LenLexTrie
   // ......8.602s
-  // [106]: KnuthBendix: kbmag/standalone/kb_data/f27_2gen - RPOTrie
+  // [106]: KnuthBendix: kbmag/standalone/kb_data/f27_2gen - RevRPOTrie
   // ......3.956s
   // Takes > 19s (knuth_bendix), didn't run to the end
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
@@ -250,7 +254,7 @@ namespace libsemigroups {
 
     knuth_bendix::by_overlap_length(kb);
     REQUIRE(kb.rewriting_system().confluent());
-    if constexpr (std::is_same_v<TestType, RPOTrie>) {
+    if constexpr (std::is_same_v<TestType, RevRPOTrie>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 4);
     } else {
       REQUIRE(kb.rewriting_system().number_of_rules() == 19);
@@ -261,7 +265,7 @@ namespace libsemigroups {
   // [107]: KnuthBendix: Example 6.6 in Sims - LenLexTrie
   // -- plain Knuth-Bendix ......6.405s
   // -- by overlap length ......5.439s
-  // [107]: KnuthBendix: Example 6.6 in Sims - RPOTrie
+  // [107]: KnuthBendix: Example 6.6 in Sims - RevRPOTrie
   // -- plain Knuth-Bendix ......2.691s
   // -- by overlap length ......2.483s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
@@ -288,7 +292,7 @@ namespace libsemigroups {
     SECTION("by overlap length") {
       knuth_bendix::by_overlap_length(kb);
     }
-    if constexpr (std::is_same_v<TestType, RPOTrie>) {
+    if constexpr (std::is_same_v<TestType, RevRPOTrie>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 408);
     } else {
       REQUIRE(kb.rewriting_system().number_of_rules() == 1'026);
@@ -298,7 +302,7 @@ namespace libsemigroups {
   }
 
   // [108]: KnuthBendix: kbmag/standalone/kb_data/f27 - LenLexTrie ......3.072s
-  // [108]: KnuthBendix: kbmag/standalone/kb_data/f27 - RPOTrie .....20.083s
+  // [108]: KnuthBendix: kbmag/standalone/kb_data/f27 - RevRPOTrie .....20.083s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "108",
                                    "kbmag/standalone/kb_data/f27monoid",
@@ -326,7 +330,7 @@ namespace libsemigroups {
     knuth_bendix::by_overlap_length(kb);
     // Fails to terminate, or is very slow, with knuth_bendix
     REQUIRE(kb.rewriting_system().confluent());
-    if constexpr (std::is_same_v<TestType, RPOTrie>) {
+    if constexpr (std::is_same_v<TestType, RevRPOTrie>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 7);
     } else {
       REQUIRE(kb.rewriting_system().number_of_rules() == 47);
@@ -340,12 +344,12 @@ namespace libsemigroups {
   //
   // KBMAG does not seem to terminate when lenlex order is used.
   //
-  // [999]: KnuthBendix: kbmag/f27monoid - RPOTrie .....29.123s
+  // [999]: KnuthBendix: kbmag/f27monoid - RevRPOTrie .....29.123s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "999",
                                    "kbmag/f27monoid",
                                    "[extreme][knuth-bendix][kbmag]",
-                                   RPOTrie) {
+                                   RevRPOTrie) {
     auto                      rg = ReportGuard(true);
     Presentation<std::string> p;
     p.alphabet("abcdefg"s);
@@ -372,7 +376,7 @@ namespace libsemigroups {
   // [109]: KnuthBendix: kbmag/standalone/kb_data/l32ext - LenLexTrie
   // -- plain Knuth-Bendix ......6.502s
   // -- by overlap length ......5.480s
-  // [109]: KnuthBendix: kbmag/standalone/kb_data/l32ext - RPOTrie
+  // [109]: KnuthBendix: kbmag/standalone/kb_data/l32ext - RevRPOTrie
   // -- plain Knuth-Bendix ......2.713s
   // -- by overlap length ......2.622s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
@@ -403,7 +407,7 @@ namespace libsemigroups {
     }
 
     REQUIRE(kb.rewriting_system().confluent());
-    if constexpr (std::is_same_v<TestType, RPOTrie>) {
+    if constexpr (std::is_same_v<TestType, RevRPOTrie>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 408);
     } else {
       REQUIRE(kb.rewriting_system().number_of_rules() == 1'026);
@@ -416,7 +420,7 @@ namespace libsemigroups {
 
   // [117]: KnuthBendix: example with undecidable word problem - LenLexTrie
   // .....10.056s
-  //  [117]: KnuthBendix: example with undecidable word problem - RPOTrie
+  //  [117]: KnuthBendix: example with undecidable word problem - RevRPOTrie
   //  .....10.052s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "117",
@@ -440,11 +444,11 @@ namespace libsemigroups {
   // [146]: KnuthBendix: process millions of pending rules - LenLexTrie
   // -- sorted by lhs_rev_lex_cmp ......5.979s
   // -- sorted by lhs_lex_cmp ......6.223s
-  // -- sorted by rpo_cmp ......6.279s
-  // [146]: KnuthBendix: process millions of pending rules - RPOTrie
+  // -- sorted by rev_rpo_cmp ......6.279s
+  // [146]: KnuthBendix: process millions of pending rules - RevRPOTrie
   // -- sorted by lhs_rev_lex_cmp ......5.810s
   // -- sorted by lhs_lex_cmp ......6.241s
-  // -- sorted by rpo_cmp ......6.300s
+  // -- sorted by rev_rpo_cmp ......6.300s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "146",
                                    "process millions of pending rules",
@@ -471,8 +475,8 @@ namespace libsemigroups {
       k.rewriting_system().reduce();
       REQUIRE(k.rewriting_system().number_of_rules() == 2'045'649);
     }
-    SECTION("sorted by rpo_cmp") {
-      k.rewriting_system().sort_pending_rules_by(detail::rpo_cmp);
+    SECTION("sorted by rev_rpo_cmp") {
+      k.rewriting_system().sort_pending_rules_by(detail::rev_rpo_cmp);
       k.rewriting_system().reduce();
       REQUIRE(k.rewriting_system().number_of_rules() == 2'041'466);
     }
@@ -493,14 +497,14 @@ namespace libsemigroups {
   // presentation here was derived by first applying the NQA to find the
   // maximal nilpotent quotient, and then introducing new generators for
   // the PCP generators.
-  // [932]: KnuthBendix: kbmag/heinnilp - RPOTrie
+  // [932]: KnuthBendix: kbmag/heinnilp - RevRPOTrie
   // -- using a separate trie for new rules .....15.710s
   // -- NOT using a separate trie for new rules ......9.897s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "932",
                                    "kbmag/heinnilp",
                                    "[extreme][knuth-bendix][kbmag][recursive]",
-                                   RPOTrie) {
+                                   RevRPOTrie) {
     auto rg = ReportGuard(true);
 
     Presentation<std::string> p;
@@ -519,7 +523,7 @@ namespace libsemigroups {
     KnuthBendix<std::string, TestType> kb(twosided, p);
     REQUIRE(!kb.rewriting_system().confluent());
     kb.rewriting_system().settings().reduction_threshold = 1024;
-    kb.rewriting_system().sort_pending_rules_by(detail::rpo_cmp);
+    kb.rewriting_system().sort_pending_rules_by(detail::rev_rpo_cmp);
     SECTION("using a separate trie for new rules") {
       kb.rewriting_system().use_new_rule_trie([](auto const&) { return true; });
     }
@@ -557,12 +561,12 @@ namespace libsemigroups {
              {"ya", "ayf"},   {"yb", "by"},     {"yc", "cy"},   {"yd", "dy"}}));
 
     REQUIRE(std::all_of(rules1.begin(), rules1.end(), [&p](auto const& rule) {
-      return rpo_cmp(p.alphabet_v4(), rule.second, rule.first);
+      return rev_rpo_cmp(p.alphabet_v4(), rule.second, rule.first);
     }));
   }
 
   // [144]: KnuthBendix: process pending rules x3 - LenLexTrie .....25.231s
-  // [144]: KnuthBendix: process pending rules x3 - RPOTrie .....25.169s
+  // [144]: KnuthBendix: process pending rules x3 - RevRPOTrie .....25.169s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "144",
                                    "process pending rules x3",
@@ -587,7 +591,7 @@ namespace libsemigroups {
   }
 
   // [118]: KnuthBendix: process pending rules x1 - LenLexTrie .....22.597s
-  // [118]: KnuthBendix: process pending rules x1 - RPOTrie .....22.983s
+  // [118]: KnuthBendix: process pending rules x1 - RevRPOTrie .....22.983s
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "118",
                                    "process pending rules x1",
@@ -611,7 +615,7 @@ namespace libsemigroups {
 
   // [139]: KnuthBendix: partial_transformation_monoid5 - LenLexTrie
   // ......6.295s
-  // [139]: KnuthBendix: partial_transformation_monoid5 - RPOTrie
+  // [139]: KnuthBendix: partial_transformation_monoid5 - RevRPOTrie
   // .......262ms
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "139",
@@ -663,7 +667,7 @@ namespace libsemigroups {
                                    "057",
                                    "1-relation hard case",
                                    "[extreme][knuth-bendix][tietze-explorer]",
-                                   RPOTrie) {
+                                   RevRPOTrie) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ba"s);
@@ -697,12 +701,12 @@ namespace libsemigroups {
     REQUIRE(!dora.number_of_threads(4).result().has_value());
   }
 
-  // Fails with depth_max(3) + RPOTrie too in ~10 minutes
+  // Fails with depth_max(3) + RevRPOTrie too in ~10 minutes
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "151",
                                    "baaabaaa = aba",
                                    "[extreme][tietze-explorer]",
-                                   RPOTrie) {
+                                   RevRPOTrie) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("ab"s);
@@ -728,7 +732,7 @@ namespace libsemigroups {
                                    "152",
                                    "baa(ba)^N=a",
                                    "[extreme][tietze-explorer]",
-                                   RPOTrie) {
+                                   RevRPOTrie) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;

--- a/tests/test-knuth-bendix-fail.cpp
+++ b/tests/test-knuth-bendix-fail.cpp
@@ -61,10 +61,14 @@ namespace libsemigroups {
 
   using LenLexTrie = detail::RewritingSystemTrie<LenLexCmp>;
   using LenLexSet  = detail::RewritingSystemSet<LenLexCmp>;
-  using RPOTrie    = detail::RewritingSystemTrie<RPOCmp>;
-  using RPOSet     = detail::RewritingSystemSet<RPOCmp>;
 
-#define REWRITING_SYSTEM_TYPES LenLexTrie, RPOTrie
+  using RPOTrie = detail::RewritingSystemTrie<RPOCmp>;
+  using RPOSet  = detail::RewritingSystemSet<RPOCmp>;
+
+  using RevRPOTrie = detail::RewritingSystemTrie<RevRPOCmp>;
+  using RevRPOSet  = detail::RewritingSystemSet<RevRPOCmp>;
+
+#define REWRITING_SYSTEM_TYPES LenLexTrie, RevRPOTrie
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "110",
@@ -92,7 +96,7 @@ namespace libsemigroups {
                                    "111",
                                    "kbmag/standalone/kb_data/verifynilp",
                                    "[fail][knuth-bendix][kbmag]",
-                                   RPOTrie) {
+                                   RevRPOTrie) {
     auto        rg    = ReportGuard();
     std::string lphbt = "hHgGfFyYdDcCbBaA";
     std::string invrs = "HhGgFfYyDdCcBbAa";
@@ -116,7 +120,7 @@ namespace libsemigroups {
     KnuthBendix<std::string, TestType> kb(twosided, p);
 
     REQUIRE(!kb.rewriting_system().confluent());
-    kb.rewriting_system().sort_pending_rules_by(detail::rpo_cmp);
+    kb.rewriting_system().sort_pending_rules_by(detail::rev_rpo_cmp);
 
     knuth_bendix::by_overlap_length(kb);
     REQUIRE(kb.rewriting_system().number_of_rules() == 0);

--- a/tests/test-knuth-bendix-from-froidure-pin.cpp
+++ b/tests/test-knuth-bendix-from-froidure-pin.cpp
@@ -67,7 +67,10 @@ namespace libsemigroups {
   using RPOTrie = detail::RewritingSystemTrie<RPOCmp>;
   using RPOSet  = detail::RewritingSystemSet<RPOCmp>;
 
-#define REWRITING_SYSTEM_TYPES LenLexTrie, LenLexSet, RPOTrie, RPOSet
+  using RevRPOTrie = detail::RewritingSystemTrie<RevRPOCmp>;
+  using RevRPOSet  = detail::RewritingSystemSet<RevRPOCmp>;
+
+#define REWRITING_SYSTEM_TYPES LenLexTrie, LenLexSet, RevRPOTrie, RevRPOSet
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "119",
@@ -586,8 +589,8 @@ namespace libsemigroups {
                                    "995",
                                    "finite semigroup congruence",
                                    "[quick][congruence][knuth-bendix]",
-                                   RPOTrie,
-                                   RPOSet) {
+                                   RevRPOTrie,
+                                   RevRPOSet) {
     auto rg      = ReportGuard(false);
     using Transf = LeastTransf<5>;
     FroidurePin<Transf> S;

--- a/tests/test-knuth-bendix-maf-quick.cpp
+++ b/tests/test-knuth-bendix-maf-quick.cpp
@@ -5628,7 +5628,7 @@ namespace libsemigroups {
     presentation::add_rule(p, "srslsrslsrsl"s, ""s);
     presentation::add_rule(p, "j"s, ""s);
 
-    using RewritingSystem = detail::RewritingSystemTrie<RPOCmp>;
+    using RewritingSystem = detail::RewritingSystemTrie<RevRPOCmp>;
     KnuthBendix<std::string, RewritingSystem> kb;
     kb.init(congruence_kind::twosided, p);
     kb.run();

--- a/tests/test-knuth-bendix-standard.cpp
+++ b/tests/test-knuth-bendix-standard.cpp
@@ -59,10 +59,14 @@ namespace libsemigroups {
 
   using LenLexTrie = detail::RewritingSystemTrie<LenLexCmp>;
   using LenLexSet  = detail::RewritingSystemSet<LenLexCmp>;
-  using RPOTrie    = detail::RewritingSystemTrie<RPOCmp>;
-  using RPOSet     = detail::RewritingSystemSet<RPOCmp>;
 
-#define REWRITING_SYSTEM_TYPES LenLexTrie, LenLexSet, RPOTrie, RPOSet
+  using RPOTrie = detail::RewritingSystemTrie<RPOCmp>;
+  using RPOSet  = detail::RewritingSystemSet<RPOCmp>;
+
+  using RevRPOTrie = detail::RewritingSystemTrie<RevRPOCmp>;
+  using RevRPOSet  = detail::RewritingSystemSet<RevRPOCmp>;
+
+#define REWRITING_SYSTEM_TYPES LenLexTrie, LenLexSet, RevRPOTrie, RevRPOSet
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "065",
@@ -108,12 +112,12 @@ namespace libsemigroups {
   }
 
   // Takes approx. 2s
-  // RPOTrie + RPOSet return different numbers of rules at the end.
+  // RevRPOTrie + RevRPOSet return different numbers of rules at the end.
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "100",
                                    "Sims Ex. 6.6 (limited overlap lengths)",
                                    "[standard][knuth-bendix]",
-                                   RPOTrie,
+                                   RevRPOTrie,
                                    LenLexTrie) {
     auto rg = ReportGuard(false);
 
@@ -138,14 +142,14 @@ namespace libsemigroups {
       kb.max_overlap(45);
       kb.run();
       REQUIRE(kb.rewriting_system().number_of_rules() == 1'026);
-    } else if (std::is_same_v<order, RPOCmp<Default, false>>) {
+    } else if (std::is_same_v<order, RevRPOCmp<Default, false>>) {
       kb.max_overlap(56);
       kb.run();
       REQUIRE(kb.rewriting_system().number_of_rules() == 407);
     }
   }
 
-  // Takes approx. 2s, is very slow with RPO
+  // Takes approx. 2s, is very slow with RevRPO
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "101",
                                    "kbmag/standalone/kb_data/funny3",
@@ -190,7 +194,7 @@ namespace libsemigroups {
                                    "kbmag/standalone/kb_data/e8",
                                    "[standard][knuth-bendix][kbmag]",
                                    LenLexTrie,
-                                   RPOTrie) {
+                                   RevRPOTrie) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -240,7 +244,7 @@ namespace libsemigroups {
                                    "full_transformation_monoid Iwahori",
                                    "[standard][knuth-bendix]",
                                    LenLexTrie,
-                                   RPOTrie) {
+                                   RevRPOTrie) {
     auto rg = ReportGuard(false);
 
     size_t n = 5;
@@ -248,7 +252,7 @@ namespace libsemigroups {
     KnuthBendix<word_type, TestType> kb(twosided, p);
     REQUIRE(!is_obviously_infinite(kb));
     kb.run();
-    if constexpr (std::is_same_v<TestType, RPOTrie>) {
+    if constexpr (std::is_same_v<TestType, RevRPOTrie>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 230);
     } else {
       REQUIRE(kb.rewriting_system().number_of_rules() == 1'162);
@@ -315,7 +319,7 @@ namespace libsemigroups {
                                    "150",
                                    "baabbbaba=a",
                                    "[standard][tietze-explorer]",
-                                   RPOTrie) {
+                                   RevRPOTrie) {
     auto rg = ReportGuard(false);
     fmt::print("\n");
     Presentation<std::string> p;

--- a/tests/test-knuth-bendix-string-quick-1.cpp
+++ b/tests/test-knuth-bendix-string-quick-1.cpp
@@ -60,6 +60,11 @@ namespace libsemigroups {
   using RPOTrie = detail::RewritingSystemTrie<RPOCmp>;
   using RPOSet  = detail::RewritingSystemSet<RPOCmp>;
 
+  using RevRPOTrie = detail::RewritingSystemTrie<RevRPOCmp>;
+  using RevRPOSet  = detail::RewritingSystemSet<RevRPOCmp>;
+
+#define REWRITING_SYSTEM_TYPES LenLexTrie, LenLexSet, RevRPOTrie, RevRPOSet
+
   static_assert(std::is_default_constructible_v<
                 KnuthBendix<std::string, LenLexTrie, LenLexCmp>>);
   static_assert(
@@ -70,8 +75,6 @@ namespace libsemigroups {
   static_assert(
       std::is_same_v<typename detail::KnuthBendixImpl<>::reduction_order,
                      LenLexCmp<Default, false>>);
-
-#define REWRITING_SYSTEM_TYPES LenLexTrie, LenLexSet, RPOTrie, RPOSet
 
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "000",
@@ -826,7 +829,7 @@ namespace libsemigroups {
                                    "017",
                                    "non-trivial classes",
                                    "[quick][knuth-bendix]",
-                                   RPOTrie) {
+                                   RevRPOTrie) {
     using order = typename TestType::reduction_order;
 
     auto                      rg = ReportGuard(false);
@@ -1073,8 +1076,8 @@ namespace libsemigroups {
                                    "994",
                                    "kbmag/verifynilp",
                                    "[quick][knuth-bendix][kbmag][recursive]",
-                                   RPOTrie,
-                                   RPOSet) {
+                                   RevRPOTrie,
+                                   RevRPOSet) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -1124,8 +1127,8 @@ namespace libsemigroups {
                                    "996",
                                    "kbmag/nonhopf",
                                    "[quick][knuth-bendix][kbmag][recursive]",
-                                   RPOTrie,
-                                   RPOSet) {
+                                   RevRPOTrie,
+                                   RevRPOSet) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
 
@@ -1156,8 +1159,8 @@ namespace libsemigroups {
                                    "997",
                                    "kbmag/freenilpc3",
                                    "[quick][knuth-bendix][kbmag][recursive]",
-                                   RPOTrie,
-                                   RPOSet) {
+                                   RevRPOTrie,
+                                   RevRPOSet) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -1214,8 +1217,8 @@ namespace libsemigroups {
                                    "998",
                                    "kbmag/nilp2",
                                    "[quick][knuth-bendix][kbmag][recursive]",
-                                   RPOTrie,
-                                   RPOSet) {
+                                   RevRPOTrie,
+                                   RevRPOSet) {
     auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.alphabet("cCbBaA"s).contains_empty_word(true);

--- a/tests/test-knuth-bendix-string-quick-2.cpp
+++ b/tests/test-knuth-bendix-string-quick-2.cpp
@@ -58,7 +58,10 @@ namespace libsemigroups {
   using RPOTrie = detail::RewritingSystemTrie<RPOCmp>;
   using RPOSet  = detail::RewritingSystemSet<RPOCmp>;
 
-#define REWRITING_SYSTEM_TYPES LenLexTrie, LenLexSet, RPOTrie, RPOSet
+  using RevRPOTrie = detail::RewritingSystemTrie<RevRPOCmp>;
+  using RevRPOSet  = detail::RewritingSystemSet<RevRPOCmp>;
+
+#define REWRITING_SYSTEM_TYPES LenLexTrie, LenLexSet, RevRPOTrie, RevRPOSet
 
   // Fibonacci group F(2,5) - monoid presentation - has order 12 (group
   // elements + empty word)
@@ -105,7 +108,7 @@ namespace libsemigroups {
               {"a", "b", "c", "d", "e", "aa", "ac", "ad", "bb", "be", "aad"}));
       REQUIRE(kb.number_of_classes() == 11);
       REQUIRE(nf.min(1).max(POSITIVE_INFINITY).count() == 11);
-    } else if (std::is_same_v<order, RPOCmp<Default, false>>) {
+    } else if (std::is_same_v<order, RevRPOCmp<Default, false>>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 5);
     }
 
@@ -136,14 +139,14 @@ namespace libsemigroups {
   }
 
   // trivial group - BHN presentation
-  // RPOTrie is very slow here
+  // RevRPOTrie is very slow here
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "028",
                                    "kbmag/standalone/kb_data/degen4a",
                                    "[quick][knuth-bendix][kbmag][no-valgrind]",
                                    LenLexSet,
                                    LenLexTrie,
-                                   RPOSet) {
+                                   RevRPOSet) {
     auto rg = ReportGuard(false);
 
     Presentation<std::string> p;
@@ -305,7 +308,7 @@ namespace libsemigroups {
                                            "AB",
                                            "Ba",
                                            "BA"}));
-    } else if (std::is_same_v<order, RPOCmp<Default, false>>) {
+    } else if (std::is_same_v<order, RevRPOCmp<Default, false>>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 72);
     }
 
@@ -680,7 +683,7 @@ namespace libsemigroups {
                                           {"BabB", "abab"},
                                           {"Baaba", "abaaB"},
                                           {"Bababa", "ababaB"}}}));
-    } else if (std::is_same_v<order, RPOCmp<Default, false>>) {
+    } else if (std::is_same_v<order, RevRPOCmp<Default, false>>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 4);
       REQUIRE((kb.active_rules() | sort(weird_cmp()) | to_vector())
               == std::vector<rule_type>({{"B", "bb"},
@@ -835,7 +838,7 @@ namespace libsemigroups {
                    {"dc", "y"},  {"dd", "by"},  {"dy", "a"},  {"ya", "b"},
                    {"yb", "by"}, {"yc", "bb"},  {"yd", "a"},  {"yy", "ac"},
                    {"aaa", "y"}, {"aac", "by"}, {"bbb", "a"}, {"bby", "aad"}}));
-    } else if (std::is_same_v<order, RPOCmp<Default, false>>) {
+    } else if (std::is_same_v<order, RevRPOCmp<Default, false>>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 5);
       REQUIRE((kb.active_rules() | sort(weird_cmp()) | to_vector())
               == std::vector<rule_type>({{"b", "aaaa"},
@@ -847,7 +850,7 @@ namespace libsemigroups {
   }
 
   // Von Dyck (2,3,7) group - infinite hyperbolic
-  // both RPOTrie + RPOSet very slow here
+  // both RevRPOTrie + RevRPOSet very slow here
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "038",
                                    "kbmag/standalone/kb_data/237",
@@ -999,7 +1002,7 @@ namespace libsemigroups {
                                           {"baabba", "abbaab"},
                                           {"bbaabb", "abba"}}}));
       // codespell:end-ignore
-    } else if (std::is_same_v<order, RPOCmp<Default, false>>) {
+    } else if (std::is_same_v<order, RevRPOCmp<Default, false>>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 11);
       // codespell:begin-ignore
       REQUIRE((kb.active_rules() | sort(weird_cmp()) | to_vector())
@@ -1110,7 +1113,7 @@ namespace libsemigroups {
   }
 
   // Von Dyck (2,3,7) group - infinite hyperbolic
-  // at least RPOSet very slow here
+  // at least RevRPOSet very slow here
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "044",
                                    "KnuthBendix 071 again",
@@ -1261,7 +1264,7 @@ namespace libsemigroups {
     using order = typename TestType::reduction_order;
     if constexpr (std::is_same_v<order, LenLexCmp<Default, false>>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 11);
-    } else if (std::is_same_v<order, RPOCmp<Default, false>>) {
+    } else if (std::is_same_v<order, RevRPOCmp<Default, false>>) {
       REQUIRE(kb.rewriting_system().number_of_rules() == 5);
     }
     REQUIRE(kb.rewriting_system().confluent());
@@ -1351,7 +1354,7 @@ namespace libsemigroups {
                    "AC", "AD",  "AY",  "AF",  "BA",  "BD", "BY", "CY",
                    "DB", "ABA", "ABD", "ABY", "ACY", "ADB"}));
       // codespell:end-ignore
-    } else if (std::is_same_v<order, RPOCmp<Default, false>>) {
+    } else if (std::is_same_v<order, RevRPOCmp<Default, false>>) {
       REQUIRE((knuth_bendix::normal_forms(kb) | to_vector())
               == std::vector<std::string>(
                   {"",           "A",          "B",         "AB",
@@ -1427,7 +1430,7 @@ namespace libsemigroups {
     REQUIRE(kb3.presentation().rules.size() / 2 == 1);
   }
 
-  // RPO very slow here
+  // RevRPO very slow here
   LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
                                    "054",
                                    "small overlap 1",

--- a/tests/test-knuth-bendix-string-quick-3.cpp
+++ b/tests/test-knuth-bendix-string-quick-3.cpp
@@ -55,6 +55,7 @@ namespace libsemigroups {
   using LenLexTrie = detail::RewritingSystemTrie<LenLexCmp>;
   using LenLexSet  = detail::RewritingSystemSet<LenLexCmp>;
   using RPOTrie    = detail::RewritingSystemTrie<RPOCmp>;
+  using RevRPOTrie = detail::RewritingSystemTrie<RevRPOCmp>;
 
 #define REWRITING_SYSTEM_TYPES LenLexTrie, LenLexSet
 
@@ -1235,7 +1236,7 @@ namespace libsemigroups {
                                    "114",
                                    "hard 2-generated 1-relation monoid",
                                    "[quick][knuth-bendix][tietze-explorer]",
-                                   RPOTrie) {
+                                   RevRPOTrie) {
     auto rg = ReportGuard(false);
     fmt::print("\n");
     Presentation<std::string> p;
@@ -1263,12 +1264,11 @@ namespace libsemigroups {
     REQUIRE(kb.number_of_classes() == POSITIVE_INFINITY);
   }
 
-  LIBSEMIGROUPS_TEMPLATE_TEST_CASE(
-      "KnuthBendix",
-      "099",
-      "Giles Gardam (https://arxiv.org/abs/2102.11818)",
-      "[quick][tietze-explorer][no-valgrind]",
-      RPOTrie) {
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("KnuthBendix",
+                                   "099",
+                                   "Gardam (https://arxiv.org/abs/2102.11818)",
+                                   "[quick][tietze-explorer][no-valgrind]",
+                                   RevRPOTrie) {
     auto rg = ReportGuard(false);
     fmt::print("\n");
     Presentation<std::string> p;

--- a/tests/test-knuth-bendix-word-quick.cpp
+++ b/tests/test-knuth-bendix-word-quick.cpp
@@ -65,6 +65,7 @@ namespace libsemigroups {
   using LenLexSet  = detail::RewritingSystemSet<LenLexCmp>;
   using RPOTrie    = detail::RewritingSystemTrie<RPOCmp>;
   using RPOSet     = detail::RewritingSystemSet<RPOCmp>;
+  using RevRPOTrie = detail::RewritingSystemTrie<RevRPOCmp>;
 
 // TODO update to use RPO also
 #define REWRITING_SYSTEM_TYPES LenLexTrie, LenLexSet
@@ -98,7 +99,7 @@ namespace libsemigroups {
                                    "non-trivial classes x 4",
                                    "[quick][knuth-bendix]",
                                    REWRITING_SYSTEM_TYPES,
-                                   RPOTrie) {
+                                   RevRPOTrie) {
     using order = typename TestType::reduction_order;
 
     auto                    rg = ReportGuard(false);

--- a/tests/test-order.cpp
+++ b/tests/test-order.cpp
@@ -719,212 +719,212 @@ namespace libsemigroups {
                           "invalid letter 'b', valid letters are \"cd\"");
   }
 
-  LIBSEMIGROUPS_TEST_CASE("rev_rpo_cmp",
+  LIBSEMIGROUPS_TEST_CASE("rpo_cmp",
                           "040",
                           "random examples",
                           "[quick][order]") {
     using std::literals::string_literals::operator""s;
-    REQUIRE(!rev_rpo_cmp(""s, ""s));
-    REQUIRE(!rev_rpo_cmp("a"s, ""s));
-    REQUIRE(!rev_rpo_cmp("b"s, ""s));
-    REQUIRE(!rev_rpo_cmp("c"s, ""s));
-    REQUIRE(!rev_rpo_cmp("c"s, "c"s));
-    REQUIRE(!rev_rpo_cmp("ab"s, ""s));
-    REQUIRE(!rev_rpo_cmp("caa"s, ""s));
-    REQUIRE(!rev_rpo_cmp("cba"s, ""s));
-    REQUIRE(!rev_rpo_cmp("cc"s, "ab"s));
-    REQUIRE(!rev_rpo_cmp("cc"s, "ba"s));
-    REQUIRE(!rev_rpo_cmp("cccb"s, ""s));
-    REQUIRE(!rev_rpo_cmp("ca"s, "aab"s));
-    REQUIRE(!rev_rpo_cmp("caa"s, "bb"s));
-    REQUIRE(!rev_rpo_cmp("cca"s, "bb"s));
-    REQUIRE(!rev_rpo_cmp("aaca"s, "c"s));
-    REQUIRE(!rev_rpo_cmp("acbb"s, "b"s));
-    REQUIRE(!rev_rpo_cmp("abcbb"s, ""s));
-    REQUIRE(!rev_rpo_cmp("cbcca"s, ""s));
-    REQUIRE(!rev_rpo_cmp("bcc"s, "aca"s));
-    REQUIRE(!rev_rpo_cmp("cbc"s, "bca"s));
-    REQUIRE(!rev_rpo_cmp("ccb"s, "aab"s));
-    REQUIRE(!rev_rpo_cmp("aacaa"s, "b"s));
-    REQUIRE(!rev_rpo_cmp("cabbb"s, "a"s));
-    REQUIRE(!rev_rpo_cmp("cbbab"s, "a"s));
-    REQUIRE(!rev_rpo_cmp("acabac"s, ""s));
-    REQUIRE(!rev_rpo_cmp("bbcbac"s, ""s));
-    REQUIRE(!rev_rpo_cmp("bcabcb"s, ""s));
-    REQUIRE(!rev_rpo_cmp("cabcaa"s, ""s));
-    REQUIRE(!rev_rpo_cmp("cbbbac"s, ""s));
-    REQUIRE(!rev_rpo_cmp("bcab"s, "bbc"s));
-    REQUIRE(!rev_rpo_cmp("aaccc"s, "ab"s));
-    REQUIRE(!rev_rpo_cmp("aabcbbc"s, ""s));
-    REQUIRE(!rev_rpo_cmp("caba"s, "aaac"s));
-    REQUIRE(!rev_rpo_cmp("accac"s, "ccb"s));
-    REQUIRE(!rev_rpo_cmp("ccaaab"s, "ac"s));
-    REQUIRE(!rev_rpo_cmp("bcaabac"s, "c"s));
-    REQUIRE(!rev_rpo_cmp("aabaacbb"s, ""s));
-    REQUIRE(!rev_rpo_cmp("bcccbabb"s, ""s));
-    REQUIRE(!rev_rpo_cmp("bbcc"s, "aaaab"s));
-    REQUIRE(!rev_rpo_cmp("acccc"s, "bbca"s));
-    REQUIRE(!rev_rpo_cmp("bcbcc"s, "caaa"s));
-    REQUIRE(!rev_rpo_cmp("cccaab"s, "aac"s));
-    REQUIRE(!rev_rpo_cmp("acabbba"s, "ac"s));
-    REQUIRE(!rev_rpo_cmp("bcabbbc"s, "bc"s));
-    REQUIRE(!rev_rpo_cmp("caaccbcb"s, "c"s));
-    REQUIRE(!rev_rpo_cmp("cc"s, "bbacabbb"s));
-    REQUIRE(!rev_rpo_cmp("acc"s, "aabcbba"s));
-    REQUIRE(!rev_rpo_cmp("acaa"s, "aababc"s));
-    REQUIRE(!rev_rpo_cmp("acaa"s, "abbabb"s));
-    REQUIRE(!rev_rpo_cmp("cbcaacca"s, "ac"s));
-    REQUIRE(!rev_rpo_cmp("caaccccaa"s, "a"s));
-    REQUIRE(!rev_rpo_cmp("aabaabcabc"s, ""s));
-    REQUIRE(!rev_rpo_cmp("abbbacacac"s, ""s));
-    REQUIRE(!rev_rpo_cmp("cbacbbaaca"s, ""s));
-    REQUIRE(!rev_rpo_cmp("bbbc"s, "abbaaba"s));
-    REQUIRE(!rev_rpo_cmp("bccbaa"s, "cabbc"s));
-    REQUIRE(!rev_rpo_cmp("abaacaaabb"s, "b"s));
-    REQUIRE(!rev_rpo_cmp("cbaacbbbbc"s, "b"s));
-    REQUIRE(!rev_rpo_cmp("ccaabc"s, "abcaaa"s));
-    REQUIRE(!rev_rpo_cmp("ccacca"s, "baaccc"s));
-    REQUIRE(!rev_rpo_cmp("aacbccc"s, "bbacc"s));
-    REQUIRE(!rev_rpo_cmp("bcacbbc"s, "bacab"s));
-    REQUIRE(!rev_rpo_cmp("cacbbac"s, "bcbac"s));
-    REQUIRE(!rev_rpo_cmp("cccacbb"s, "cccac"s));
-    REQUIRE(!rev_rpo_cmp("cbabaabb"s, "bbbb"s));
-    REQUIRE(!rev_rpo_cmp("cbacbcba"s, "baab"s));
-    REQUIRE(!rev_rpo_cmp("abcacacbb"s, "bab"s));
-    REQUIRE(!rev_rpo_cmp("abacbbcccc"s, "ac"s));
-    REQUIRE(!rev_rpo_cmp("bcacbbbccb"s, "ca"s));
-    REQUIRE(!rev_rpo_cmp("caccbbacbc"s, "ab"s));
-    REQUIRE(!rev_rpo_cmp("accaa"s, "aabaacac"s));
-    REQUIRE(!rev_rpo_cmp("acacbaa"s, "bcbabc"s));
-    REQUIRE(!rev_rpo_cmp("acbcbaca"s, "aabcb"s));
-    REQUIRE(!rev_rpo_cmp("abcbaabaa"s, "abcb"s));
-    REQUIRE(!rev_rpo_cmp("bbcacabca"s, "caaa"s));
-    REQUIRE(!rev_rpo_cmp("bcaababaa"s, "babb"s));
-    REQUIRE(!rev_rpo_cmp("cbbcbcbacc"s, "bcb"s));
-    REQUIRE(!rev_rpo_cmp("cccbbccccb"s, "aaa"s));
-    REQUIRE(!rev_rpo_cmp("acccaa"s, "cacbbaca"s));
-    REQUIRE(!rev_rpo_cmp("baccbcba"s, "ccabab"s));
-    REQUIRE(!rev_rpo_cmp("caaccbab"s, "babbcb"s));
-    REQUIRE(!rev_rpo_cmp("abcacaaab"s, "cabac"s));
-    REQUIRE(!rev_rpo_cmp("baabccccb"s, "caacb"s));
-    REQUIRE(!rev_rpo_cmp("aaabccaabc"s, "bbcc"s));
-    REQUIRE(!rev_rpo_cmp("acccba"s, "bbcabccaa"s));
-    REQUIRE(!rev_rpo_cmp("bcacac"s, "bcbaaacba"s));
-    REQUIRE(!rev_rpo_cmp("accbcacc"s, "abbbcba"s));
-    REQUIRE(!rev_rpo_cmp("ccaccacc"s, "bcbabcb"s));
-    REQUIRE(!rev_rpo_cmp("ccacac"s, "acbaacbaba"s));
-    REQUIRE(!rev_rpo_cmp("aaaccbcb"s, "acabacca"s));
-    REQUIRE(!rev_rpo_cmp("cbbbbcab"s, "babbabca"s));
-    REQUIRE(!rev_rpo_cmp("ccabaaacab"s, "aabaaa"s));
-    REQUIRE(!rev_rpo_cmp("cbccbcb"s, "aaccbbaaab"s));
-    REQUIRE(!rev_rpo_cmp("bccaccbca"s, "cacccbba"s));
-    REQUIRE(!rev_rpo_cmp("aabcacbacc"s, "bccbbca"s));
-    REQUIRE(!rev_rpo_cmp("cbcacacbab"s, "caccbaa"s));
-    REQUIRE(!rev_rpo_cmp("acacbbacab"s, "abbbccba"s));
-    REQUIRE(!rev_rpo_cmp("bcbabcacac"s, "ccababcc"s));
-    REQUIRE(!rev_rpo_cmp("abacccaaab"s, "aaaccacab"s));
-    REQUIRE(!rev_rpo_cmp("bccccbbbbc"s, "bbabccbcbb"s));
+    REQUIRE(!rpo_cmp(""s, ""s));
+    REQUIRE(!rpo_cmp("a"s, ""s));
+    REQUIRE(!rpo_cmp("b"s, ""s));
+    REQUIRE(!rpo_cmp("c"s, ""s));
+    REQUIRE(!rpo_cmp("c"s, "c"s));
+    REQUIRE(!rpo_cmp("ab"s, ""s));
+    REQUIRE(!rpo_cmp("caa"s, ""s));
+    REQUIRE(!rpo_cmp("cba"s, ""s));
+    REQUIRE(!rpo_cmp("cc"s, "ab"s));
+    REQUIRE(!rpo_cmp("cc"s, "ba"s));
+    REQUIRE(!rpo_cmp("cccb"s, ""s));
+    REQUIRE(!rpo_cmp("ca"s, "aab"s));
+    REQUIRE(!rpo_cmp("caa"s, "bb"s));
+    REQUIRE(!rpo_cmp("cca"s, "bb"s));
+    REQUIRE(!rpo_cmp("aaca"s, "c"s));
+    REQUIRE(!rpo_cmp("acbb"s, "b"s));
+    REQUIRE(!rpo_cmp("abcbb"s, ""s));
+    REQUIRE(!rpo_cmp("cbcca"s, ""s));
+    REQUIRE(!rpo_cmp("bcc"s, "aca"s));
+    REQUIRE(!rpo_cmp("cbc"s, "bca"s));
+    REQUIRE(!rpo_cmp("ccb"s, "aab"s));
+    REQUIRE(!rpo_cmp("aacaa"s, "b"s));
+    REQUIRE(!rpo_cmp("cabbb"s, "a"s));
+    REQUIRE(!rpo_cmp("cbbab"s, "a"s));
+    REQUIRE(!rpo_cmp("acabac"s, ""s));
+    REQUIRE(!rpo_cmp("bbcbac"s, ""s));
+    REQUIRE(!rpo_cmp("bcabcb"s, ""s));
+    REQUIRE(!rpo_cmp("cabcaa"s, ""s));
+    REQUIRE(!rpo_cmp("cbbbac"s, ""s));
+    REQUIRE(!rpo_cmp("bcab"s, "bbc"s));
+    REQUIRE(!rpo_cmp("aaccc"s, "ab"s));
+    REQUIRE(!rpo_cmp("aabcbbc"s, ""s));
+    REQUIRE(!rpo_cmp("caba"s, "aaac"s));
+    REQUIRE(!rpo_cmp("accac"s, "ccb"s));
+    REQUIRE(!rpo_cmp("ccaaab"s, "ac"s));
+    REQUIRE(!rpo_cmp("bcaabac"s, "c"s));
+    REQUIRE(!rpo_cmp("aabaacbb"s, ""s));
+    REQUIRE(!rpo_cmp("bcccbabb"s, ""s));
+    REQUIRE(!rpo_cmp("bbcc"s, "aaaab"s));
+    REQUIRE(!rpo_cmp("acccc"s, "bbca"s));
+    REQUIRE(!rpo_cmp("bcbcc"s, "caaa"s));
+    REQUIRE(!rpo_cmp("cccaab"s, "aac"s));
+    REQUIRE(!rpo_cmp("acabbba"s, "ac"s));
+    REQUIRE(!rpo_cmp("bcabbbc"s, "bc"s));
+    REQUIRE(!rpo_cmp("caaccbcb"s, "c"s));
+    REQUIRE(!rpo_cmp("cc"s, "bbacabbb"s));
+    REQUIRE(!rpo_cmp("acc"s, "aabcbba"s));
+    REQUIRE(!rpo_cmp("acaa"s, "aababc"s));
+    REQUIRE(!rpo_cmp("acaa"s, "abbabb"s));
+    REQUIRE(!rpo_cmp("cbcaacca"s, "ac"s));
+    REQUIRE(!rpo_cmp("caaccccaa"s, "a"s));
+    REQUIRE(!rpo_cmp("aabaabcabc"s, ""s));
+    REQUIRE(!rpo_cmp("abbbacacac"s, ""s));
+    REQUIRE(!rpo_cmp("cbacbbaaca"s, ""s));
+    REQUIRE(!rpo_cmp("bbbc"s, "abbaaba"s));
+    REQUIRE(!rpo_cmp("bccbaa"s, "cabbc"s));
+    REQUIRE(!rpo_cmp("abaacaaabb"s, "b"s));
+    REQUIRE(!rpo_cmp("cbaacbbbbc"s, "b"s));
+    REQUIRE(!rpo_cmp("ccaabc"s, "abcaaa"s));
+    REQUIRE(!rpo_cmp("ccacca"s, "baaccc"s));
+    REQUIRE(!rpo_cmp("aacbccc"s, "bbacc"s));
+    REQUIRE(!rpo_cmp("bcacbbc"s, "bacab"s));
+    REQUIRE(!rpo_cmp("cacbbac"s, "bcbac"s));
+    REQUIRE(!rpo_cmp("cccacbb"s, "cccac"s));
+    REQUIRE(!rpo_cmp("cbabaabb"s, "bbbb"s));
+    REQUIRE(!rpo_cmp("cbacbcba"s, "baab"s));
+    REQUIRE(!rpo_cmp("abcacacbb"s, "bab"s));
+    REQUIRE(!rpo_cmp("abacbbcccc"s, "ac"s));
+    REQUIRE(!rpo_cmp("bcacbbbccb"s, "ca"s));
+    REQUIRE(!rpo_cmp("caccbbacbc"s, "ab"s));
+    REQUIRE(!rpo_cmp("accaa"s, "aabaacac"s));
+    REQUIRE(!rpo_cmp("acacbaa"s, "bcbabc"s));
+    REQUIRE(!rpo_cmp("acbcbaca"s, "aabcb"s));
+    REQUIRE(!rpo_cmp("abcbaabaa"s, "abcb"s));
+    REQUIRE(!rpo_cmp("bbcacabca"s, "caaa"s));
+    REQUIRE(!rpo_cmp("bcaababaa"s, "babb"s));
+    REQUIRE(!rpo_cmp("cbbcbcbacc"s, "bcb"s));
+    REQUIRE(!rpo_cmp("cccbbccccb"s, "aaa"s));
+    REQUIRE(!rpo_cmp("acccaa"s, "cacbbaca"s));
+    REQUIRE(!rpo_cmp("baccbcba"s, "ccabab"s));
+    REQUIRE(!rpo_cmp("caaccbab"s, "babbcb"s));
+    REQUIRE(!rpo_cmp("abcacaaab"s, "cabac"s));
+    REQUIRE(!rpo_cmp("baabccccb"s, "caacb"s));
+    REQUIRE(!rpo_cmp("aaabccaabc"s, "bbcc"s));
+    REQUIRE(!rpo_cmp("acccba"s, "bbcabccaa"s));
+    REQUIRE(!rpo_cmp("bcacac"s, "bcbaaacba"s));
+    REQUIRE(!rpo_cmp("accbcacc"s, "abbbcba"s));
+    REQUIRE(!rpo_cmp("ccaccacc"s, "bcbabcb"s));
+    REQUIRE(!rpo_cmp("ccacac"s, "acbaacbaba"s));
+    REQUIRE(!rpo_cmp("aaaccbcb"s, "acabacca"s));
+    REQUIRE(!rpo_cmp("cbbbbcab"s, "babbabca"s));
+    REQUIRE(!rpo_cmp("ccabaaacab"s, "aabaaa"s));
+    REQUIRE(!rpo_cmp("cbccbcb"s, "aaccbbaaab"s));
+    REQUIRE(!rpo_cmp("bccaccbca"s, "cacccbba"s));
+    REQUIRE(!rpo_cmp("aabcacbacc"s, "bccbbca"s));
+    REQUIRE(!rpo_cmp("cbcacacbab"s, "caccbaa"s));
+    REQUIRE(!rpo_cmp("acacbbacab"s, "abbbccba"s));
+    REQUIRE(!rpo_cmp("bcbabcacac"s, "ccababcc"s));
+    REQUIRE(!rpo_cmp("abacccaaab"s, "aaaccacab"s));
+    REQUIRE(!rpo_cmp("bccccbbbbc"s, "bbabccbcbb"s));
 
-    REQUIRE(rev_rpo_cmp(""s, "a"s));
-    REQUIRE(rev_rpo_cmp(""s, "b"s));
-    REQUIRE(rev_rpo_cmp(""s, "c"s));
-    REQUIRE(rev_rpo_cmp(""s, "ba"s));
-    REQUIRE(rev_rpo_cmp(""s, "bca"s));
-    REQUIRE(rev_rpo_cmp("a"s, "bc"s));
-    REQUIRE(rev_rpo_cmp("a"s, "cc"s));
-    REQUIRE(rev_rpo_cmp("bb"s, "bc"s));
-    REQUIRE(rev_rpo_cmp(""s, "bbbcc"s));
-    REQUIRE(rev_rpo_cmp("a"s, "aabc"s));
-    REQUIRE(rev_rpo_cmp("c"s, "ccaa"s));
-    REQUIRE(rev_rpo_cmp("ab"s, "cca"s));
-    REQUIRE(rev_rpo_cmp("baa"s, "bc"s));
-    REQUIRE(rev_rpo_cmp("abab"s, "c"s));
-    REQUIRE(rev_rpo_cmp("baaa"s, "c"s));
-    REQUIRE(rev_rpo_cmp(""s, "accabc"s));
-    REQUIRE(rev_rpo_cmp(""s, "bccbcc"s));
-    REQUIRE(rev_rpo_cmp(""s, "cbabcc"s));
-    REQUIRE(rev_rpo_cmp("a"s, "acbba"s));
-    REQUIRE(rev_rpo_cmp("c"s, "bbbac"s));
-    REQUIRE(rev_rpo_cmp("c"s, "ccbbc"s));
-    REQUIRE(rev_rpo_cmp("ab"s, "acaa"s));
-    REQUIRE(rev_rpo_cmp("ab"s, "baab"s));
-    REQUIRE(rev_rpo_cmp("bb"s, "bcba"s));
-    REQUIRE(rev_rpo_cmp("aac"s, "acb"s));
-    REQUIRE(rev_rpo_cmp("abb"s, "bba"s));
-    REQUIRE(rev_rpo_cmp(""s, "cabaacc"s));
-    REQUIRE(rev_rpo_cmp("b"s, "ccaacb"s));
-    REQUIRE(rev_rpo_cmp("bb"s, "acaac"s));
-    REQUIRE(rev_rpo_cmp("bcb"s, "ccca"s));
-    REQUIRE(rev_rpo_cmp(""s, "aacaacba"s));
-    REQUIRE(rev_rpo_cmp(""s, "bacbaaba"s));
-    REQUIRE(rev_rpo_cmp(""s, "bbbaacca"s));
-    REQUIRE(rev_rpo_cmp(""s, "cbacbbab"s));
-    REQUIRE(rev_rpo_cmp(""s, "cbccccba"s));
-    REQUIRE(rev_rpo_cmp("a"s, "bbababb"s));
-    REQUIRE(rev_rpo_cmp("ab"s, "ccaabc"s));
-    REQUIRE(rev_rpo_cmp("bb"s, "bacaaa"s));
-    REQUIRE(rev_rpo_cmp("bc"s, "cbcaac"s));
-    REQUIRE(rev_rpo_cmp("bbca"s, "acbb"s));
-    REQUIRE(rev_rpo_cmp(""s, "abcacbbcb"s));
-    REQUIRE(rev_rpo_cmp(""s, "cacabaaca"s));
-    REQUIRE(rev_rpo_cmp("b"s, "bcabbcaa"s));
-    REQUIRE(rev_rpo_cmp("b"s, "cbcbaacb"s));
-    REQUIRE(rev_rpo_cmp("abc"s, "cbabac"s));
-    REQUIRE(rev_rpo_cmp("cac"s, "cabcaa"s));
-    REQUIRE(rev_rpo_cmp("cbc"s, "cabcba"s));
-    REQUIRE(rev_rpo_cmp("aacb"s, "caaca"s));
-    REQUIRE(rev_rpo_cmp("baab"s, "aaacc"s));
-    REQUIRE(rev_rpo_cmp("caab"s, "bccaa"s));
-    REQUIRE(rev_rpo_cmp("abbbaa"s, "cca"s));
-    REQUIRE(rev_rpo_cmp(""s, "babbcbabaa"s));
-    REQUIRE(rev_rpo_cmp(""s, "cabacacabb"s));
-    REQUIRE(rev_rpo_cmp("c"s, "babaabaca"s));
-    REQUIRE(rev_rpo_cmp("bc"s, "acbbccaa"s));
-    REQUIRE(rev_rpo_cmp("aba"s, "aacaacc"s));
-    REQUIRE(rev_rpo_cmp("abc"s, "bbabbcb"s));
-    REQUIRE(rev_rpo_cmp("cbb"s, "ccbaabc"s));
-    REQUIRE(rev_rpo_cmp("bbca"s, "babacc"s));
-    REQUIRE(rev_rpo_cmp("bbabc"s, "bcabb"s));
-    REQUIRE(rev_rpo_cmp("bcabba"s, "cbbb"s));
-    REQUIRE(rev_rpo_cmp("cabaac"s, "accb"s));
-    REQUIRE(rev_rpo_cmp("c"s, "cbccbcabba"s));
-    REQUIRE(rev_rpo_cmp("ab"s, "cbacabbcc"s));
-    REQUIRE(rev_rpo_cmp("aac"s, "aaccbbac"s));
-    REQUIRE(rev_rpo_cmp("aca"s, "aabccccc"s));
-    REQUIRE(rev_rpo_cmp("babaa"s, "ccacbb"s));
-    REQUIRE(rev_rpo_cmp("bacbaca"s, "ccac"s));
-    REQUIRE(rev_rpo_cmp("aa"s, "cbbbbbcbca"s));
-    REQUIRE(rev_rpo_cmp("bc"s, "bccbcaaaca"s));
-    REQUIRE(rev_rpo_cmp("cbcbb"s, "cbbcacc"s));
-    REQUIRE(rev_rpo_cmp("babbbabc"s, "ccaa"s));
-    REQUIRE(rev_rpo_cmp("aaa"s, "cccbccaabc"s));
-    REQUIRE(rev_rpo_cmp("cbcc"s, "cccbaacca"s));
-    REQUIRE(rev_rpo_cmp("bbcbaa"s, "bcbcbcc"s));
-    REQUIRE(rev_rpo_cmp("cbcbbb"s, "bccacca"s));
-    REQUIRE(rev_rpo_cmp("bcbc"s, "aabbcccccb"s));
-    REQUIRE(rev_rpo_cmp("caaa"s, "acbabcbbab"s));
-    REQUIRE(rev_rpo_cmp("ccac"s, "abccaabcaa"s));
-    REQUIRE(rev_rpo_cmp("aabbb"s, "baccbcccc"s));
-    REQUIRE(rev_rpo_cmp("abbcab"s, "cabccaca"s));
-    REQUIRE(rev_rpo_cmp("aabbbbacb"s, "aaccc"s));
-    REQUIRE(rev_rpo_cmp("bbbcabbbc"s, "ccbab"s));
-    REQUIRE(rev_rpo_cmp("cbabbabaac"s, "bcca"s));
-    REQUIRE(rev_rpo_cmp("aacca"s, "cacccccbbb"s));
-    REQUIRE(rev_rpo_cmp("baaca"s, "abaaaabcca"s));
-    REQUIRE(rev_rpo_cmp("bbaab"s, "bbccaaacba"s));
-    REQUIRE(rev_rpo_cmp("cabbcb"s, "aaacbcbaa"s));
-    REQUIRE(rev_rpo_cmp("cabaccc"s, "acbcbcbc"s));
-    REQUIRE(rev_rpo_cmp("acaabc"s, "bcaccccbbc"s));
-    REQUIRE(rev_rpo_cmp("acccca"s, "cbacacacca"s));
-    REQUIRE(rev_rpo_cmp("aaacabcc"s, "cbcbbbbc"s));
-    REQUIRE(rev_rpo_cmp("aacacacc"s, "baccacbc"s));
-    REQUIRE(rev_rpo_cmp("ccbaabba"s, "ccbabcca"s));
-    REQUIRE(rev_rpo_cmp("cabacbcbb"s, "bcbcccc"s));
-    REQUIRE(rev_rpo_cmp("acbacacb"s, "cbaacbccb"s));
-    REQUIRE(rev_rpo_cmp("bcbbbbbb"s, "bacababcb"s));
-    REQUIRE(rev_rpo_cmp("ccaababc"s, "aacbccbab"s));
-    REQUIRE(rev_rpo_cmp("aaaacbacba"s, "ccbbacb"s));
-    REQUIRE(rev_rpo_cmp("bcbabcbbc"s, "acbbabcacb"s));
+    REQUIRE(rpo_cmp(""s, "a"s));
+    REQUIRE(rpo_cmp(""s, "b"s));
+    REQUIRE(rpo_cmp(""s, "c"s));
+    REQUIRE(rpo_cmp(""s, "ba"s));
+    REQUIRE(rpo_cmp(""s, "bca"s));
+    REQUIRE(rpo_cmp("a"s, "bc"s));
+    REQUIRE(rpo_cmp("a"s, "cc"s));
+    REQUIRE(rpo_cmp("bb"s, "bc"s));
+    REQUIRE(rpo_cmp(""s, "bbbcc"s));
+    REQUIRE(rpo_cmp("a"s, "aabc"s));
+    REQUIRE(rpo_cmp("c"s, "ccaa"s));
+    REQUIRE(rpo_cmp("ab"s, "cca"s));
+    REQUIRE(rpo_cmp("baa"s, "bc"s));
+    REQUIRE(rpo_cmp("abab"s, "c"s));
+    REQUIRE(rpo_cmp("baaa"s, "c"s));
+    REQUIRE(rpo_cmp(""s, "accabc"s));
+    REQUIRE(rpo_cmp(""s, "bccbcc"s));
+    REQUIRE(rpo_cmp(""s, "cbabcc"s));
+    REQUIRE(rpo_cmp("a"s, "acbba"s));
+    REQUIRE(rpo_cmp("c"s, "bbbac"s));
+    REQUIRE(rpo_cmp("c"s, "ccbbc"s));
+    REQUIRE(rpo_cmp("ab"s, "acaa"s));
+    REQUIRE(rpo_cmp("ab"s, "baab"s));
+    REQUIRE(rpo_cmp("bb"s, "bcba"s));
+    REQUIRE(rpo_cmp("aac"s, "acb"s));
+    REQUIRE(rpo_cmp("abb"s, "bba"s));
+    REQUIRE(rpo_cmp(""s, "cabaacc"s));
+    REQUIRE(rpo_cmp("b"s, "ccaacb"s));
+    REQUIRE(rpo_cmp("bb"s, "acaac"s));
+    REQUIRE(rpo_cmp("bcb"s, "ccca"s));
+    REQUIRE(rpo_cmp(""s, "aacaacba"s));
+    REQUIRE(rpo_cmp(""s, "bacbaaba"s));
+    REQUIRE(rpo_cmp(""s, "bbbaacca"s));
+    REQUIRE(rpo_cmp(""s, "cbacbbab"s));
+    REQUIRE(rpo_cmp(""s, "cbccccba"s));
+    REQUIRE(rpo_cmp("a"s, "bbababb"s));
+    REQUIRE(rpo_cmp("ab"s, "ccaabc"s));
+    REQUIRE(rpo_cmp("bb"s, "bacaaa"s));
+    REQUIRE(rpo_cmp("bc"s, "cbcaac"s));
+    REQUIRE(rpo_cmp("bbca"s, "acbb"s));
+    REQUIRE(rpo_cmp(""s, "abcacbbcb"s));
+    REQUIRE(rpo_cmp(""s, "cacabaaca"s));
+    REQUIRE(rpo_cmp("b"s, "bcabbcaa"s));
+    REQUIRE(rpo_cmp("b"s, "cbcbaacb"s));
+    REQUIRE(rpo_cmp("abc"s, "cbabac"s));
+    REQUIRE(rpo_cmp("cac"s, "cabcaa"s));
+    REQUIRE(rpo_cmp("cbc"s, "cabcba"s));
+    REQUIRE(rpo_cmp("aacb"s, "caaca"s));
+    REQUIRE(rpo_cmp("baab"s, "aaacc"s));
+    REQUIRE(rpo_cmp("caab"s, "bccaa"s));
+    REQUIRE(rpo_cmp("abbbaa"s, "cca"s));
+    REQUIRE(rpo_cmp(""s, "babbcbabaa"s));
+    REQUIRE(rpo_cmp(""s, "cabacacabb"s));
+    REQUIRE(rpo_cmp("c"s, "babaabaca"s));
+    REQUIRE(rpo_cmp("bc"s, "acbbccaa"s));
+    REQUIRE(rpo_cmp("aba"s, "aacaacc"s));
+    REQUIRE(rpo_cmp("abc"s, "bbabbcb"s));
+    REQUIRE(rpo_cmp("cbb"s, "ccbaabc"s));
+    REQUIRE(rpo_cmp("bbca"s, "babacc"s));
+    REQUIRE(rpo_cmp("bbabc"s, "bcabb"s));
+    REQUIRE(rpo_cmp("bcabba"s, "cbbb"s));
+    REQUIRE(rpo_cmp("cabaac"s, "accb"s));
+    REQUIRE(rpo_cmp("c"s, "cbccbcabba"s));
+    REQUIRE(rpo_cmp("ab"s, "cbacabbcc"s));
+    REQUIRE(rpo_cmp("aac"s, "aaccbbac"s));
+    REQUIRE(rpo_cmp("aca"s, "aabccccc"s));
+    REQUIRE(rpo_cmp("babaa"s, "ccacbb"s));
+    REQUIRE(rpo_cmp("bacbaca"s, "ccac"s));
+    REQUIRE(rpo_cmp("aa"s, "cbbbbbcbca"s));
+    REQUIRE(rpo_cmp("bc"s, "bccbcaaaca"s));
+    REQUIRE(rpo_cmp("cbcbb"s, "cbbcacc"s));
+    REQUIRE(rpo_cmp("babbbabc"s, "ccaa"s));
+    REQUIRE(rpo_cmp("aaa"s, "cccbccaabc"s));
+    REQUIRE(rpo_cmp("cbcc"s, "cccbaacca"s));
+    REQUIRE(rpo_cmp("bbcbaa"s, "bcbcbcc"s));
+    REQUIRE(rpo_cmp("cbcbbb"s, "bccacca"s));
+    REQUIRE(rpo_cmp("bcbc"s, "aabbcccccb"s));
+    REQUIRE(rpo_cmp("caaa"s, "acbabcbbab"s));
+    REQUIRE(rpo_cmp("ccac"s, "abccaabcaa"s));
+    REQUIRE(rpo_cmp("aabbb"s, "baccbcccc"s));
+    REQUIRE(rpo_cmp("abbcab"s, "cabccaca"s));
+    REQUIRE(rpo_cmp("aabbbbacb"s, "aaccc"s));
+    REQUIRE(rpo_cmp("bbbcabbbc"s, "ccbab"s));
+    REQUIRE(rpo_cmp("cbabbabaac"s, "bcca"s));
+    REQUIRE(rpo_cmp("aacca"s, "cacccccbbb"s));
+    REQUIRE(rpo_cmp("baaca"s, "abaaaabcca"s));
+    REQUIRE(rpo_cmp("bbaab"s, "bbccaaacba"s));
+    REQUIRE(rpo_cmp("cabbcb"s, "aaacbcbaa"s));
+    REQUIRE(rpo_cmp("cabaccc"s, "acbcbcbc"s));
+    REQUIRE(rpo_cmp("acaabc"s, "bcaccccbbc"s));
+    REQUIRE(rpo_cmp("acccca"s, "cbacacacca"s));
+    REQUIRE(rpo_cmp("aaacabcc"s, "cbcbbbbc"s));
+    REQUIRE(rpo_cmp("aacacacc"s, "baccacbc"s));
+    REQUIRE(rpo_cmp("ccbaabba"s, "ccbabcca"s));
+    REQUIRE(rpo_cmp("cabacbcbb"s, "bcbcccc"s));
+    REQUIRE(rpo_cmp("acbacacb"s, "cbaacbccb"s));
+    REQUIRE(rpo_cmp("bcbbbbbb"s, "bacababcb"s));
+    REQUIRE(rpo_cmp("ccaababc"s, "aacbccbab"s));
+    REQUIRE(rpo_cmp("aaaacbacba"s, "ccbbacb"s));
+    REQUIRE(rpo_cmp("bcbabcbbc"s, "acbbabcacb"s));
   }
 
   LIBSEMIGROUPS_TEST_CASE("rev_rpo_cmp",
@@ -1154,8 +1154,66 @@ namespace libsemigroups {
   // rev_rpo_cmp with alphabet
   // =========================================================================
 
+  LIBSEMIGROUPS_TEST_CASE("rpo_cmp", "044", "with alphabet", "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    StringRange sr;
+    sr.alphabet("ab").min(2).max(5);
+
+    auto strings = (sr | rx::to_vector());
+
+    std::sort(
+        strings.begin(), strings.end(), [](auto const& lhop, auto const& rhop) {
+          return rpo_cmp(lhop, rhop);
+        });
+
+    REQUIRE(strings == std::vector({"aa"s,   "aaa"s,  "aaaa"s, "ab"s,   "aab"s,
+                                    "aaab"s, "ba"s,   "aba"s,  "aaba"s, "baa"s,
+                                    "abaa"s, "baaa"s, "bb"s,   "abb"s,  "aabb"s,
+                                    "bab"s,  "abab"s, "baab"s, "bba"s,  "abba"s,
+                                    "baba"s, "bbaa"s, "bbb"s,  "abbb"s, "babb"s,
+                                    "bbab"s, "bbba"s, "bbbb"s}));
+
+    Alphabet alphabet("ba"s);
+
+    std::sort(strings.begin(),
+              strings.end(),
+              [&alphabet](auto const& lhop, auto const& rhop) {
+                return rpo_cmp(alphabet, lhop, rhop);
+              });
+
+    REQUIRE(strings == std::vector({"bb"s,   "bbb"s,  "bbbb"s, "ba"s,   "bba"s,
+                                    "bbba"s, "ab"s,   "bab"s,  "bbab"s, "abb"s,
+                                    "babb"s, "abbb"s, "aa"s,   "baa"s,  "bbaa"s,
+                                    "aba"s,  "baba"s, "abba"s, "aab"s,  "baab"s,
+                                    "abab"s, "aabb"s, "aaa"s,  "baaa"s, "abaa"s,
+                                    "aaba"s, "aaab"s, "aaaa"s}));
+
+    std::sort(strings.begin(), strings.end(), RPOCmp());
+
+    REQUIRE(strings == std::vector({"aa"s,   "aaa"s,  "aaaa"s, "ab"s,   "aab"s,
+                                    "aaab"s, "ba"s,   "aba"s,  "aaba"s, "baa"s,
+                                    "abaa"s, "baaa"s, "bb"s,   "abb"s,  "aabb"s,
+                                    "bab"s,  "abab"s, "baab"s, "bba"s,  "abba"s,
+                                    "baba"s, "bbaa"s, "bbb"s,  "abbb"s, "babb"s,
+                                    "bbab"s, "bbba"s, "bbbb"s}));
+
+    std::sort(strings.begin(), strings.end(), RPOCmp(alphabet));
+
+    REQUIRE(strings == std::vector({"bb"s,   "bbb"s,  "bbbb"s, "ba"s,   "bba"s,
+                                    "bbba"s, "ab"s,   "bab"s,  "bbab"s, "abb"s,
+                                    "babb"s, "abbb"s, "aa"s,   "baa"s,  "bbaa"s,
+                                    "aba"s,  "baba"s, "abba"s, "aab"s,  "baab"s,
+                                    "abab"s, "aabb"s, "aaa"s,  "baaa"s, "abaa"s,
+                                    "aaba"s, "aaab"s, "aaaa"s}));
+  }
+
+  // =========================================================================
+  // rpo_cmp with alphabet
+  // =========================================================================
+
   LIBSEMIGROUPS_TEST_CASE("rev_rpo_cmp",
-                          "044",
+                          "045",
                           "with alphabet",
                           "[quick][order]") {
     using std::string_literals::operator""s;
@@ -1170,64 +1228,6 @@ namespace libsemigroups {
           return rev_rpo_cmp(lhop, rhop);
         });
 
-    REQUIRE(strings == std::vector({"aa"s,   "aaa"s,  "aaaa"s, "ab"s,   "aab"s,
-                                    "aaab"s, "ba"s,   "aba"s,  "aaba"s, "baa"s,
-                                    "abaa"s, "baaa"s, "bb"s,   "abb"s,  "aabb"s,
-                                    "bab"s,  "abab"s, "baab"s, "bba"s,  "abba"s,
-                                    "baba"s, "bbaa"s, "bbb"s,  "abbb"s, "babb"s,
-                                    "bbab"s, "bbba"s, "bbbb"s}));
-
-    Alphabet alphabet("ba"s);
-
-    std::sort(strings.begin(),
-              strings.end(),
-              [&alphabet](auto const& lhop, auto const& rhop) {
-                return rev_rpo_cmp(alphabet, lhop, rhop);
-              });
-
-    REQUIRE(strings == std::vector({"bb"s,   "bbb"s,  "bbbb"s, "ba"s,   "bba"s,
-                                    "bbba"s, "ab"s,   "bab"s,  "bbab"s, "abb"s,
-                                    "babb"s, "abbb"s, "aa"s,   "baa"s,  "bbaa"s,
-                                    "aba"s,  "baba"s, "abba"s, "aab"s,  "baab"s,
-                                    "abab"s, "aabb"s, "aaa"s,  "baaa"s, "abaa"s,
-                                    "aaba"s, "aaab"s, "aaaa"s}));
-
-    std::sort(strings.begin(), strings.end(), RevRPOCmp());
-
-    REQUIRE(strings == std::vector({"aa"s,   "aaa"s,  "aaaa"s, "ab"s,   "aab"s,
-                                    "aaab"s, "ba"s,   "aba"s,  "aaba"s, "baa"s,
-                                    "abaa"s, "baaa"s, "bb"s,   "abb"s,  "aabb"s,
-                                    "bab"s,  "abab"s, "baab"s, "bba"s,  "abba"s,
-                                    "baba"s, "bbaa"s, "bbb"s,  "abbb"s, "babb"s,
-                                    "bbab"s, "bbba"s, "bbbb"s}));
-
-    std::sort(strings.begin(), strings.end(), RevRPOCmp(alphabet));
-
-    REQUIRE(strings == std::vector({"bb"s,   "bbb"s,  "bbbb"s, "ba"s,   "bba"s,
-                                    "bbba"s, "ab"s,   "bab"s,  "bbab"s, "abb"s,
-                                    "babb"s, "abbb"s, "aa"s,   "baa"s,  "bbaa"s,
-                                    "aba"s,  "baba"s, "abba"s, "aab"s,  "baab"s,
-                                    "abab"s, "aabb"s, "aaa"s,  "baaa"s, "abaa"s,
-                                    "aaba"s, "aaab"s, "aaaa"s}));
-  }
-
-  // =========================================================================
-  // rpo_cmp with alphabet
-  // =========================================================================
-
-  LIBSEMIGROUPS_TEST_CASE("rpo_cmp", "045", "with alphabet", "[quick][order]") {
-    using std::string_literals::operator""s;
-
-    StringRange sr;
-    sr.alphabet("ab").min(2).max(5);
-
-    auto strings = (sr | rx::to_vector());
-
-    std::sort(
-        strings.begin(), strings.end(), [](auto const& lhop, auto const& rhop) {
-          return rpo_cmp(lhop, rhop);
-        });
-
     REQUIRE(strings == std::vector({"aa"s,   "aaa"s,  "aaaa"s, "ba"s,   "baa"s,
                                     "baaa"s, "ab"s,   "aba"s,  "abaa"s, "aab"s,
                                     "aaba"s, "aaab"s, "bb"s,   "bba"s,  "bbaa"s,
@@ -1240,7 +1240,7 @@ namespace libsemigroups {
     std::sort(strings.begin(),
               strings.end(),
               [&alphabet](auto const& lhop, auto const& rhop) {
-                return rpo_cmp(alphabet, lhop, rhop);
+                return rev_rpo_cmp(alphabet, lhop, rhop);
               });
 
     REQUIRE(strings == std::vector({"bb"s,   "bbb"s,  "bbbb"s, "ab"s,   "abb"s,
@@ -1250,7 +1250,7 @@ namespace libsemigroups {
                                     "baba"s, "bbaa"s, "aaa"s,  "aaab"s, "aaba"s,
                                     "abaa"s, "baaa"s, "aaaa"s}));
 
-    std::sort(strings.begin(), strings.end(), RPOCmp());
+    std::sort(strings.begin(), strings.end(), RevRPOCmp());
 
     REQUIRE(strings == std::vector({"aa"s,   "aaa"s,  "aaaa"s, "ba"s,   "baa"s,
                                     "baaa"s, "ab"s,   "aba"s,  "abaa"s, "aab"s,
@@ -1261,7 +1261,7 @@ namespace libsemigroups {
 
     alphabet.init("cd"s);
     REQUIRE_EXCEPTION_MSG(
-        std::sort(strings.begin(), strings.end(), RPOCmp(alphabet)),
+        std::sort(strings.begin(), strings.end(), RevRPOCmp(alphabet)),
         "invalid letter 'a', valid letters are \"cd\"");
   }
 
@@ -1416,10 +1416,10 @@ namespace libsemigroups {
                                    (LenLexCmp<Default, false>),
                                    RevLenLexCmp<>,
                                    (RevLenLexCmp<Default, false>),
-                                   RevRPOCmp<>,
-                                   (RevRPOCmp<Default, false>),
                                    RPOCmp<>,
-                                   (RPOCmp<Default, false>) ) {
+                                   (RPOCmp<Default, false>),
+                                   RevRPOCmp<>,
+                                   (RevRPOCmp<Default, false>) ) {
     using std::string_literals::operator""s;
 
     auto rg = ReportGuard(false);
@@ -1454,8 +1454,8 @@ namespace libsemigroups {
                                    RevLexCmp<std::string>,
                                    LenLexCmp<std::string>,
                                    RevLenLexCmp<std::string>,
-                                   RevRPOCmp<std::string>,
-                                   RPOCmp<std::string>) {
+                                   RPOCmp<std::string>,
+                                   RevRPOCmp<std::string>) {
     using std::string_literals::operator""s;
 
     auto                  rg = ReportGuard(false);
@@ -1503,8 +1503,8 @@ namespace libsemigroups {
                                    (RevLexCmp<std::string, false>),
                                    (LenLexCmp<std::string, false>),
                                    (RevLenLexCmp<std::string, false>),
-                                   (RevRPOCmp<std::string, false>),
-                                   (RPOCmp<std::string, false>) ) {
+                                   (RPOCmp<std::string, false>),
+                                   (RevRPOCmp<std::string, false>) ) {
     using std::string_literals::operator""s;
 
     auto                  rg = ReportGuard(false);
@@ -2151,30 +2151,8 @@ namespace libsemigroups {
         strings.end(),
         [&cmp](auto const& lhop, auto const& rhop) { return cmp(lhop, rhop); });
 
-    REQUIRE(std::is_sorted(strings.begin(), strings.end(), RPOCmp(alphabet)));
-  }
-
-  LIBSEMIGROUPS_TEST_CASE("RevRPOCmp",
-                          "077",
-                          "to_human_readable_repr",
-                          "[quick][order]") {
-    using std::string_literals::operator""s;
-
-    auto rg = ReportGuard(false);
-
-    REQUIRE(to_human_readable_repr(RevRPOCmp<>()) == "<RevRPOCmp object>");
-    REQUIRE(to_human_readable_repr(RevRPOCmp<Default, false>())
-            == "<RevRPOCmp object>");
-
-    Alphabet alphabet("ba"s);
-    REQUIRE(to_human_readable_repr(RevRPOCmp(alphabet))
-            == "<RevRPOCmp object over <alphabet \"ba\">>");
-    REQUIRE(to_human_readable_repr(RevRPOCmp<std::string, false>(alphabet))
-            == "<RevRPOCmp object over <alphabet \"ba\">>");
-
-    Alphabet<word_type> large_alphabet(10);
-    REQUIRE(to_human_readable_repr(RevRPOCmp(large_alphabet))
-            == "<RevRPOCmp object over <alphabet with 10 letters>>");
+    REQUIRE(
+        std::is_sorted(strings.begin(), strings.end(), RevRPOCmp(alphabet)));
   }
 
   LIBSEMIGROUPS_TEST_CASE("RPOCmp",
@@ -2198,6 +2176,29 @@ namespace libsemigroups {
     Alphabet<word_type> large_alphabet(10);
     REQUIRE(to_human_readable_repr(RPOCmp(large_alphabet))
             == "<RPOCmp object over <alphabet with 10 letters>>");
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("RevRPOCmp",
+                          "077",
+                          "to_human_readable_repr",
+                          "[quick][order]") {
+    using std::string_literals::operator""s;
+
+    auto rg = ReportGuard(false);
+
+    REQUIRE(to_human_readable_repr(RevRPOCmp<>()) == "<RevRPOCmp object>");
+    REQUIRE(to_human_readable_repr(RevRPOCmp<Default, false>())
+            == "<RevRPOCmp object>");
+
+    Alphabet alphabet("ba"s);
+    REQUIRE(to_human_readable_repr(RevRPOCmp(alphabet))
+            == "<RevRPOCmp object over <alphabet \"ba\">>");
+    REQUIRE(to_human_readable_repr(RevRPOCmp<std::string, false>(alphabet))
+            == "<RevRPOCmp object over <alphabet \"ba\">>");
+
+    Alphabet<word_type> large_alphabet(10);
+    REQUIRE(to_human_readable_repr(RevRPOCmp(large_alphabet))
+            == "<RevRPOCmp object over <alphabet with 10 letters>>");
   }
 
   LIBSEMIGROUPS_TEST_CASE("RevLenLexCmp",

--- a/tests/test-to-todd-coxeter.cpp
+++ b/tests/test-to-todd-coxeter.cpp
@@ -62,7 +62,7 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 21);
     tc.shrink_to_fit();
     REQUIRE(tc.number_of_classes() == 21);
-    tc.standardize(Order::rpo);
+    tc.standardize(Order::rev_rpo);
     auto w = (todd_coxeter::normal_forms(tc) | rx::to_vector());
     REQUIRE(w.size() == 21);
     REQUIRE(w
@@ -71,7 +71,7 @@ namespace libsemigroups {
                             001_w,  11_w,    110_w,   1100_w, 11000_w, 011_w,
                             0110_w, 01100_w, 011000_w}));
     REQUIRE(std::unique(w.begin(), w.end()) == w.end());
-    REQUIRE(std::is_sorted(w.cbegin(), w.cend(), RPOCmp{}));
+    REQUIRE(std::is_sorted(w.cbegin(), w.cend(), RevRPOCmp{}));
     REQUIRE((todd_coxeter::normal_forms(tc) | rx::all_of([&tc](auto const& u) {
                return todd_coxeter::word_of(tc, todd_coxeter::index_of(tc, u))
                       == u;
@@ -110,7 +110,7 @@ namespace libsemigroups {
     REQUIRE(tc.number_of_classes() == 21);
     tc.shrink_to_fit();
     REQUIRE(tc.number_of_classes() == 21);
-    tc.standardize(Order::rpo);
+    tc.standardize(Order::rev_rpo);
     auto w = (todd_coxeter::normal_forms(tc) | rx::to_vector());
     REQUIRE(w.size() == 21);
     REQUIRE(w
@@ -119,7 +119,7 @@ namespace libsemigroups {
                  "baaa", "ab",   "aba",   "abaa", "abaaa", "aab",   "bb",
                  "bba",  "bbaa", "bbaaa", "abb",  "abba",  "abbaa", "abbaaa"}));
     REQUIRE(std::unique(w.begin(), w.end()) == w.end());
-    REQUIRE(std::is_sorted(w.cbegin(), w.cend(), RPOCmp{}));
+    REQUIRE(std::is_sorted(w.cbegin(), w.cend(), RevRPOCmp{}));
     REQUIRE((todd_coxeter::normal_forms(tc) | rx::all_of([&tc](auto const& u) {
                return todd_coxeter::word_of(tc, todd_coxeter::index_of(tc, u))
                       == u;

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -427,7 +427,7 @@ namespace libsemigroups {
     //   }
     // }
 
-    tc.standardize(Order::rpo);
+    tc.standardize(Order::rev_rpo);
     REQUIRE(tc.current_word_graph().is_standardized());
 
     REQUIRE(word_of(tc, 0) == 0_w);
@@ -435,7 +435,7 @@ namespace libsemigroups {
     REQUIRE(word_of(tc, 2) == 1_w);
     REQUIRE(word_of(tc, 3) == 10_w);
     REQUIRE(word_of(tc, 4) == 100_w);
-    REQUIRE(is_sorted(normal_forms(tc), RPOCmp{}));
+    REQUIRE(is_sorted(normal_forms(tc), RevRPOCmp{}));
 
     check_normal_forms(tc, tc.number_of_classes());
   }
@@ -476,8 +476,8 @@ namespace libsemigroups {
 
     REQUIRE(tc.finished());
 
-    tc.standardize(Order::rpo);
-    REQUIRE(is_sorted(normal_forms(tc), RPOCmp{}));
+    tc.standardize(Order::rev_rpo);
+    REQUIRE(is_sorted(normal_forms(tc), RevRPOCmp{}));
     REQUIRE(
         (normal_forms(tc) | take(10) | to_vector())
         == std::vector(

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -43,54 +43,54 @@ namespace libsemigroups {
   struct LibsemigroupsException;  // forward decl
 
   namespace {
-    std::vector<word_type> rpo_blocks(word_type const& word,
-                                      letter_type      largest_letter) {
-      std::vector<word_type> result(1);
-      for (auto letter : word) {
-        if (letter == largest_letter) {
-          result.emplace_back();
-        } else {
-          result.back().push_back(letter);
-        }
+
+    bool rpo_cmp_recursive_impl(word_type& lhs, word_type& rhs) {
+      if (rhs.empty()) {
+        return false;
       }
-      return result;
+      if (lhs.empty()) {
+        return true;
+      }
+
+      auto const a = lhs.front();
+      auto const b = rhs.front();
+
+      if (a == b) {
+        lhs.erase(lhs.begin());
+        rhs.erase(rhs.begin());
+      } else if (a < b) {
+        lhs.erase(lhs.begin());
+      } else {
+        rhs.erase(rhs.begin());
+      }
+
+      return rpo_cmp_recursive_impl(lhs, rhs);
     }
 
-    bool rpo_less(word_type const& lhs,
-                  word_type const& rhs,
-                  size_t           alphabet_size) {
-      if (alphabet_size <= 1) {
-        return lhs.size() < rhs.size();
-      }
+    bool rpo_cmp_recursive(word_type lhs, word_type rhs) {
+      auto [common_suffix_lhs, common_suffix_rhs]
+          = std::mismatch(lhs.rbegin(), lhs.rend(), rhs.rbegin(), rhs.rend());
 
-      auto const largest_letter = static_cast<letter_type>(alphabet_size - 1);
-      auto const lhs_blocks     = rpo_blocks(lhs, largest_letter);
-      auto const rhs_blocks     = rpo_blocks(rhs, largest_letter);
-
-      if (lhs_blocks.size() != rhs_blocks.size()) {
-        return lhs_blocks.size() < rhs_blocks.size();
-      }
-
-      for (size_t i = 0; i < lhs_blocks.size(); ++i) {
-        if (rpo_less(lhs_blocks[i], rhs_blocks[i], alphabet_size - 1)) {
-          return true;
-        }
-        if (rpo_less(rhs_blocks[i], lhs_blocks[i], alphabet_size - 1)) {
-          return false;
-        }
-      }
-      return false;
+      lhs.erase(common_suffix_lhs.base(), lhs.end());
+      rhs.erase(common_suffix_rhs.base(), rhs.end());
+      return rpo_cmp_recursive_impl(lhs, rhs);
     }
 
-    template <typename Node>
-    std::vector<word_type> minimal_rpo_words(WordGraph<Node> const& wg) {
+    bool rev_rpo_cmp_recursive(word_type lhs, word_type rhs) {
+      std::reverse(lhs.begin(), lhs.end());
+      std::reverse(rhs.begin(), rhs.end());
+      return rpo_cmp_recursive(lhs, rhs);
+    }
+
+    template <typename Node, typename Func>
+    std::vector<word_type> minimal_words(WordGraph<Node> const& wg, Func cmp) {
       struct Candidate {
         word_type word;
         Node      node;
       };
 
-      // This best-first search computes the true minimal word of each
-      // reachable state directly from the rpo order, independently of the
+      // This best-first search computes the minimal word of each
+      // reachable node directly from the given order, independently of the
       // standardization routine under test.
       auto const nr_reachable
           = v4::word_graph::number_of_nodes_reachable_from(wg, 0);
@@ -103,11 +103,11 @@ namespace libsemigroups {
         auto const it = std::min_element(
             frontier.cbegin(),
             frontier.cend(),
-            [&wg](Candidate const& lhs, Candidate const& rhs) {
-              if (rpo_less(lhs.word, rhs.word, wg.out_degree())) {
+            [&cmp](Candidate const& lhs, Candidate const& rhs) {
+              if (cmp(lhs.word, rhs.word)) {
                 return true;
               }
-              if (rpo_less(rhs.word, lhs.word, wg.out_degree())) {
+              if (cmp(rhs.word, lhs.word)) {
                 return false;
               }
               return lhs.node < rhs.node;
@@ -115,8 +115,7 @@ namespace libsemigroups {
         REQUIRE(it != frontier.cend());
 
         auto current = *it;
-        frontier.erase(frontier.begin()
-                       + static_cast<std::ptrdiff_t>(it - frontier.cbegin()));
+        frontier.erase(it);
         if (seen[current.node]) {
           continue;
         }
@@ -136,18 +135,18 @@ namespace libsemigroups {
       return result;
     }
 
-    template <typename Node>
+    template <typename Node, typename Func>
     std::pair<WordGraph<Node>, std::vector<word_type>>
-    canonical_rpo_standardization(WordGraph<Node> const& wg) {
-      auto const minimal_words = minimal_rpo_words(wg);
+    canonical_standardization(WordGraph<Node> const& wg, Func cmp) {
+      std::vector<word_type> const min_words = minimal_words(wg, cmp);
 
       std::vector<Node> p(wg.number_of_nodes());
       std::iota(p.begin(), p.end(), static_cast<Node>(0));
-      std::sort(p.begin(), p.end(), [&minimal_words, &wg](Node lhs, Node rhs) {
-        if (rpo_less(minimal_words[lhs], minimal_words[rhs], wg.out_degree())) {
+      std::sort(p.begin(), p.end(), [&min_words, &cmp](Node lhs, Node rhs) {
+        if (cmp(min_words[lhs], min_words[rhs])) {
           return true;
         }
-        if (rpo_less(minimal_words[rhs], minimal_words[lhs], wg.out_degree())) {
+        if (cmp(min_words[rhs], min_words[lhs])) {
           return false;
         }
         return lhs < rhs;
@@ -164,7 +163,7 @@ namespace libsemigroups {
       std::vector<word_type> ordered_words;
       ordered_words.reserve(p.size());
       for (auto node : p) {
-        ordered_words.push_back(minimal_words[node]);
+        ordered_words.push_back(min_words[node]);
       }
       return {std::move(result), std::move(ordered_words)};
     }
@@ -1066,7 +1065,7 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
                           "048",
-                          "rpo standardization | textbook example",
+                          "rev_rpo standardization | textbook example",
                           "[quick][word-graph]") {
     auto rg = ReportGuard(false);
 
@@ -1075,20 +1074,20 @@ namespace libsemigroups {
 
     auto const expected_words
         = std::vector<word_type>({{}, {0}, {0, 0}, {1}, {1, 0}, {0, 0, 1}});
-    REQUIRE(minimal_rpo_words(wg) == expected_words);
-    REQUIRE(v4::word_graph::is_standardized(wg, Order::rpo));
+    REQUIRE(minimal_words(wg, rev_rpo_cmp_recursive) == expected_words);
+    REQUIRE(v4::word_graph::is_standardized(wg, Order::rev_rpo));
 
     Forest f;
-    REQUIRE(!v4::word_graph::standardize(wg, f, Order::rpo));
-    REQUIRE(v4::word_graph::is_standardized(wg, Order::rpo));
-    REQUIRE(
-        std::is_sorted(expected_words.begin(), expected_words.end(), RPOCmp()));
+    REQUIRE(!v4::word_graph::standardize(wg, f, Order::rev_rpo));
+    REQUIRE(v4::word_graph::is_standardized(wg, Order::rev_rpo));
+    REQUIRE(std::is_sorted(
+        expected_words.begin(), expected_words.end(), RevRPOCmp()));
     REQUIRE(words_from_forest(f) == expected_words);
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
                           "049",
-                          "rpo standardization | permuted textbook example",
+                          "rev_rpo standardization | permuted textbook example",
                           "[quick][word-graph]") {
     auto rg = ReportGuard(false);
 
@@ -1106,45 +1105,47 @@ namespace libsemigroups {
     }
     permuted.standardize_no_checks(q, p);
 
-    REQUIRE(v4::word_graph::is_standardized(canonical, Order::rpo));
+    REQUIRE(v4::word_graph::is_standardized(canonical, Order::rev_rpo));
     REQUIRE(permuted
             == v4::make<WordGraph<size_t>>(
                 6, {{2, 4}, {0}, {3}, {0, 1}, {5}, {UNDEFINED, 3}}));
 
-    REQUIRE(!v4::word_graph::is_standardized(permuted, Order::rpo));
+    REQUIRE(!v4::word_graph::is_standardized(permuted, Order::rev_rpo));
 
     Forest f;
-    REQUIRE(v4::word_graph::standardize(permuted, f, Order::rpo));
+    REQUIRE(v4::word_graph::standardize(permuted, f, Order::rev_rpo));
     REQUIRE(permuted == canonical);
-    REQUIRE(v4::word_graph::is_standardized(permuted, Order::rpo));
-    REQUIRE(words_from_forest(f) == minimal_rpo_words(canonical));
+    REQUIRE(v4::word_graph::is_standardized(permuted, Order::rev_rpo));
+    REQUIRE(words_from_forest(f)
+            == minimal_words(canonical, rev_rpo_cmp_recursive));
     auto const words = words_from_forest(f);
-    REQUIRE(std::is_sorted(words.begin(), words.end(), RPOCmp()));
+    REQUIRE(std::is_sorted(words.begin(), words.end(), RevRPOCmp()));
   }
 
-  LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "050",
-                          "rpo standardization | recursive three-letter case",
-                          "[quick][word-graph]") {
+  LIBSEMIGROUPS_TEST_CASE(
+      "WordGraph",
+      "050",
+      "rev_rpo standardization | recursive three-letter case",
+      "[quick][word-graph]") {
     auto rg = ReportGuard(false);
 
     auto wg = v4::make<WordGraph<size_t>>(
         7, {{1, 3, 5}, {2, 4}, {}, {6}, {}, {4}, {}});
 
-    auto const expected = canonical_rpo_standardization(wg);
+    auto const expected = canonical_standardization(wg, rev_rpo_cmp_recursive);
 
-    REQUIRE(!v4::word_graph::is_standardized(wg, Order::rpo));
+    REQUIRE(!v4::word_graph::is_standardized(wg, Order::rev_rpo));
 
     Forest f;
-    REQUIRE(v4::word_graph::standardize(wg, f, Order::rpo));
+    REQUIRE(v4::word_graph::standardize(wg, f, Order::rev_rpo));
     REQUIRE(wg == expected.first);
-    REQUIRE(v4::word_graph::is_standardized(wg, Order::rpo));
+    REQUIRE(v4::word_graph::is_standardized(wg, Order::rev_rpo));
     REQUIRE(words_from_forest(f) == expected.second);
     REQUIRE(
         expected.second
         == std::vector<word_type>({{}, {0}, {0, 0}, {1}, {1, 0}, {0, 1}, {2}}));
     REQUIRE(std::is_sorted(
-        expected.second.begin(), expected.second.end(), RPOCmp()));
+        expected.second.begin(), expected.second.end(), RevRPOCmp()));
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",


### PR DESCRIPTION
This PR swaps the meaning of `rpo_cmp` and `rev_rpo_cmp` so that `rpo_cmp` is left-to-right and `rev_rpo_cmp` is right-to-left.