### PR TITLE
presentation: fix `InversePresentation` setter chaining

### DIFF
--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -3468,7 +3468,9 @@ namespace libsemigroups {
     word_type _inverses;
 
    public:
-    using Presentation<Word>::Presentation;
+    ////////////////////////////////////////////////////////////////////////
+    // Constructors + initializers
+    ////////////////////////////////////////////////////////////////////////
 
     InversePresentation()                                      = default;
     InversePresentation(InversePresentation const&)            = default;
@@ -3478,7 +3480,21 @@ namespace libsemigroups {
 
     ~InversePresentation() = default;
 
-    // TODO(later) init functions
+    //! \brief Remove the alphabet, rules, and inverses.
+    //!
+    //! This function clears the alphabet, rules, and inverses, putting the
+    //! presentation back into the state it would be in if it was newly
+    //! default constructed.
+    //!
+    //! \returns A reference to `this`.
+    //!
+    //! \exceptions
+    //! \no_libsemigroups_except
+    InversePresentation& init() {
+      Presentation<Word>::init();
+      _inverses.clear();
+      return *this;
+    }
 
     //! \brief Construct an InversePresentation from a Presentation reference.
     //!
@@ -3500,6 +3516,100 @@ namespace libsemigroups {
     //! \param p an rvalue reference to the Presentation to construct from.
     explicit InversePresentation(Presentation<Word>&& p)
         : Presentation<Word>(p), _inverses() {}
+
+    ////////////////////////////////////////////////////////////////////////
+    // Overrides of Presentation mem fns
+    ////////////////////////////////////////////////////////////////////////
+
+    // The following mostly exist so that the return type of the mem fns is
+    // correct, even though they do nothing special here.
+
+    using Presentation<Word>::add_generator;
+    using Presentation<Word>::contains_empty_word;
+
+    //! \copydoc Presentation<Word>::alphabet() const
+    [[nodiscard]] word_type const& alphabet() const noexcept {
+      return Presentation<Word>::alphabet();
+    }
+
+    //! \copydoc Presentation<Word>::alphabet(size_type)
+    InversePresentation& alphabet(size_type n) {
+      Presentation<Word>::alphabet(n);
+      return *this;
+    }
+
+    //! \copydoc Presentation<Word>::alphabet(word_type const&)
+    InversePresentation& alphabet(word_type const& lphbt) {
+      Presentation<Word>::alphabet(lphbt);
+      return *this;
+    }
+
+    //! \copydoc Presentation<Word>::alphabet(word_type&&)
+    InversePresentation& alphabet(word_type&& lphbt) {
+      Presentation<Word>::alphabet(std::move(lphbt));
+      return *this;
+    }
+
+    //! \copydoc Presentation<Word>::alphabet_from_rules
+    InversePresentation& alphabet_from_rules() {
+      Presentation<Word>::alphabet_from_rules();
+      return *this;
+    }
+
+    //! \copydoc Presentation<Word>::add_rule_no_checks
+    template <typename Iterator1, typename Iterator2>
+    InversePresentation& add_rule_no_checks(Iterator1 lhs_begin,
+                                            Iterator1 lhs_end,
+                                            Iterator2 rhs_begin,
+                                            Iterator2 rhs_end) {
+      Presentation<Word>::add_rule_no_checks(
+          lhs_begin, lhs_end, rhs_begin, rhs_end);
+      return *this;
+    }
+
+    //! \copydoc Presentation<Word>::add_rule
+    template <typename Iterator1, typename Iterator2>
+    InversePresentation& add_rule(Iterator1 lhs_begin,
+                                  Iterator1 lhs_end,
+                                  Iterator2 rhs_begin,
+                                  Iterator2 rhs_end) {
+      Presentation<Word>::add_rule(lhs_begin, lhs_end, rhs_begin, rhs_end);
+      return *this;
+    }
+
+    //! \copydoc Presentation<Word>::add_generator_no_checks
+    InversePresentation& add_generator_no_checks(letter_type x) {
+      Presentation<Word>::add_generator_no_checks(x);
+      return *this;
+    }
+
+    //! \copydoc Presentation<Word>::add_generator(letter_type)
+    InversePresentation& add_generator(letter_type x) {
+      Presentation<Word>::add_generator(x);
+      return *this;
+    }
+
+    //! \copydoc Presentation<Word>::remove_generator_no_checks
+    InversePresentation& remove_generator_no_checks(letter_type x) {
+      Presentation<Word>::remove_generator_no_checks(x);
+      return *this;
+    }
+
+    //! \copydoc Presentation<Word>::remove_generator
+    InversePresentation& remove_generator(letter_type x) {
+      Presentation<Word>::remove_generator(x);
+      return *this;
+    }
+
+    //! \copydoc Presentation<Word>::contains_empty_word(bool)
+    InversePresentation& contains_empty_word(bool val) noexcept {
+      Presentation<Word>::contains_empty_word(val);
+      return *this;
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // InversePresentation specific mem fns
+    ////////////////////////////////////////////////////////////////////////
 
     //! \brief Set the inverse of each letter in the alphabet.
     //!
@@ -3589,7 +3699,7 @@ namespace libsemigroups {
       Presentation<Word>::throw_if_bad_alphabet_or_rules();
       presentation::throw_if_bad_inverses(*this, inverses());
     }
-  };
+  };  // class InversePresentation
 
   //! \ingroup presentations_group
   //!

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -3154,6 +3154,52 @@ namespace libsemigroups {
     ip.throw_if_bad_alphabet_rules_or_inverses();
   }
 
+  LIBSEMIGROUPS_TEST_CASE("InversePresentation",
+                          "067",
+                          "fluent modifiers",
+                          "[quick][presentation]") {
+    auto rg = ReportGuard(false);
+
+    using inverse_presentation_type = InversePresentation<std::string>;
+    inverse_presentation_type p;
+    static_assert(
+        std::is_same_v<decltype(p.alphabet("aA")), inverse_presentation_type&>);
+    static_assert(std::is_same_v<decltype(p.alphabet()), std::string const&>);
+    static_assert(std::is_same_v<decltype(p.contains_empty_word()), bool>);
+
+    auto& result = p.alphabet("aA").contains_empty_word(true).inverses("Aa");
+    REQUIRE(&result == &p);
+    REQUIRE(p.alphabet() == "aA");
+    REQUIRE(p.inverses() == "Aa");
+    REQUIRE(p.contains_empty_word());
+
+    REQUIRE(&p.init() == &p);
+    REQUIRE(p.alphabet().empty());
+    REQUIRE(p.inverses().empty());
+    REQUIRE_FALSE(p.contains_empty_word());
+
+    InversePresentation<word_type> q;
+    static_assert(std::is_same_v<decltype(q.add_generator()),
+                                 InversePresentation<word_type>::letter_type>);
+    word_type lhs = {0, 0};
+    word_type rhs = {1};
+    auto&     other_result
+        = q.alphabet(word_type({0, 1}))
+              .add_generator(2)
+              .remove_generator(2)
+              .add_generator_no_checks(2)
+              .remove_generator_no_checks(2)
+              .add_rule_no_checks(
+                  lhs.cbegin(), lhs.cend(), rhs.cbegin(), rhs.cend())
+              .add_rule(lhs.cbegin(), lhs.cend(), rhs.cbegin(), rhs.cend())
+              .alphabet_from_rules()
+              .inverses({1, 0});
+    REQUIRE(&other_result == &q);
+    REQUIRE(q.alphabet() == word_type({0, 1}));
+    REQUIRE(q.inverses() == word_type({1, 0}));
+    REQUIRE(q.rules == std::vector<word_type>({lhs, rhs, lhs, rhs}));
+  }
+
   LIBSEMIGROUPS_TEST_CASE("Presentation",
                           "067",
                           "longest_subword_reducing_length #01",


### PR DESCRIPTION
Forward inherited fluent modifiers so calls on InversePresentation preserve the derived return type. Reset inverse data in init and add regression coverage for supported overloads.

AI disclosure: OpenAI Codex implemented the fluent forwarding methods, documentation, and regression tests with review and direction from James Mitchell.

Resolves Issue #1053 