### PR TITLE
Refactor alphabet validation

### DIFF
--- a/include/libsemigroups/alphabet-class.tpp
+++ b/include/libsemigroups/alphabet-class.tpp
@@ -129,7 +129,9 @@ namespace libsemigroups {
   void
   Alphabet<Word>::throw_if_letter_not_in_alphabet(native_letter_type c) const {
     if (empty()) {
-      LIBSEMIGROUPS_EXCEPTION("there are no letters in the alphabet");
+      LIBSEMIGROUPS_EXCEPTION(
+          "invalid letter {}, there are no letters in the alphabet",
+          detail::to_printable(c));
     } else if (_letters_map.find(c) == _letters_map.cend()) {
       auto msg = fmt::format("invalid letter {}, valid letters are {}",
                              detail::to_printable(c),

--- a/include/libsemigroups/cong-class.hpp
+++ b/include/libsemigroups/cong-class.hpp
@@ -588,7 +588,7 @@ namespace libsemigroups {
     }
 
     ////////////////////////////////////////////////////////////////////////
-    // Congruence - interface requirements - throw_if_letter_not_in_alphabet
+    // Congruence - interface requirements - DEPRECATED
     ////////////////////////////////////////////////////////////////////////
 
     //! \ingroup congruence_class_init_group
@@ -608,8 +608,14 @@ namespace libsemigroups {
     //!
     //! \throw LibsemigroupsException if any letter in the range from \p first
     //! to \p last is out of bounds.
+    //!
+    //! \deprecated_warning{function} Use
+    //! `presentation().throw_if_empty_word_not_allowed(first, last)` and
+    //! `presentation().alphabet_v4().throw_if_letter_not_in_alphabet(first,
+    //! last)` instead.
     template <typename Iterator1, typename Iterator2>
-    void throw_if_letter_not_in_alphabet(Iterator1 first, Iterator2 last) const;
+    [[deprecated]] void throw_if_letter_not_in_alphabet(Iterator1 first,
+                                                        Iterator2 last) const;
 
     //////////////////////////////////////////////////////////////////////////
     // Congruence - member functions - public

--- a/include/libsemigroups/cong-class.tpp
+++ b/include/libsemigroups/cong-class.tpp
@@ -164,11 +164,13 @@ namespace libsemigroups {
     }
   }
 
+  // DEPRECATED
   template <typename Word>
   template <typename Iterator1, typename Iterator2>
   void Congruence<Word>::throw_if_letter_not_in_alphabet(Iterator1 first,
                                                          Iterator2 last) const {
-    _presentation.throw_if_letter_not_in_alphabet(first, last);
+    _presentation.throw_if_empty_word_not_allowed(first, last);
+    _presentation.alphabet_v4().throw_if_letter_not_in_alphabet(first, last);
   }
 
   template <typename Word>

--- a/include/libsemigroups/detail/cong-common-class.hpp
+++ b/include/libsemigroups/detail/cong-common-class.hpp
@@ -74,17 +74,6 @@ namespace libsemigroups {
       CongruenceCommon& operator=(CongruenceCommon const&);
       CongruenceCommon& operator=(CongruenceCommon&&);
 
-      ////////////////////////////////////////////////////////////////////////////
-      // CongruenceCommon - validation - protected
-      ////////////////////////////////////////////////////////////////////////////
-
-      template <typename Subclass, typename Iterator1, typename Iterator2>
-      void throw_if_letter_not_in_alphabet(Iterator1 first,
-                                           Iterator2 last) const {
-        static_cast<Subclass const*>(this)->throw_if_letter_not_in_alphabet(
-            first, last);
-      }
-
      public:
       ~CongruenceCommon();
 
@@ -117,7 +106,7 @@ namespace libsemigroups {
       }
 
       ////////////////////////////////////////////////////////////////////////
-      // CongruenceCommon - add_internal_generating_pair
+      // CongruenceCommon - add generating pairs
       ////////////////////////////////////////////////////////////////////////
 
       // The functions in this section are used as aliases in the derived
@@ -175,11 +164,7 @@ namespace libsemigroups {
       [[nodiscard]] bool contains(Iterator1 first1,
                                   Iterator2 last1,
                                   Iterator3 first2,
-                                  Iterator4 last2) {
-        throw_if_letter_not_in_alphabet<Subclass>(first1, last1);
-        throw_if_letter_not_in_alphabet<Subclass>(first2, last2);
-        return contains_no_checks<Subclass>(first1, last1, first2, last2);
-      }
+                                  Iterator4 last2);
 
       ////////////////////////////////////////////////////////////////////////
       // CongruenceCommon - reduce

--- a/include/libsemigroups/detail/cong-common-class.tpp
+++ b/include/libsemigroups/detail/cong-common-class.tpp
@@ -23,8 +23,50 @@ namespace libsemigroups {
   namespace detail {
 
     ////////////////////////////////////////////////////////////////////////
-    // Out of line member functions for CongruenceCommon
+    // CongruenceCommon - add generating pairs
     ////////////////////////////////////////////////////////////////////////
+
+    template <typename Subclass,
+              typename Iterator1,
+              typename Iterator2,
+              typename Iterator3,
+              typename Iterator4>
+    Subclass&
+    CongruenceCommon::add_internal_generating_pair_no_checks(Iterator1 first1,
+                                                             Iterator2 last1,
+                                                             Iterator3 first2,
+                                                             Iterator4 last2) {
+      LIBSEMIGROUPS_ASSERT(!started());
+      _internal_generating_pairs.emplace_back(first1, last1);
+      _internal_generating_pairs.emplace_back(first2, last2);
+      return static_cast<Subclass&>(*this);
+    }
+
+    template <typename Subclass,
+              typename Iterator1,
+              typename Iterator2,
+              typename Iterator3,
+              typename Iterator4>
+    Subclass& CongruenceCommon::add_generating_pair(Iterator1 first1,
+                                                    Iterator2 last1,
+                                                    Iterator3 first2,
+                                                    Iterator4 last2) {
+      throw_if_started();
+      auto const& p = static_cast<Subclass const&>(*this).presentation();
+      p.throw_if_empty_word_not_allowed(first1, last1);
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(first1, last1);
+      p.throw_if_empty_word_not_allowed(first2, last2);
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(first2, last2);
+      return static_cast<Subclass&>(*this).add_generating_pair_no_checks(
+          first1, last1, first2, last2);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // CongruenceCommon - contains
+    ////////////////////////////////////////////////////////////////////////
+
+    // NOTE: currently_contains_no_checks must be implemented in the derived
+    // class.
 
     template <typename Subclass,
               typename Iterator1,
@@ -35,8 +77,11 @@ namespace libsemigroups {
                                               Iterator2 last1,
                                               Iterator3 first2,
                                               Iterator4 last2) const {
-      throw_if_letter_not_in_alphabet<Subclass>(first1, last1);
-      throw_if_letter_not_in_alphabet<Subclass>(first2, last2);
+      auto const& p = static_cast<Subclass const&>(*this).presentation();
+      p.throw_if_empty_word_not_allowed(first1, last1);
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(first1, last1);
+      p.throw_if_empty_word_not_allowed(first2, last2);
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(first2, last2);
       return static_cast<Subclass const&>(*this).currently_contains_no_checks(
           first1, last1, first2, last2);
     }
@@ -50,6 +95,11 @@ namespace libsemigroups {
                                               Iterator2 last1,
                                               Iterator3 first2,
                                               Iterator4 last2) {
+      // NOTE: the implementation of currently_contains_no_checks must check
+      // std::equal(first1, last1, first2, last2) or equivalent, and not return
+      // tril::unknown for identical words.
+      // TODO(1): the note above not withstanding, removing the next 3 lines
+      // causes a seg fault, so that should be investigated and fixed.
       if (std::equal(first1, last1, first2, last2)) {
         return true;
       }
@@ -84,32 +134,23 @@ namespace libsemigroups {
               typename Iterator2,
               typename Iterator3,
               typename Iterator4>
-    Subclass&
-    CongruenceCommon::add_internal_generating_pair_no_checks(Iterator1 first1,
-                                                             Iterator2 last1,
-                                                             Iterator3 first2,
-                                                             Iterator4 last2) {
-      LIBSEMIGROUPS_ASSERT(!started());
-      _internal_generating_pairs.emplace_back(first1, last1);
-      _internal_generating_pairs.emplace_back(first2, last2);
-      return static_cast<Subclass&>(*this);
+    bool CongruenceCommon::contains(Iterator1 first1,
+                                    Iterator2 last1,
+                                    Iterator3 first2,
+                                    Iterator4 last2) {
+      auto const& p = static_cast<Subclass const&>(*this).presentation();
+      p.throw_if_empty_word_not_allowed(first1, last1);
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(first1, last1);
+      p.throw_if_empty_word_not_allowed(first2, last2);
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(first2, last2);
+      return contains_no_checks<Subclass>(first1, last1, first2, last2);
     }
 
-    template <typename Subclass,
-              typename Iterator1,
-              typename Iterator2,
-              typename Iterator3,
-              typename Iterator4>
-    Subclass& CongruenceCommon::add_generating_pair(Iterator1 first1,
-                                                    Iterator2 last1,
-                                                    Iterator3 first2,
-                                                    Iterator4 last2) {
-      throw_if_started();
-      throw_if_letter_not_in_alphabet<Subclass>(first1, last1);
-      throw_if_letter_not_in_alphabet<Subclass>(first2, last2);
-      return static_cast<Subclass&>(*this).add_generating_pair_no_checks(
-          first1, last1, first2, last2);
-    }
+    ////////////////////////////////////////////////////////////////////////
+    // CongruenceCommon - reduce
+    ////////////////////////////////////////////////////////////////////////
+
+    // NOTE: reduce_no_run_no_checks must be implemented in the derived class
 
     template <typename Subclass,
               typename OutputIterator,
@@ -118,7 +159,9 @@ namespace libsemigroups {
     OutputIterator CongruenceCommon::reduce_no_run(OutputIterator d_first,
                                                    Iterator1      first,
                                                    Iterator2      last) const {
-      throw_if_letter_not_in_alphabet<Subclass>(first, last);
+      auto const& p = static_cast<Subclass const&>(*this).presentation();
+      p.throw_if_empty_word_not_allowed(first, last);
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(first, last);
       if (finished() && !success()) {  // for Kambites
         LIBSEMIGROUPS_EXCEPTION(
             "cannot reduce words, the algorithm failed to finish successfully!")
@@ -134,7 +177,9 @@ namespace libsemigroups {
     OutputIterator CongruenceCommon::reduce(OutputIterator d_first,
                                             InputIterator1 first,
                                             InputIterator2 last) {
-      throw_if_letter_not_in_alphabet<Subclass>(first, last);
+      auto const& p = static_cast<Subclass const&>(*this).presentation();
+      p.throw_if_empty_word_not_allowed(first, last);
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(first, last);
       run();
       if (!success()) {  // for Kambites
         LIBSEMIGROUPS_EXCEPTION(

--- a/include/libsemigroups/detail/knuth-bendix-impl.hpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.hpp
@@ -264,6 +264,9 @@ namespace libsemigroups {
       // generating pairs contained in CongruenceCommon are word_types, and
       // so we don't require any conversion here (since chars can be converted
       // implicitly to letter_types)
+
+      // NOTE: there are no "checks" versions of the functions below because
+      // this isn't a user-facing class and they are redundant.
       template <typename Iterator1,
                 typename Iterator2,
                 typename Iterator3,
@@ -275,19 +278,6 @@ namespace libsemigroups {
         LIBSEMIGROUPS_ASSERT(!started());
         return CongruenceCommon::add_internal_generating_pair_no_checks<
             KnuthBendixImpl>(first1, last1, first2, last2);
-      }
-
-      template <typename Iterator1,
-                typename Iterator2,
-                typename Iterator3,
-                typename Iterator4>
-      KnuthBendixImpl& add_generating_pair(Iterator1 first1,
-                                           Iterator2 last1,
-                                           Iterator3 first2,
-                                           Iterator4 last2) {
-        LIBSEMIGROUPS_ASSERT(!started());
-        return CongruenceCommon::add_generating_pair<KnuthBendixImpl>(
-            first1, last1, first2, last2);
       }
 
       ////////////////////////////////////////////////////////////////////////
@@ -318,6 +308,9 @@ namespace libsemigroups {
       // KnuthBendixImpl - interface requirements - contains
       ////////////////////////////////////////////////////////////////////////
 
+      // NOTE: there are no "checks" versions of the functions below because
+      // this isn't a user-facing class and they are redundant.
+
       //! \ingroup knuth_bendix_class_intf_group
       //! \brief Check containment of a pair of words via iterators.
       //!
@@ -344,21 +337,6 @@ namespace libsemigroups {
                                                       Iterator2 last1,
                                                       Iterator3 first2,
                                                       Iterator4 last2) const;
-
-      // Documented in KnuthBendix (because it appears there because we call
-      // CongruenceCommon::currently_contains directly so that bounds checks are
-      // done in KnuthBendix)
-      template <typename Iterator1,
-                typename Iterator2,
-                typename Iterator3,
-                typename Iterator4>
-      [[nodiscard]] tril currently_contains(Iterator1 first1,
-                                            Iterator2 last1,
-                                            Iterator3 first2,
-                                            Iterator4 last2) const {
-        return CongruenceCommon::currently_contains<KnuthBendixImpl>(
-            first1, last1, first2, last2);
-      }
 
       //! \ingroup knuth_bendix_class_intf_group
       //!
@@ -388,24 +366,12 @@ namespace libsemigroups {
             first1, last1, first2, last2);
       }
 
-      // Documented in KnuthBendix (because it appears there because we call
-      // CongruenceCommon::contains directly so that bounds checks are
-      // done in KnuthBendix)
-      template <typename Iterator1,
-                typename Iterator2,
-                typename Iterator3,
-                typename Iterator4>
-      [[nodiscard]] bool contains(Iterator1 first1,
-                                  Iterator2 last1,
-                                  Iterator3 first2,
-                                  Iterator4 last2) {
-        return CongruenceCommon::contains<KnuthBendixImpl>(
-            first1, last1, first2, last2);
-      }
-
       ////////////////////////////////////////////////////////////////////////
       // KnuthBendixImpl - interface requirements - reduce
       ////////////////////////////////////////////////////////////////////////
+
+      // NOTE: there are no "checks" versions of the functions below because
+      // this isn't a user-facing class and they are redundant.
 
       template <typename OutputIterator,
                 typename InputIterator1,
@@ -413,19 +379,6 @@ namespace libsemigroups {
       OutputIterator reduce_no_run_no_checks(OutputIterator d_first,
                                              InputIterator1 first,
                                              InputIterator2 last) const;
-
-      // Documented in KnuthBendix (because it appears there because we call
-      // CongruenceCommon::reduce_no_run directly so that bounds checks are
-      // done in KnuthBendix)
-      template <typename OutputIterator,
-                typename InputIterator1,
-                typename InputIterator2>
-      OutputIterator reduce_no_run(OutputIterator d_first,
-                                   InputIterator1 first,
-                                   InputIterator2 last) const {
-        return CongruenceCommon::reduce_no_run<KnuthBendixImpl>(
-            d_first, first, last);
-      }
 
       template <typename OutputIterator,
                 typename InputIterator1,
@@ -435,18 +388,6 @@ namespace libsemigroups {
                                       InputIterator2 last) {
         return CongruenceCommon::reduce_no_checks<KnuthBendixImpl>(
             d_first, first, last);
-      }
-
-      // Documented in KnuthBendix (because it appears there because we call
-      // CongruenceCommon::reduce directly so that bounds checks are
-      // done in KnuthBendix)
-      template <typename OutputIterator,
-                typename InputIterator1,
-                typename InputIterator2>
-      OutputIterator reduce(OutputIterator d_first,
-                            InputIterator1 first,
-                            InputIterator2 last) {
-        return CongruenceCommon::reduce<KnuthBendixImpl>(d_first, first, last);
       }
 
       // TODO(1) implement reduce_inplace x4 if possible.

--- a/include/libsemigroups/detail/knuth-bendix-impl.hpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.hpp
@@ -647,13 +647,6 @@ namespace libsemigroups {
       // KnuthBendixImpl - member functions for rules and rewriting - public
       //////////////////////////////////////////////////////////////////////////
 
-      // TODO(1) remove
-      template <typename Iterator1, typename Iterator2>
-      void throw_if_letter_not_in_alphabet(Iterator1 first,
-                                           Iterator2 last) const {
-        internal_presentation().throw_if_letter_not_in_alphabet(first, last);
-      }
-
       [[nodiscard]] Presentation<native_word_type> const&
       internal_presentation() const noexcept {
         return _presentation;

--- a/include/libsemigroups/detail/stephen-impl.hpp
+++ b/include/libsemigroups/detail/stephen-impl.hpp
@@ -138,7 +138,9 @@ namespace libsemigroups {
 
       template <typename Iterator1, typename Iterator2>
       StephenImpl& set_internal_word(Iterator1 first, Iterator2 last) {
-        internal_presentation().throw_if_letter_not_in_alphabet(first, last);
+        internal_presentation().throw_if_empty_word_not_allowed(first, last);
+        internal_presentation().alphabet_v4().throw_if_letter_not_in_alphabet(
+            first, last);
         return set_internal_word_no_checks(first, last);
       }
 

--- a/include/libsemigroups/detail/todd-coxeter-impl.hpp
+++ b/include/libsemigroups/detail/todd-coxeter-impl.hpp
@@ -564,12 +564,6 @@ namespace libsemigroups {
                             WordGraph<Node> const&         wg);
 #endif
 
-      template <typename Iterator1, typename Iterator2>
-      void throw_if_letter_not_in_alphabet(Iterator1 first,
-                                           Iterator2 last) const {
-        internal_presentation().throw_if_letter_not_in_alphabet(first, last);
-      }
-
       ////////////////////////////////////////////////////////////////////////
       // Interface requirements - add_generating_pair
       ////////////////////////////////////////////////////////////////////////
@@ -2128,7 +2122,9 @@ namespace libsemigroups {
       //! \cong_common_throws_if_letters_out_of_bounds
       template <typename Iterator1, typename Iterator2>
       index_type current_index_of(Iterator1 first, Iterator2 last) const {
-        throw_if_letter_not_in_alphabet(first, last);
+        internal_presentation().throw_if_empty_word_not_allowed(first, last);
+        internal_presentation().alphabet_v4().throw_if_letter_not_in_alphabet(
+            first, last);
         return current_index_of_no_checks(first, last);
       }
 
@@ -2187,7 +2183,9 @@ namespace libsemigroups {
       //! \cong_common_throws_if_letters_out_of_bounds
       template <typename Iterator1, typename Iterator2>
       index_type index_of(Iterator1 first, Iterator2 last) {
-        throw_if_letter_not_in_alphabet(first, last);
+        internal_presentation().throw_if_empty_word_not_allowed(first, last);
+        internal_presentation().alphabet_v4().throw_if_letter_not_in_alphabet(
+            first, last);
         return index_of_no_checks(first, last);
       }
 

--- a/include/libsemigroups/detail/todd-coxeter-impl.hpp
+++ b/include/libsemigroups/detail/todd-coxeter-impl.hpp
@@ -586,18 +586,6 @@ namespace libsemigroups {
             ToddCoxeterImpl>(first1, last1, first2, last2);
       }
 
-      template <typename Iterator1,
-                typename Iterator2,
-                typename Iterator3,
-                typename Iterator4>
-      ToddCoxeterImpl& add_generating_pair(Iterator1 first1,
-                                           Iterator2 last1,
-                                           Iterator3 first2,
-                                           Iterator4 last2) {
-        return CongruenceCommon::add_generating_pair<ToddCoxeterImpl>(
-            first1, last1, first2, last2);
-      }
-
       ////////////////////////////////////////////////////////////////////////
       // Interface requirements - number_of_classes
       ////////////////////////////////////////////////////////////////////////
@@ -621,6 +609,9 @@ namespace libsemigroups {
       // Interface requirements - contains
       ////////////////////////////////////////////////////////////////////////
 
+      // NOTE: there are no "checks" versions of the functions below because
+      // this isn't a user-facing class and they are redundant.
+
       template <typename Iterator1,
                 typename Iterator2,
                 typename Iterator3,
@@ -634,31 +625,10 @@ namespace libsemigroups {
                 typename Iterator2,
                 typename Iterator3,
                 typename Iterator4>
-      tril currently_contains(Iterator1 first1,
-                              Iterator2 last1,
-                              Iterator3 first2,
-                              Iterator4 last2) const {
-        return CongruenceCommon::currently_contains<ToddCoxeterImpl>(
-            first1, last1, first2, last2);
-      }
-
-      template <typename Iterator1,
-                typename Iterator2,
-                typename Iterator3,
-                typename Iterator4>
       bool contains_no_checks(Iterator1 first1,
                               Iterator2 last1,
                               Iterator3 first2,
                               Iterator4 last2);
-
-      template <typename Iterator1,
-                typename Iterator2,
-                typename Iterator3,
-                typename Iterator4>
-      bool contains(Iterator1 first1,
-                    Iterator2 last1,
-                    Iterator3 first2,
-                    Iterator4 last2);
 
       ////////////////////////////////////////////////////////////////////////
       // Interface requirements - reduce
@@ -674,30 +644,11 @@ namespace libsemigroups {
       template <typename OutputIterator,
                 typename InputIterator1,
                 typename InputIterator2>
-      OutputIterator reduce_no_run(OutputIterator d_first,
-                                   InputIterator1 first,
-                                   InputIterator2 last) const {
-        return CongruenceCommon::reduce_no_run<ToddCoxeterImpl>(
-            d_first, first, last);
-      }
-
-      template <typename OutputIterator,
-                typename InputIterator1,
-                typename InputIterator2>
       OutputIterator reduce_no_checks(OutputIterator d_first,
                                       InputIterator1 first,
                                       InputIterator2 last) {
         return CongruenceCommon::reduce_no_checks<ToddCoxeterImpl>(
             d_first, first, last);
-      }
-
-      template <typename OutputIterator,
-                typename InputIterator1,
-                typename InputIterator2>
-      OutputIterator reduce(OutputIterator d_first,
-                            InputIterator1 first,
-                            InputIterator2 last) {
-        return CongruenceCommon::reduce<ToddCoxeterImpl>(d_first, first, last);
       }
 
       ////////////////////////////////////////////////////////////////////////

--- a/include/libsemigroups/detail/todd-coxeter-impl.tpp
+++ b/include/libsemigroups/detail/todd-coxeter-impl.tpp
@@ -306,24 +306,6 @@ namespace libsemigroups {
           first1, last1, first2, last2);
     }
 
-    template <typename Iterator1,
-              typename Iterator2,
-              typename Iterator3,
-              typename Iterator4>
-    bool ToddCoxeterImpl::contains(Iterator1 first1,
-                                   Iterator2 last1,
-                                   Iterator3 first2,
-                                   Iterator4 last2) {
-      // TODO(1) should be
-      // return detail::CongruenceCommon::contains<ToddCoxeterImpl>(
-      //     first1, last1, first2, last2);
-      // when is_free is implemented. Not currently so that the analogue of
-      // is_free is called.
-      internal_presentation().throw_if_letter_not_in_alphabet(first1, last1);
-      internal_presentation().throw_if_letter_not_in_alphabet(first2, last2);
-      return contains_no_checks(first1, last1, first2, last2);
-    }
-
     template <typename OutputIterator,
               typename InputIterator1,
               typename InputIterator2>

--- a/include/libsemigroups/kambites-class.hpp
+++ b/include/libsemigroups/kambites-class.hpp
@@ -783,10 +783,16 @@ namespace libsemigroups {
     //!
     //! \throw LibsemigroupsException if any letter in the range from
     //! \p first to \p last is out of bounds.
+    //!
+    //! \deprecated_warning{function} Use
+    //! `presentation().throw_if_empty_word_not_allowed(first, last)` and
+    //! `presentation().alphabet_v4().throw_if_letter_not_in_alphabet(first,
+    //! last)` instead.
     template <typename Iterator1, typename Iterator2>
-    void throw_if_letter_not_in_alphabet(Iterator1 first,
-                                         Iterator2 last) const {
-      _presentation.throw_if_letter_not_in_alphabet(first, last);
+    [[deprecated]] void throw_if_letter_not_in_alphabet(Iterator1 first,
+                                                        Iterator2 last) const {
+      _presentation.throw_if_empty_word_not_allowed(first, last);
+      _presentation.alphabet_v4().throw_if_letter_not_in_alphabet(first, last);
     }
 
     //! \ingroup kambites_class_init_group

--- a/include/libsemigroups/knuth-bendix-class.hpp
+++ b/include/libsemigroups/knuth-bendix-class.hpp
@@ -548,6 +548,8 @@ namespace libsemigroups {
                             Iterator4 last2) const {
       // Call CongruenceCommon version so that we perform bound checks
       // in KnuthBendix and not KnuthBendixImpl_
+      throw_if_extra_letter(first1, last1);
+      throw_if_extra_letter(first2, last2);
       return detail::CongruenceCommon::currently_contains<KnuthBendix>(
           first1, last1, first2, last2);
     }
@@ -556,12 +558,10 @@ namespace libsemigroups {
     //!
     //! \brief Check containment of a pair of words via iterators.
     //!
-    //! This function checks whether or not the words represented by the
-    //! ranges
+    //! This function checks whether or not the words represented by the ranges
     //! \p first1 to \p last1 and \p first2 to \p last2 are contained in the
-    //! congruence represented by a \ref_knuth_bendix
-    //! instance. This function triggers a full enumeration,
-    //! which may never terminate.
+    //! congruence represented by a \ref_knuth_bendix instance. This function
+    //! triggers a full enumeration, which may never terminate.
     //!
     //! \cong_common_params_contains
     //!
@@ -677,6 +677,7 @@ namespace libsemigroups {
                                  InputIterator2 last) const {
       // Call CongruenceCommon version so that we perform bound checks
       // in KnuthBendix and not KnuthBendixImpl_
+      throw_if_extra_letter(first, last);
       return detail::CongruenceCommon::reduce_no_run<KnuthBendix>(
           d_first, first, last);
     }
@@ -711,6 +712,7 @@ namespace libsemigroups {
                           InputIterator2 last) {
       // Call CongruenceCommon version so that we perform bound checks
       // in KnuthBendix and not KnuthBendixImpl_
+      throw_if_extra_letter(first, last);
       return detail::CongruenceCommon::reduce<KnuthBendix>(
           d_first, first, last);
     }
@@ -746,6 +748,9 @@ namespace libsemigroups {
 
    private:
     void run_impl();
+
+    template <typename Iterator1, typename Iterator2>
+    void throw_if_extra_letter(Iterator1 first, Iterator2 last) const;
 
     [[nodiscard]] bool requires_extra_letter() const {
       return (!generating_pairs().empty()

--- a/include/libsemigroups/knuth-bendix-class.tpp
+++ b/include/libsemigroups/knuth-bendix-class.tpp
@@ -110,7 +110,20 @@ namespace libsemigroups {
   template <typename Iterator1, typename Iterator2>
   void KnuthBendix<Word, RewritingSystem, ReductionOrder>::
       throw_if_letter_not_in_alphabet(Iterator1 first, Iterator2 last) const {
-    presentation().throw_if_letter_not_in_alphabet(first, last);
+    presentation().throw_if_empty_word_not_allowed(first, last);
+    presentation().alphabet_v4().throw_if_letter_not_in_alphabet(first, last);
+    throw_if_extra_letter(first, last);
+  }
+
+  template <typename Word,
+            typename RewritingSystem,
+            template <typename, bool>
+            typename ReductionOrder>
+  template <typename Iterator1, typename Iterator2>
+  void
+  KnuthBendix<Word, RewritingSystem, ReductionOrder>::throw_if_extra_letter(
+      Iterator1 first,
+      Iterator2 last) const {
     if (_extra_letter_added) {
       // It is necessary to represent the "extra" letter in the alphabet here
       // because o/w the output of (for example) active_rules inexplicably
@@ -193,6 +206,8 @@ namespace libsemigroups {
     }
     // Call detail::CongruenceCommon version so that we perform bound checks
     // in KnuthBendix and not KnuthBendixImpl
+    throw_if_extra_letter(first1, last1);
+    throw_if_extra_letter(first2, last2);
     return detail::CongruenceCommon::add_generating_pair<KnuthBendix>(
         first1, last1, first2, last2);
   }
@@ -216,6 +231,8 @@ namespace libsemigroups {
     }
     // Call CongruenceCommon version so that we perform bound checks in
     // KnuthBendix and not KnuthBendixImpl_
+    throw_if_extra_letter(first1, last1);
+    throw_if_extra_letter(first2, last2);
     return detail::CongruenceCommon::contains<KnuthBendix>(
         first1, last1, first2, last2);
   }

--- a/include/libsemigroups/knuth-bendix-class.tpp
+++ b/include/libsemigroups/knuth-bendix-class.tpp
@@ -21,7 +21,11 @@ namespace libsemigroups {
             typename RewritingSystem,
             template <typename, bool>
             typename ReductionOrder>
-  KnuthBendix<Word, RewritingSystem, ReductionOrder>::KnuthBendix() = default;
+  KnuthBendix<Word, RewritingSystem, ReductionOrder>::KnuthBendix()
+      : KnuthBendixImpl_(),
+        _extra_letter_added(false),
+        _generating_pairs(),
+        _presentation() {}
 
   template <typename Word,
             typename RewritingSystem,
@@ -37,11 +41,11 @@ namespace libsemigroups {
             typename ReductionOrder>
   KnuthBendix<Word, RewritingSystem, ReductionOrder>::KnuthBendix(KnuthBendix&&)
       = default;
+
   template <typename Word,
             typename RewritingSystem,
             template <typename, bool>
             typename ReductionOrder>
-
   KnuthBendix<Word, RewritingSystem, ReductionOrder>&
   KnuthBendix<Word, RewritingSystem, ReductionOrder>::operator=(
       KnuthBendix const&)
@@ -129,7 +133,9 @@ namespace libsemigroups {
       // because o/w the output of (for example) active_rules inexplicably
       // includes an extra letter.
       auto const& alpha = presentation().alphabet();
-      auto        it    = std::find_if(first, last, [&alpha](auto val) {
+      LIBSEMIGROUPS_ASSERT(!alpha.empty());  // If alpha.empty(), then
+                                             // alpha.back() etc below BOOM!
+      auto it = std::find_if(first, last, [&alpha](auto val) {
         return static_cast<typename native_word_type::value_type>(val)
                == alpha.back();
       });

--- a/include/libsemigroups/presentation.hpp
+++ b/include/libsemigroups/presentation.hpp
@@ -498,8 +498,10 @@ namespace libsemigroups {
                            Iterator1 lhs_end,
                            Iterator2 rhs_begin,
                            Iterator2 rhs_end) {
-      throw_if_letter_not_in_alphabet(lhs_begin, lhs_end);
-      throw_if_letter_not_in_alphabet(rhs_begin, rhs_end);
+      throw_if_empty_word_not_allowed(lhs_begin, lhs_end);
+      _alphabet.throw_if_letter_not_in_alphabet(lhs_begin, lhs_end);
+      throw_if_empty_word_not_allowed(rhs_begin, rhs_end);
+      _alphabet.throw_if_letter_not_in_alphabet(rhs_begin, rhs_end);
       return add_rule_no_checks(lhs_begin, lhs_end, rhs_begin, rhs_end);
     }
 
@@ -649,9 +651,10 @@ namespace libsemigroups {
     //!
     //! \complexity
     //! Linear in the length of the alphabet.
-    // TODO(v4) remove in favour of a direct call to Alphabet mem fn given
-    // below
-    void throw_if_alphabet_has_duplicates() const {
+    //!
+    //! \deprecated_warning{function} Use
+    //! `alphabet_v4().throw_if_duplicate_letters()` instead.
+    [[deprecated]] void throw_if_alphabet_has_duplicates() const {
       _alphabet.throw_if_duplicate_letters();
     }
 
@@ -666,17 +669,37 @@ namespace libsemigroups {
     //! \complexity
     //! Constant on average, worst case linear in the size of the alphabet.
     //!
-    // TODO(v4) remove in favour of direct call to Alphabet mem fn of the same
-    // name
-    void throw_if_letter_not_in_alphabet(native_letter_type c) const {
+    //! \deprecated_warning{function} Use
+    //! `alphabet_v4().throw_if_letter_not_in_alphabet(c)` instead.
+    [[deprecated]] void
+    throw_if_letter_not_in_alphabet(native_letter_type c) const {
       _alphabet.throw_if_letter_not_in_alphabet(c);
     }
+
+    //! \brief Check if a range is an allowed empty word.
+    //!
+    //! Check if the range [\p first, \p last) is empty when
+    //! \ref contains_empty_word returns \c false.
+    //!
+    //! \tparam Iterator1 the type of the first argument (an iterator).
+    //! \tparam Iterator2 the type of the second argument (an iterator).
+    //! \param first iterator pointing at the first letter to check.
+    //! \param last iterator pointing one beyond the last letter to check.
+    //!
+    //! \throws LibsemigroupsException if \p first equals \p last and
+    //! \ref contains_empty_word returns \c false.
+    //!
+    //! \complexity
+    //! Constant.
+    template <typename Iterator1, typename Iterator2>
+    void throw_if_empty_word_not_allowed(Iterator1 first, Iterator2 last) const;
 
     //! \brief Check if every letter in a range belongs to the alphabet.
     //!
     //! Check if every letter in a range belongs to the alphabet.
     //!
-    //! \tparam Iterator the type of the arguments (iterators).
+    //! \tparam Iterator1 the type of the first argument (an iterator).
+    //! \tparam Iterator2 the type of the second argument (an iterator).
     //! \param first iterator pointing at the first letter to check.
     //! \param last iterator pointing one beyond the last letter to check.
     //!
@@ -686,10 +709,13 @@ namespace libsemigroups {
     //! \complexity
     //! Worst case \f$O(mn)\f$ where \f$m\f$ is the length of the longest
     //! word, and \f$n\f$ is the size of the alphabet.
-    // TODO(v4) remove in favour of direct call to Alphabet mem fn of the same
-    // name
+    //!
+    //! \deprecated_warning{function} Use
+    //! \ref throw_if_empty_word_not_allowed and
+    //! `alphabet_v4().throw_if_letter_not_in_alphabet(first, last)` instead.
     template <typename Iterator1, typename Iterator2>
-    void throw_if_letter_not_in_alphabet(Iterator1 first, Iterator2 last) const;
+    [[deprecated]] void throw_if_letter_not_in_alphabet(Iterator1 first,
+                                                        Iterator2 last) const;
 
     //! \brief Check if every word in every rule consists only of letters
     //! belonging to the alphabet.
@@ -713,15 +739,16 @@ namespace libsemigroups {
     //!
     //! Check if the alphabet and rules are valid.
     //!
-    //! \throws LibsemigroupsException if \ref throw_if_alphabet_has_duplicates
-    //! or \ref throw_if_bad_rules does.
+    //! \throws LibsemigroupsException if
+    //! `alphabet_v4().throw_if_duplicate_letters()` or \ref throw_if_bad_rules
+    //! throws.
     //!
     //! \complexity
     //! Worst case \f$O(mnp)\f$ where \f$m\f$ is the length of length of the
     //! word, \f$n\f$ is the size of the alphabet and \f$p\f$ is the number of
     //! rules.
     void throw_if_bad_alphabet_or_rules() const {
-      throw_if_alphabet_has_duplicates();
+      _alphabet.throw_if_duplicate_letters();
       throw_if_bad_rules();
     }
   };  // class Presentation
@@ -837,7 +864,9 @@ namespace libsemigroups {
                             Iterator                  last) {
       // TODO(0) check if there are an odd number of rules
       for (auto it = first; it != last; ++it) {
-        p.throw_if_letter_not_in_alphabet(it->cbegin(), it->cend());
+        p.throw_if_empty_word_not_allowed(it->cbegin(), it->cend());
+        p.alphabet_v4().throw_if_letter_not_in_alphabet(it->cbegin(),
+                                                        it->cend());
       }
     }
 
@@ -872,14 +901,15 @@ namespace libsemigroups {
     //! \p alphabet.
     //!
     //! \complexity
-    //! Worst case \f$O(mn)\f$ where \f$m\f$ is the length of \p word and
-    //! \f$n\f$ is the length of \p alphabet.
-    // TODO(1): This is very similar to the checks done in
-    // throw_if_letter_not_in_alphabet, except there is no alphabet_map here. It
-    // would be good if there was not duplication
+    //! On average \f$O(m + n)\f$, worst case \f$O(n^2 + mn)\f$, where \f$m\f$
+    //! is the length of \p word and \f$n\f$ is the length of \p alphabet.
+    //!
+    //! \deprecated_warning{function} Construct an \ref Alphabet from
+    //! \p alphabet and use `Alphabet::throw_if_letter_not_in_alphabet`
+    //! instead.
     template <typename Word>
-    void throw_if_word_not_over_alphabet(Word const& alphabet,
-                                         Word const& word);
+    [[deprecated]] void throw_if_word_not_over_alphabet(Word const& alphabet,
+                                                        Word const& word);
 
     //! \brief Throws an exception if \p inverses fails the inverse consistency
     //! checks for \p alphabet.
@@ -937,7 +967,8 @@ namespace libsemigroups {
     template <typename Word>
     void throw_if_bad_inverses(Presentation<Word> const& p,
                                Word const&               inverses) {
-      p.throw_if_letter_not_in_alphabet(inverses.begin(), inverses.end());
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(inverses.begin(),
+                                                      inverses.end());
       throw_if_bad_inverses(p.alphabet(), inverses);
     }
 
@@ -2394,8 +2425,10 @@ namespace libsemigroups {
     //! `p.alphabet()`.
     template <typename Word>
     void add_idempotent_rules(Presentation<Word>& p, Word const& letters) {
-      p.throw_if_letter_not_in_alphabet(std::cbegin(letters),
+      p.throw_if_empty_word_not_allowed(std::cbegin(letters),
                                         std::cend(letters));
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::cbegin(letters),
+                                                      std::cend(letters));
       add_idempotent_rules_no_checks(p, letters);
     }
 
@@ -2508,8 +2541,10 @@ namespace libsemigroups {
     //! `p.alphabet()`.
     template <typename Word>
     void add_commutes_rules(Presentation<Word>& p, Word const& letters) {
-      p.throw_if_letter_not_in_alphabet(std::cbegin(letters),
+      p.throw_if_empty_word_not_allowed(std::cbegin(letters),
                                         std::cend(letters));
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::cbegin(letters),
+                                                      std::cend(letters));
       add_commutes_rules_no_checks(p, letters);
     }
 
@@ -3276,8 +3311,8 @@ namespace libsemigroups {
     //!
     //! \param p the presentation.
     //!
-    //! \throws LibsemigroupsException if `p.throw_if_alphabet_has_duplicates()`
-    //! throws.
+    //! \throws LibsemigroupsException if
+    //! `p.alphabet_v4().throw_if_duplicate_letters()` throws.
     //! \throws LibsemigroupsException if any of the letters in the alphabet of
     //! \p p are not lowercase.
     //!
@@ -3709,10 +3744,10 @@ namespace libsemigroups {
     //! duplicate letters.
     //!
     //! \sa
-    //! * \ref Presentation<Word>::throw_if_alphabet_has_duplicates
+    //! * \ref Alphabet::throw_if_duplicate_letters
     //! * \ref presentation::throw_if_bad_inverses
     InversePresentation& inverses(word_type const& w) {
-      Presentation<Word>::throw_if_alphabet_has_duplicates();
+      this->alphabet_v4().throw_if_duplicate_letters();
       presentation::throw_if_bad_inverses(*this, w);
       return inverses_no_checks(w);
     }

--- a/include/libsemigroups/presentation.tpp
+++ b/include/libsemigroups/presentation.tpp
@@ -88,13 +88,21 @@ namespace libsemigroups {
   template <typename Word>
   template <typename Iterator1, typename Iterator2>
   void
-  Presentation<Word>::throw_if_letter_not_in_alphabet(Iterator1 first,
+  Presentation<Word>::throw_if_empty_word_not_allowed(Iterator1 first,
                                                       Iterator2 last) const {
     if (first == last && !contains_empty_word()) {
       LIBSEMIGROUPS_EXCEPTION(
           "the presentation does not contain the empty word, did you mean to "
           "call contains_empty_word(true) first?");
     }
+  }
+
+  template <typename Word>
+  template <typename Iterator1, typename Iterator2>
+  void
+  Presentation<Word>::throw_if_letter_not_in_alphabet(Iterator1 first,
+                                                      Iterator2 last) const {
+    throw_if_empty_word_not_allowed(first, last);
     _alphabet.throw_if_letter_not_in_alphabet(first, last);
   }
 
@@ -157,23 +165,8 @@ namespace libsemigroups {
     template <typename Word>
     void throw_if_word_not_over_alphabet(Word const& alphabet,
                                          Word const& word) {
-      for (auto const& letter : word) {
-        if (auto it
-            = std::find(std::cbegin(alphabet), std::end(alphabet), letter);
-            it == std::cend(alphabet)) {
-          auto msg = fmt::format("invalid letter {}, valid letters are {}",
-                                 detail::to_printable(letter),
-                                 detail::to_printable(alphabet));
-          if constexpr (std::is_same_v<typename Word::value_type, char>) {
-            if (!std::isprint(letter) && detail::isprint(alphabet)) {
-              msg += fmt::format(
-                  " == {}",
-                  std::vector<int>(std::cbegin(alphabet), std::cend(alphabet)));
-            }
-          }
-          LIBSEMIGROUPS_EXCEPTION(msg);
-        }
-      }
+      Alphabet<Word>(alphabet).throw_if_letter_not_in_alphabet(word.cbegin(),
+                                                               word.cend());
     }
 
     template <typename Word>
@@ -214,7 +207,9 @@ namespace libsemigroups {
       } else {
         // Must check that letters is valid because it obviously is when we
         // create q.
-        p.throw_if_letter_not_in_alphabet(letters.begin(), letters.end());
+        p.throw_if_empty_word_not_allowed(letters.begin(), letters.end());
+        p.alphabet_v4().throw_if_letter_not_in_alphabet(letters.begin(),
+                                                        letters.end());
         Presentation<Word> q;
         q.alphabet(letters);
         throw_if_bad_inverses(q, inverses);
@@ -250,7 +245,7 @@ namespace libsemigroups {
     void
     add_identity_rules(Presentation<Word>&                             p,
                        typename Presentation<Word>::native_letter_type id) {
-      p.throw_if_letter_not_in_alphabet(id);
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(id);
       for (auto it = p.alphabet().cbegin(); it != p.alphabet().cend(); ++it) {
         Word       lhs = {*it, id};
         Word const rhs = {*it};
@@ -265,7 +260,7 @@ namespace libsemigroups {
     template <typename Word>
     void add_zero_rules(Presentation<Word>&                             p,
                         typename Presentation<Word>::native_letter_type z) {
-      p.throw_if_letter_not_in_alphabet(z);
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(z);
       for (auto it = p.alphabet().cbegin(); it != p.alphabet().cend(); ++it) {
         Word       lhs = {*it, z};
         Word const rhs = {z};
@@ -868,10 +863,14 @@ namespace libsemigroups {
     void add_commutes_rules(Presentation<Word>& p,
                             Word const&         letters1,
                             Word const&         letters2) {
-      p.throw_if_letter_not_in_alphabet(std::cbegin(letters1),
+      p.throw_if_empty_word_not_allowed(std::cbegin(letters1),
                                         std::cend(letters1));
-      p.throw_if_letter_not_in_alphabet(std::cbegin(letters2),
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::cbegin(letters1),
+                                                      std::cend(letters1));
+      p.throw_if_empty_word_not_allowed(std::cbegin(letters2),
                                         std::cend(letters2));
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::cbegin(letters2),
+                                                      std::cend(letters2));
       add_commutes_rules_no_checks(p, letters1, letters2);
     }
 
@@ -897,10 +896,14 @@ namespace libsemigroups {
     void add_commutes_rules(Presentation<Word>&      p,
                             Word const&              letters,
                             std::vector<Word> const& words) {
-      p.throw_if_letter_not_in_alphabet(std::cbegin(letters),
+      p.throw_if_empty_word_not_allowed(std::cbegin(letters),
                                         std::cend(letters));
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::cbegin(letters),
+                                                      std::cend(letters));
       for (Word const& word : words) {
-        p.throw_if_letter_not_in_alphabet(std::cbegin(word), std::cend(word));
+        p.throw_if_empty_word_not_allowed(std::cbegin(word), std::cend(word));
+        p.alphabet_v4().throw_if_letter_not_in_alphabet(std::cbegin(word),
+                                                        std::cend(word));
       }
       add_commutes_rules_no_checks(p, letters, words);
     }
@@ -935,8 +938,9 @@ namespace libsemigroups {
       detail::throw_if_duplicates(
           alphabet.begin(), alphabet.end(), "letter in alphabet");
       throw_if_bad_inverses(alphabet, inverses);
-      throw_if_word_not_over_alphabet(alphabet, x);
-      throw_if_word_not_over_alphabet(alphabet, y);
+      Alphabet<Word> lphbt(alphabet);
+      lphbt.throw_if_letter_not_in_alphabet(x.cbegin(), x.cend());
+      lphbt.throw_if_letter_not_in_alphabet(y.cbegin(), y.cend());
 
       return commutator_no_checks(x, y, alphabet, inverses);
     }
@@ -947,20 +951,29 @@ namespace libsemigroups {
                     Word const&               y,
                     Word const&               inverses) {
       throw_if_bad_inverses(p, inverses);
-      p.throw_if_letter_not_in_alphabet(std::cbegin(x), std::cend(x));
-      p.throw_if_letter_not_in_alphabet(std::cbegin(y), std::cend(y));
+      p.throw_if_empty_word_not_allowed(std::cbegin(x), std::cend(x));
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::cbegin(x),
+                                                      std::cend(x));
+      p.throw_if_empty_word_not_allowed(std::cbegin(y), std::cend(y));
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::cbegin(y),
+                                                      std::cend(y));
 
       return commutator_no_checks(p, x, y, inverses);
     }
 
     template <typename Word>
     Word commutator(Presentation<Word> const& p, Word const& x, Word const& y) {
-      p.throw_if_letter_not_in_alphabet(std::cbegin(x), std::cend(x));
-      p.throw_if_letter_not_in_alphabet(std::cbegin(y), std::cend(y));
+      p.throw_if_empty_word_not_allowed(std::cbegin(x), std::cend(x));
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::cbegin(x),
+                                                      std::cend(x));
+      p.throw_if_empty_word_not_allowed(std::cbegin(y), std::cend(y));
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::cbegin(y),
+                                                      std::cend(y));
 
       auto [alphabet, inverses] = try_detect_group_inverses(p);
-      throw_if_word_not_over_alphabet(alphabet, x);
-      throw_if_word_not_over_alphabet(alphabet, y);
+      Alphabet<Word> lphbt(alphabet);
+      lphbt.throw_if_letter_not_in_alphabet(x.cbegin(), x.cend());
+      lphbt.throw_if_letter_not_in_alphabet(y.cbegin(), y.cend());
       return commutator_no_checks(x, y, alphabet, inverses);
     }
 
@@ -972,17 +985,22 @@ namespace libsemigroups {
                         Word const&         alphabet,
                         Word const&         inverses,
                         typename Presentation<Word>::native_letter_type id) {
-      p.throw_if_letter_not_in_alphabet(std::begin(alphabet),
+      p.throw_if_empty_word_not_allowed(std::begin(alphabet),
                                         std::end(alphabet));
-      p.throw_if_letter_not_in_alphabet(std::begin(inverses),
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::begin(alphabet),
+                                                      std::end(alphabet));
+      p.throw_if_empty_word_not_allowed(std::begin(inverses),
                                         std::end(inverses));
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::begin(inverses),
+                                                      std::end(inverses));
       detail::throw_if_duplicates(
           alphabet.begin(), alphabet.end(), "letter in alphabet");
       throw_if_bad_inverses(alphabet, inverses);
-      throw_if_word_not_over_alphabet(alphabet, x);
-      throw_if_word_not_over_alphabet(alphabet, y);
+      Alphabet<Word> lphbt(alphabet);
+      lphbt.throw_if_letter_not_in_alphabet(x.cbegin(), x.cend());
+      lphbt.throw_if_letter_not_in_alphabet(y.cbegin(), y.cend());
       if (id != UNDEFINED) {
-        p.throw_if_letter_not_in_alphabet(id);
+        p.alphabet_v4().throw_if_letter_not_in_alphabet(id);
       }
 
       add_commutator_rule_no_checks(p, x, y, alphabet, inverses, id);
@@ -995,13 +1013,19 @@ namespace libsemigroups {
                         Word const&         y,
                         Word const&         inverses,
                         typename Presentation<Word>::native_letter_type id) {
-      p.throw_if_letter_not_in_alphabet(std::begin(inverses),
+      p.throw_if_empty_word_not_allowed(std::begin(inverses),
                                         std::end(inverses));
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::begin(inverses),
+                                                      std::end(inverses));
       throw_if_bad_inverses(p, inverses);
-      p.throw_if_letter_not_in_alphabet(std::begin(x), std::end(x));
-      p.throw_if_letter_not_in_alphabet(std::begin(y), std::end(y));
+      p.throw_if_empty_word_not_allowed(std::begin(x), std::end(x));
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::begin(x),
+                                                      std::end(x));
+      p.throw_if_empty_word_not_allowed(std::begin(y), std::end(y));
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::begin(y),
+                                                      std::end(y));
       if (id != UNDEFINED) {
-        p.throw_if_letter_not_in_alphabet(id);
+        p.alphabet_v4().throw_if_letter_not_in_alphabet(id);
       }
 
       add_commutator_rule_no_checks(p, x, y, inverses, id);
@@ -1013,15 +1037,20 @@ namespace libsemigroups {
                         Word const&                                     x,
                         Word const&                                     y,
                         typename Presentation<Word>::native_letter_type id) {
-      p.throw_if_letter_not_in_alphabet(std::begin(x), std::end(x));
-      p.throw_if_letter_not_in_alphabet(std::begin(y), std::end(y));
+      p.throw_if_empty_word_not_allowed(std::begin(x), std::end(x));
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::begin(x),
+                                                      std::end(x));
+      p.throw_if_empty_word_not_allowed(std::begin(y), std::end(y));
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::begin(y),
+                                                      std::end(y));
       if (id != UNDEFINED) {
-        p.throw_if_letter_not_in_alphabet(id);
+        p.alphabet_v4().throw_if_letter_not_in_alphabet(id);
       }
 
       auto [alphabet, inverses] = try_detect_group_inverses(p);
-      throw_if_word_not_over_alphabet(alphabet, x);
-      throw_if_word_not_over_alphabet(alphabet, y);
+      Alphabet<Word> lphbt(alphabet);
+      lphbt.throw_if_letter_not_in_alphabet(x.cbegin(), x.cend());
+      lphbt.throw_if_letter_not_in_alphabet(y.cbegin(), y.cend());
 
       add_commutator_rule_no_checks(p, x, y, alphabet, inverses, id);
     }
@@ -1146,7 +1175,9 @@ namespace libsemigroups {
 
     template <typename Word>
     void add_involution_rules(Presentation<Word>& p, Word const& letters) {
-      p.throw_if_letter_not_in_alphabet(std::begin(letters), std::end(letters));
+      p.throw_if_empty_word_not_allowed(std::begin(letters), std::end(letters));
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(std::begin(letters),
+                                                      std::end(letters));
       if (!p.contains_empty_word()) {
         LIBSEMIGROUPS_EXCEPTION("this function requires the presentation to "
                                 "contain the empty word, did you mean to "
@@ -1167,7 +1198,9 @@ namespace libsemigroups {
 
     template <typename Word>
     void add_cyclic_conjugates(Presentation<Word>& p, Word const& relator) {
-      p.throw_if_letter_not_in_alphabet(relator.begin(), relator.end());
+      // TODO should relator be non-empty too?
+      p.alphabet_v4().throw_if_letter_not_in_alphabet(relator.begin(),
+                                                      relator.end());
       if (!p.contains_empty_word()) {
         LIBSEMIGROUPS_EXCEPTION("this function requires the presentation to "
                                 "contain the empty word, did you mean to "
@@ -1349,8 +1382,10 @@ namespace libsemigroups {
         //
         // We could "throw_if_bad_inverses" here instead, but there's no need
         // because nothing actually goes wrong below if there are no inverses.
-        ip.throw_if_letter_not_in_alphabet(ip.inverses().begin(),
+        ip.throw_if_empty_word_not_allowed(ip.inverses().begin(),
                                            ip.inverses().end());
+        ip.alphabet_v4().throw_if_letter_not_in_alphabet(ip.inverses().begin(),
+                                                         ip.inverses().end());
       }
       InversePresentation<WordOutput> result(
           std::move(v4::to<Presentation<WordOutput>>(ip, f)));

--- a/include/libsemigroups/sims.hpp
+++ b/include/libsemigroups/sims.hpp
@@ -879,11 +879,16 @@ namespace libsemigroups {
     //!
     //! \throw LibsemigroupsException if any letter in the range from \p first
     //! to \p last is out of bounds.
-    // TODO(1) rm
+    //!
+    //! \deprecated_warning{function} Use
+    //! `presentation().throw_if_empty_word_not_allowed(first, last)` and
+    //! `presentation().alphabet_v4().throw_if_letter_not_in_alphabet(first,
+    //! last)` instead.
     template <typename Iterator1, typename Iterator2>
-    void throw_if_letter_not_in_alphabet(Iterator1 first,
-                                         Iterator2 last) const {
-      presentation().throw_if_letter_not_in_alphabet(first, last);
+    [[deprecated]] void throw_if_letter_not_in_alphabet(Iterator1 first,
+                                                        Iterator2 last) const {
+      presentation().throw_if_empty_word_not_allowed(first, last);
+      presentation().alphabet_v4().throw_if_letter_not_in_alphabet(first, last);
     }
 
    protected:
@@ -917,8 +922,12 @@ namespace libsemigroups {
                               Iterator3               first2,
                               Iterator4               last2,
                               std::vector<word_type>& include_or_exclude) {
-      throw_if_letter_not_in_alphabet(first1, last1);
-      throw_if_letter_not_in_alphabet(first2, last2);
+      presentation().throw_if_empty_word_not_allowed(first1, last1);
+      presentation().alphabet_v4().throw_if_letter_not_in_alphabet(first1,
+                                                                   last1);
+      presentation().throw_if_empty_word_not_allowed(first2, last2);
+      presentation().alphabet_v4().throw_if_letter_not_in_alphabet(first2,
+                                                                   last2);
       return static_cast<Subclass&>(*this).include_exclude_no_checks(
           first1, last1, first2, last2, include_or_exclude);
     }

--- a/include/libsemigroups/stephen.hpp
+++ b/include/libsemigroups/stephen.hpp
@@ -403,7 +403,8 @@ namespace libsemigroups {
     //! \sa stephen::set_word
     template <typename Iterator1, typename Iterator2>
     Stephen& set_word(Iterator1 first, Iterator2 last) {
-      presentation().throw_if_letter_not_in_alphabet(first, last);
+      presentation().throw_if_empty_word_not_allowed(first, last);
+      presentation().alphabet_v4().throw_if_letter_not_in_alphabet(first, last);
       return set_word_no_checks(first, last);
     }
 

--- a/include/libsemigroups/stephen.tpp
+++ b/include/libsemigroups/stephen.tpp
@@ -107,11 +107,8 @@ namespace libsemigroups {
     template <typename PresentationType>
     bool accepts(Stephen<PresentationType>&                         s,
                  typename PresentationType::native_word_type const& w) {
-      if (!w.empty()) {
-        // Here we always allow w to be empty, but the following line throws if
-        // s.presentation() does not contain the empty word and w is empty.
-        s.presentation().throw_if_letter_not_in_alphabet(w.begin(), w.end());
-      }
+      s.presentation().alphabet_v4().throw_if_letter_not_in_alphabet(w.begin(),
+                                                                     w.end());
       return accepts_no_checks(s, w);
     }
 
@@ -127,11 +124,8 @@ namespace libsemigroups {
     template <typename PresentationType>
     bool is_left_factor(Stephen<PresentationType>&                         s,
                         typename PresentationType::native_word_type const& w) {
-      if (!w.empty()) {
-        // Here we always allow w to be empty, but the following line throws if
-        // s.presentation() does not contain the empty word and w is empty.
-        s.presentation().throw_if_letter_not_in_alphabet(w.begin(), w.end());
-      }
+      s.presentation().alphabet_v4().throw_if_letter_not_in_alphabet(w.begin(),
+                                                                     w.end());
       return is_left_factor_no_checks(s, w);
     }
 

--- a/include/libsemigroups/todd-coxeter-class.hpp
+++ b/include/libsemigroups/todd-coxeter-class.hpp
@@ -611,10 +611,16 @@ namespace libsemigroups {
     //!
     //! \throw LibsemigroupsException if any letter in the range from
     //! \p first to \p last is out of bounds.
+    //!
+    //! \deprecated_warning{function} Use
+    //! `presentation().throw_if_empty_word_not_allowed(first, last)` and
+    //! `presentation().alphabet_v4().throw_if_letter_not_in_alphabet(first,
+    //! last)` instead.
     template <typename Iterator1, typename Iterator2>
-    void throw_if_letter_not_in_alphabet(Iterator1 first,
-                                         Iterator2 last) const {
-      presentation().throw_if_letter_not_in_alphabet(first, last);
+    [[deprecated]] void throw_if_letter_not_in_alphabet(Iterator1 first,
+                                                        Iterator2 last) const {
+      presentation().throw_if_empty_word_not_allowed(first, last);
+      presentation().alphabet_v4().throw_if_letter_not_in_alphabet(first, last);
     }
 
     //! \ingroup todd_coxeter_class_intf_group
@@ -1057,7 +1063,8 @@ namespace libsemigroups {
     //! \cong_common_throws_if_letters_out_of_bounds
     template <typename Iterator1, typename Iterator2>
     index_type current_index_of(Iterator1 first, Iterator2 last) const {
-      throw_if_letter_not_in_alphabet(first, last);
+      presentation().throw_if_empty_word_not_allowed(first, last);
+      presentation().alphabet_v4().throw_if_letter_not_in_alphabet(first, last);
       return current_index_of_no_checks(first, last);
     }
 
@@ -1117,7 +1124,8 @@ namespace libsemigroups {
     //! \cong_common_throws_if_letters_out_of_bounds
     template <typename Iterator1, typename Iterator2>
     index_type index_of(Iterator1 first, Iterator2 last) {
-      throw_if_letter_not_in_alphabet(first, last);
+      presentation().throw_if_empty_word_not_allowed(first, last);
+      presentation().alphabet_v4().throw_if_letter_not_in_alphabet(first, last);
       return index_of_no_checks(first, last);
     }
 

--- a/src/detail/todd-coxeter-impl-stats.cpp
+++ b/src/detail/todd-coxeter-impl-stats.cpp
@@ -37,6 +37,12 @@ namespace libsemigroups::detail {
     create_or_init_time = std::chrono::high_resolution_clock::now();
     run_index           = 0;
 
+    all_runs_time              = std::chrono::nanoseconds::zero();
+    all_hlt_phases_time        = std::chrono::nanoseconds::zero();
+    all_felsch_phases_time     = std::chrono::nanoseconds::zero();
+    all_lookahead_phases_time  = std::chrono::nanoseconds::zero();
+    all_lookbehind_phases_time = std::chrono::nanoseconds::zero();
+
     all_num_hlt_phases        = 0;
     all_num_felsch_phases     = 0;
     all_num_lookahead_phases  = 0;

--- a/src/presentation.cpp
+++ b/src/presentation.cpp
@@ -243,7 +243,7 @@ namespace libsemigroups {
     }
 
     std::string to_ace_string(Presentation<std::string> const& p) {
-      p.throw_if_alphabet_has_duplicates();
+      p.alphabet_v4().throw_if_duplicate_letters();
       if (std::any_of(
               p.alphabet().cbegin(),
               p.alphabet().cend(),

--- a/tests/test-alphabet.cpp
+++ b/tests/test-alphabet.cpp
@@ -16,9 +16,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include <cstdint>        // for uint8_t
 #include <string>         // for basic_string, operator==
+#include <type_traits>    // for is_unsigned_v
 #include <unordered_set>  // for unordered_set
 #include <utility>        // for move
+#include <vector>         // for vector
 
 #include "test-main.hpp"  // for LIBSEMIGROUPS_TEST_CASE
 
@@ -168,6 +171,12 @@ namespace libsemigroups {
 
   LIBSEMIGROUPS_TEST_CASE("Alphabet", "005", "letter validation", "[quick]") {
     auto                  rg = ReportGuard(false);
+    Alphabet<std::string> empty;
+    REQUIRE_EXCEPTION_MSG(
+        empty.throw_if_letter_not_in_alphabet(0),
+        "invalid letter (char with value) 0, there are no letters in the "
+        "alphabet");
+
     Alphabet<std::string> a("ab");
     REQUIRE_NOTHROW(a.throw_if_letter_not_in_alphabet('a'));
     REQUIRE_NOTHROW(a.throw_if_letter_not_in_alphabet('b'));
@@ -177,6 +186,29 @@ namespace libsemigroups {
     REQUIRE_EXCEPTION_MSG(a.throw_if_letter_not_in_alphabet(0),
                           "invalid letter (char with value) 0, valid letters "
                           "are \"ab\" == [97, 98]");
+    if constexpr (std::is_unsigned_v<char>) {
+      REQUIRE_EXCEPTION_MSG(a.throw_if_letter_not_in_alphabet(-109),
+                            "invalid letter (char with value) 147, valid "
+                            "letters are \"ab\" == [97, 98]");
+    } else {
+      REQUIRE_EXCEPTION_MSG(a.throw_if_letter_not_in_alphabet(-109),
+                            "invalid letter (char with value) -109, valid "
+                            "letters are \"ab\" == [97, 98]");
+    }
+
+    a.init(std::string({0, 1}));
+    REQUIRE_EXCEPTION_MSG(
+        a.throw_if_letter_not_in_alphabet('c'),
+        "invalid letter 'c', valid letters are (char values) [0, 1]");
+    if constexpr (std::is_unsigned_v<char>) {
+      REQUIRE_EXCEPTION_MSG(a.throw_if_letter_not_in_alphabet(-109),
+                            "invalid letter (char with value) 147, valid "
+                            "letters are (char values) [0, 1]");
+    } else {
+      REQUIRE_EXCEPTION_MSG(a.throw_if_letter_not_in_alphabet(-109),
+                            "invalid letter (char with value) -109, valid "
+                            "letters are (char values) [0, 1]");
+    }
 
     Alphabet b(word_type({0, 1}));
     REQUIRE_NOTHROW(b.throw_if_letter_not_in_alphabet(0));
@@ -186,6 +218,12 @@ namespace libsemigroups {
 
     word_type w = {0, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1};
     REQUIRE_NOTHROW(b.throw_if_letter_not_in_alphabet(w.begin(), w.end()));
+
+    Alphabet<std::vector<uint8_t>> c(2);
+    REQUIRE_EXCEPTION_MSG(c.throw_if_letter_not_in_alphabet(99),
+                          "invalid letter 99, valid letters are [0, 1]");
+    REQUIRE_EXCEPTION_MSG(c.throw_if_letter_not_in_alphabet(109),
+                          "invalid letter 109, valid letters are [0, 1]");
   }
 
   LIBSEMIGROUPS_TEST_CASE("Alphabet",

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -220,8 +220,15 @@ namespace libsemigroups {
     auto rg = ReportGuard(false);
     using W = TestType;
     Presentation<W> p;
+    W               empty;
+    REQUIRE_EXCEPTION_MSG(
+        p.throw_if_empty_word_not_allowed(empty.cbegin(), empty.cend()),
+        "the presentation does not contain the empty word, did you mean to "
+        "call contains_empty_word(true) first?");
     REQUIRE(!p.contains_empty_word());
     p.contains_empty_word(true);
+    REQUIRE_NOTHROW(
+        p.throw_if_empty_word_not_allowed(empty.cbegin(), empty.cend()));
     REQUIRE(p.contains_empty_word());
     p.contains_empty_word(false);
     REQUIRE(!p.contains_empty_word());
@@ -2627,31 +2634,7 @@ namespace libsemigroups {
 
     {
       Presentation<std::string> p;
-      p.alphabet("ab"s);
-      REQUIRE_EXCEPTION_MSG(p.throw_if_letter_not_in_alphabet('c'),
-                            "invalid letter \'c\', valid letters are \"ab\"");
-      if constexpr (std::is_unsigned_v<char>) {
-        REQUIRE_EXCEPTION_MSG(p.throw_if_letter_not_in_alphabet(-109),
-                              "invalid letter (char with value) 147, valid "
-                              "letters are \"ab\" == [97, 98]");
-      } else {
-        REQUIRE_EXCEPTION_MSG(p.throw_if_letter_not_in_alphabet(-109),
-                              "invalid letter (char with value) -109, valid "
-                              "letters are \"ab\" == [97, 98]");
-      }
       p.alphabet(std::string({0, 1}));
-      REQUIRE_EXCEPTION_MSG(
-          p.throw_if_letter_not_in_alphabet('c'),
-          "invalid letter 'c', valid letters are (char values) [0, 1]");
-      if constexpr (std::is_unsigned_v<char>) {
-        REQUIRE_EXCEPTION_MSG(p.throw_if_letter_not_in_alphabet(-109),
-                              "invalid letter (char with value) 147, valid "
-                              "letters are (char values) [0, 1]");
-      } else {
-        REQUIRE_EXCEPTION_MSG(p.throw_if_letter_not_in_alphabet(-109),
-                              "invalid letter (char with value) -109, valid "
-                              "letters are (char values) [0, 1]");
-      }
       REQUIRE_EXCEPTION_MSG(
           p.alphabet(257), "expected a value in the range [0, 257), found 257");
       REQUIRE_EXCEPTION_MSG(
@@ -2688,18 +2671,21 @@ namespace libsemigroups {
     // {
     //   Presentation<std::basic_string<uint8_t>>
     //   p; p.alphabet({97, 98});
-    //   REQUIRE_EXCEPTION_MSG(p.throw_if_letter_not_in_alphabet(99),
+    //   REQUIRE_EXCEPTION_MSG(
+    //       p.alphabet_v4().throw_if_letter_not_in_alphabet(99),
     //                         "invalid letter
     //                         99, valid
     //                         letters are [97,
     //                         98]");
-    //   REQUIRE_EXCEPTION_MSG(p.throw_if_letter_not_in_alphabet(147),
+    //   REQUIRE_EXCEPTION_MSG(
+    //       p.alphabet_v4().throw_if_letter_not_in_alphabet(147),
     //                         "invalid letter
     //                         147, valid
     //                         letters are [97,
     //                         98]");
     //   p.alphabet({0, 1});
-    //   REQUIRE_EXCEPTION_MSG(p.throw_if_letter_not_in_alphabet('c'),
+    //   REQUIRE_EXCEPTION_MSG(
+    //       p.alphabet_v4().throw_if_letter_not_in_alphabet('c'),
     //                         "invalid letter
     //                         99, valid
     //                         letters are [0,
@@ -2757,10 +2743,6 @@ namespace libsemigroups {
       Presentation<std::vector<uint8_t>> p;
       p.alphabet(2);
       p.contains_empty_word(true);
-      REQUIRE_EXCEPTION_MSG(p.throw_if_letter_not_in_alphabet(99),
-                            "invalid letter 99, valid letters are [0, 1]");
-      REQUIRE_EXCEPTION_MSG(p.throw_if_letter_not_in_alphabet(109),
-                            "invalid letter 109, valid letters are [0, 1]");
       REQUIRE_EXCEPTION_MSG(
           p.alphabet(257), "expected a value in the range [0, 257), found 257");
       REQUIRE(p.alphabet().size() == 2);
@@ -3702,10 +3684,12 @@ namespace libsemigroups {
     SECTION("alphabet specified, inverses specified ") {
       REQUIRE_EXCEPTION_MSG(
           presentation::commutator(W{0}, W{}, W{}, W{}),
-          "invalid letter (char with value) 0, valid letters are \"\" == []");
+          "invalid letter (char with value) 0, there are no letters in the "
+          "alphabet");
       REQUIRE_EXCEPTION_MSG(
           presentation::commutator(W{}, W{0}, W{}, W{}),
-          "invalid letter (char with value) 0, valid letters are \"\" == []");
+          "invalid letter (char with value) 0, there are no letters in the "
+          "alphabet");
       REQUIRE_EXCEPTION_MSG(
           presentation::commutator(W{}, W{}, W{0}, W{}),
           "invalid number of inverses, expected 1 but found 0");
@@ -3728,8 +3712,10 @@ namespace libsemigroups {
     SECTION("alphabet inferred, inverses specified") {
       Presentation<W> p;
       p.contains_empty_word(true);
-      REQUIRE_EXCEPTION_MSG(presentation::commutator(p, W{0}, W{}, W{}),
-                            "there are no letters in the alphabet");
+      REQUIRE_EXCEPTION_MSG(
+          presentation::commutator(p, W{0}, W{}, W{}),
+          "invalid letter (char with value) 0, there are no letters in the "
+          "alphabet");
 
       p.alphabet(W({0}));
       REQUIRE_EXCEPTION_MSG(presentation::commutator(p, W{1}, W{}, W{0}),
@@ -3763,8 +3749,10 @@ namespace libsemigroups {
     SECTION("alphabet inferred, inverses inferred") {
       Presentation<W> p;
       p.contains_empty_word(true);
-      REQUIRE_EXCEPTION_MSG(presentation::commutator(p, W{0}, W{}),
-                            "there are no letters in the alphabet");
+      REQUIRE_EXCEPTION_MSG(
+          presentation::commutator(p, W{0}, W{}),
+          "invalid letter (char with value) 0, there are no letters in the "
+          "alphabet");
 
       p.alphabet(W({0}));
       REQUIRE_EXCEPTION_MSG(presentation::commutator(p, W{1}, W{}),
@@ -3865,10 +3853,12 @@ namespace libsemigroups {
       // The words are not over the provided alphabet
       REQUIRE_EXCEPTION_MSG(
           presentation::add_commutator_rule(p, W{0}, W{}, W{}, W{}),
-          "invalid letter (char with value) 0, valid letters are \"\" == []");
+          "invalid letter (char with value) 0, there are no letters in the "
+          "alphabet");
       REQUIRE_EXCEPTION_MSG(
           presentation::add_commutator_rule(p, W{}, W{0}, W{}, W{}),
-          "invalid letter (char with value) 0, valid letters are \"\" == []");
+          "invalid letter (char with value) 0, there are no letters in the "
+          "alphabet");
 
       // The words are not over the presentation's alphabet
       REQUIRE_EXCEPTION_MSG(
@@ -3921,7 +3911,8 @@ namespace libsemigroups {
       p.contains_empty_word(true);
       REQUIRE_EXCEPTION_MSG(
           presentation::add_commutator_rule(p, W{0}, W{}, W{}),
-          "there are no letters in the alphabet");
+          "invalid letter (char with value) 0, there are no letters in the "
+          "alphabet");
       p.alphabet(W({0}));
       // The words are not over the presentation's alphabet
       REQUIRE_EXCEPTION_MSG(
@@ -3961,8 +3952,10 @@ namespace libsemigroups {
     }
     SECTION("alphabet inferred, inverses inferred") {
       p.contains_empty_word(true);
-      REQUIRE_EXCEPTION_MSG(presentation::add_commutator_rule(p, W{0}, W{}),
-                            "there are no letters in the alphabet");
+      REQUIRE_EXCEPTION_MSG(
+          presentation::add_commutator_rule(p, W{0}, W{}),
+          "invalid letter (char with value) 0, there are no letters in the "
+          "alphabet");
 
       p.alphabet(W({0}));
       // The words are not over the presentation's alphabet

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -5386,14 +5386,10 @@ namespace libsemigroups {
     // directly so that it is still possible to use ToddCoxeterImpl
     // directly if there are perf. issues with using ToddCoxeter.
     word_type word = 010100101_w;
-    REQUIRE(static_cast<detail::ToddCoxeterImpl&>(tc).contains(
+    REQUIRE(static_cast<detail::ToddCoxeterImpl&>(tc).contains_no_checks(
         word.begin(), word.end(), word.begin(), word.end()));
-    REQUIRE(!static_cast<detail::ToddCoxeterImpl&>(tc).contains(
+    REQUIRE(!static_cast<detail::ToddCoxeterImpl&>(tc).contains_no_checks(
         word.begin(), word.end(), word.begin(), word.begin() + 1));
-    word = 010100201_w;
-    REQUIRE_THROWS_AS(static_cast<detail::ToddCoxeterImpl&>(tc).contains(
-                          word.begin(), word.end(), word.begin(), word.end()),
-                      LibsemigroupsException);
   }
 
   LIBSEMIGROUPS_TEST_CASE("ToddCoxeter",

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -5514,6 +5514,7 @@ namespace libsemigroups {
                           "135",
                           "From FroidurePin",
                           "[todd-coxeter][quick]") {
+    auto rg               = ReportGuard(false);
     using Transf          = LeastTransf<5>;
     FroidurePin<Transf> S = make<FroidurePin>(
         {make<Transf>({1, 3, 4, 2, 3}), make<Transf>({3, 2, 1, 3, 3})});
@@ -5525,6 +5526,9 @@ namespace libsemigroups {
         froidure_pin::factorisation(S, make<Transf>({3, 1, 3, 3, 3})));
     WordRange words;
     words.alphabet_size(2).min(1).max(5);
+
+    auto w = 010001_w;
+    REQUIRE(tc.current_index_of(w.begin(), w.end()) == 49);
     tc.run();
     REQUIRE(v4::word_graph::number_of_nodes_reachable_from(
                 tc.current_word_graph(), 0)


### PR DESCRIPTION
Make Alphabet the canonical letter validator, separate Presentation's empty-word policy, and deprecate redundant compatibility validators while preserving Knuth-Bendix's extra-letter checks.

AI disclosure: Codex assisted with implementation, refactoring, documentation, and tests.