### PR TITLE
Correct validation boundaries and diagnostics

### DIFF
--- a/include/libsemigroups/action.tpp
+++ b/include/libsemigroups/action.tpp
@@ -392,7 +392,7 @@ namespace libsemigroups {
             side LeftOrRight>
   void Action<Element, Point, Func, Traits, LeftOrRight>::
       throw_if_index_out_of_range(index_type i) const {
-    if (i > _orb.size()) {
+    if (i >= _orb.size()) {
       LIBSEMIGROUPS_EXCEPTION(
           "index out of range, expected value in [0, {}) but found {}",
           current_size(),

--- a/include/libsemigroups/is-transf.hpp
+++ b/include/libsemigroups/is-transf.hpp
@@ -62,6 +62,7 @@ namespace libsemigroups {
     template <typename Iterator, typename Func>
     void throw_if_value_out_of_range(Iterator         first,
                                      Iterator         last,
+                                     size_t           upper_bound,
                                      Func&&           func,
                                      std::string_view where);
 

--- a/include/libsemigroups/is-transf.tpp
+++ b/include/libsemigroups/is-transf.tpp
@@ -53,17 +53,17 @@ namespace libsemigroups {
     template <typename Iterator, typename Func>
     void throw_if_value_out_of_range(Iterator         first,
                                      Iterator         last,
+                                     size_t           upper_bound,
                                      Func&&           func,
                                      std::string_view where) {
       static_assert(std::is_unsigned_v<
                     std::decay_t<decltype(*std::declval<Iterator>())>>);
-      auto const M  = std::distance(first, last);
       auto const it = std::find_if(first, last, std::forward<Func>(func));
       if (it != last) {
         LIBSEMIGROUPS_EXCEPTION("{} value out of bounds, expected value in "
                                 "[0, {}), found {} in position {}",
                                 where,
-                                M,
+                                upper_bound,
                                 *it,
                                 std::distance(first, it));
       }
@@ -77,6 +77,7 @@ namespace libsemigroups {
       throw_if_value_out_of_range(
           first,
           last,
+          deg,
           [&deg](auto val) { return val >= deg && val != UNDEFINED; },
           std::string_view("image"));
     }
@@ -111,13 +112,15 @@ namespace libsemigroups {
       throw_if_value_out_of_range(
           dom_first,
           dom_last,
+          deg,
           [&deg](auto val) { return val >= deg && val != UNDEFINED; },
           "domain");
       throw_if_value_out_of_range(
           img_first,
           img_last,
+          deg,
           [&deg](auto val) { return val >= deg && val != UNDEFINED; },
-          "domain");
+          "image");
 
       throw_if_duplicates(dom_first, dom_last, "domain value");
 
@@ -147,6 +150,7 @@ namespace libsemigroups {
       throw_if_value_out_of_range(
           first,
           last,
+          deg,
           [&deg](auto val) { return val >= deg; },
           std::string_view("image"));
     }

--- a/include/libsemigroups/max-plus-trunc-mat.tpp
+++ b/include/libsemigroups/max-plus-trunc-mat.tpp
@@ -125,8 +125,8 @@ namespace libsemigroups {
           LIBSEMIGROUPS_EXCEPTION("the matrix in position {} has threshold {} "
                                   "but should have threshold {}",
                                   std::distance(first, it),
-                                  t,
-                                  matrix::threshold(*it));
+                                  matrix::threshold(*it),
+                                  t);
         }
       }
     } else {

--- a/tests/test-action.cpp
+++ b/tests/test-action.cpp
@@ -558,6 +558,12 @@ namespace libsemigroups {
     REQUIRE(o[1] == 1);
     REQUIRE(o.at(0) == 0);
     REQUIRE(o.at(1) == 1);
+    REQUIRE_EXCEPTION_MSG(
+        static_cast<void>(o.multiplier_to_scc_root(o.current_size())),
+        "index out of range, expected value in [0, 8) but found 8");
+    REQUIRE_EXCEPTION_MSG(
+        static_cast<void>(o.multiplier_from_scc_root(o.current_size())),
+        "index out of range, expected value in [0, 8) but found 8");
     REQUIRE_THROWS_AS(o.multiplier_to_scc_root(10), LibsemigroupsException);
     REQUIRE_THROWS_AS(o.multiplier_from_scc_root(10), LibsemigroupsException);
     REQUIRE((o.range() | sort() | rx::to_vector())

--- a/tests/test-is-transf.cpp
+++ b/tests/test-is-transf.cpp
@@ -38,6 +38,10 @@ namespace libsemigroups {
     TestType vec = {0, 1, 12, 1, 13, 1, 3, 3, 13, 13, 1, 41, 4, 41, 14, 4};
     REQUIRE(vec.size() == 16);
     REQUIRE_NOTHROW(detail::throw_if_not_ptransf(vec.begin(), vec.end(), 42));
+    REQUIRE_EXCEPTION_MSG(
+        detail::throw_if_not_ptransf(vec.begin(), vec.end(), 40),
+        "image value out of bounds, expected value in "
+        "[0, 40), found 41 in position 11");
     REQUIRE_EXCEPTION_MSG(detail::throw_if_not_ptransf(vec.begin(), vec.end()),
                           "image value out of bounds, expected value in "
                           "[0, 16), found 41 in position 11");
@@ -60,6 +64,13 @@ namespace libsemigroups {
             vec.begin(), vec.begin() + 3, vec.begin() + 3, vec.begin() + 4, 16),
         "domain and image size mismatch, domain has "
         "size 3 but image has size 1");
+    REQUIRE_EXCEPTION_MSG(detail::throw_if_not_ptransf(vec.begin(),
+                                                       vec.begin() + 2,
+                                                       vec.begin() + 10,
+                                                       vec.begin() + 12,
+                                                       16),
+                          "image value out of bounds, expected value in "
+                          "[0, 16), found 41 in position 1");
     REQUIRE_EXCEPTION_MSG(
         detail::throw_if_not_ptransf(vec.begin() + 7,
                                      vec.begin() + 9,
@@ -91,6 +102,10 @@ namespace libsemigroups {
     TestType vec = {0, 1, 12, 1, 13, 1, 3, 3, 13, 13, 1, 41, 4, 41, 14, 4};
     REQUIRE(vec.size() == 16);
     REQUIRE_NOTHROW(detail::throw_if_not_transf(vec.begin(), vec.end(), 42));
+    REQUIRE_EXCEPTION_MSG(
+        detail::throw_if_not_transf(vec.begin(), vec.end(), 40),
+        "image value out of bounds, expected value in "
+        "[0, 40), found 41 in position 11");
     REQUIRE_EXCEPTION_MSG(detail::throw_if_not_transf(vec.begin(), vec.end()),
                           "image value out of bounds, expected value in "
                           "[0, 16), found 41 in position 11");

--- a/tests/test-konieczny-maxplustrunc.cpp
+++ b/tests/test-konieczny-maxplustrunc.cpp
@@ -731,7 +731,12 @@ namespace libsemigroups {
          make<Mat>(sr.get(),
                    {{NEGATIVE_INFINITY, 0}, {1, NEGATIVE_INFINITY}})});
 
-    auto bad = std::make_unique<MaxPlusTruncSemiring<>>(13);
+    auto             bad   = std::make_unique<MaxPlusTruncSemiring<>>(13);
+    std::vector<Mat> mixed = {make<Mat>(sr.get(), {{1, 3}, {2, 1}}),
+                              make<Mat>(bad.get(), {{2, 1}, {4, 0}})};
+    REQUIRE_EXCEPTION_MSG(static_cast<void>(make<Konieczny>(mixed)),
+                          "the matrix in position 1 has threshold 13 but "
+                          "should have threshold 5");
     REQUIRE_EXCEPTION_MSG(
         S.add_generator(make<Mat>(bad.get(), {{1, 3}, {2, 1}})),
         "the matrix has threshold 13 but should have threshold 5");


### PR DESCRIPTION
## Summary

- reject Action indices equal to current_size()
- report the supplied transformation degree and correctly identify domain versus image failures
- report max-plus truncation thresholds in found/expected order
- add regression coverage for all four discrepancies

## Testing

- make test_action test_is_transf test_konieczny -j8
- ./test_action "[quick]"
- ./test_is_transf "[quick]"
- ./test_konieczny "[Konieczny 039]"
- pre-commit run --hook-stage pre-push --files <changed files>

AI disclosure: Codex assisted with diagnosis, implementation, tests, verification, the commit message, and this pull request description.