### PR TITLE
Presentation: fix normalization bug

### DIFF
--- a/include/libsemigroups/presentation.tpp
+++ b/include/libsemigroups/presentation.tpp
@@ -127,8 +127,8 @@ namespace libsemigroups {
         return false;
       }
       auto it = std::max_element(first, last);
-      return it != last
-             && *it == static_cast<native_letter_type>(p.alphabet().size() - 1);
+      return it == last
+             || *it == static_cast<native_letter_type>(p.alphabet().size() - 1);
     }
 
     template <typename Word>

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -4212,4 +4212,31 @@ End;)xxx");
     REQUIRE(p.inverses() == "badc");
     REQUIRE_NOTHROW(p.throw_if_bad_alphabet_rules_or_inverses());
   }
+
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "106",
+                          "is_normalized",
+                          "[quick][presentation]") {
+    auto                      rg = ReportGuard(false);
+    Presentation<std::string> p;
+    REQUIRE(presentation::is_normalized(p));
+    REQUIRE_NOTHROW(presentation::throw_if_not_normalized(p));
+
+    p.alphabet(std::string{2, 1, 0});
+    REQUIRE(!presentation::is_normalized(p));
+    REQUIRE_EXCEPTION_MSG(presentation::throw_if_not_normalized(p),
+                          "the 1st argument (presentation) must have sorted "
+                          "alphabet, found (char values) [2, 1, 0]");
+
+    p.alphabet(std::string{0, 1, 4});
+    REQUIRE(!presentation::is_normalized(p));
+    REQUIRE_EXCEPTION_MSG(
+        presentation::throw_if_not_normalized(p),
+        "the 1st argument (presentation) has invalid "
+        "alphabet, expected [0, ..., 2] found (char values) [0, 1, 4]");
+
+    p.alphabet(std::string{0, 1, 2});
+    REQUIRE(presentation::is_normalized(p));
+    REQUIRE_NOTHROW(presentation::throw_if_not_normalized(p));
+  }
 }  // namespace libsemigroups


### PR DESCRIPTION
This PR fixes an issue where a presentation with an empty alphabet was not considered to be normalised.