### PR TITLE
General standardize

### DIFF
--- a/include/libsemigroups/detail/stephen-impl.hpp
+++ b/include/libsemigroups/detail/stephen-impl.hpp
@@ -199,7 +199,7 @@ namespace libsemigroups {
       }
 
       void standardize() {
-        word_graph::standardize_no_checks(_word_graph);
+        word_graph::standardize_no_checks(_word_graph, LenLexCmp());
         _word_graph.induced_subgraph_no_checks(
             0, _word_graph.number_of_nodes_active());
       }

--- a/include/libsemigroups/detail/stephen-impl.tpp
+++ b/include/libsemigroups/detail/stephen-impl.tpp
@@ -99,7 +99,7 @@ namespace libsemigroups {
       }
 
       void disjoint_union_inplace_no_checks(StephenGraph& that) {
-        word_graph::standardize_no_checks(that);
+        word_graph::standardize_no_checks(that, LenLexCmp());
         LIBSEMIGROUPS_ASSERT(word_graph::is_standardized(that));
         size_t const N = number_of_nodes_active();
         // TODO(2): the following 2 lines are a bit awkward

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -1537,11 +1537,6 @@ namespace libsemigroups {
     //! \note If any target of any edge in the word graph \p wg is out of
     //! bounds, then this is ignored by this function.
     //!
-    //! \note If \p cmp corresponds to one of the orders in \ref Order for which
-    //! there is a bespoke standardization algorithm, then
-    //! \ref standardize_no_checks(Graph&, Forest&, Order) should be used
-    //! instead of this function for improved performance.
-    //!
     //! \warning If there are nodes in the \p wg that are not reachable from
     //! the node \c 0, then this function may not preserve \p wg up to
     //! isomorphism. However, the isomorphism type of the sub-word-graph
@@ -1574,11 +1569,6 @@ namespace libsemigroups {
     //!
     //! \throws LibsemigroupsException if any target or any label of \p wg is
     //! out of bounds.
-    //!
-    //! \note If \p cmp corresponds to one of the orders in \ref Order for which
-    //! there is a bespoke standardization algorithm, then
-    //! \ref standardize(Graph&, Forest&, Order) should be used instead of this
-    //! function for improved performance.
     //!
     //! \warning If there are nodes in the \p wg that are not reachable from
     //! the node \c 0, then this function may not preserve \p wg up to
@@ -1620,11 +1610,6 @@ namespace libsemigroups {
     //! \note If any target of any edge in the word graph \p wg is out of
     //! bounds, then this is ignored by this function.
     //!
-    //! \note If \p cmp corresponds to one of the orders in \ref Order for which
-    //! there is a bespoke standardization algorithm, then
-    //! \ref standardize_no_checks(Graph&, Order) should be used instead of this
-    //! function for improved performance.
-    //!
     //! \warning If there are nodes in the \p wg that are not reachable from
     //! the node \c 0, then this function may not preserve \p wg up to
     //! isomorphism. However, the isomorphism type of the sub-word-graph
@@ -1662,11 +1647,6 @@ namespace libsemigroups {
     //!
     //! \throws LibsemigroupsException if any target or any label of \p wg is
     //! out of bounds.
-    //!
-    //! \note If \p cmp corresponds to one of the orders in \ref Order for which
-    //! there is a bespoke standardization algorithm, then
-    //! \ref standardize(Graph&, Order) should be used instead of this function
-    //! for improved performance.
     //!
     //! \warning If there are nodes in the \p wg that are not reachable from
     //! the node \c 0, then this function may not preserve \p wg up to
@@ -1710,12 +1690,17 @@ namespace libsemigroups {
     //! the node \c 0, then this function may not preserve \p wg up to
     //! isomorphism. However, the isomorphism type of the sub-word-graph
     //! consisting of those nodes reachable from the node \c 0 is preserved.
+    //!
+    //! \deprecated_warning{function} Use
+    //! \ref standardize_no_checks(Graph&, Forest&, Cmp&&) instead.
     // NOTE: there's no WordGraphView version of this function because it
     // modifies it's argument and WordGraphView is read-only.
     //
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph>
-    bool standardize_no_checks(Graph& wg, Forest& f, Order val);
+    [[deprecated(
+        "Use standardize_no_checks(Graph&, Forest&, Cmp&&) instead.")]] bool
+    standardize_no_checks(Graph& wg, Forest& f, Order val);
 
     //! \brief Standardizes a word graph in-place.
     //!
@@ -1743,12 +1728,15 @@ namespace libsemigroups {
     //! isomorphism. However, the isomorphism type of the sub-word-graph
     //! consisting of those nodes reachable from the node \c 0 is preserved.
     //!
+    //! \deprecated_warning{function} Use
+    //! \ref standardize(Graph&, Forest&, Cmp&&) instead.
     // NOTE: there's no WordGraphView version of this function because it
     // modifies it's argument and WordGraphView is read-only.
     //
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph>
-    bool standardize(Graph& wg, Forest& f, Order val) {
+    [[deprecated("Use standardize(Graph&, Forest&, Cmp&&) instead.")]] bool
+    standardize(Graph& wg, Forest& f, Order val) {
       libsemigroups::word_graph::throw_if_any_target_out_of_bounds(wg);
       return standardize_no_checks(wg, f, val);
     }
@@ -1782,13 +1770,18 @@ namespace libsemigroups {
     //! the node \c 0, then this function may not preserve \p wg up to
     //! isomorphism. However, the isomorphism type of the sub-word-graph
     //! consisting of those nodes reachable from the node \c 0 is preserved.
+    //!
+    //! \deprecated_warning{function} Use
+    //! \ref standardize_no_checks(Graph&, Cmp&&) instead.
     // NOTE: there's no WordGraphView version of this function because it
     // modifies it's argument and WordGraphView is read-only.
     //
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph>
-    std::pair<bool, Forest> standardize_no_checks(Graph& wg,
-                                                  Order  val = Order::lenlex);
+    [[deprecated(
+        "Use standardize_no_checks(Graph&, Cmp&&) instead.")]] std::pair<bool,
+                                                                         Forest>
+    standardize_no_checks(Graph& wg, Order val = Order::lenlex);
 
     //! \brief Standardizes a word graph in-place.
     //!
@@ -1816,12 +1809,17 @@ namespace libsemigroups {
     //! the node \c 0, then this function may not preserve \p wg up to
     //! isomorphism. However, the isomorphism type of the sub-word-graph
     //! consisting of those nodes reachable from the node \c 0 is preserved.
+    //!
+    //! \deprecated_warning{function} Use
+    //! \ref standardize_checks(Graph&, Cmp&&) instead.
     // NOTE: there's no WordGraphView version of this function because it
     // modifies it's argument and WordGraphView is read-only.
     //
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph>
-    std::pair<bool, Forest> standardize(Graph& wg, Order val = Order::lenlex) {
+    [[deprecated(
+        "Use standardize(Graph&, Cmp&&) instead.")]] std::pair<bool, Forest>
+    standardize(Graph& wg, Order val = Order::lenlex) {
       libsemigroups::word_graph::throw_if_any_target_out_of_bounds(wg);
       return standardize_no_checks(wg, val);
     }
@@ -1864,8 +1862,13 @@ namespace libsemigroups {
     //!
     //! \sa
     //! standardize.
+    //!
+    //! \deprecated_warning{function} Use
+    //! \ref is_standardized(WordGraph<Node> const&, Cmp&&) instead.
     template <typename Node>
-    bool is_standardized(WordGraph<Node> const& wg, Order val = Order::lenlex) {
+    [[deprecated(
+        "Use is_standardized(WordGraph<Node> const&, Cmp&&) instead.")]] bool
+    is_standardized(WordGraph<Node> const& wg, Order val = Order::lenlex) {
       return is_standardized(WordGraphView<Node>(wg), val);
     }
 

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -1551,7 +1551,7 @@ namespace libsemigroups {
     //
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph, typename Cmp>
-    bool standardize_no_checks(Graph& wg, Forest& f, Cmp cmp);
+    bool standardize_no_checks(Graph& wg, Forest& f, Cmp&& cmp);
 
     //! \brief Standardizes a word graph in-place.
     //!
@@ -1589,9 +1589,9 @@ namespace libsemigroups {
     //
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph, typename Cmp>
-    bool standardize(Graph& wg, Forest& f, Cmp cmp) {
+    bool standardize(Graph& wg, Forest& f, Cmp&& cmp) {
       libsemigroups::word_graph::throw_if_any_target_out_of_bounds(wg);
-      return standardize_no_checks(wg, f, cmp);
+      return standardize_no_checks(wg, f, std::forward<Cmp>(cmp));
     }
 
     //! \brief Standardizes a word graph in-place.
@@ -1634,9 +1634,9 @@ namespace libsemigroups {
     //
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph, typename Cmp>
-    std::pair<bool, Forest> standardize_no_checks(Graph& wg, Cmp cmp) {
+    std::pair<bool, Forest> standardize_no_checks(Graph& wg, Cmp&& cmp) {
       Forest f;
-      bool   result = standardize_no_checks(wg, f, cmp);
+      bool   result = standardize_no_checks(wg, f, std::forward<Cmp>(cmp));
       return std::make_pair(result, f);
     }
 
@@ -1677,9 +1677,9 @@ namespace libsemigroups {
     //
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph, typename Cmp>
-    std::pair<bool, Forest> standardize(Graph& wg, Cmp cmp) {
+    std::pair<bool, Forest> standardize(Graph& wg, Cmp&& cmp) {
       libsemigroups::word_graph::throw_if_any_target_out_of_bounds(wg);
-      return standardize_no_checks(wg, cmp);
+      return standardize_no_checks(wg, std::forward<Cmp>(cmp));
     }
 
     //! \brief Standardizes a word graph in-place.
@@ -1845,8 +1845,8 @@ namespace libsemigroups {
     //! \sa
     //! standardize.
     template <typename Node, typename Cmp>
-    bool is_standardized(WordGraph<Node> const& wg, Cmp cmp) {
-      return is_standardized(WordGraphView<Node>(wg), cmp);
+    bool is_standardized(WordGraph<Node> const& wg, Cmp&& cmp) {
+      return is_standardized(WordGraphView<Node>(wg), std::forward<Cmp>(cmp));
     }
 
     //! \brief Check if a word graph is standardized.

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -1827,7 +1827,7 @@ namespace libsemigroups {
     //! Order::lenlex).
     //!
     //! \throws LibsemigroupsException if \p val is not one of: Order::none,
-    //! Order::lenlex or Order::rev_rpo.
+    //! Order::lenlex, Order::rpo or Order::rev_rpo.
     //!
     //! \sa
     //! standardize.

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -1818,6 +1818,29 @@ namespace libsemigroups {
     //! \brief Check if a word graph is standardized.
     //!
     //! This function checks if the word graph \p wg is standardized according
+    //! to the reduction order specified by \p cmp.
+    //!
+    //! \tparam Node the type of the node in \p wg.
+    //! \tparam Cmp the type of the comparator \p cmp.
+    //!
+    //! \param wg the word graph to check.
+    //! \param cmp the order to use for standardization check.
+    //!
+    //! \note If \p cmp corresponds to one of the orders in \ref Order for which
+    //! there is a bespoke salgorithm for checking standardization, then
+    //! \ref is_standardized(WordGraph&, Order) should be used instead of this
+    //! function for improved performance.
+    //!
+    //! \sa
+    //! standardize.
+    template <typename Node, typename Cmp>
+    bool is_standardized(WordGraph<Node> const& wg, Cmp cmp) {
+      return is_standardized(WordGraphView<Node>(wg), cmp);
+    }
+
+    //! \brief Check if a word graph is standardized.
+    //!
+    //! This function checks if the word graph \p wg is standardized according
     //! to the reduction order specified by \p val.
     //!
     //! \tparam Node the type of the node in \p wg.

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -1515,6 +1515,165 @@ namespace libsemigroups {
     //! \brief Standardizes a word graph in-place.
     //!
     //! This function standardizes the word graph \p wg according to the
+    //! reduction order specified by \p cmp, and replaces the contents of the
+    //! Forest \p f with a spanning tree rooted at \c 0 for the node reachable
+    //! from \c 0. The spanning tree corresponds to the order \p cmp.
+    //!
+    //! \tparam Graph the type of the word graph \p wg.
+    //! \tparam Cmp the type of the comparator \p cmp.
+    //!
+    //! \param wg the word graph.
+    //! \param f the Forest object to store the spanning tree.
+    //! \param cmp the order to use for standardization.
+    //!
+    //! \returns
+    //! This function returns \c true if the word graph \p wg is modified by
+    //! this function (i.e. it was not standardized already), and \c false
+    //! otherwise.
+    //!
+    //! \exceptions
+    //! \no_libsemigroups_except
+    //!
+    //! \note If any target of any edge in the word graph \p wg is out of
+    //! bounds, then this is ignored by this function.
+    //!
+    //! \note If \p cmp corresponds to one of the orders in \ref Order for which
+    //! there is a bespoke standardization algorithm, then
+    //! \ref standardize_no_checks(Graph&, Forest&, Order) should be used
+    //! instead of this function for improved performance.
+    //!
+    //! \warning If there are nodes in the \p wg that are not reachable from
+    //! the node \c 0, then this function may not preserve \p wg up to
+    //! isomorphism. However, the isomorphism type of the sub-word-graph
+    //! consisting of those nodes reachable from the node \c 0 is preserved.
+    // Not nodiscard because sometimes we just don't want the output
+    template <typename Graph, typename Cmp>
+    bool standardize_no_checks(Graph& wg, Forest& f, Cmp cmp);
+
+    //! \brief Standardizes a word graph in-place.
+    //!
+    //! This function standardizes the word graph \p wg according to the
+    //! reduction order specified by \p cmp, and replaces the contents of the
+    //! Forest \p f with a spanning tree rooted at \c 0 for the node reachable
+    //! from \c 0. The spanning tree corresponds to the order \p val.
+    //!
+    //! \tparam Graph the type of the word graph \p wg.
+    //! \tparam Cmp the type of the comparator \p cmp.
+    //!
+    //! \param wg the word graph.
+    //! \param f the Forest object to store the spanning tree.
+    //! \param cmp the order to use for standardization.
+    //!
+    //! \returns
+    //! This function returns \c true if the word graph \p wg is modified by
+    //! this function (i.e. it was not standardized already), and \c false
+    //! otherwise.
+    //!
+    //! \throws LibsemigroupsException if any target or any label of \p wg is
+    //! out of bounds.
+    //!
+    //! \note If \p cmp corresponds to one of the orders in \ref Order for which
+    //! there is a bespoke standardization algorithm, then
+    //! \ref standardize(Graph&, Forest&, Order) should be used instead of this
+    //! function for improved performance.
+    //!
+    //! \warning If there are nodes in the \p wg that are not reachable from
+    //! the node \c 0, then this function may not preserve \p wg up to
+    //! isomorphism. However, the isomorphism type of the sub-word-graph
+    //! consisting of those nodes reachable from the node \c 0 is preserved.
+    //!
+    // Not nodiscard because sometimes we just don't want the output
+    template <typename Graph, typename Cmp>
+    bool standardize(Graph& wg, Forest& f, Cmp cmp) {
+      libsemigroups::word_graph::throw_if_any_target_out_of_bounds(wg);
+      return standardize_no_checks(wg, f, cmp);
+    }
+
+    //! \brief Standardizes a word graph in-place.
+    //!
+    //! This function standardizes the word graph \p wg according to the
+    //! reduction order specified by \p cmp, and returns a Forest object
+    //! containing a spanning tree rooted at \c 0 for the node reachable from
+    //! \c 0. The spanning tree corresponds to the order \p val.
+    //!
+    //! \tparam Graph the type of the word graph \p wg.
+    //! \tparam Cmp the type of the comparator \p cmp.
+    //!
+    //! \param wg the word graph.
+    //! \param cmp the order to use for standardization.
+    //!
+    //! \returns
+    //! A std::pair the first entry of which is \c true if the word graph
+    //! \p wg is modified by this function (i.e. it was not standardized
+    //! already), and
+    //! \c false otherwise. The second entry is a Forest object containing a
+    //! spanning tree for \p wg.
+    //!
+    //! \exceptions
+    //! \no_libsemigroups_except
+    //!
+    //! \note If any target of any edge in the word graph \p wg is out of
+    //! bounds, then this is ignored by this function.
+    //!
+    //! \note If \p cmp corresponds to one of the orders in \ref Order for which
+    //! there is a bespoke standardization algorithm, then
+    //! \ref standardize_no_checks(Graph&, Order) should be used instead of this
+    //! function for improved performance.
+    //!
+    //! \warning If there are nodes in the \p wg that are not reachable from
+    //! the node \c 0, then this function may not preserve \p wg up to
+    //! isomorphism. However, the isomorphism type of the sub-word-graph
+    //! consisting of those nodes reachable from the node \c 0 is preserved.
+    // Not nodiscard because sometimes we just don't want the output
+    template <typename Graph, typename Cmp>
+    std::pair<bool, Forest> standardize_no_checks(Graph& wg, Cmp cmp) {
+      Forest f;
+      bool   result = standardize_no_checks(wg, f, cmp);
+      return std::make_pair(result, f);
+    }
+
+    //! \brief Standardizes a word graph in-place.
+    //!
+    //! This function standardizes the word graph \p wg according to the
+    //! reduction order specified by \p cmp, and returns a Forest object
+    //! containing a spanning tree rooted at \c 0 for the node reachable from
+    //! \c 0. The spanning tree corresponds to the order \p val.
+    //!
+    //! \tparam Graph the type of the word graph \p wg.
+    //! \tparam Cmp the type of the comparator \p cmp.
+    //!
+    //! \param wg the word graph.
+    //! \param cmp the order to use for standardization.
+    //!
+    //! \returns
+    //! A std::pair the first entry of which is \c true if the word graph
+    //! \p wg is modified by this function (i.e. it was not standardized
+    //! already), and
+    //! \c false otherwise. The second entry is a Forest object containing a
+    //! spanning tree for \p wg.
+    //!
+    //! \throws LibsemigroupsException if any target or any label of \p wg is
+    //! out of bounds.
+    //!
+    //! \note If \p cmp corresponds to one of the orders in \ref Order for which
+    //! there is a bespoke standardization algorithm, then
+    //! \ref standardize(Graph&, Order) should be used instead of this function
+    //! for improved performance.
+    //!
+    //! \warning If there are nodes in the \p wg that are not reachable from
+    //! the node \c 0, then this function may not preserve \p wg up to
+    //! isomorphism. However, the isomorphism type of the sub-word-graph
+    //! consisting of those nodes reachable from the node \c 0 is preserved.
+    // Not nodiscard because sometimes we just don't want the output
+    template <typename Graph, typename Cmp>
+    std::pair<bool, Forest> standardize(Graph& wg, Cmp cmp) {
+      libsemigroups::word_graph::throw_if_any_target_out_of_bounds(wg);
+      return standardize_no_checks(wg, cmp);
+    }
+
+    //! \brief Standardizes a word graph in-place.
+    //!
+    //! This function standardizes the word graph \p wg according to the
     //! reduction order specified by \p val, and replaces the contents of the
     //! Forest \p f with a spanning tree rooted at \c 0 for the node reachable
     //! from \c 0. The spanning tree corresponds to the order \p val.

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -1849,8 +1849,7 @@ namespace libsemigroups {
     //! \param val the order to use for standardization check (defaults to
     //! Order::lenlex).
     //!
-    //! \throws LibsemigroupsException if \p val is not one of: Order::none,
-    //! Order::lenlex, Order::rpo or Order::rev_rpo.
+    //! \no_libsemigroups_except
     //!
     //! \sa
     //! standardize.

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -1546,6 +1546,9 @@ namespace libsemigroups {
     //! the node \c 0, then this function may not preserve \p wg up to
     //! isomorphism. However, the isomorphism type of the sub-word-graph
     //! consisting of those nodes reachable from the node \c 0 is preserved.
+    // NOTE: there's no WordGraphView version of this function because it
+    // modifies it's argument and WordGraphView is read-only.
+    //
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph, typename Cmp>
     bool standardize_no_checks(Graph& wg, Forest& f, Cmp cmp);
@@ -1581,7 +1584,9 @@ namespace libsemigroups {
     //! the node \c 0, then this function may not preserve \p wg up to
     //! isomorphism. However, the isomorphism type of the sub-word-graph
     //! consisting of those nodes reachable from the node \c 0 is preserved.
-    //!
+    // NOTE: there's no WordGraphView version of this function because it
+    // modifies it's argument and WordGraphView is read-only.
+    //
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph, typename Cmp>
     bool standardize(Graph& wg, Forest& f, Cmp cmp) {
@@ -1624,6 +1629,9 @@ namespace libsemigroups {
     //! the node \c 0, then this function may not preserve \p wg up to
     //! isomorphism. However, the isomorphism type of the sub-word-graph
     //! consisting of those nodes reachable from the node \c 0 is preserved.
+    // NOTE: there's no WordGraphView version of this function because it
+    // modifies it's argument and WordGraphView is read-only.
+    //
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph, typename Cmp>
     std::pair<bool, Forest> standardize_no_checks(Graph& wg, Cmp cmp) {
@@ -1664,6 +1672,9 @@ namespace libsemigroups {
     //! the node \c 0, then this function may not preserve \p wg up to
     //! isomorphism. However, the isomorphism type of the sub-word-graph
     //! consisting of those nodes reachable from the node \c 0 is preserved.
+    // NOTE: there's no WordGraphView version of this function because it
+    // modifies it's argument and WordGraphView is read-only.
+    //
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph, typename Cmp>
     std::pair<bool, Forest> standardize(Graph& wg, Cmp cmp) {

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -142,7 +142,7 @@ namespace libsemigroups {
           if (t == UNDEFINED || seen(t)) {
             return false;
           }
-          set_next_smallset(t);
+          set_next_smallest(t);
           LIBSEMIGROUPS_ASSERT(s != _largest_used_node);
           _forest.set_parent_and_label_no_checks(_largest_used_node, s, x);
           return true;
@@ -156,7 +156,7 @@ namespace libsemigroups {
           if (seen(t)) {
             return false;
           }
-          set_next_smallset(t);
+          set_next_smallest(t);
           _forest.set_parent_and_label_no_checks(
               _largest_used_node, _p_inverse[s], x);
           return true;
@@ -193,7 +193,7 @@ namespace libsemigroups {
           }
         }
 
-        void set_next_smallset(node_type t) {
+        void set_next_smallest(node_type t) {
           ++_largest_used_node;
           if (_largest_used_node >= _forest.number_of_nodes()) {
             _forest.add_nodes(1);

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -175,6 +175,8 @@ namespace libsemigroups {
         }
 
         bool standardize() {
+          LIBSEMIGROUPS_ASSERT(number_of_nodes_reachable_from(_wg, 0)
+                               == _largest_used_node + 1);
           if (_is_non_trivial_permutation) {
             _p.resize(_largest_used_node + 1);
             _wg.standardize_no_checks(_p, _p_inverse);

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -407,6 +407,7 @@ namespace libsemigroups {
       // always has the shortest word.
       while (!frontier.empty()) {
         std::pop_heap(frontier.begin(), frontier.end(), candidate_comparator);
+        // NOLINTNEXTLINE(whitespace/braces)
         auto const [current_word, current_node, parent_node] = frontier.back();
         frontier.pop_back();
 

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -134,33 +134,43 @@ namespace libsemigroups {
         // Follow the edge labelled <x> out of the node currently occupying
         // position <s>. If that edge leads to a node that is larger than
         // <_largest_used_node>, then <_largest_used_node> is incremented and
-        // p[_largest_used_node] is set to the newly discovered node.
+        // the newly discovered node is set to be the next smallest.
         //
         // Returns true if a previously-unseen node was discovered.
         bool try_set_next_smallest(node_type s, label_type x) {
-          node_type const target = _wg.target_no_checks(_p[s], x);
-          if (target == UNDEFINED || _p_inverse[target] != UNDEFINED) {
+          node_type const t = _wg.target_no_checks(_p[s], x);
+          if (t == UNDEFINED || seen(t)) {
             return false;
           }
-          ++_largest_used_node;
-          if (_largest_used_node >= _forest.number_of_nodes()) {
-            _forest.add_nodes(1);
-          }
-          _p[_largest_used_node] = target;
-          _p_inverse[target]     = _largest_used_node;
-          if (target != _largest_used_node) {
-            _is_non_trivial_permutation = true;
-          }
-          _forest.set_parent_and_label_no_checks(
-              _largest_used_node, (s == _largest_used_node ? target : s), x);
+          set_next_smallset(t);
+          LIBSEMIGROUPS_ASSERT(s != _largest_used_node);
+          _forest.set_parent_and_label_no_checks(_largest_used_node, s, x);
           return true;
         }
 
-        node_type largest_used_node() {
+        // Try to make <t> the next smallest node, with parent _p_inverse[s] and
+        // label <x>.
+        bool try_set_next_smallest_from_old(node_type  s,
+                                            label_type x,
+                                            node_type  t) {
+          if (seen(t)) {
+            return false;
+          }
+          set_next_smallset(t);
+          _forest.set_parent_and_label_no_checks(
+              _largest_used_node, _p_inverse[s], x);
+          return true;
+        }
+
+        node_type largest_used_node() const noexcept {
           return _largest_used_node;
         }
 
-        bool stop_early() {
+        bool seen(node_type s) const {
+          return _p_inverse[s] != UNDEFINED;
+        }
+
+        bool stop_early() const {
           return _largest_used_node >= max_node();
         }
 
@@ -180,6 +190,18 @@ namespace libsemigroups {
             return _wg.number_of_nodes_active() - 1;
           } else {
             return _wg.number_of_nodes() - 1;
+          }
+        }
+
+        void set_next_smallset(node_type t) {
+          ++_largest_used_node;
+          if (_largest_used_node >= _forest.number_of_nodes()) {
+            _forest.add_nodes(1);
+          }
+          _p[_largest_used_node] = t;
+          _p_inverse[t]          = _largest_used_node;
+          if (t != _largest_used_node) {
+            _is_non_trivial_permutation = true;
           }
         }
 
@@ -350,7 +372,76 @@ namespace libsemigroups {
         init_adjacency_matrix(WordGraphView<Node>(wg), mat);
       }
 #endif
+
+      template <typename Node>
+      struct FrontierCandidate {
+        word_type word;
+        Node      node;
+        Node      parent;
+
+        FrontierCandidate(word_type w, Node n, Node p)
+            : word{w}, node{n}, parent{p} {};
+      };
+
     }  // namespace detail
+
+    template <typename Graph, typename Cmp>
+    bool standardize_no_checks(Graph& wg, Forest& f, Cmp cmp) {
+      if (wg.number_of_nodes() == 0) {
+        return false;
+      }
+
+      if (f.number_of_nodes() == 0) {
+        f.add_nodes(1);
+      }
+
+      using node_type          = typename Graph::node_type;
+      using label_type         = typename Graph::label_type;
+      using FrontierCandidate_ = detail::FrontierCandidate<node_type>;
+
+      size_t const                    n = wg.out_degree();
+      detail::Standardizer<Graph>     standardizer(wg, f);
+      std::vector<FrontierCandidate_> frontier{{{}, 0, 0}};
+      auto const& candidate_comparator = [&cmp](FrontierCandidate_ const& lhs,
+                                                FrontierCandidate_ const& rhs) {
+        // We want a min-heap, so we need to return true if lhs > rhs
+        if (lhs.word != rhs.word) {
+          return cmp(rhs.word, lhs.word);
+        } else {
+          return lhs.node > rhs.node;
+        }
+      };
+      std::make_heap(frontier.begin(), frontier.end(), candidate_comparator);
+
+      // BFS through wg using a heap, so that the next node that is considered
+      // always has the shortest word.
+      while (!frontier.empty()) {
+        std::pop_heap(frontier.begin(), frontier.end(), candidate_comparator);
+        auto const [current_word, current_node, parent_node] = frontier.back();
+        frontier.pop_back();
+
+        if (!current_word.empty()) {
+          if (!standardizer.try_set_next_smallest_from_old(
+                  parent_node, current_word.back(), current_node)) {
+            continue;
+          }
+        }
+
+        for (label_type x = 0; x < n; ++x) {
+          node_type new_node = wg.target_no_checks(current_node, x);
+          if (new_node == UNDEFINED || standardizer.seen(new_node)) {
+            continue;
+          }
+          word_type new_word(current_word);
+          new_word.push_back(x);
+          frontier.emplace_back(new_word, new_node, current_node);
+          std::push_heap(
+              frontier.begin(), frontier.end(), candidate_comparator);
+        }
+      }
+
+      return standardizer.standardize();
+    }
 
     template <typename Graph>
     std::pair<bool, Forest> standardize_no_checks(Graph& wg, Order val) {

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -385,6 +385,19 @@ namespace libsemigroups {
         f.add_nodes(1);
       }
 
+      // TODO(1): improve this so that we can use the bespoke standardization
+      // functions with non-standard alphabets
+      // TODO(1): Also catch the functions like lenlex_cmp?
+      if constexpr (std::is_same_v<std::decay_t<Cmp>, LenLexCmp<>>) {
+        return detail::lenlex_standardize(wg, f);
+      } else if (std::is_same_v<std::decay_t<Cmp>, LexCmp<>>) {
+        return detail::lex_standardize(wg, f);
+      } else if (std::is_same_v<std::decay_t<Cmp>, RPOCmp<>>) {
+        return detail::rpo_standardize(wg, f);
+      } else if (std::is_same_v<std::decay_t<Cmp>, RevRPOCmp<>>) {
+        return detail::rev_rpo_standardize(wg, f);
+      }
+
       using node_type          = typename Graph::node_type;
       using label_type         = typename Graph::label_type;
       using FrontierCandidate_ = detail::FrontierCandidate<node_type>;

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -373,16 +373,6 @@ namespace libsemigroups {
       }
 #endif
 
-      template <typename Node>
-      struct FrontierCandidate {
-        word_type word;
-        Node      node;
-        Node      parent;
-
-        FrontierCandidate(word_type w, Node n, Node p)
-            : word{w}, node{n}, parent{p} {};
-      };
-
     }  // namespace detail
 
     template <typename Graph, typename Cmp>

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -376,7 +376,7 @@ namespace libsemigroups {
     }  // namespace detail
 
     template <typename Graph, typename Cmp>
-    bool standardize_no_checks(Graph& wg, Forest& f, Cmp cmp) {
+    bool standardize_no_checks(Graph& wg, Forest& f, Cmp&& cmp) {
       if (wg.number_of_nodes() == 0) {
         return false;
       }

--- a/include/libsemigroups/word-graph-view-helpers.hpp
+++ b/include/libsemigroups/word-graph-view-helpers.hpp
@@ -1262,11 +1262,6 @@ namespace libsemigroups {
     //! \param wg the word graph to check.
     //! \param cmp the order to use for standardization check.
     //!
-    //! \note If \p cmp corresponds to one of the orders in \ref Order for which
-    //! there is a bespoke salgorithm for checking standardization, then
-    //! \ref is_standardized(WordGraph&, Order) should be used instead of this
-    //! function for improved performance.
-    //!
     //! \sa
     //! standardize.
     // TODO(1): Add is_standardized_no_checks?
@@ -1288,10 +1283,13 @@ namespace libsemigroups {
     //!
     //! \sa
     //! standardize.
-    // TODO(1): Add is_standardized_no_checks?
+    //!
+    //! \deprecated_warning{function} Use
+    //! \ref is_standardized(WordGraphView<Node> const&, Cmp&&) instead.
     template <typename Node>
-    bool is_standardized(WordGraphView<Node> const& wg,
-                         Order                      val = Order::lenlex);
+    [[deprecated("Use is_standardized(WordGraphView<Node> const&, Cmp&&) "
+                 "instead.")]] bool
+    is_standardized(WordGraphView<Node> const& wg, Order val = Order::lenlex);
 
     //! \brief Returns the nodes of the word graph in topological order (see
     //! below) if possible.

--- a/include/libsemigroups/word-graph-view-helpers.hpp
+++ b/include/libsemigroups/word-graph-view-helpers.hpp
@@ -1254,6 +1254,28 @@ namespace libsemigroups {
     //! \brief Check if a word graph is standardized.
     //!
     //! This function checks if the word graph \p wg is standardized according
+    //! to the reduction order specified by \p cmp.
+    //!
+    //! \tparam Node the type of the node in \p wg.
+    //! \tparam Cmp the type of the comparator \p cmp.
+    //!
+    //! \param wg the word graph to check.
+    //! \param cmp the order to use for standardization check.
+    //!
+    //! \note If \p cmp corresponds to one of the orders in \ref Order for which
+    //! there is a bespoke salgorithm for checking standardization, then
+    //! \ref is_standardized(WordGraph&, Order) should be used instead of this
+    //! function for improved performance.
+    //!
+    //! \sa
+    //! standardize.
+    // TODO(1): Add is_standardized_no_checks?
+    template <typename Node, typename Cmp>
+    bool is_standardized(WordGraphView<Node> const& wg, Cmp cmp);
+
+    //! \brief Check if a word graph is standardized.
+    //!
+    //! This function checks if the word graph \p wg is standardized according
     //! to the reduction order specified by \p val.
     //!
     //! \tparam Node the type of the node in \p wg.

--- a/include/libsemigroups/word-graph-view-helpers.hpp
+++ b/include/libsemigroups/word-graph-view-helpers.hpp
@@ -1263,7 +1263,7 @@ namespace libsemigroups {
     //! Order::lenlex).
     //!
     //! \throws LibsemigroupsException if \p val is not one of: Order::none,
-    //! Order::lenlex, or Order::rev_rpo.
+    //! Order::lenlex, Order::rev_rpo or Order::rev_rpo.
     //!
     //! \sa
     //! standardize.

--- a/include/libsemigroups/word-graph-view-helpers.hpp
+++ b/include/libsemigroups/word-graph-view-helpers.hpp
@@ -1284,8 +1284,7 @@ namespace libsemigroups {
     //! \param val the order to use for standardization check (defaults to
     //! Order::lenlex).
     //!
-    //! \throws LibsemigroupsException if \p val is not one of: Order::none,
-    //! Order::lenlex, Order::rev_rpo or Order::rev_rpo.
+    //! \no_libsemigroups_except
     //!
     //! \sa
     //! standardize.

--- a/include/libsemigroups/word-graph-view-helpers.hpp
+++ b/include/libsemigroups/word-graph-view-helpers.hpp
@@ -1271,7 +1271,7 @@ namespace libsemigroups {
     //! standardize.
     // TODO(1): Add is_standardized_no_checks?
     template <typename Node, typename Cmp>
-    bool is_standardized(WordGraphView<Node> const& wg, Cmp cmp);
+    bool is_standardized(WordGraphView<Node> const& wg, Cmp&& cmp);
 
     //! \brief Check if a word graph is standardized.
     //!

--- a/include/libsemigroups/word-graph-view-helpers.tpp
+++ b/include/libsemigroups/word-graph-view-helpers.tpp
@@ -81,6 +81,47 @@ namespace libsemigroups {
       }
 
       template <typename Node>
+      bool is_rpo_standardized(WordGraphView<Node> const& wg) {
+        if (wg.number_of_nodes_no_checks() == 0) {
+          return true;
+        }
+
+        using node_type  = typename WordGraphView<Node>::node_type;
+        using label_type = typename WordGraphView<Node>::label_type;
+
+        size_t const           n                 = wg.out_degree();
+        label_type             x                 = 0;
+        node_type              largest_used_node = 0;
+        std::vector<node_type> next_node(n, 0);
+
+        while (x < n) {
+          bool            changed           = false;
+          node_type const largest_this_pass = largest_used_node;
+          while (next_node[x] <= largest_this_pass) {
+            node_type const s = next_node[x];
+            ++next_node[x];
+            node_type const t = wg.target_no_checks(s, x);
+            if (t == UNDEFINED || t <= largest_used_node) {
+              continue;
+            }
+            if (t == largest_used_node + 1) {
+              changed = true;
+              ++largest_used_node;
+            } else {
+              return false;
+            }
+          }
+          if (changed) {
+            x = 0;
+          } else {
+            ++x;
+          }
+        }
+
+        return true;
+      }
+
+      template <typename Node>
       bool is_rev_rpo_standardized(WordGraphView<Node> const& wg) {
         using node_type = typename WordGraphView<Node>::node_type;
 
@@ -249,9 +290,10 @@ namespace libsemigroups {
           return true;
         case Order::lenlex:
           return detail::is_lenlex_standardized(wg);
+        case Order::rpo:
+          return detail::is_rpo_standardized(wg);
         case Order::rev_rpo:
           return detail::is_rev_rpo_standardized(wg);
-        case Order::rpo:
         case Order::lex:
         default:
           LIBSEMIGROUPS_EXCEPTION("not yet implemented")

--- a/include/libsemigroups/word-graph-view-helpers.tpp
+++ b/include/libsemigroups/word-graph-view-helpers.tpp
@@ -123,45 +123,36 @@ namespace libsemigroups {
 
       template <typename Node>
       bool is_rev_rpo_standardized(WordGraphView<Node> const& wg) {
-        using node_type = typename WordGraphView<Node>::node_type;
-
-        auto const N = wg.number_of_nodes_no_checks();
-        if (N == 0) {
+        if (wg.number_of_nodes_no_checks() == 0) {
           return true;
         }
 
-        auto const nr_reachable = number_of_nodes_reachable_from(wg, 0);
-        if (nr_reachable <= 1) {
-          return true;
-        }
+        using node_type  = typename WordGraphView<Node>::node_type;
+        using label_type = typename WordGraphView<Node>::label_type;
 
-        std::vector<bool>      seen(N, false);
-        std::vector<node_type> next_node(wg.out_degree_no_checks(), 0);
-        node_type              max_seen = 0;
+        size_t const           n                 = wg.out_degree();
+        node_type              largest_used_node = 0;
+        std::vector<node_type> next_node(n, 0);
 
-        seen[0] = true;
-
-      start_is_rev_rpo_standardized:
-        for (letter_type x = 0; x < wg.out_degree_no_checks(); ++x) {
-          while (next_node[x] <= max_seen) {
+      start_is_rev_rpo_standardize_search:
+        for (label_type x = 0; x < n; ++x) {
+          while (next_node[x] <= largest_used_node) {
             node_type const s = next_node[x];
             ++next_node[x];
-
             node_type const t = wg.target_no_checks(s, x);
-            if (t < N && !seen[t]) {
-              if (t != max_seen + 1) {
-                return false;
-              }
-              seen[t] = true;
-              ++max_seen;
-              if (static_cast<size_t>(max_seen + 1) == nr_reachable) {
-                return true;
-              }
-              goto start_is_rev_rpo_standardized;
+            if (t == UNDEFINED || t <= largest_used_node) {
+              continue;
+            }
+            if (t == largest_used_node + 1) {
+              ++largest_used_node;
+              goto start_is_rev_rpo_standardize_search;
+            } else {
+              return false;
             }
           }
         }
-        return static_cast<size_t>(max_seen + 1) == nr_reachable;
+
+        return true;
       }
 
       // Helper function for the two versions of is_acyclic below.

--- a/include/libsemigroups/word-graph-view-helpers.tpp
+++ b/include/libsemigroups/word-graph-view-helpers.tpp
@@ -329,7 +329,7 @@ namespace libsemigroups {
 
     // TODO(1) reduce duplication with standardized(Graph&, Cmp cmp)
     template <typename Node, typename Cmp>
-    bool is_standardized(WordGraphView<Node> const& wg, Cmp cmp) {
+    bool is_standardized(WordGraphView<Node> const& wg, Cmp&& cmp) {
       if (wg.number_of_nodes_no_checks() == 0) {
         return true;
       }

--- a/include/libsemigroups/word-graph-view-helpers.tpp
+++ b/include/libsemigroups/word-graph-view-helpers.tpp
@@ -272,7 +272,75 @@ namespace libsemigroups {
       }
 #endif
 
+      template <typename Node>
+      struct FrontierCandidate {
+        word_type word;
+        Node      node;
+        Node      parent;
+
+        FrontierCandidate(word_type w, Node n, Node p)
+            : word{w}, node{n}, parent{p} {};
+      };
+
     }  // namespace detail
+
+    // TODO(1) reduce duplication with standardized(Graph&, Cmp cmp)
+    template <typename Node, typename Cmp>
+    bool is_standardized(WordGraphView<Node> const& wg, Cmp cmp) {
+      using node_type          = typename WordGraphView<Node>::node_type;
+      using label_type         = typename WordGraphView<Node>::label_type;
+      using FrontierCandidate_ = detail::FrontierCandidate<node_type>;
+
+      size_t const                    n                 = wg.out_degree();
+      node_type                       largest_used_node = 0;
+      std::vector<FrontierCandidate_> frontier{{{}, 0, 0}};
+      auto const& candidate_comparator = [&cmp](FrontierCandidate_ const& lhs,
+                                                FrontierCandidate_ const& rhs) {
+        // We want a min-heap, so we need to return true if lhs > rhs
+        if (lhs.word != rhs.word) {
+          return cmp(rhs.word, lhs.word);
+        } else {
+          return lhs.node > rhs.node;
+        }
+      };
+      std::make_heap(frontier.begin(), frontier.end(), candidate_comparator);
+
+      // BFS through wg using a heap, so that the next node that is considered
+      // always has the shortest word.
+      while (!frontier.empty()) {
+        std::pop_heap(frontier.begin(), frontier.end(), candidate_comparator);
+        // We don't actually need parent_node at all in this function, but it
+        // appears so that FrontierCandidate can be used in both standardize and
+        // is_standardized.
+        auto const [current_word, current_node, parent_node] = frontier.back();
+        frontier.pop_back();
+
+        if (!current_word.empty()) {
+          if (current_node <= largest_used_node) {
+            continue;
+          }
+          if (current_node == largest_used_node + 1) {
+            ++largest_used_node;
+          } else {
+            return false;
+          }
+        }
+
+        for (label_type x = 0; x < n; ++x) {
+          node_type new_node = wg.target_no_checks(current_node, x);
+          if (new_node == UNDEFINED || new_node <= largest_used_node) {
+            continue;
+          }
+          word_type new_word(current_word);
+          new_word.push_back(x);
+          frontier.emplace_back(new_word, new_node, current_node);
+          std::push_heap(
+              frontier.begin(), frontier.end(), candidate_comparator);
+        }
+      }
+
+      return true;
+    }
 
     template <typename Node>
     bool is_standardized(WordGraphView<Node> const& wg, Order val) {

--- a/include/libsemigroups/word-graph-view-helpers.tpp
+++ b/include/libsemigroups/word-graph-view-helpers.tpp
@@ -352,6 +352,7 @@ namespace libsemigroups {
         // We don't actually need parent_node at all in this function, but it
         // appears so that FrontierCandidate can be used in both standardize and
         // is_standardized.
+        // NOLINTNEXTLINE(whitespace/braces)
         auto const [current_word, current_node, parent_node] = frontier.back();
         frontier.pop_back();
 

--- a/include/libsemigroups/word-graph-view-helpers.tpp
+++ b/include/libsemigroups/word-graph-view-helpers.tpp
@@ -81,6 +81,46 @@ namespace libsemigroups {
       }
 
       template <typename Node>
+      bool is_lex_standardized(WordGraphView<Node> const& wg) {
+        using node_type  = typename WordGraphView<Node>::node_type;
+        using label_type = typename WordGraphView<Node>::label_type;
+
+        node_type    s                 = 0;
+        label_type   x                 = 0;
+        size_t const n                 = wg.out_degree();
+        node_type    largest_used_node = 0;
+
+        // TODO(1): replace this with a forest?
+        std::vector<node_type>  parents(wg.number_of_nodes());
+        std::vector<label_type> labels(wg.number_of_nodes());
+        parents[0] = UNDEFINED;
+        labels[0]  = 0;
+
+        // Perform a DFS through wg
+        while (s <= largest_used_node) {
+          node_type const t = wg.target_no_checks(s, x);
+          if (t != UNDEFINED && t > largest_used_node) {
+            if (t == largest_used_node + 1) {
+              ++largest_used_node;
+              parents[t] = s;
+              labels[t]  = x;
+              s          = largest_used_node;
+              x          = 0;
+              continue;
+            } else {
+              return false;
+            }
+          }
+          x++;
+          if (x == n) {  // backtrack
+            x = labels[s];
+            s = parents[s];
+          }
+        }
+        return true;
+      }
+
+      template <typename Node>
       bool is_rpo_standardized(WordGraphView<Node> const& wg) {
         if (wg.number_of_nodes_no_checks() == 0) {
           return true;
@@ -349,11 +389,12 @@ namespace libsemigroups {
           return true;
         case Order::lenlex:
           return detail::is_lenlex_standardized(wg);
+        case Order::lex:
+          return detail::is_lex_standardized(wg);
         case Order::rpo:
           return detail::is_rpo_standardized(wg);
         case Order::rev_rpo:
           return detail::is_rev_rpo_standardized(wg);
-        case Order::lex:
         default:
           LIBSEMIGROUPS_EXCEPTION("not yet implemented")
       }

--- a/include/libsemigroups/word-graph-view-helpers.tpp
+++ b/include/libsemigroups/word-graph-view-helpers.tpp
@@ -62,9 +62,11 @@ namespace libsemigroups {
       template <typename Node>
       // TODO rename to _no_checks and add a checks version?
       bool is_lenlex_standardized(WordGraphView<Node> const& wg) {
+        LIBSEMIGROUPS_ASSERT(wg.number_of_nodes_no_checks() != 0);
+
         Node current_max_node = 0;
 
-        for (auto s : wg.nodes_no_checks()) {
+        for (Node s = 0; s <= current_max_node; s++) {
           for (auto t : wg.targets_no_checks(s)) {
             if (t != UNDEFINED) {
               if (t > current_max_node) {
@@ -82,9 +84,8 @@ namespace libsemigroups {
 
       template <typename Node>
       bool is_lex_standardized(WordGraphView<Node> const& wg) {
-        if (wg.number_of_nodes_no_checks() == 0) {
-          return true;
-        }
+        LIBSEMIGROUPS_ASSERT(wg.number_of_nodes_no_checks() != 0);
+
         using node_type  = typename WordGraphView<Node>::node_type;
         using label_type = typename WordGraphView<Node>::label_type;
 
@@ -125,9 +126,7 @@ namespace libsemigroups {
 
       template <typename Node>
       bool is_rpo_standardized(WordGraphView<Node> const& wg) {
-        if (wg.number_of_nodes_no_checks() == 0) {
-          return true;
-        }
+        LIBSEMIGROUPS_ASSERT(wg.number_of_nodes_no_checks() != 0);
 
         using node_type  = typename WordGraphView<Node>::node_type;
         using label_type = typename WordGraphView<Node>::label_type;
@@ -166,9 +165,7 @@ namespace libsemigroups {
 
       template <typename Node>
       bool is_rev_rpo_standardized(WordGraphView<Node> const& wg) {
-        if (wg.number_of_nodes_no_checks() == 0) {
-          return true;
-        }
+        LIBSEMIGROUPS_ASSERT(wg.number_of_nodes_no_checks() != 0);
 
         using node_type  = typename WordGraphView<Node>::node_type;
         using label_type = typename WordGraphView<Node>::label_type;
@@ -330,7 +327,7 @@ namespace libsemigroups {
     // TODO(1) reduce duplication with standardized(Graph&, Cmp cmp)
     template <typename Node, typename Cmp>
     bool is_standardized(WordGraphView<Node> const& wg, Cmp&& cmp) {
-      if (wg.number_of_nodes_no_checks() == 0) {
+      if (wg.number_of_nodes_no_checks() <= 1) {
         return true;
       }
 
@@ -405,6 +402,10 @@ namespace libsemigroups {
 
     template <typename Node>
     bool is_standardized(WordGraphView<Node> const& wg, Order val) {
+      if (wg.number_of_nodes_no_checks() <= 1) {
+        return true;
+      }
+
       switch (val) {
         case Order::none:
           return true;

--- a/include/libsemigroups/word-graph-view-helpers.tpp
+++ b/include/libsemigroups/word-graph-view-helpers.tpp
@@ -334,6 +334,19 @@ namespace libsemigroups {
         return true;
       }
 
+      // TODO(1): improve this so that we can use the bespoke standardization
+      // functions with non-standard alphabets
+      // TODO(1): Also catch the functions like lenlex_cmp?
+      if constexpr (std::is_same_v<std::decay_t<Cmp>, LenLexCmp<>>) {
+        return detail::is_lenlex_standardized(wg);
+      } else if (std::is_same_v<std::decay_t<Cmp>, LexCmp<>>) {
+        return detail::is_lex_standardized(wg);
+      } else if (std::is_same_v<std::decay_t<Cmp>, RPOCmp<>>) {
+        return detail::is_rpo_standardized(wg);
+      } else if (std::is_same_v<std::decay_t<Cmp>, RevRPOCmp<>>) {
+        return detail::is_rev_rpo_standardized(wg);
+      }
+
       using node_type          = typename WordGraphView<Node>::node_type;
       using label_type         = typename WordGraphView<Node>::label_type;
       using FrontierCandidate_ = detail::FrontierCandidate<node_type>;

--- a/include/libsemigroups/word-graph-view-helpers.tpp
+++ b/include/libsemigroups/word-graph-view-helpers.tpp
@@ -82,6 +82,9 @@ namespace libsemigroups {
 
       template <typename Node>
       bool is_lex_standardized(WordGraphView<Node> const& wg) {
+        if (wg.number_of_nodes_no_checks() == 0) {
+          return true;
+        }
         using node_type  = typename WordGraphView<Node>::node_type;
         using label_type = typename WordGraphView<Node>::label_type;
 
@@ -327,6 +330,10 @@ namespace libsemigroups {
     // TODO(1) reduce duplication with standardized(Graph&, Cmp cmp)
     template <typename Node, typename Cmp>
     bool is_standardized(WordGraphView<Node> const& wg, Cmp cmp) {
+      if (wg.number_of_nodes_no_checks() == 0) {
+        return true;
+      }
+
       using node_type          = typename WordGraphView<Node>::node_type;
       using label_type         = typename WordGraphView<Node>::label_type;
       using FrontierCandidate_ = detail::FrontierCandidate<node_type>;

--- a/src/detail/todd-coxeter-impl.cpp
+++ b/src/detail/todd-coxeter-impl.cpp
@@ -355,9 +355,37 @@ namespace libsemigroups::detail {
     }
     _forest.init();
     _forest.add_nodes(number_of_nodes_active());
-    // NOTE: the cursor() does not survive the next line
+
+    // NOTE: the cursor() does not survive the next block of code,
     // but lookahead_cursor() should
-    bool result            = word_graph::standardize(*this, _forest, val);
+
+    bool result = false;
+
+    // TODO(1): The following is basically the old implementation of
+    // stadardize(Graph& wg, Forest& f, Order val). We should make <val> a
+    // functor that can be used for comparison, and replace this switch
+    // statement with a single call to standardize.
+    switch (val) {
+      case Order::none:
+        result = false;
+        break;
+      case Order::lenlex:
+        result = word_graph::standardize(*this, _forest, LenLexCmp());
+        break;
+      case Order::lex:
+        result = word_graph::standardize(*this, _forest, LexCmp());
+        break;
+      case Order::rpo:
+        result = word_graph::standardize(*this, _forest, RPOCmp());
+        break;
+      case Order::rev_rpo:
+        result = word_graph::standardize(*this, _forest, RevRPOCmp());
+        break;
+      // Intentional fall-through
+      default:
+        result = false;
+    }
+
     _forest_valid          = true;
     _standardization_order = val;
     report_default("ToddCoxeter: the word graph was {} standardized in {}\n",

--- a/tests/test-todd-coxeter.cpp
+++ b/tests/test-todd-coxeter.cpp
@@ -4980,7 +4980,7 @@ namespace libsemigroups {
     tc.shrink_to_fit();
     // Have to standardize or otherwise what we are about to do below
     // makes no sense
-    REQUIRE(word_graph::is_standardized(wg));
+    REQUIRE(word_graph::is_standardized(wg, LenLexCmp()));
     auto const& tree = tc.current_word_graph().current_spanning_tree();
     for (uint32_t n = 0; n != tree.number_of_nodes(); ++n) {
       if (n != 0) {

--- a/tests/test-word-graph-view.cpp
+++ b/tests/test-word-graph-view.cpp
@@ -494,22 +494,21 @@ namespace libsemigroups {
     WordGraph<size_t> empty(0, 2);
     WordGraphView     empty_view(empty);
     REQUIRE(word_graph::is_strictly_cyclic(empty_view));
-    REQUIRE(word_graph::is_standardized(empty_view, Order::none));
-    REQUIRE(word_graph::is_standardized(empty_view, Order::lenlex));
-    REQUIRE(word_graph::is_standardized(empty_view, Order::rev_rpo));
+    REQUIRE(word_graph::is_standardized(empty_view, LenLexCmp()));
+    REQUIRE(word_graph::is_standardized(empty_view, RevRPOCmp()));
 
     WordGraph<size_t> singleton(1, 2);
     WordGraphView     singleton_view(singleton);
-    REQUIRE(word_graph::is_standardized(singleton_view, Order::rev_rpo));
+    REQUIRE(word_graph::is_standardized(singleton_view, RevRPOCmp()));
 
     auto          canonical = make<WordGraph<size_t>>(3, {{1, 2}, {}, {}});
     WordGraphView canonical_view(canonical);
-    REQUIRE(word_graph::is_standardized(canonical_view, Order::lenlex));
+    REQUIRE(word_graph::is_standardized(canonical_view, LenLexCmp()));
 
     auto          noncanonical = make<WordGraph<size_t>>(3, {{2, 1}, {}, {}});
     WordGraphView noncanonical_view(noncanonical);
-    REQUIRE(!word_graph::is_standardized(noncanonical_view, Order::lenlex));
-    REQUIRE(!word_graph::is_standardized(noncanonical_view, Order::rpo));
+    REQUIRE(!word_graph::is_standardized(noncanonical_view, LenLexCmp()));
+    REQUIRE(!word_graph::is_standardized(noncanonical_view, RPOCmp()));
 
     auto const matrix = word_graph::adjacency_matrix(canonical_view);
     REQUIRE(matrix(0, 1) == 1);

--- a/tests/test-word-graph-view.cpp
+++ b/tests/test-word-graph-view.cpp
@@ -509,9 +509,7 @@ namespace libsemigroups {
     auto          noncanonical = make<WordGraph<size_t>>(3, {{2, 1}, {}, {}});
     WordGraphView noncanonical_view(noncanonical);
     REQUIRE(!word_graph::is_standardized(noncanonical_view, Order::lenlex));
-    REQUIRE_THROWS_AS(
-        word_graph::is_standardized(noncanonical_view, Order::rpo),
-        LibsemigroupsException);
+    REQUIRE(!word_graph::is_standardized(noncanonical_view, Order::rpo));
 
     auto const matrix = word_graph::adjacency_matrix(canonical_view);
     REQUIRE(matrix(0, 1) == 1);

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -1499,4 +1499,34 @@ namespace libsemigroups {
       REQUIRE(word_graph::is_standardized(wg3, Order::rev_rpo));
     }
   }
+
+  LIBSEMIGROUPS_TEST_CASE("WordGraph",
+                          "058",
+                          "random generic is_standardized",
+                          "[quick][word-graph]") {
+    auto rg = ReportGuard(false);
+
+    WordGraph wg = WordGraph<size_t>::random(5000, 8);
+    REQUIRE(wg.number_of_nodes() == 5000);
+    REQUIRE(wg.number_of_edges() == 40000);
+    WordGraph<size_t> wg1 = wg;
+    WordGraph<size_t> wg2 = wg;
+    WordGraph<size_t> wg3 = wg;
+
+    SECTION("LenLex") {
+      REQUIRE(!word_graph::is_standardized(wg1, Order::lenlex));
+      word_graph::standardize(wg1, Order::lenlex);
+      REQUIRE(word_graph::is_standardized(wg1, LenLexCmp()));
+    }
+    SECTION("RPO") {
+      REQUIRE(!word_graph::is_standardized(wg2, Order::rpo));
+      word_graph::standardize(wg2, Order::rpo);
+      REQUIRE(word_graph::is_standardized(wg2, RPOCmp()));
+    }
+    SECTION("RevRPO") {
+      REQUIRE(!word_graph::is_standardized(wg3, Order::rev_rpo));
+      word_graph::standardize(wg3, Order::rev_rpo);
+      REQUIRE(word_graph::is_standardized(wg3, RevRPOCmp()));
+    }
+  }
 }  // namespace libsemigroups

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -1098,7 +1098,7 @@ namespace libsemigroups {
     REQUIRE(!word_graph::is_standardized(permuted, Order::rev_rpo));
 
     Forest f;
-    REQUIRE(word_graph::standardize(permuted, f, Order::rev_rpo));
+    REQUIRE(word_graph::standardize(permuted, f, RevRPOCmp()));
     REQUIRE(permuted == canonical);
     REQUIRE(word_graph::is_standardized(permuted, Order::rev_rpo));
     REQUIRE(words_from_forest(f)
@@ -1375,5 +1375,98 @@ namespace libsemigroups {
 
     WordGraph<uint32_t> wrong_out_degree(1, 2);
     REQUIRE_THROWS_AS(join1(graph, wrong_out_degree), LibsemigroupsException);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("WordGraph",
+                          "059",
+                          "random generic standardization",
+                          "[quick][word-graph]") {
+    auto rg = ReportGuard(false);
+
+    WordGraph wg = WordGraph<size_t>::random(5000, 8);
+    REQUIRE(wg.number_of_nodes() == 5000);
+    REQUIRE(wg.number_of_edges() == 40000);
+    WordGraph<size_t> wg1 = wg;
+    WordGraph<size_t> wg2 = wg;
+    WordGraph<size_t> wg3 = wg;
+    WordGraph<size_t> wg4 = wg;
+    WordGraph<size_t> wg5 = wg;
+    WordGraph<size_t> wg6 = wg;
+    WordGraph<size_t> wg7 = wg;
+    WordGraph<size_t> wg8 = wg;
+
+    SECTION("LenLex") {
+      word_graph::standardize(wg1, Order::lenlex);
+      word_graph::standardize(wg2, LenLexCmp());
+      REQUIRE(wg1 == wg2);
+    }
+    SECTION("Lex") {
+      word_graph::standardize(wg3, Order::lex);
+      word_graph::standardize(wg4, LexCmp());
+      REQUIRE(wg3 == wg4);
+    }
+    SECTION("RPO") {
+      word_graph::standardize(wg5, Order::rpo);
+      word_graph::standardize(wg6, RPOCmp());
+      REQUIRE(wg5 == wg6);
+    }
+    SECTION("RevRPO") {
+      word_graph::standardize(wg5, Order::rev_rpo);
+      word_graph::standardize(wg6, RevRPOCmp());
+      REQUIRE(wg7 == wg8);
+    }
+  }
+  LIBSEMIGROUPS_TEST_CASE("WordGraph",
+                          "060",
+                          "all words generic standardization",
+                          "[quick][word-graph]") {
+    auto rg = ReportGuard(false);
+
+    // Construct the WordGraph such that the paths from 0 are labelled by the
+    // words with length in [0, max_depth), consisting of letters in
+    // [0, num_letters).
+    size_t const max_depth   = 8;
+    size_t const num_letters = 5;
+    size_t const num_nodes
+        = (std::pow(num_letters, max_depth) - 1) / (num_letters - 1);
+    size_t const num_sources
+        = (std::pow(num_letters, max_depth - 1) - 1) / (num_letters - 1);
+    WordGraph<size_t> wg(num_nodes, num_letters);
+
+    for (size_t s = 0; s < num_sources; s++) {
+      size_t t = s * num_letters + 1;
+      for (size_t letter = 0; letter < num_letters; letter++) {
+        wg.target(s, letter, t + letter);
+      }
+    }
+    WordGraph<size_t> wg1 = wg;
+    WordGraph<size_t> wg2 = wg;
+    WordGraph<size_t> wg3 = wg;
+    WordGraph<size_t> wg4 = wg;
+
+    SECTION("LenLex") {
+      Forest const f = word_graph::standardize(wg1, LenLexCmp()).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(std::is_sorted(
+          sorted_words.begin(), sorted_words.end(), LenLexCmp()));
+    }
+    SECTION("Lex") {
+      Forest const           f = word_graph::standardize(wg2, LexCmp()).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(
+          std::is_sorted(sorted_words.begin(), sorted_words.end(), LexCmp()));
+    }
+    SECTION("RPO") {
+      Forest const           f = word_graph::standardize(wg3, RPOCmp()).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(
+          std::is_sorted(sorted_words.begin(), sorted_words.end(), RPOCmp()));
+    }
+    SECTION("RevRPO") {
+      Forest const f = word_graph::standardize(wg4, RevRPOCmp()).second;
+      std::vector<word_type> sorted_words = words_from_forest(f);
+      REQUIRE(std::is_sorted(
+          sorted_words.begin(), sorted_words.end(), RevRPOCmp()));
+    }
   }
 }  // namespace libsemigroups

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -1469,4 +1469,34 @@ namespace libsemigroups {
           sorted_words.begin(), sorted_words.end(), RevRPOCmp()));
     }
   }
+
+  LIBSEMIGROUPS_TEST_CASE("WordGraph",
+                          "057",
+                          "random is_standardized",
+                          "[quick][word-graph]") {
+    auto rg = ReportGuard(false);
+
+    WordGraph wg = WordGraph<size_t>::random(5000, 8);
+    REQUIRE(wg.number_of_nodes() == 5000);
+    REQUIRE(wg.number_of_edges() == 40000);
+    WordGraph<size_t> wg1 = wg;
+    WordGraph<size_t> wg2 = wg;
+    WordGraph<size_t> wg3 = wg;
+
+    SECTION("LenLex") {
+      REQUIRE(!word_graph::is_standardized(wg1, Order::lenlex));
+      word_graph::standardize(wg1, Order::lenlex);
+      REQUIRE(word_graph::is_standardized(wg1, Order::lenlex));
+    }
+    SECTION("RPO") {
+      REQUIRE(!word_graph::is_standardized(wg2, Order::rpo));
+      word_graph::standardize(wg2, Order::rpo);
+      REQUIRE(word_graph::is_standardized(wg2, Order::rpo));
+    }
+    SECTION("RevRPO") {
+      REQUIRE(!word_graph::is_standardized(wg3, Order::rev_rpo));
+      word_graph::standardize(wg3, Order::rev_rpo);
+      REQUIRE(word_graph::is_standardized(wg3, Order::rev_rpo));
+    }
+  }
 }  // namespace libsemigroups

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -1482,21 +1482,27 @@ namespace libsemigroups {
     WordGraph<size_t> wg1 = wg;
     WordGraph<size_t> wg2 = wg;
     WordGraph<size_t> wg3 = wg;
+    WordGraph<size_t> wg4 = wg;
 
     SECTION("LenLex") {
       REQUIRE(!word_graph::is_standardized(wg1, Order::lenlex));
       word_graph::standardize(wg1, Order::lenlex);
       REQUIRE(word_graph::is_standardized(wg1, Order::lenlex));
     }
+    SECTION("Lex") {
+      REQUIRE(!word_graph::is_standardized(wg2, Order::lex));
+      word_graph::standardize(wg2, Order::lex);
+      REQUIRE(word_graph::is_standardized(wg2, Order::lex));
+    }
     SECTION("RPO") {
-      REQUIRE(!word_graph::is_standardized(wg2, Order::rpo));
-      word_graph::standardize(wg2, Order::rpo);
-      REQUIRE(word_graph::is_standardized(wg2, Order::rpo));
+      REQUIRE(!word_graph::is_standardized(wg3, Order::rpo));
+      word_graph::standardize(wg3, Order::rpo);
+      REQUIRE(word_graph::is_standardized(wg3, Order::rpo));
     }
     SECTION("RevRPO") {
-      REQUIRE(!word_graph::is_standardized(wg3, Order::rev_rpo));
-      word_graph::standardize(wg3, Order::rev_rpo);
-      REQUIRE(word_graph::is_standardized(wg3, Order::rev_rpo));
+      REQUIRE(!word_graph::is_standardized(wg4, Order::rev_rpo));
+      word_graph::standardize(wg4, Order::rev_rpo);
+      REQUIRE(word_graph::is_standardized(wg4, Order::rev_rpo));
     }
   }
 
@@ -1512,21 +1518,27 @@ namespace libsemigroups {
     WordGraph<size_t> wg1 = wg;
     WordGraph<size_t> wg2 = wg;
     WordGraph<size_t> wg3 = wg;
+    WordGraph<size_t> wg4 = wg;
 
     SECTION("LenLex") {
       REQUIRE(!word_graph::is_standardized(wg1, Order::lenlex));
       word_graph::standardize(wg1, Order::lenlex);
       REQUIRE(word_graph::is_standardized(wg1, LenLexCmp()));
     }
+    SECTION("Lex") {
+      REQUIRE(!word_graph::is_standardized(wg2, Order::lex));
+      word_graph::standardize(wg2, Order::lex);
+      REQUIRE(word_graph::is_standardized(wg2, LexCmp()));
+    }
     SECTION("RPO") {
-      REQUIRE(!word_graph::is_standardized(wg2, Order::rpo));
-      word_graph::standardize(wg2, Order::rpo);
-      REQUIRE(word_graph::is_standardized(wg2, RPOCmp()));
+      REQUIRE(!word_graph::is_standardized(wg3, Order::rpo));
+      word_graph::standardize(wg3, Order::rpo);
+      REQUIRE(word_graph::is_standardized(wg3, RPOCmp()));
     }
     SECTION("RevRPO") {
-      REQUIRE(!word_graph::is_standardized(wg3, Order::rev_rpo));
-      word_graph::standardize(wg3, Order::rev_rpo);
-      REQUIRE(word_graph::is_standardized(wg3, RevRPOCmp()));
+      REQUIRE(!word_graph::is_standardized(wg4, Order::rev_rpo));
+      word_graph::standardize(wg4, Order::rev_rpo);
+      REQUIRE(word_graph::is_standardized(wg4, RevRPOCmp()));
     }
   }
 }  // namespace libsemigroups

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -1471,7 +1471,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "057",
+                          "061",
                           "random is_standardized",
                           "[quick][word-graph]") {
     auto rg = ReportGuard(false);
@@ -1507,7 +1507,7 @@ namespace libsemigroups {
   }
 
   LIBSEMIGROUPS_TEST_CASE("WordGraph",
-                          "058",
+                          "062",
                           "random generic is_standardized",
                           "[quick][word-graph]") {
     auto rg = ReportGuard(false);

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -1411,8 +1411,8 @@ namespace libsemigroups {
       REQUIRE(wg5 == wg6);
     }
     SECTION("RevRPO") {
-      word_graph::standardize(wg5, Order::rev_rpo);
-      word_graph::standardize(wg6, RevRPOCmp());
+      word_graph::standardize(wg7, Order::rev_rpo);
+      word_graph::standardize(wg8, RevRPOCmp());
       REQUIRE(wg7 == wg8);
     }
   }

--- a/tests/test-word-graph.cpp
+++ b/tests/test-word-graph.cpp
@@ -30,6 +30,7 @@
 #include "word-graph-test-common.hpp"  // for add_clique etc
 
 #include "libsemigroups/forest.hpp"              // for Forest
+#include "libsemigroups/order.hpp"               // for LenLexCmp, LexCmp, ...
 #include "libsemigroups/paths.hpp"               // for cbegin_pilo
 #include "libsemigroups/word-graph-helpers.hpp"  // for word_graph
 #include "libsemigroups/word-graph.hpp"          // for WordGraph
@@ -902,7 +903,7 @@ namespace libsemigroups {
     meet(xy, x, y);
     REQUIRE(xy == make<WordGraph<size_t>>(4, {{1, 2}, {3, 3}, {2, 2}, {3, 3}}));
 
-    word_graph::standardize(xy);
+    word_graph::standardize(xy, LenLexCmp());
     REQUIRE(xy == make<WordGraph<size_t>>(4, {{1, 2}, {3, 3}, {2, 2}, {3, 3}}));
 
     x = xy;
@@ -920,7 +921,7 @@ namespace libsemigroups {
     Meeter meet;
     auto   xy = meet(x, y);
     REQUIRE(xy == make<WordGraph<size_t>>(4, {{1, 2}, {1, 3}, {1, 2}, {1, 3}}));
-    word_graph::standardize(xy);
+    word_graph::standardize(xy, LenLexCmp());
     REQUIRE(xy == make<WordGraph<size_t>>(4, {{1, 2}, {1, 3}, {1, 2}, {1, 3}}));
 
     Joiner join;
@@ -1060,11 +1061,11 @@ namespace libsemigroups {
     auto const expected_words
         = std::vector<word_type>({{}, {0}, {0, 0}, {1}, {1, 0}, {0, 0, 1}});
     REQUIRE(minimal_words(wg, rev_rpo_cmp_recursive) == expected_words);
-    REQUIRE(word_graph::is_standardized(wg, Order::rev_rpo));
+    REQUIRE(word_graph::is_standardized(wg, RevRPOCmp()));
 
     Forest f;
-    REQUIRE(!word_graph::standardize(wg, f, Order::rev_rpo));
-    REQUIRE(word_graph::is_standardized(wg, Order::rev_rpo));
+    REQUIRE(!word_graph::standardize(wg, f, RevRPOCmp()));
+    REQUIRE(word_graph::is_standardized(wg, RevRPOCmp()));
     REQUIRE(std::is_sorted(
         expected_words.begin(), expected_words.end(), RevRPOCmp()));
     REQUIRE(words_from_forest(f) == expected_words);
@@ -1090,17 +1091,17 @@ namespace libsemigroups {
     }
     permuted.standardize_no_checks(q, p);
 
-    REQUIRE(word_graph::is_standardized(canonical, Order::rev_rpo));
+    REQUIRE(word_graph::is_standardized(canonical, RevRPOCmp()));
     REQUIRE(permuted
             == make<WordGraph<size_t>>(
                 6, {{2, 4}, {0}, {3}, {0, 1}, {5}, {UNDEFINED, 3}}));
 
-    REQUIRE(!word_graph::is_standardized(permuted, Order::rev_rpo));
+    REQUIRE(!word_graph::is_standardized(permuted, RevRPOCmp()));
 
     Forest f;
     REQUIRE(word_graph::standardize(permuted, f, RevRPOCmp()));
     REQUIRE(permuted == canonical);
-    REQUIRE(word_graph::is_standardized(permuted, Order::rev_rpo));
+    REQUIRE(word_graph::is_standardized(permuted, RevRPOCmp()));
     REQUIRE(words_from_forest(f)
             == minimal_words(canonical, rev_rpo_cmp_recursive));
     auto const words = words_from_forest(f);
@@ -1119,12 +1120,12 @@ namespace libsemigroups {
 
     auto const expected = canonical_standardization(wg, rev_rpo_cmp_recursive);
 
-    REQUIRE(!word_graph::is_standardized(wg, Order::rev_rpo));
+    REQUIRE(!word_graph::is_standardized(wg, RevRPOCmp()));
 
     Forest f;
-    REQUIRE(word_graph::standardize(wg, f, Order::rev_rpo));
+    REQUIRE(word_graph::standardize(wg, f, RevRPOCmp()));
     REQUIRE(wg == expected.first);
-    REQUIRE(word_graph::is_standardized(wg, Order::rev_rpo));
+    REQUIRE(word_graph::is_standardized(wg, RevRPOCmp()));
     REQUIRE(words_from_forest(f) == expected.second);
     REQUIRE(
         expected.second
@@ -1148,25 +1149,25 @@ namespace libsemigroups {
     WordGraph<size_t> wg4 = wg;
 
     SECTION("LenLex") {
-      Forest const f = word_graph::standardize(wg1, Order::lenlex).second;
+      Forest const f = word_graph::standardize(wg1, LenLexCmp()).second;
       std::vector<word_type> sorted_words = words_from_forest(f);
       REQUIRE(std::is_sorted(
           sorted_words.begin(), sorted_words.end(), LenLexCmp()));
     }
     SECTION("Lex") {
-      Forest const f = word_graph::standardize(wg2, Order::lex).second;
+      Forest const           f = word_graph::standardize(wg2, LexCmp()).second;
       std::vector<word_type> sorted_words = words_from_forest(f);
       REQUIRE(
           std::is_sorted(sorted_words.begin(), sorted_words.end(), LexCmp()));
     }
     SECTION("RPO") {
-      Forest const f = word_graph::standardize(wg3, Order::rpo).second;
+      Forest const           f = word_graph::standardize(wg3, RPOCmp()).second;
       std::vector<word_type> sorted_words = words_from_forest(f);
       REQUIRE(
           std::is_sorted(sorted_words.begin(), sorted_words.end(), RPOCmp()));
     }
     SECTION("RevRPO") {
-      Forest const f = word_graph::standardize(wg4, Order::rev_rpo).second;
+      Forest const f = word_graph::standardize(wg4, RevRPOCmp()).second;
       std::vector<word_type> sorted_words = words_from_forest(f);
       REQUIRE(std::is_sorted(
           sorted_words.begin(), sorted_words.end(), RevRPOCmp()));
@@ -1202,25 +1203,25 @@ namespace libsemigroups {
     WordGraph<size_t> wg4 = wg;
 
     SECTION("LenLex") {
-      Forest const f = word_graph::standardize(wg1, Order::lenlex).second;
+      Forest const f = word_graph::standardize(wg1, LenLexCmp()).second;
       std::vector<word_type> sorted_words = words_from_forest(f);
       REQUIRE(std::is_sorted(
           sorted_words.begin(), sorted_words.end(), LenLexCmp()));
     }
     SECTION("Lex") {
-      Forest const f = word_graph::standardize(wg2, Order::lex).second;
+      Forest const           f = word_graph::standardize(wg2, LexCmp()).second;
       std::vector<word_type> sorted_words = words_from_forest(f);
       REQUIRE(
           std::is_sorted(sorted_words.begin(), sorted_words.end(), LexCmp()));
     }
     SECTION("RPO") {
-      Forest const f = word_graph::standardize(wg3, Order::rpo).second;
+      Forest const           f = word_graph::standardize(wg3, RPOCmp()).second;
       std::vector<word_type> sorted_words = words_from_forest(f);
       REQUIRE(
           std::is_sorted(sorted_words.begin(), sorted_words.end(), RPOCmp()));
     }
     SECTION("RevRPO") {
-      Forest const f = word_graph::standardize(wg4, Order::rev_rpo).second;
+      Forest const f = word_graph::standardize(wg4, RevRPOCmp()).second;
       std::vector<word_type> sorted_words = words_from_forest(f);
       REQUIRE(std::is_sorted(
           sorted_words.begin(), sorted_words.end(), RevRPOCmp()));
@@ -1351,12 +1352,9 @@ namespace libsemigroups {
 
     WordGraph<uint32_t> empty;
     Forest              forest;
-    REQUIRE(!word_graph::standardize_no_checks(empty, forest, Order::lenlex));
+    REQUIRE(!word_graph::standardize_no_checks(empty, forest, LenLexCmp()));
 
     WordGraph<uint32_t> graph(1, 1);
-    REQUIRE(!word_graph::standardize_no_checks(graph, forest, Order::none));
-    REQUIRE(!word_graph::standardize_no_checks(
-        graph, forest, static_cast<Order>(255)));
 
     Joiner join1;
     Joiner join2(join1);
@@ -1396,23 +1394,29 @@ namespace libsemigroups {
     WordGraph<size_t> wg8 = wg;
 
     SECTION("LenLex") {
-      word_graph::standardize(wg1, Order::lenlex);
-      word_graph::standardize(wg2, LenLexCmp());
+      word_graph::standardize(wg1, LenLexCmp());
+      word_graph::standardize(wg2, [](auto const& w1, auto const& w2) {
+        return lenlex_cmp(w1, w2);
+      });
       REQUIRE(wg1 == wg2);
     }
     SECTION("Lex") {
-      word_graph::standardize(wg3, Order::lex);
-      word_graph::standardize(wg4, LexCmp());
+      word_graph::standardize(wg3, LexCmp());
+      word_graph::standardize(
+          wg4, [](auto const& w1, auto const& w2) { return lex_cmp(w1, w2); });
       REQUIRE(wg3 == wg4);
     }
     SECTION("RPO") {
-      word_graph::standardize(wg5, Order::rpo);
-      word_graph::standardize(wg6, RPOCmp());
+      word_graph::standardize(wg5, RPOCmp());
+      word_graph::standardize(
+          wg6, [](auto const& w1, auto const& w2) { return rpo_cmp(w1, w2); });
       REQUIRE(wg5 == wg6);
     }
     SECTION("RevRPO") {
-      word_graph::standardize(wg7, Order::rev_rpo);
-      word_graph::standardize(wg8, RevRPOCmp());
+      word_graph::standardize(wg7, RevRPOCmp());
+      word_graph::standardize(wg8, [](auto const& w1, auto const& w2) {
+        return rev_rpo_cmp(w1, w2);
+      });
       REQUIRE(wg7 == wg8);
     }
   }
@@ -1445,25 +1449,37 @@ namespace libsemigroups {
     WordGraph<size_t> wg4 = wg;
 
     SECTION("LenLex") {
-      Forest const f = word_graph::standardize(wg1, LenLexCmp()).second;
+      Forest const f
+          = word_graph::standardize(wg1, [](auto const& w1, auto const& w2) {
+              return lenlex_cmp(w1, w2);
+            }).second;
       std::vector<word_type> sorted_words = words_from_forest(f);
       REQUIRE(std::is_sorted(
           sorted_words.begin(), sorted_words.end(), LenLexCmp()));
     }
     SECTION("Lex") {
-      Forest const           f = word_graph::standardize(wg2, LexCmp()).second;
+      Forest const f
+          = word_graph::standardize(wg2, [](auto const& w1, auto const& w2) {
+              return lex_cmp(w1, w2);
+            }).second;
       std::vector<word_type> sorted_words = words_from_forest(f);
       REQUIRE(
           std::is_sorted(sorted_words.begin(), sorted_words.end(), LexCmp()));
     }
     SECTION("RPO") {
-      Forest const           f = word_graph::standardize(wg3, RPOCmp()).second;
+      Forest const f
+          = word_graph::standardize(wg3, [](auto const& w1, auto const& w2) {
+              return rpo_cmp(w1, w2);
+            }).second;
       std::vector<word_type> sorted_words = words_from_forest(f);
       REQUIRE(
           std::is_sorted(sorted_words.begin(), sorted_words.end(), RPOCmp()));
     }
     SECTION("RevRPO") {
-      Forest const f = word_graph::standardize(wg4, RevRPOCmp()).second;
+      Forest const f
+          = word_graph::standardize(wg4, [](auto const& w1, auto const& w2) {
+              return rev_rpo_cmp(w1, w2);
+            }).second;
       std::vector<word_type> sorted_words = words_from_forest(f);
       REQUIRE(std::is_sorted(
           sorted_words.begin(), sorted_words.end(), RevRPOCmp()));
@@ -1485,24 +1501,24 @@ namespace libsemigroups {
     WordGraph<size_t> wg4 = wg;
 
     SECTION("LenLex") {
-      REQUIRE(!word_graph::is_standardized(wg1, Order::lenlex));
-      word_graph::standardize(wg1, Order::lenlex);
-      REQUIRE(word_graph::is_standardized(wg1, Order::lenlex));
+      REQUIRE(!word_graph::is_standardized(wg1, LenLexCmp()));
+      word_graph::standardize(wg1, LenLexCmp());
+      REQUIRE(word_graph::is_standardized(wg1, LenLexCmp()));
     }
     SECTION("Lex") {
-      REQUIRE(!word_graph::is_standardized(wg2, Order::lex));
-      word_graph::standardize(wg2, Order::lex);
-      REQUIRE(word_graph::is_standardized(wg2, Order::lex));
+      REQUIRE(!word_graph::is_standardized(wg2, LexCmp()));
+      word_graph::standardize(wg2, LexCmp());
+      REQUIRE(word_graph::is_standardized(wg2, LexCmp()));
     }
     SECTION("RPO") {
-      REQUIRE(!word_graph::is_standardized(wg3, Order::rpo));
-      word_graph::standardize(wg3, Order::rpo);
-      REQUIRE(word_graph::is_standardized(wg3, Order::rpo));
+      REQUIRE(!word_graph::is_standardized(wg3, RPOCmp()));
+      word_graph::standardize(wg3, RPOCmp());
+      REQUIRE(word_graph::is_standardized(wg3, RPOCmp()));
     }
     SECTION("RevRPO") {
-      REQUIRE(!word_graph::is_standardized(wg4, Order::rev_rpo));
-      word_graph::standardize(wg4, Order::rev_rpo);
-      REQUIRE(word_graph::is_standardized(wg4, Order::rev_rpo));
+      REQUIRE(!word_graph::is_standardized(wg4, RevRPOCmp()));
+      word_graph::standardize(wg4, RevRPOCmp());
+      REQUIRE(word_graph::is_standardized(wg4, RevRPOCmp()));
     }
   }
 
@@ -1521,24 +1537,40 @@ namespace libsemigroups {
     WordGraph<size_t> wg4 = wg;
 
     SECTION("LenLex") {
-      REQUIRE(!word_graph::is_standardized(wg1, Order::lenlex));
-      word_graph::standardize(wg1, Order::lenlex);
-      REQUIRE(word_graph::is_standardized(wg1, LenLexCmp()));
+      REQUIRE(
+          !word_graph::is_standardized(wg1, [](auto const& w1, auto const& w2) {
+            return lenlex_cmp(w1, w2);
+          }));
+      word_graph::standardize(wg1, LenLexCmp());
+      REQUIRE(
+          word_graph::is_standardized(wg1, [](auto const& w1, auto const& w2) {
+            return lenlex_cmp(w1, w2);
+          }));
     }
     SECTION("Lex") {
-      REQUIRE(!word_graph::is_standardized(wg2, Order::lex));
-      word_graph::standardize(wg2, Order::lex);
-      REQUIRE(word_graph::is_standardized(wg2, LexCmp()));
+      REQUIRE(!word_graph::is_standardized(
+          wg2, [](auto const& w1, auto const& w2) { return lex_cmp(w1, w2); }));
+      word_graph::standardize(wg2, LexCmp());
+      REQUIRE(word_graph::is_standardized(
+          wg2, [](auto const& w1, auto const& w2) { return lex_cmp(w1, w2); }));
     }
     SECTION("RPO") {
-      REQUIRE(!word_graph::is_standardized(wg3, Order::rpo));
-      word_graph::standardize(wg3, Order::rpo);
-      REQUIRE(word_graph::is_standardized(wg3, RPOCmp()));
+      REQUIRE(!word_graph::is_standardized(
+          wg3, [](auto const& w1, auto const& w2) { return rpo_cmp(w1, w2); }));
+      word_graph::standardize(wg3, RPOCmp());
+      REQUIRE(word_graph::is_standardized(
+          wg3, [](auto const& w1, auto const& w2) { return rpo_cmp(w1, w2); }));
     }
     SECTION("RevRPO") {
-      REQUIRE(!word_graph::is_standardized(wg4, Order::rev_rpo));
-      word_graph::standardize(wg4, Order::rev_rpo);
-      REQUIRE(word_graph::is_standardized(wg4, RevRPOCmp()));
+      REQUIRE(
+          !word_graph::is_standardized(wg4, [](auto const& w1, auto const& w2) {
+            return rev_rpo_cmp(w1, w2);
+          }));
+      word_graph::standardize(wg4, RevRPOCmp());
+      REQUIRE(
+          word_graph::is_standardized(wg4, [](auto const& w1, auto const& w2) {
+            return rev_rpo_cmp(w1, w2);
+          }));
     }
   }
 }  // namespace libsemigroups


### PR DESCRIPTION
This PR adds some missing standardization functionality. In particular, it adds:
- `is_lex_standardized`
- `is_rpo_standardized`
- a generic `standardize` function that takes an arbitrary reduction order. and
- a generic `is_standardized` function that takes an arbitrary reduction order.

This was done on top of #1068, and will therefore need a bit of rebasing before merging I suspect. Reviewing one commit at a time ought to be doable. 