### PR TITLE
word-graph: fix some issues after file split

### DIFF
--- a/include/libsemigroups/word-graph-class.hpp
+++ b/include/libsemigroups/word-graph-class.hpp
@@ -20,7 +20,7 @@
 //
 // The header include order is:
 // 1. word-graph-class.hpp
-// 2. word-graph-view.hpp
+// 2. word-graph-view-class.hpp
 // 3. word-graph-view-helpers.hpp
 // 4. word-graph-helpers.hpp
 

--- a/include/libsemigroups/word-graph-helpers.hpp
+++ b/include/libsemigroups/word-graph-helpers.hpp
@@ -16,7 +16,20 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-// This file contains helper functions for word graphs
+// This file contains helper functions for word graphs, which mostly just
+// delegate to the WordGraphView overloads. The exception is when the WordGraph
+// is to be modified, then the functionality is implemented here and not
+// available for WordGraphView which provide read-only const access to the
+// underlying WordGraph.
+//
+// The header include order is:
+// 1. word-graph-class.hpp
+// 2. word-graph-view-class.hpp
+// 3. word-graph-view-helpers.hpp
+// 4. word-graph-helpers.hpp
+
+// TODO(v4): * remove all the extraneous overloads using Node1, Node2, and
+// Iterator1 and Iterator2, use one type Node and one for Iterator only.
 
 #ifndef LIBSEMIGROUPS_WORD_GRAPH_HELPERS_HPP_
 #define LIBSEMIGROUPS_WORD_GRAPH_HELPERS_HPP_
@@ -90,6 +103,7 @@ namespace libsemigroups {
     void throw_if_label_out_of_bounds(WordGraph<Node> const&               wg,
                                       typename WordGraph<Node>::label_type a);
 
+    // TODO deprecate
     template <typename Node>
     void throw_if_label_out_of_bounds(WordGraph<Node> const& wg,
                                       word_type const&       word);
@@ -129,6 +143,8 @@ namespace libsemigroups {
     //!
     //! \note
     //! The edges added by this function are all labelled \c 0.
+    // NOTE: there's no WordGraphView version of this function because it
+    // modifies it's argument and WordGraphView is read-only.
     // TODO(1) add add_cycle with checks version.
     template <typename Node, typename Iterator>
     void add_cycle_no_checks(WordGraph<Node>& wg,
@@ -150,6 +166,8 @@ namespace libsemigroups {
     //!
     //! \note
     //! The edges added by this function are all labelled \c 0.
+    // NOTE: there's no WordGraphView version of this function because it
+    // modifies it's argument and WordGraphView is read-only.
     template <typename Node>
     void add_cycle(WordGraph<Node>& wg, size_t N) {
       size_t M = wg.number_of_nodes();
@@ -360,6 +378,7 @@ namespace libsemigroups {
     //! Linear in the length of \p path.
     // TODO(2) example
     // not noexcept because WordGraph::target isn't
+    // TODO deprecate in favour of the iterator version
     template <typename Node1, typename Node2>
     [[nodiscard]] Node1 follow_path(WordGraph<Node1> const& wg,
                                     Node2                   from,
@@ -429,6 +448,7 @@ namespace libsemigroups {
     //!
     //! \warning
     //! No checks on the arguments of this function are performed.
+    // TODO deprecate in favour of the iterator overload
     template <typename Node1, typename Node2>
     [[nodiscard]] Node1 follow_path_no_checks(WordGraph<Node1> const& wg,
                                               Node2                   from,
@@ -707,6 +727,7 @@ namespace libsemigroups {
     //! \note This function ignores out of bound targets in \p wg (if any).
     //!
     //! \warning This function does not check that its arguments are valid.
+    // TODO deprecate
     template <typename Node, typename Iterator1, typename Iterator2>
     bool is_compatible_no_checks(WordGraph<Node> const& wg,
                                  Iterator1              first_node,
@@ -754,6 +775,7 @@ namespace libsemigroups {
     //! between
     //! \p first_rule and \p last_rule contains an invalid label (i.e. one
     //! greater than or equal to WordGraph::out_degree).
+    // TODO deprecate
     template <typename Node, typename Iterator1, typename Iterator2>
     bool is_compatible(WordGraph<Node> const& wg,
                        Iterator1              first_node,
@@ -763,91 +785,6 @@ namespace libsemigroups {
       return is_compatible(
           WordGraphView<Node>(wg), first_node, last_node, lhs, rhs);
     }
-
-    /*
-    //! \brief Check if a word graph or word graph view is compatible with
-    //! some relations at a range of nodes.
-    //!
-    //! This function returns \c true if the word graph \p wg is compatible
-    //! with the relations in the range \p first_rule to \p last_rule at every
-    //! node in the range from \p first_node to \p last_node. This means that
-    //! the paths with given sources that are labelled by one side of a
-    //! relation leads to the same node as the path labelled by the other side
-    //! of the relation.
-    //!
-    //! \tparam Node  the type of the nodes of the WordGraph.
-    //! \p wg.
-    //!
-    //! \tparam Iterator1 the type of \p first_node.
-    //!
-    //! \tparam Iterator2 the type of \p last_node.
-    //!
-    //! \tparam Iterator3 the type of \p first_rule and \p last_rule.
-    //!
-    //! \param wg the word graph.
-    //!
-    //! \param first_node iterator pointing at the first node.
-    //!
-    //! \param last_node iterator pointing at one beyond the last node.
-    //!
-    //! \param first_rule iterator pointing to the first rule.
-    //!
-    //! \param last_rule iterator pointing one beyond the last rule.
-    //!
-    //! \return Whether or not the word graph is compatible with the given
-    //! rules at each one of the given nodes.
-    //!
-    //! \throws LibsemigroupsException if any of the nodes in the range
-    //! between
-    //! \p first_node and \p last_node does not belong to \p wg (i.e. is
-    //! greater than or equal to WordGraph::number_of_nodes).
-    //!
-    //! \throws LibsemigroupsException if any of the rules in the range
-    //! between
-    //! \p first_rule and \p last_rule contains an invalid label (i.e. one
-    //! greater than or equal to WordGraph::out_degree).
-    //!
-    //! \note This function ignores out of bound targets in \p wg (if any).
-    TODO(0): Remove or delete
-    template <typename WordGraphType,
-              typename Iterator1,
-              typename Iterator2,
-              typename Iterator3,
-              typename = std::enable_if_t<
-                  std::is_same_v<WordGraphType,
-                                 WordGraph<typename
-                                 WordGraphType::node_type>>
-                  || std::is_same_v<
-                      WordGraphType,
-                      WordGraphView<typename WordGraphType::node_type>>>>
-    bool is_compatible(WordGraphType const& wg,
-                       Iterator1            first_node,
-                       Iterator2            last_node,
-                       Iterator3            first_rule,
-                       Iterator3            last_rule) {
-      if constexpr (std::is_same_v<
-                        WordGraphType,
-                        WordGraph<typename WordGraphType::node_type>>) {
-        return is_compatible(
-            static_cast<WordGraph<typename WordGraphType::node_type>
-            const&>(
-                wg),
-            first_node,
-            last_node,
-            first_rule,
-            last_rule);
-      } else {
-        return is_compatible(
-            static_cast<
-                WordGraphView<typename WordGraphType::node_type>
-                const&>(wg),
-            first_node,
-            last_node,
-            first_rule,
-            last_rule);
-      }
-    }
-    */
 
     //! \brief Check if every node in a range has exactly
     //! WordGraph::out_degree out-edges.
@@ -1200,6 +1137,7 @@ namespace libsemigroups {
     //! assumed that \p source is a node in the word graph \p wg; and that the
     //! letters in the word described by \p first and \p last belong to the
     //! range \c 0 to WordGraph::out_degree.
+    // TODO deprecate
     template <typename Node1, typename Node2>
     std::pair<Node1, word_type::const_iterator>
     last_node_on_path_no_checks(WordGraph<Node1> const& wg,
@@ -1229,6 +1167,7 @@ namespace libsemigroups {
     //! WordGraph::number_of_nodes), the path labelled by the word exits the
     //! word graph, which is reflected in the result value of this function,
     //! but does not cause an exception to be thrown.
+    // TODO deprecate
     template <typename Node1, typename Node2>
     std::pair<Node1, word_type::const_iterator>
     last_node_on_path(WordGraph<Node1> const& wg,
@@ -1596,12 +1535,15 @@ namespace libsemigroups {
     //!
     //! \note If any target of any edge in the word graph \p wg is out of
     //! bounds, then this is ignored by this function.
-    // Not nodiscard because sometimes we just don't want the output
     //!
     //! \warning If there are nodes in the \p wg that are not reachable from
     //! the node \c 0, then this function may not preserve \p wg up to
     //! isomorphism. However, the isomorphism type of the sub-word-graph
     //! consisting of those nodes reachable from the node \c 0 is preserved.
+    // NOTE: there's no WordGraphView version of this function because it
+    // modifies it's argument and WordGraphView is read-only.
+    //
+    // Not nodiscard because sometimes we just don't want the output
     template <typename Graph>
     bool standardize_no_checks(Graph& wg, Forest& f, Order val);
 
@@ -1631,6 +1573,9 @@ namespace libsemigroups {
     //! isomorphism. However, the isomorphism type of the sub-word-graph
     //! consisting of those nodes reachable from the node \c 0 is preserved.
     //!
+    // NOTE: there's no WordGraphView version of this function because it
+    // modifies it's argument and WordGraphView is read-only.
+    //
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph>
     bool standardize(Graph& wg, Forest& f, Order val) {
@@ -1662,12 +1607,15 @@ namespace libsemigroups {
     //!
     //! \note If any target of any edge in the word graph \p wg is out of
     //! bounds, then this is ignored by this function.
-    // Not nodiscard because sometimes we just don't want the output
     //!
     //! \warning If there are nodes in the \p wg that are not reachable from
     //! the node \c 0, then this function may not preserve \p wg up to
     //! isomorphism. However, the isomorphism type of the sub-word-graph
     //! consisting of those nodes reachable from the node \c 0 is preserved.
+    // NOTE: there's no WordGraphView version of this function because it
+    // modifies it's argument and WordGraphView is read-only.
+    //
+    // Not nodiscard because sometimes we just don't want the output
     template <typename Graph>
     std::pair<bool, Forest> standardize_no_checks(Graph& wg,
                                                   Order  val = Order::lenlex);
@@ -1698,6 +1646,9 @@ namespace libsemigroups {
     //! the node \c 0, then this function may not preserve \p wg up to
     //! isomorphism. However, the isomorphism type of the sub-word-graph
     //! consisting of those nodes reachable from the node \c 0 is preserved.
+    // NOTE: there's no WordGraphView version of this function because it
+    // modifies it's argument and WordGraphView is read-only.
+    //
     // Not nodiscard because sometimes we just don't want the output
     template <typename Graph>
     std::pair<bool, Forest> standardize(Graph& wg, Order val = Order::lenlex) {
@@ -1796,6 +1747,7 @@ namespace libsemigroups {
     //!
     //! \throws LibsemigroupsException if any value in \p word is out of
     //! bounds.
+    // TODO deprecate
     template <typename Node>
     void throw_if_label_out_of_bounds(WordGraph<Node> const& wg,
                                       word_type const&       word);

--- a/include/libsemigroups/word-graph-helpers.tpp
+++ b/include/libsemigroups/word-graph-helpers.tpp
@@ -174,9 +174,9 @@ namespace libsemigroups {
 
        private:
         inline node_type max_node() const noexcept {
-          if constexpr (std::is_base_of_v<
-                            libsemigroups::detail::NodeManagedGraph<node_type>,
-                            Graph>) {
+          if constexpr (std::is_base_of_v<::libsemigroups::detail::
+                                              NodeManagedGraph<node_type>,
+                                          Graph>) {
             return _wg.number_of_nodes_active() - 1;
           } else {
             return _wg.number_of_nodes() - 1;
@@ -189,7 +189,7 @@ namespace libsemigroups {
         std::vector<node_type> _p_inverse;
         bool                   _is_non_trivial_permutation;
         Graph&                 _wg;
-      };
+      };  // class Standardizer
 
       // For best performance ensure that <f> has the correct number of nodes
       // when calling this function.
@@ -401,11 +401,11 @@ namespace libsemigroups {
                   WordGraph<Node> const& y,
                   Node                   first,
                   Node                   last) {
-      // TODO(v4) Remove the libsemigroups prefix
-      libsemigroups::word_graph::throw_if_node_out_of_bounds(x, first);
-      libsemigroups::word_graph::throw_if_node_out_of_bounds(x, last - 1);
-      libsemigroups::word_graph::throw_if_node_out_of_bounds(y, first);
-      libsemigroups::word_graph::throw_if_node_out_of_bounds(y, last - 1);
+      // TODO move to word-graph-view-helpers
+      throw_if_node_out_of_bounds(x, first);
+      throw_if_node_out_of_bounds(x, last - 1);
+      throw_if_node_out_of_bounds(y, first);
+      throw_if_node_out_of_bounds(y, last - 1);
       return equal_to_no_checks(x, y, first, last);
     }
 

--- a/include/libsemigroups/word-graph-view-helpers.hpp
+++ b/include/libsemigroups/word-graph-view-helpers.hpp
@@ -16,7 +16,13 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-// This file contains helper functions for word graph views
+// This file contains helper functions for word graph views.
+//
+// The header include order is:
+// 1. word-graph-class.hpp
+// 2. word-graph-view-class.hpp
+// 3. word-graph-view-helpers.hpp
+// 4. word-graph-helpers.hpp
 
 #ifndef LIBSEMIGROUPS_WORD_GRAPH_VIEW_HELPERS_HPP_
 #define LIBSEMIGROUPS_WORD_GRAPH_VIEW_HELPERS_HPP_

--- a/include/libsemigroups/word-graph-view-helpers.tpp
+++ b/include/libsemigroups/word-graph-view-helpers.tpp
@@ -307,7 +307,6 @@ namespace libsemigroups {
                        word_type const&           lhs,
                        word_type const&           rhs) {
       wg.throw_if_node_out_of_bounds(first_node, last_node);
-      // TODO(1) be better to use follow_path in is_compatible_no_checks
       wg.throw_if_label_out_of_bounds(lhs);
       wg.throw_if_label_out_of_bounds(rhs);
       return is_compatible_no_checks(wg, first_node, last_node, lhs, rhs);
@@ -323,8 +322,12 @@ namespace libsemigroups {
                        Iterator2                  last_node,
                        Iterator3                  first_rule,
                        Iterator3                  last_rule) {
+      wg.throw_if_node_out_of_bounds(first_node, last_node);
       for (auto rit = first_rule; rit < last_rule; rit += 2) {
-        if (!is_compatible(wg, first_node, last_node, *rit, *(rit + 1))) {
+        wg.throw_if_label_out_of_bounds(*rit);
+        wg.throw_if_label_out_of_bounds(*(rit + 1));
+        if (!is_compatible_no_checks(
+                wg, first_node, last_node, *rit, *(rit + 1))) {
           return false;
         }
       }
@@ -526,6 +529,7 @@ namespace libsemigroups {
       return order;
     }
 
+    // TODO should be _no_checks
     template <typename Node1, typename Node2>
     std::vector<Node1> topological_sort(WordGraphView<Node1> const& wg,
                                         Node2                       source) {
@@ -549,9 +553,11 @@ namespace libsemigroups {
       Mat mat;
       detail::init_adjacency_matrix(wg, mat);
 
+      size_t const N = wg.number_of_nodes_no_checks();
+
       for (auto s : wg.nodes_no_checks()) {
         for (auto t : wg.targets_no_checks(s)) {
-          if (t != UNDEFINED) {
+          if (t < N) {
             mat(s, t) += 1;
           }
         }
@@ -608,7 +614,7 @@ namespace libsemigroups {
       for (Node1 s = 0; s < N; ++s) {
         for (label_type a = 0; a < M; ++a) {
           auto t = wg.target_no_checks(s, a);
-          if (t != UNDEFINED) {
+          if (t < N) {
             in_neighbours[t].push_back(s);
           }
         }
@@ -639,33 +645,6 @@ namespace libsemigroups {
     }
 
     template <typename Node1, typename Node2, typename Iterator>
-    Node1 follow_path(WordGraphView<Node1> const& wg,
-                      Node2                       from,
-                      Iterator                    first,
-                      Iterator                    last) {
-      static_assert(sizeof(Node1) <= sizeof(size_t));
-      static_assert(sizeof(Node2) <= sizeof(Node1));
-
-      wg.throw_if_node_out_of_bounds(from);
-
-      if constexpr (::libsemigroups::detail::HasLessEqual<Iterator,
-                                                          Iterator>::value) {
-        if (last <= first) {
-          return from;
-        }
-      }
-      size_t const N = wg.number_of_nodes_no_checks();
-
-      for (auto it = first; it != last && static_cast<size_t>(from) < N; ++it) {
-        from = wg.target_no_checks(from, *it);
-      }
-      if (static_cast<size_t>(from) >= N) {
-        return UNDEFINED;
-      }
-      return from;
-    }
-
-    template <typename Node1, typename Node2, typename Iterator>
     Node1 follow_path_no_checks(WordGraphView<Node1> const& wg,
                                 Node2                       from,
                                 Iterator                    first,
@@ -686,6 +665,19 @@ namespace libsemigroups {
         return UNDEFINED;
       }
       return from;
+    }
+
+    template <typename Node1, typename Node2, typename Iterator>
+    Node1 follow_path(WordGraphView<Node1> const& wg,
+                      Node2                       from,
+                      Iterator                    first,
+                      Iterator                    last) {
+      static_assert(sizeof(Node1) <= sizeof(size_t));
+      static_assert(sizeof(Node2) <= sizeof(Node1));
+
+      wg.throw_if_node_out_of_bounds(from);
+      wg.throw_if_label_out_of_bounds(first, last);
+      return follow_path_no_checks(wg, from, first, last);
     }
 
     template <typename Node1, typename Node2, typename Iterator>
@@ -715,26 +707,8 @@ namespace libsemigroups {
                                                  Iterator first,
                                                  Iterator last) {
       wg.throw_if_node_out_of_bounds(from);
-
-      static_assert(sizeof(Node2) <= sizeof(Node1));
-      auto         it   = first;
-      Node1        prev = from;
-      Node1        to   = from;
-      size_t const n    = wg.out_degree_no_checks();
-      for (; it < last && to != UNDEFINED; ++it) {
-        prev = to;
-        if (*it >= n) {
-          to = UNDEFINED;
-        } else {
-          to = wg.target_no_checks(to, *it);
-        }
-      }
-      if (it != last || to == UNDEFINED) {
-        LIBSEMIGROUPS_ASSERT(prev != UNDEFINED);
-        return {prev, it - 1};
-      } else {
-        return {to, it};
-      }
+      wg.throw_if_label_out_of_bounds(first, last);
+      return last_node_on_path_no_checks(wg, from, first, last);
     }
 
     template <typename Node1, typename Node2>

--- a/tests/test-word-graph-view.cpp
+++ b/tests/test-word-graph-view.cpp
@@ -592,7 +592,7 @@ namespace libsemigroups {
 
     auto            path_graph = make<WordGraph<size_t>>(2, {{1}, {UNDEFINED}});
     WordGraphView   path_view(path_graph);
-    word_type const path = {0, 1};
+    word_type const path = {0, 0};
     auto const      last = word_graph::last_node_on_path(path_view, 0, path);
     REQUIRE(last.first == 1);
     REQUIRE(last.second == path.cbegin() + 1);


### PR DESCRIPTION
Some of the duplicated functionality in the `wordgraph` namespace and the `v4::word_graph` namespace seems to have become out of sync, which is causing the CI to fail in:

https://github.com/libsemigroups/libsemigroups_pybind11/pull/486

This PR fixes this.