### PR TITLE
doctests: add `ReportGuard` + fix

### DIFF
--- a/etc/extract-doc-examples.py
+++ b/etc/extract-doc-examples.py
@@ -273,6 +273,8 @@ def process_folder(folder_path, recursive=False, exclude=[]):
                                 file_path.relative_to(folder)
                             }:{block["start_line"]}", "[docs][quick]") {{\n'
                         )
+                        if not re.search(r"\bReportGuard\b", block["content"]):
+                            testfile.write("    auto rg = ReportGuard(false);\n")
                         if block["content"].strip():
                             testfile.write("    " + block["content"])
                         else:

--- a/include/libsemigroups/word-graph-view-helpers.hpp
+++ b/include/libsemigroups/word-graph-view-helpers.hpp
@@ -750,9 +750,9 @@ namespace libsemigroups {
     //! WordGraph<size_t> g;
     //! g.add_nodes(4);
     //! g.add_to_out_degree(1);
-    //! g.target(0, 1, 0);
+    //! g.target(0, 0, 1);
     //! g.target(1, 0, 0);
-    //! g.target(2, 3, 0);
+    //! g.target(2, 0, 3);
     //! WordGraphView<size_t> wg(g);
     //! word_graph::is_reachable_no_checks(wg, 0, 1); // returns true
     //! word_graph::is_reachable_no_checks(wg, 1, 0); // returns true

--- a/tests/test-docs-code-examples.cpp
+++ b/tests/test-docs-code-examples.cpp
@@ -28,13 +28,12 @@
 using namespace libsemigroups::literals;
 
 namespace libsemigroups {
-  using std::literals::operator""s;
-
   // action.hpp: Line 59
   LIBSEMIGROUPS_TEST_CASE("docs",
                           "000",
                           "./include/libsemigroups/action.hpp:59",
                           "[docs][quick]") {
+    auto rg = ReportGuard(false);
     RightAction<PPerm<16>, PPerm<16>, ImageRightAction<PPerm<16>, PPerm<16>>> o;
     o.add_seed(PPerm<16>::one(16));
     o.add_generator(
@@ -91,6 +90,7 @@ namespace libsemigroups {
                           "002",
                           "./include/libsemigroups/cong-class.hpp:145",
                           "[docs][quick]") {
+    auto                    rg = ReportGuard(false);
     Presentation<word_type> p;
     p.alphabet(2);
     p.contains_empty_word(true);
@@ -107,6 +107,7 @@ namespace libsemigroups {
                           "003",
                           "./include/libsemigroups/freeband.hpp:75",
                           "[docs][quick]") {
+    auto rg = ReportGuard(false);
     bool example
         = freeband_equal_to({0, 1, 2, 3, 2, 1, 0}, {0, 1, 2, 3, 2, 3, 2, 1, 0});
     REQUIRE(example == true);
@@ -131,11 +132,12 @@ namespace libsemigroups {
     REQUIRE(example == true);
   }
 
-  // froidure-pin-base.hpp: Line 1338
+  // froidure-pin-base.hpp: Line 1343
   LIBSEMIGROUPS_TEST_CASE("docs",
                           "004",
-                          "./include/libsemigroups/froidure-pin-base.hpp:1338",
+                          "./include/libsemigroups/froidure-pin-base.hpp:1343",
                           "[docs][quick]") {
+    auto               rg = ReportGuard(false);
     FroidurePin<BMat8> S;
     S.add_generator(
         BMat8({{1, 0, 0, 0}, {1, 0, 0, 0}, {1, 0, 0, 0}, {1, 0, 0, 0}}));
@@ -165,11 +167,12 @@ namespace libsemigroups {
     //  {{3, 3}, {3}}}
   }
 
-  // froidure-pin-base.hpp: Line 1442
+  // froidure-pin-base.hpp: Line 1447
   LIBSEMIGROUPS_TEST_CASE("docs",
                           "005",
-                          "./include/libsemigroups/froidure-pin-base.hpp:1442",
+                          "./include/libsemigroups/froidure-pin-base.hpp:1447",
                           "[docs][quick]") {
+    auto               rg = ReportGuard(false);
     FroidurePin<BMat8> S;
     S.add_generator(
         BMat8({{1, 0, 0, 0}, {1, 0, 0, 0}, {1, 0, 0, 0}, {1, 0, 0, 0}}));
@@ -204,6 +207,7 @@ namespace libsemigroups {
                           "006",
                           "./include/libsemigroups/is_specialization_of.hpp:46",
                           "[docs][quick]") {
+    auto rg = ReportGuard(false);
     REQUIRE(is_specialization_of_v<std::vector<int>, std::vector> == true);
     REQUIRE(is_specialization_of_v<std::vector<int>, std::unordered_map>
             == false);
@@ -214,6 +218,7 @@ namespace libsemigroups {
                           "007",
                           "./include/libsemigroups/is_specialization_of.hpp:75",
                           "[docs][quick]") {
+    auto rg = ReportGuard(false);
     REQUIRE(is_specialization_of_v<std::vector<int>, std::vector> == true);
     REQUIRE(is_specialization_of_v<std::vector<int>, std::unordered_map>
             == false);
@@ -224,13 +229,14 @@ namespace libsemigroups {
                           "008",
                           "./include/libsemigroups/knuth-bendix-class.hpp:78",
                           "[docs][quick]") {
+    auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     p.contains_empty_word(true);
-    p.alphabet("abcd"s);
-    presentation::add_rule_no_checks(p, "ab"s, ""s);
-    presentation::add_rule_no_checks(p, "ba"s, ""s);
-    presentation::add_rule_no_checks(p, "cd"s, ""s);
-    presentation::add_rule_no_checks(p, "dc"s, ""s);
+    p.alphabet("abcd");
+    presentation::add_rule_no_checks(p, "ab", "");
+    presentation::add_rule_no_checks(p, "ba", "");
+    presentation::add_rule_no_checks(p, "cd", "");
+    presentation::add_rule_no_checks(p, "dc", "");
 
     KnuthBendix kb(congruence_kind::twosided, p);
 
@@ -246,11 +252,12 @@ namespace libsemigroups {
                           "009",
                           "./include/libsemigroups/konieczny.hpp:69",
                           "[docs][quick]") {
-    auto S = make<Konieczny>(
+    auto rg = ReportGuard(false);
+    auto S  = make<Konieczny>(
         {BMat8({{0, 1, 0, 0}, {1, 0, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}),
-         BMat8({{0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}, {1, 0, 0, 0}}),
-         BMat8({{1, 0, 0, 0}, {1, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}),
-         BMat8({{0, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}})});
+          BMat8({{0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}, {1, 0, 0, 0}}),
+          BMat8({{1, 0, 0, 0}, {1, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}),
+          BMat8({{0, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}})});
     S.size();                   // returns 63'904
     S.number_of_idempotents();  // returns 2'360
   }
@@ -260,6 +267,7 @@ namespace libsemigroups {
                           "010",
                           "./include/libsemigroups/matrix-class.hpp:270",
                           "[docs][quick]") {
+    auto rg   = ReportGuard(false);
     using Mat = BMat8;
     Mat m({{1, 1}, {0, 0}});
   }
@@ -269,6 +277,7 @@ namespace libsemigroups {
                           "011",
                           "./include/libsemigroups/matrix-class.hpp:1216",
                           "[docs][quick]") {
+    auto rg   = ReportGuard(false);
     using Mat = IntMat<>;
     Mat m(2, 3);  // construct a 2 x 3 matrix
   }
@@ -278,6 +287,7 @@ namespace libsemigroups {
                           "012",
                           "./include/libsemigroups/matrix-class.hpp:1239",
                           "[docs][quick]") {
+    auto rg   = ReportGuard(false);
     using Mat = BMat<>;
     Mat m({1, 1, 0, 0});
   }
@@ -287,6 +297,7 @@ namespace libsemigroups {
                           "013",
                           "./include/libsemigroups/matrix-class.hpp:1262",
                           "[docs][quick]") {
+    auto rg   = ReportGuard(false);
     using Mat = IntMat<>;
     Mat m({{1, 1}, {0, 0}});
   }
@@ -296,6 +307,7 @@ namespace libsemigroups {
                           "014",
                           "./include/libsemigroups/matrix-class.hpp:2009",
                           "[docs][quick]") {
+    auto rg = ReportGuard(false);
     // default construct an uninitialized 3 x 3 static matrix
     [[maybe_unused]] BMat<3> m3;
     // construct an uninitialized 4 x 4 dynamic matrix
@@ -307,6 +319,7 @@ namespace libsemigroups {
                           "015",
                           "./include/libsemigroups/matrix-class.hpp:2205",
                           "[docs][quick]") {
+    auto rg = ReportGuard(false);
     // default construct an uninitialized 3 x 3 static matrix
     [[maybe_unused]] IntMat<3> m3;
     // construct an uninitialized 4 x 4 dynamic matrix
@@ -318,6 +331,7 @@ namespace libsemigroups {
                           "016",
                           "./include/libsemigroups/matrix-class.hpp:2419",
                           "[docs][quick]") {
+    auto rg = ReportGuard(false);
     // default construct an uninitialized 3 x 3 static matrix
     [[maybe_unused]] MaxPlusMat<3> m3;
     // construct an uninitialized 4 x 4 dynamic matrix
@@ -329,6 +343,7 @@ namespace libsemigroups {
                           "017",
                           "./include/libsemigroups/matrix-class.hpp:2633",
                           "[docs][quick]") {
+    auto rg = ReportGuard(false);
     // default construct an uninitialized 3 x 3 static matrix
     [[maybe_unused]] MinPlusMat<3> m3;
     // construct an uninitialized 4 x 4 dynamic matrix
@@ -340,6 +355,7 @@ namespace libsemigroups {
                           "018",
                           "./include/libsemigroups/matrix-class.hpp:2857",
                           "[docs][quick]") {
+    auto rg = ReportGuard(false);
     // construct an uninitialized 3 x 3 static matrix with threshold 11
     [[maybe_unused]] MaxPlusTruncMat<11, 3> m3_11;
     // construct an uninitialized 4 x 4 dynamic matrix with threshold 11
@@ -356,6 +372,7 @@ namespace libsemigroups {
                           "019",
                           "./include/libsemigroups/matrix-class.hpp:3204",
                           "[docs][quick]") {
+    auto rg = ReportGuard(false);
     // construct an uninitialized 3 x 3 static matrix with threshold 11
     [[maybe_unused]] MinPlusTruncMat<11, 3> m3_11;
     // construct an uninitialized 4 x 4 dynamic matrix with threshold 11
@@ -372,6 +389,7 @@ namespace libsemigroups {
                           "020",
                           "./include/libsemigroups/matrix-class.hpp:3552",
                           "[docs][quick]") {
+    auto rg = ReportGuard(false);
     // construct an uninitialized 3 x 3 static matrix with threshold
     // 11, period 2
     [[maybe_unused]] NTPMat<11, 2, 3> m3_11_2;
@@ -390,6 +408,7 @@ namespace libsemigroups {
                           "021",
                           "./include/libsemigroups/matrix-class.hpp:4358",
                           "[docs][quick]") {
+    auto rg = ReportGuard(false);
     // default construct an uninitialized 3 x 3 static matrix
     ProjMaxPlusMat<3> m3;
     // construct an uninitialized 4 x 4 dynamic matrix
@@ -401,7 +420,8 @@ namespace libsemigroups {
                           "022",
                           "./include/libsemigroups/matrix-helpers.hpp:241",
                           "[docs][quick]") {
-    auto x = make<ProjMaxPlusMat<>>({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
+    auto rg = ReportGuard(false);
+    auto x  = make<ProjMaxPlusMat<>>({{-2, 2, 0}, {-1, 0, 0}, {1, -3, 1}});
     // returns {{-1, 0, -1}, {-2, -1, -2}, {-1, 0, -1}}
     matrix::pow(x, 100);
   }
@@ -411,15 +431,17 @@ namespace libsemigroups {
                           "023",
                           "./include/libsemigroups/matrix-helpers.hpp:805",
                           "[docs][quick]") {
-    auto x = make<BMat<>>({{1, 0, 0}, {0, 0, 1}, {0, 1, 0}});
+    auto rg = ReportGuard(false);
+    auto x  = make<BMat<>>({{1, 0, 0}, {0, 0, 1}, {0, 1, 0}});
     matrix::row_space_size(x);  // returns 7
   }
 
-  // presentation.hpp: Line 978
+  // presentation.hpp: Line 1183
   LIBSEMIGROUPS_TEST_CASE("docs",
                           "024",
-                          "./include/libsemigroups/presentation.hpp:978",
+                          "./include/libsemigroups/presentation.hpp:1183",
                           "[docs][quick]") {
+    auto                      rg = ReportGuard(false);
     Presentation<std::string> p;
     presentation::to_report_string(p);
     // "|A| = 0, |R| = 0, |u| + |v| ∈ [0, 0], ∑(|u| + |v|) = 0"
@@ -430,6 +452,7 @@ namespace libsemigroups {
                           "025",
                           "./include/libsemigroups/ranges.hpp:87",
                           "[docs][quick]") {
+    auto      rg = ReportGuard(false);
     using rx::operator|;
     auto      wg = make<WordGraph<uint8_t>>(4, {{0, 1}, {1, 0}, {2, 2}});
     Paths     p(wg);
@@ -443,6 +466,7 @@ namespace libsemigroups {
                           "026",
                           "./include/libsemigroups/schreier-sims.hpp:167",
                           "[docs][quick]") {
+    auto            rg = ReportGuard(false);
     SchreierSims<5> S;
     using Perm = decltype(S)::element_type;
     S.add_generator(Perm({1, 0, 2, 3, 4}));
@@ -455,6 +479,7 @@ namespace libsemigroups {
                           "027",
                           "./include/libsemigroups/todd-coxeter-class.hpp:80",
                           "[docs][quick]") {
+    auto rg       = ReportGuard(false);
     using options = detail::ToddCoxeterImpl::options;
 
     Presentation<word_type> p;
@@ -474,6 +499,7 @@ namespace libsemigroups {
                           "028",
                           "./include/libsemigroups/todd-coxeter-class.hpp:96",
                           "[docs][quick]") {
+    auto rg       = ReportGuard(false);
     using options = detail::ToddCoxeterImpl::options;
 
     Presentation<word_type> p;
@@ -521,78 +547,80 @@ namespace libsemigroups {
     //  0121212121_w};
   }
 
-  // word-graph.hpp: Line 1585
-  LIBSEMIGROUPS_TEST_CASE("docs",
-                          "029",
-                          "./include/libsemigroups/word-graph.hpp:1585",
-                          "[docs][quick]") {
+  // word-graph-view-helpers.hpp: Line 298
+  LIBSEMIGROUPS_TEST_CASE(
+      "docs",
+      "029",
+      "./include/libsemigroups/word-graph-view-helpers.hpp:298",
+      "[docs][quick]") {
+    auto              rg = ReportGuard(false);
     WordGraph<size_t> wg;
     wg.add_nodes(2);
     wg.add_to_out_degree(1);
     wg.target(0, 0, 1);
     wg.target(1, 0, 0);
-    REQUIRE(word_graph::is_acyclic(wg) == false);
+    word_graph::is_acyclic(WordGraphView<size_t>(wg));  // returns false
   }
 
-  // word-graph.hpp: Line 1633
-  LIBSEMIGROUPS_TEST_CASE("docs",
-                          "030",
-                          "./include/libsemigroups/word-graph.hpp:1633",
-                          "[docs][quick]") {
-    WordGraph<size_t> wg;
-    wg.add_nodes(4);
-    wg.add_to_out_degree(1);
-    wg.target(0, 0, 1);
-    wg.target(1, 0, 0);
-    wg.target(2, 0, 3);
-    REQUIRE(word_graph::is_acyclic(wg) == false);
-    REQUIRE(word_graph::is_acyclic(wg, 0) == false);
-    REQUIRE(word_graph::is_acyclic(wg, 1) == false);
-    REQUIRE(word_graph::is_acyclic(wg, 2) == true);
-    REQUIRE(word_graph::is_acyclic(wg, 3) == true);
+  // word-graph-view-helpers.hpp: Line 341
+  LIBSEMIGROUPS_TEST_CASE(
+      "docs",
+      "030",
+      "./include/libsemigroups/word-graph-view-helpers.hpp:341",
+      "[docs][quick]") {
+    auto              rg = ReportGuard(false);
+    WordGraph<size_t> g;
+    g.add_nodes(4);
+    g.add_to_out_degree(1);
+    g.target(0, 0, 1);
+    g.target(1, 0, 0);
+    g.target(2, 0, 3);
+    WordGraphView<size_t> wg(g);
+    word_graph::is_acyclic(wg);     // returns false
+    word_graph::is_acyclic(wg, 0);  // returns false
+    word_graph::is_acyclic(wg, 1);  // returns false
+    word_graph::is_acyclic(wg, 2);  // returns true
+    word_graph::is_acyclic(wg, 3);  // returns true
   }
 
-  // word-graph.hpp: Line 2070
-  LIBSEMIGROUPS_TEST_CASE("docs",
-                          "031",
-                          "./include/libsemigroups/word-graph.hpp:2070",
-                          "[docs][quick]") {
-    WordGraph<size_t> wg;
-    wg.add_nodes(4);
-    wg.add_to_out_degree(4);
-    wg.target(0, 1, 0);
-    wg.target(1, 0, 0);
-    wg.target(2, 3, 0);
-    REQUIRE(word_graph::is_reachable_no_checks(wg, 0, 1) == false);
-    REQUIRE(word_graph::is_reachable_no_checks(wg, 1, 0) == true);
-    REQUIRE(word_graph::is_reachable_no_checks(wg, 1, 2) == false);
-    REQUIRE(word_graph::is_reachable_no_checks(wg, 2, 3) == false);
-    REQUIRE(word_graph::is_reachable_no_checks(wg, 3, 2) == false);
+  // word-graph-view-helpers.hpp: Line 750
+  LIBSEMIGROUPS_TEST_CASE(
+      "docs",
+      "031",
+      "./include/libsemigroups/word-graph-view-helpers.hpp:750",
+      "[docs][quick]") {
+    auto              rg = ReportGuard(false);
+    WordGraph<size_t> g;
+    g.add_nodes(4);
+    g.add_to_out_degree(1);
+    g.target(0, 0, 1);
+    g.target(1, 0, 0);
+    g.target(2, 0, 3);
+    WordGraphView<size_t> wg(g);
+    word_graph::is_reachable_no_checks(wg, 0, 1);  // returns true
+    word_graph::is_reachable_no_checks(wg, 1, 0);  // returns true
+    word_graph::is_reachable_no_checks(wg, 1, 2);  // returns false
+    word_graph::is_reachable_no_checks(wg, 2, 3);  // returns true
+    word_graph::is_reachable_no_checks(wg, 3, 2);  // returns false
   }
 
-  // word-graph.hpp: Line 2154
-  LIBSEMIGROUPS_TEST_CASE("docs",
-                          "032",
-                          "./include/libsemigroups/word-graph.hpp:2154",
-                          "[docs][quick]") {
+  // word-graph-view-helpers.hpp: Line 833
+  LIBSEMIGROUPS_TEST_CASE(
+      "docs",
+      "032",
+      "./include/libsemigroups/word-graph-view-helpers.hpp:833",
+      "[docs][quick]") {
+    auto rg = ReportGuard(false);
     auto wg = make<WordGraph<uint8_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
-    REQUIRE(word_graph::is_strictly_cyclic(wg) == false);
-  }
-
-  // word-graph.hpp: Line 2968
-  LIBSEMIGROUPS_TEST_CASE("docs",
-                          "033",
-                          "./include/libsemigroups/word-graph.hpp:2968",
-                          "[docs][quick]") {
-    // Construct a word graph with 5 nodes and 10 edges (7 specified)
-    auto wg = make<WordGraph<uint8_t>>(5, {{0, 0}, {1, 1}, {2}, {3, 3}});
+    word_graph::is_strictly_cyclic(WordGraphView<uint8_t>(wg));  //
   }
 
   // word-range.hpp: Line 183
   LIBSEMIGROUPS_TEST_CASE("docs",
-                          "034",
+                          "033",
                           "./include/libsemigroups/word-range.hpp:183",
                           "[docs][quick]") {
+    auto rg = ReportGuard(false);
     std::vector<word_type>(cbegin_wilo(2, 3, {0}, {1, 1, 1}),
                            cend_wilo(2, 3, {0}, {1, 1, 1}));
     // {{0}, {0, 0}, {0, 1}, {1}, {1, 0}, {1, 1}};
@@ -600,9 +628,10 @@ namespace libsemigroups {
 
   // word-range.hpp: Line 253
   LIBSEMIGROUPS_TEST_CASE("docs",
-                          "035",
+                          "034",
                           "./include/libsemigroups/word-range.hpp:253",
                           "[docs][quick]") {
+    auto rg = ReportGuard(false);
     std::vector<word_type>(cbegin_wislo(2, {0}, {0, 0, 0}),
                            cend_wislo(2, {0}, {0, 0, 0}));
     // {{0}, {1}, {0, 0}, {0, 1}, {1, 0}, {1, 1}};
@@ -610,9 +639,10 @@ namespace libsemigroups {
 
   // word-range.hpp: Line 313
   LIBSEMIGROUPS_TEST_CASE("docs",
-                          "036",
+                          "035",
                           "./include/libsemigroups/word-range.hpp:313",
                           "[docs][quick]") {
+    auto      rg = ReportGuard(false);
     WordRange words;
     words
         .order(Order::lenlex)  // words in lenlex order
@@ -623,9 +653,10 @@ namespace libsemigroups {
 
   // word-range.hpp: Line 761
   LIBSEMIGROUPS_TEST_CASE("docs",
-                          "037",
+                          "036",
                           "./include/libsemigroups/word-range.hpp:761",
                           "[docs][quick]") {
+    auto   rg = ReportGuard(false);
     ToWord toword("bac");
     REQUIRE(toword("bac") == 012_w);
     REQUIRE(toword("bababbbcbc") == 0101000202_w);
@@ -636,9 +667,10 @@ namespace libsemigroups {
 
   // word-range.hpp: Line 1050
   LIBSEMIGROUPS_TEST_CASE("docs",
-                          "038",
+                          "037",
                           "./include/libsemigroups/word-range.hpp:1050",
                           "[docs][quick]") {
+    auto        rg = ReportGuard(false);
     using rx::  operator|;
     StringRange strings;
     strings.alphabet("ab").first("a").last("bbbb");
@@ -653,9 +685,10 @@ namespace libsemigroups {
 
   // word-range.hpp: Line 1155
   LIBSEMIGROUPS_TEST_CASE("docs",
-                          "039",
+                          "038",
                           "./include/libsemigroups/word-range.hpp:1155",
                           "[docs][quick]") {
+    auto     rg = ReportGuard(false);
     ToString tostring("bac");
     REQUIRE(tostring(word_type({1, 0, 2})) == "abc");
     REQUIRE(tostring(word_type({0, 1, 1, 0, 1, 1, 0, 2})) == "baabaabc");
@@ -666,9 +699,10 @@ namespace libsemigroups {
 
   // word-range.hpp: Line 1406
   LIBSEMIGROUPS_TEST_CASE("docs",
-                          "040",
+                          "039",
                           "./include/libsemigroups/word-range.hpp:1406",
                           "[docs][quick]") {
+    auto      rg = ReportGuard(false);
     using rx::operator|;
     WordRange words;
     words.alphabet_size(1).min(0).max(10);
@@ -681,9 +715,10 @@ namespace libsemigroups {
 
   // word-range.hpp: Line 1604
   LIBSEMIGROUPS_TEST_CASE("docs",
-                          "041",
+                          "040",
                           "./include/libsemigroups/word-range.hpp:1604",
                           "[docs][quick]") {
+    auto        rg = ReportGuard(false);
     StringRange strings;
     strings
         .order(Order::lenlex)  // strings in lenlex order
@@ -694,9 +729,10 @@ namespace libsemigroups {
 
   // word-range.hpp: Line 2344
   LIBSEMIGROUPS_TEST_CASE("docs",
-                          "042",
+                          "041",
                           "./include/libsemigroups/word-range.hpp:2344",
                           "[docs][quick]") {
+    auto rg = ReportGuard(false);
     using namespace words;
     word_type w = 012345_w;
     prod(w, 0, 5, 2);               // {0, 2, 4}


### PR DESCRIPTION
To ensure that we include a `ReportGuard` in every quick test, I've updated the doctest generation script to add one if it isn't already present, I've regenerated the file, and also fixed one failing manual example.