### PR TITLE
dev: check ReportGuard only in changed quick tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,11 @@ repos:
     hooks:
       - id: codespell
         stages: ["pre-push"]
+  - repo: local
+    hooks:
+      - id: check-quick-report-guard
+        name: check quick tests disable reporting
+        entry: python3 etc/check-quick-report-guard.py
+        language: system
+        stages: ["pre-push"]
+        files: ^tests/.*\.(cc|cpp|cxx)$

--- a/etc/check-quick-report-guard.py
+++ b/etc/check-quick-report-guard.py
@@ -3,11 +3,13 @@
 
 The script should be run from the libsemigroups root directory. By default it
 checks libsemigroups test and benchmark .cpp files, excluding third_party.
-Pass file or directory paths to restrict the check.
+Pass file or directory paths to restrict the check, or use --changed to check
+only staged, unstaged, and untracked files.
 """
 
 import argparse
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -241,8 +243,32 @@ def files_from_args(paths):
             yield filename
 
 
+def changed_files():
+    """Yield changed and untracked paths reported by Git."""
+    commands = (
+        ("diff", "--name-only", "-z", "HEAD", "--"),
+        ("ls-files", "--others", "--exclude-standard", "-z", "--"),
+    )
+    for command in commands:
+        try:
+            output = subprocess.check_output(
+                ("git",) + command,
+                text=True,
+            )
+        except FileNotFoundError as exception:
+            raise RuntimeError("could not find Git") from exception
+        except subprocess.CalledProcessError as exception:
+            raise RuntimeError("could not determine changed files") from exception
+        yield from (path for path in output.split("\0") if path)
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--changed",
+        action="store_true",
+        help="check only staged, unstaged, and untracked files",
+    )
     parser.add_argument(
         "paths",
         nargs="*",
@@ -250,7 +276,20 @@ def main():
     )
     args = parser.parse_args()
 
-    files = sorted(set(files_from_args(args.paths) if args.paths else default_files()))
+    if args.changed and args.paths:
+        parser.error("--changed cannot be combined with paths")
+
+    try:
+        if args.changed:
+            files = files_from_args(changed_files())
+        elif args.paths:
+            files = files_from_args(args.paths)
+        else:
+            files = default_files()
+        files = sorted(set(files))
+    except RuntimeError as exception:
+        parser.error(str(exception))
+
     failures = []
     quick_count = 0
 


### PR DESCRIPTION
## Summary

- add a --changed mode that checks staged, unstaged, and untracked source files
- add a pre-push hook that runs the checker only on changed C++ files under tests/
- preserve the existing full-repository and explicit-path modes

## Validation

- pre-commit configuration validation passed
- the hook passed on a compliant test file
- the hook correctly rejected a noncompliant test file
- pre-push hooks passed while pushing this branch
- git diff --check passed

## AI disclosure

Codex implemented and tested the changes and prepared this pull request.