### PR TITLE
presentation: improve perf of replace_subword

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1275,6 +1275,7 @@ EXTRA_PROGRAMS += bench_kambites
 EXTRA_PROGRAMS += bench_konieczny
 EXTRA_PROGRAMS += bench_konieczny_maxplus
 EXTRA_PROGRAMS += bench_multi_view
+EXTRA_PROGRAMS += bench_presentation
 EXTRA_PROGRAMS += bench_rewriting_system
 EXTRA_PROGRAMS += bench_sims
 EXTRA_PROGRAMS += bench_string_range
@@ -1787,6 +1788,7 @@ bench_all_SOURCES += benchmarks/bench-freeband.cpp
 bench_all_SOURCES += benchmarks/bench-kambites.cpp
 bench_all_SOURCES += benchmarks/bench-konieczny.cpp
 bench_all_SOURCES += benchmarks/bench-multi-view.cpp
+bench_all_SOURCES += benchmarks/bench-presentation.cpp
 bench_all_SOURCES += benchmarks/bench-rewriting-system.cpp
 bench_all_SOURCES += benchmarks/bench-string-range.cpp
 bench_all_SOURCES += benchmarks/bench-todd-coxeter.cpp
@@ -1836,6 +1838,10 @@ bench_konieczny_maxplus_LDADD = $(LDADD) $(CATCH2_LIBS) $(CATCH2MAIN_LIBS)
 bench_multi_view_SOURCES =  benchmarks/bench-multi-view.cpp
 bench_multi_view_SOURCES += $(CATCH2_SOURCES)
 bench_multi_view_LDADD = $(LDADD) $(CATCH2_LIBS) $(CATCH2MAIN_LIBS)
+
+bench_presentation_SOURCES = benchmarks/bench-presentation.cpp
+bench_presentation_SOURCES += $(CATCH2_SOURCES)
+bench_presentation_LDADD = $(LDADD) $(CATCH2_LIBS) $(CATCH2MAIN_LIBS)
 
 bench_rewriting_system_SOURCES =  benchmarks/bench-rewriting-system.cpp
 bench_rewriting_system_SOURCES += $(CATCH2_SOURCES)

--- a/benchmarks/bench-presentation.cpp
+++ b/benchmarks/bench-presentation.cpp
@@ -1,0 +1,242 @@
+//
+// libsemigroups - C++ library for semigroups and monoids
+// Copyright (C) 2026 James D. Mitchell
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "libsemigroups/config.hpp"        // for LIBSEMIGROUPS_CATCH_ALL_HEADER
+#include "libsemigroups/presentation.hpp"  // for Presentation
+
+#include LIBSEMIGROUPS_CATCH_ALL_HEADER  // for BENCHMARK, TEST_CASE
+
+namespace libsemigroups {
+
+  namespace old {
+    template <typename Word, typename Iterator1, typename Iterator2>
+    void replace_subword(Presentation<Word>& p,
+                         Iterator1           first_existing,
+                         Iterator1           last_existing,
+                         Iterator2           first_replacement,
+                         Iterator2           last_replacement) {
+      if (first_existing == last_existing) {
+        LIBSEMIGROUPS_EXCEPTION("the 2nd and 3rd argument must not be equal");
+      }
+      auto rplc_sbwrd = [&first_existing,
+                         &last_existing,
+                         &first_replacement,
+                         &last_replacement](Word& word) {
+        size_t const M  = std::distance(first_existing, last_existing);
+        size_t const N  = std::distance(first_replacement, last_replacement);
+        auto         it = std::search(
+            word.begin(), word.end(), first_existing, last_existing);
+        while (it != word.end()) {
+          // found existing
+          auto replacement_first = it - word.begin();
+          word.erase(it, it + M);
+          word.insert(word.begin() + replacement_first,
+                      first_replacement,
+                      last_replacement);
+          it = std::search(word.begin() + replacement_first + N,
+                           word.end(),
+                           first_existing,
+                           last_existing);
+        }
+      };
+      std::for_each(p.rules.begin(), p.rules.end(), rplc_sbwrd);
+    }
+
+    template <typename Word>
+    void replace_subword(Presentation<Word>& p,
+                         Word const&         existing,
+                         Word const&         replacement) {
+      replace_subword(p,
+                      existing.cbegin(),
+                      existing.cend(),
+                      replacement.cbegin(),
+                      replacement.cend());
+    }
+  }  // namespace old
+
+  using std::literals::operator""s;
+
+  TEST_CASE("replace_subword (M = existing.size(), N = "
+            "replacement.size())",
+            "[quick]") {
+    Presentation<std::string> p;
+    p.alphabet("ab"s).contains_empty_word(true);
+
+    size_t const num_rules = 1'000'000;
+    p.rules = random_strings("ab"s, num_rules, 8, 9) | rx::to_vector();
+    REQUIRE(p.rules.size() == num_rules);
+
+    auto compare = [&](char const* name,
+                       auto        replace,
+                       auto const& existing,
+                       auto const& replacement) {
+      BENCHMARK_ADVANCED(name)
+      (Catch::Benchmark::Chronometer meter) {
+        std::vector<Presentation<std::string>> inputs(meter.runs(), p);
+
+        meter.measure(
+            [&](int i) { replace(inputs[i], existing, replacement); });
+      };  // NOLINT
+    };
+
+    compare(
+        "old version (1 = M < N = 2)",
+        [](auto& p, auto const& from, auto const& to) {
+          old::replace_subword(p, from, to);
+        },
+        "a"s,
+        "ab"s);
+
+    compare(
+        "new version (1 = M < N = 2)",
+        [](auto& p, auto const& from, auto const& to) {
+          presentation::replace_subword(p, from, to);
+        },
+        "a"s,
+        "ab"s);
+
+    compare(
+        "old version (1 = M < N = 4)",
+        [](auto& p, auto const& from, auto const& to) {
+          old::replace_subword(p, from, to);
+        },
+        "a"s,
+        "abab"s);
+
+    compare(
+        "new version (1 = M < N = 4)",
+        [](auto& p, auto const& from, auto const& to) {
+          presentation::replace_subword(p, from, to);
+        },
+        "a"s,
+        "abab"s);
+
+    compare(
+        "old version (2 = M < N = 4)",
+        [](auto& p, auto const& from, auto const& to) {
+          old::replace_subword(p, from, to);
+        },
+        "ab"s,
+        "abab"s);
+
+    compare(
+        "new version (2 = M < N = 4)",
+        [](auto& p, auto const& from, auto const& to) {
+          presentation::replace_subword(p, from, to);
+        },
+        "ab"s,
+        "abab"s);
+
+    compare(
+        "old version (2 = M > N = 1)",
+        [](auto& p, auto const& from, auto const& to) {
+          old::replace_subword(p, from, to);
+        },
+        "ab"s,
+        "b"s);
+
+    compare(
+        "new version (2 = M > N = 1)",
+        [](auto& p, auto const& from, auto const& to) {
+          presentation::replace_subword(p, from, to);
+        },
+        "ab"s,
+        "b"s);
+
+    compare(
+        "old version (4 = M > N = 1)",
+        [](auto& p, auto const& from, auto const& to) {
+          old::replace_subword(p, from, to);
+        },
+        "abab"s,
+        "b"s);
+
+    compare(
+        "new version (4 = M > N = 1)",
+        [](auto& p, auto const& from, auto const& to) {
+          presentation::replace_subword(p, from, to);
+        },
+        "abab"s,
+        "b"s);
+
+    compare(
+        "old version (4 = M > N = 2)",
+        [](auto& p, auto const& from, auto const& to) {
+          old::replace_subword(p, from, to);
+        },
+        "abab"s,
+        "ba"s);
+
+    compare(
+        "new version (4 = M > N = 2)",
+        [](auto& p, auto const& from, auto const& to) {
+          presentation::replace_subword(p, from, to);
+        },
+        "abab"s,
+        "ba"s);
+
+    compare(
+        "old version (M = N = 1)",
+        [](auto& p, auto const& from, auto const& to) {
+          old::replace_subword(p, from, to);
+        },
+        "a"s,
+        "b"s);
+
+    compare(
+        "new version (M = N = 1)",
+        [](auto& p, auto const& from, auto const& to) {
+          presentation::replace_subword(p, from, to);
+        },
+        "a"s,
+        "b"s);
+
+    compare(
+        "old version (M = N = 2)",
+        [](auto& p, auto const& from, auto const& to) {
+          old::replace_subword(p, from, to);
+        },
+        "ab"s,
+        "ba"s);
+
+    compare(
+        "new version (M = N = 2)",
+        [](auto& p, auto const& from, auto const& to) {
+          presentation::replace_subword(p, from, to);
+        },
+        "ab"s,
+        "ba"s);
+
+    compare(
+        "old version (M = N = 4)",
+        [](auto& p, auto const& from, auto const& to) {
+          old::replace_subword(p, from, to);
+        },
+        "abaa"s,
+        "babb"s);
+
+    compare(
+        "new version (M = N = 4)",
+        [](auto& p, auto const& from, auto const& to) {
+          presentation::replace_subword(p, from, to);
+        },
+        "abaa"s,
+        "babb"s);
+  }
+
+}  // namespace libsemigroups

--- a/include/libsemigroups/presentation.tpp
+++ b/include/libsemigroups/presentation.tpp
@@ -524,30 +524,47 @@ namespace libsemigroups {
                          Iterator2           first_replacement,
                          Iterator2           last_replacement) {
       if (first_existing == last_existing) {
-        LIBSEMIGROUPS_EXCEPTION("the 2nd and 3rd argument must not be equal");
+        LIBSEMIGROUPS_EXCEPTION(
+            "cannot replace the empty word with a new subword, but the 2nd "
+            "and 3rd arguments (iterators) are equal and represent the empty "
+            "word");
       }
-      auto rplc_sbwrd = [&first_existing,
-                         &last_existing,
-                         &first_replacement,
-                         &last_replacement](Word& word) {
-        size_t const M  = std::distance(first_existing, last_existing);
-        size_t const N  = std::distance(first_replacement, last_replacement);
-        auto         it = std::search(
+      size_t const M = std::distance(first_existing, last_existing);
+      size_t const N = std::distance(first_replacement, last_replacement);
+
+      for (auto& word : p.rules) {
+        auto it = std::search(
             word.begin(), word.end(), first_existing, last_existing);
-        while (it != word.end()) {
-          // found existing
-          auto replacement_first = it - word.begin();
-          word.erase(it, it + M);
-          word.insert(word.begin() + replacement_first,
-                      first_replacement,
-                      last_replacement);
-          it = std::search(word.begin() + replacement_first + N,
-                           word.end(),
-                           first_existing,
-                           last_existing);
+        if (it == word.end()) {
+          continue;
         }
-      };
-      std::for_each(p.rules.begin(), p.rules.end(), rplc_sbwrd);
+        if (M == N) {
+          while (it != word.end()) {
+            std::copy(first_replacement, last_replacement, it);
+            it = std::search(it + M, word.end(), first_existing, last_existing);
+          }
+        } else if (N < M) {
+          // Compact behind the search position, then erase the tail once.
+          auto out = it;
+          while (it != word.end()) {
+            out        = std::copy(first_replacement, last_replacement, out);
+            auto first = it + M;
+            it  = std::search(first, word.end(), first_existing, last_existing);
+            out = std::move(first, it, out);
+          }
+          word.erase(out, word.end());
+        } else {
+          // Append to a new word so that each suffix is copied only once.
+          Word result(word.begin(), it);
+          while (it != word.end()) {
+            result.insert(result.end(), first_replacement, last_replacement);
+            auto first = it + M;
+            it = std::search(first, word.end(), first_existing, last_existing);
+            result.insert(result.end(), first, it);
+          }
+          word = std::move(result);
+        }
+      }
     }
 
     template <typename Word>

--- a/tests/test-presentation.cpp
+++ b/tests/test-presentation.cpp
@@ -1361,6 +1361,41 @@ namespace libsemigroups {
             == std::vector<W>(
                 {{1, 1, 2, 1, 1, 2, 1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 2, 1},
                  {1, 1, 2, 1, 1, 1, 2, 1, 1, 2, 1}}));
+
+    auto check = [&p](W const& input,
+                      W const& existing,
+                      W const& replacement,
+                      W const& expected) {
+      p.rules = {input, W(), input};
+      presentation::replace_subword(p, existing, replacement);
+      REQUIRE(p.rules == std::vector<W>({expected, W(), expected}));
+    };
+
+    // Skip overlapping matches and matches created by replacement/deletion.
+    check(W({0, 0, 0, 0, 0}), W({0, 0}), W({0, 1}), W({0, 1, 0, 1, 0}));
+    check(W({0, 0, 1, 1}), W({0, 1}), W(), W({0, 1}));
+    check(W({0, 1, 0, 1, 0}),
+          W({0, 1}),
+          W({0, 1, 0, 1}),
+          W({0, 1, 0, 1, 0, 1, 0, 1, 0}));
+
+    // Compact unmatched spans, including a prefix and a trailing suffix.
+    check(W({2, 2, 2, 0, 0, 1, 2, 2, 2, 0, 0, 1, 2, 2, 2}),
+          W({0, 0, 1}),
+          W({0}),
+          W({2, 2, 2, 0, 2, 2, 2, 0, 2, 2, 2}));
+    check(W({2, 0, 1, 2, 0, 1, 2}),
+          W({0, 1}),
+          W({0, 0, 0}),
+          W({2, 0, 0, 0, 2, 0, 0, 0, 2}));
+
+    // Exercise full-capacity StaticVector inputs and outputs.
+    check(W(size_t(64), 0), W({0}), W({1}), W(size_t(64), 1));
+    check(W(size_t(64), 0), W({0, 0}), W({1}), W(size_t(32), 1));
+    check(W(size_t(64), 0), W({0}), W(), W());
+    check(W(size_t(32), 0), W({0}), W({1, 1}), W(size_t(64), 1));
+    check(W(size_t(64), 0), W({1}), W({1, 1}), W(size_t(64), 0));
+    check(W({0}), W({0, 0}), W({1, 1, 1}), W({0}));
   }
 
   LIBSEMIGROUPS_TEST_CASE("Presentation",
@@ -4302,5 +4337,22 @@ End;)xxx");
     REQUIRE(p.rules
             == std::vector<std::string>(
                 {"aaa"s, ""s, "bbbbb"s, ""s, "abababababa"s, "ababab"s}));
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Presentation",
+                          "109",
+                          "replace_subword perf",
+                          "[quick][presentation]") {
+    Presentation<std::string> p;
+    p.alphabet("ab"s).contains_empty_word(true);
+    p.rules = random_strings("ab"s, 2'000'000, 8, 9) | rx::to_vector();
+
+    REQUIRE(p.rules.size() == 2'000'000);
+
+    presentation::replace_subword(p, "a"s, "b"s);
+    auto rule = p.rules[393450];
+    REQUIRE(rule.size() == 8);
+    REQUIRE(std::all_of(
+        rule.begin(), rule.end(), [](auto letter) { return letter == 'b'; }));
   }
 }  // namespace libsemigroups


### PR DESCRIPTION
This PR improves the performance of `presentation::replace_subword`, the gains are not as profound as for `remove_trivial_rules` but they are still there:

~~~
replace_subword (M = existing.size(), N = replacement.size())
-------------------------------------------------------------------------------
benchmarks/bench-presentation.cpp:76
...............................................................................

benchmark name                       samples       iterations    est run time
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
old version (1 = M < N = 2)                    100             1     6.66019 s
                                        65.1203 ms    65.0178 ms    65.2599 ms
                                         602.51 us     471.48 us      843.9 us

new version (1 = M < N = 2)                    100             1      4.7221 s
                                        47.2359 ms     47.145 ms     47.361 ms
                                        538.245 us    411.832 us    744.403 us

old version (1 = M < N = 4)                    100             1     7.38295 s
                                        73.4386 ms    73.3047 ms    73.7506 ms
                                        983.451 us    481.521 us    1.95362 ms

new version (1 = M < N = 4)                    100             1     5.51635 s
                                         54.945 ms    54.8704 ms    55.0269 ms
                                        398.809 us    339.554 us    509.812 us

old version (2 = M < N = 4)                    100             1     4.10735 s
                                        41.1619 ms    41.1211 ms    41.2023 ms
                                        208.149 us    181.767 us    243.617 us

new version (2 = M < N = 4)                    100             1     3.64971 s
                                        39.3463 ms    38.6016 ms    41.4054 ms
                                        5.83873 ms    2.54952 ms    12.3843 ms

old version (2 = M > N = 1)                    100             1      4.2691 s
                                        42.1409 ms    42.0258 ms    42.2564 ms
                                        589.163 us    525.351 us    679.462 us

new version (2 = M > N = 1)                    100             1     2.93335 s
                                        29.5548 ms    29.4738 ms    29.6348 ms
                                        409.976 us    365.261 us    468.564 us

old version (4 = M > N = 1)                    100             1     2.34312 s
                                        22.0488 ms    21.9786 ms    22.1141 ms
                                        346.132 us    307.118 us    392.611 us

new version (4 = M > N = 1)                    100             1     1.92154 s
                                        19.6922 ms    19.6203 ms    19.7659 ms
                                        372.935 us    330.151 us    429.206 us

old version (4 = M > N = 2)                    100             1     2.18415 s
                                        22.1209 ms    22.0468 ms    22.1949 ms
                                        376.574 us    333.969 us    441.407 us

new version (4 = M > N = 2)                    100             1     1.95219 s
                                        19.7734 ms    19.6851 ms    19.8563 ms
                                        438.449 us    396.445 us    493.041 us

old version (M = N = 1)                        100             1     6.65147 s
                                         67.563 ms    67.4605 ms    67.6621 ms
                                        512.652 us    451.967 us    592.129 us

new version (M = N = 1)                        100             1      3.1023 s
                                        31.1838 ms     31.045 ms    31.3115 ms
                                        679.397 us    601.411 us    794.836 us

old version (M = N = 2)                        100             1     4.17786 s
                                        42.2664 ms    42.1765 ms    42.3526 ms
                                        448.139 us    401.369 us    502.737 us

new version (M = N = 2)                        100             1     2.55617 s
                                        25.7111 ms     25.635 ms    25.7825 ms
                                        375.375 us    331.119 us    429.864 us

old version (M = N = 4)                        100             1     2.27307 s
                                        22.9371 ms    22.8744 ms    22.9944 ms
                                        304.768 us    266.737 us    357.696 us

new version (M = N = 4)                        100             1      1.8892 s
                                        19.1259 ms    19.0104 ms    19.2477 ms
                                        603.462 us    515.817 us     746.87 us
~~~