### PR TITLE
Add the Okada monoid presentation and share Temperley–Lieb construction

### DIFF
--- a/docs/libsemigroups.bib
+++ b/docs/libsemigroups.bib
@@ -5,6 +5,14 @@
 
 %% Saved with string encoding Unicode (UTF-8) 
 
+@misc{Hivert2026aa,
+	author = {Hivert, Florent and Scott, Jeanne},
+	title = {Diagrammatic {Okada} monoid and cellularity of the {Okada} algebra},
+	doi = {10.48550/arXiv.2609.01440},
+	url = {https://arxiv.org/abs/2609.01440},
+	year = {2026}
+}
+
 @inbook{Carnino2011,
 	title = {Random Generation of Deterministic Acyclic Automata Using Markov Chains},
 	isbn = {9783642222566},

--- a/include/libsemigroups/presentation-examples.hpp
+++ b/include/libsemigroups/presentation-examples.hpp
@@ -61,6 +61,7 @@ namespace libsemigroups {
     Presentation<word_type> not_renner_type_B_monoid(size_t l, int q);
     Presentation<word_type> not_renner_type_D_monoid(size_t l, int q);
     Presentation<word_type> not_symmetric_group(size_t n);
+    Presentation<word_type> okada_monoid(size_t n);
     Presentation<word_type> order_preserving_cyclic_inverse_monoid(size_t n);
     Presentation<word_type> order_preserving_monoid(size_t n);
     Presentation<word_type> orientation_preserving_monoid(size_t n);
@@ -415,6 +416,25 @@ namespace libsemigroups {
     //!
     //! \throws LibsemigroupsException if `n < 4`.
     [[nodiscard]] Presentation<word_type> not_symmetric_group_GKKL08(size_t n);
+
+    //! \brief A presentation for the Okada monoid.
+    //!
+    //! This function returns a monoid presentation defining the Okada monoid
+    //! of degree \p n, as in Definition 3.2 of \cite Hivert2026aa.
+    //! The monoid has \f$n!\f$ elements and \f$n - 1\f$ generators, indexed
+    //! from \c 0 to \f$n - 2\f$. Its defining relations are
+    //! \f$e_i^2 = e_i\f$, \f$e_i e_j = e_j e_i\f$ for
+    //! \f$|i - j| \geq 2\f$, and
+    //! \f$e_{i+1} e_i e_{i+1} = e_{i+1}\f$.
+    //!
+    //! \param n the degree, or equivalently the number of generators plus \c 1.
+    //!
+    //! \returns A value of type `Presentation<word_type>`.
+    //!
+    //! \throws LibsemigroupsException if `n < 1`.
+    //!
+    //! \sa temperley_lieb_monoid_Eas21.
+    [[nodiscard]] Presentation<word_type> okada_monoid_HS26(size_t n);
 
     //! \brief A presentation for the order preserving part of the cyclic
     //! inverse monoid.
@@ -811,10 +831,10 @@ namespace libsemigroups {
     //! \brief A presentation for the Temperley-Lieb monoid.
     //!
     //! This function returns a monoid presentation defining the
-    //! Temperley-Lieb monoid with \p n generators, as described in
-    //! Theorem 2.2 of \cite East2022aa.
+    //! Temperley-Lieb monoid of degree \p n with \f$n - 1\f$ generators, as
+    //! described in Theorem 2.2 of \cite East2022aa.
     //!
-    //! \param n the number of generators.
+    //! \param n the degree, or equivalently the number of generators plus \c 1.
     //!
     //! \returns A value of type `Presentation<word_type>`.
     //!
@@ -834,7 +854,6 @@ namespace libsemigroups {
     [[nodiscard]] Presentation<word_type>
     uniform_block_bijection_monoid_Fit03(size_t n);
 
-    // TODO(1) add okada_monoid
     // TODO(1) add free_semilattice
 
     //! \brief A presentation for the \f$0\f$-rook monoid.
@@ -1105,6 +1124,20 @@ namespace libsemigroups {
     //! `not_symmetric_group_GKKL08`.
     [[nodiscard]] inline Presentation<word_type> not_symmetric_group(size_t n) {
       return not_symmetric_group_GKKL08(n);
+    }
+
+    //! \copydoc okada_monoid_HS26
+    //!
+    //! \note
+    //! This function performs exactly the same as `okada_monoid_HS26`, and
+    //! exists as a convenience function for when a presentation for the
+    //! Okada monoid is required, but the relations of the presentation are
+    //! not important.
+    //!
+    //! \sa
+    //! `okada_monoid_HS26`.
+    [[nodiscard]] inline Presentation<word_type> okada_monoid(size_t n) {
+      return okada_monoid_HS26(n);
     }
 
     //! \copydoc order_preserving_cyclic_inverse_monoid_Fer22

--- a/src/presentation-examples.cpp
+++ b/src/presentation-examples.cpp
@@ -1133,6 +1133,38 @@ namespace libsemigroups {
       return p;
     }
 
+    // From Definition 3.2 in https://arxiv.org/abs/2609.01440
+    Presentation<word_type> okada_monoid_HS26(size_t n) {
+      if (n < 1) {
+        LIBSEMIGROUPS_EXCEPTION(
+            "expected 1st argument to be at least 1, found {}", n);
+      }
+
+      Presentation<word_type> p;
+      p.alphabet(n - 1);
+      p.contains_empty_word(true);
+
+      // (I)
+      presentation::add_idempotent_rules_no_checks(p, range(0, n - 1));
+
+      // (C)
+      for (size_t i = 0; i < n - 1; ++i) {
+        for (size_t j = 0; j < n - 1; ++j) {
+          if (i + 1 < j || j + 1 < i) {
+            presentation::add_rule_no_checks(
+                p, word_type({i, j}), word_type({j, i}));
+          }
+        }
+      }
+
+      // (S): only the higher-indexed generator is repeated.
+      for (size_t i = 1; i < n - 1; ++i) {
+        presentation::add_rule_no_checks(
+            p, word_type({i, i - 1, i}), word_type({i}));
+      }
+      return p;
+    }
+
     // From Theorem 2.2 in https://doi.org/10.1093/qmath/haab001
     Presentation<word_type> temperley_lieb_monoid_Eas21(size_t n) {
       if (n < 3) {
@@ -1140,34 +1172,11 @@ namespace libsemigroups {
             "expected 1st argument to be at least 3, found {}", n);
       }
 
-      Presentation<word_type> p;
-      p.alphabet(n - 1);
-      p.contains_empty_word(true);
-
-      // E1
-      presentation::add_idempotent_rules_no_checks(p, range(0, n - 1));
-
-      int64_t m = n;
-      // E2 + E3
-      for (int64_t i = 0; i < m - 1; ++i) {
-        for (int64_t j = 0; j < m - 1; ++j) {
-          auto d = std::abs(i - j);
-          if (d > 1) {
-            presentation::add_rule_no_checks(
-                p,
-                word_type(
-                    {static_cast<letter_type>(i), static_cast<letter_type>(j)}),
-                word_type({static_cast<letter_type>(j),
-                           static_cast<letter_type>(i)}));
-          } else if (d == 1) {
-            presentation::add_rule_no_checks(
-                p,
-                word_type({static_cast<letter_type>(i),
-                           static_cast<letter_type>(j),
-                           static_cast<letter_type>(i)}),
-                word_type({static_cast<letter_type>(i)}));
-          }
-        }
+      auto p = okada_monoid_HS26(n);
+      // Add the other direction of the adjacent-generator relations (E3).
+      for (size_t i = 0; i < n - 2; ++i) {
+        presentation::add_rule_no_checks(
+            p, word_type({i, i + 1, i}), word_type({i}));
       }
       return p;
     }

--- a/tests/test-presentation-examples-1.cpp
+++ b/tests/test-presentation-examples-1.cpp
@@ -1243,4 +1243,55 @@ namespace libsemigroups {
     REQUIRE(p.rules.empty());
   }
 
+  LIBSEMIGROUPS_TEST_CASE("Example",
+                          "108",
+                          "okada_monoid degree except and small degrees",
+                          "[pres-examples][quick]") {
+    REQUIRE_THROWS_AS(okada_monoid(0), LibsemigroupsException);
+    REQUIRE_THROWS_AS(okada_monoid_HS26(0), LibsemigroupsException);
+
+    auto p = okada_monoid(1);
+    p.throw_if_bad_alphabet_or_rules();
+    REQUIRE(p.contains_empty_word());
+    REQUIRE(p.alphabet().empty());
+    REQUIRE(p.rules.empty());
+
+    size_t expected_size = 1;
+    for (size_t n = 2; n <= 7; ++n) {
+      CAPTURE(n);
+      expected_size *= n;
+      p = okada_monoid(n);
+      p.throw_if_bad_alphabet_or_rules();
+      REQUIRE(p == okada_monoid_HS26(n));
+      REQUIRE(p.contains_empty_word());
+      REQUIRE(p.alphabet().size() == n - 1);
+      ToddCoxeter tc(congruence_kind::twosided, p);
+      REQUIRE(tc.number_of_classes() == expected_size);
+    }
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Example",
+                          "109",
+                          "Okada and Temperley-Lieb adjacent relations",
+                          "[pres-examples][quick]") {
+    auto        rg = ReportGuard(false);
+    ToddCoxeter okada(congruence_kind::twosided, okada_monoid(4));
+    ToddCoxeter jones(congruence_kind::twosided, temperley_lieb_monoid(4));
+    for (size_t i = 0; i < 3; ++i) {
+      REQUIRE(todd_coxeter::contains(okada, word_type({i, i}), word_type({i})));
+    }
+    REQUIRE(todd_coxeter::contains(okada, 02_w, 20_w));
+    REQUIRE(!todd_coxeter::contains(okada, 01_w, 10_w));
+    REQUIRE(todd_coxeter::contains(okada, 101_w, 1_w));
+    REQUIRE(todd_coxeter::contains(okada, 212_w, 2_w));
+    REQUIRE(!todd_coxeter::contains(okada, 010_w, 0_w));
+    REQUIRE(!todd_coxeter::contains(okada, 121_w, 1_w));
+    REQUIRE(todd_coxeter::contains(jones, 101_w, 1_w));
+    REQUIRE(todd_coxeter::contains(jones, 212_w, 2_w));
+    REQUIRE(todd_coxeter::contains(jones, 010_w, 0_w));
+    REQUIRE(todd_coxeter::contains(jones, 121_w, 1_w));
+    REQUIRE(okada.number_of_classes() == 24);
+    REQUIRE(jones.number_of_classes() == 14);
+  }
+
 }  // namespace libsemigroups


### PR DESCRIPTION
Adds `presentation::examples::okada_monoid(n)` and `okada_monoid_HS26(n)` using Definition 3.2 of [Hivert and Scott, arXiv:2609.01440](https://arxiv.org/abs/2609.01440). The presentation supports degrees `n >= 1` and uses `n - 1` generators.

The Temperley–Lieb presentation now reuses the Okada presentation and adds the other direction of the adjacent-generator relations, sharing the common construction code. This also corrects the Temperley–Lieb documentation's generator count.

Validation:

- Built `test_presentation_examples` and ran `[quick]`: 99 tests and 461 assertions passed.
- Added tests for invalid and small degrees, factorial sizes through degree 7, and the distinction between the Okada and Temperley–Lieb adjacent-generator relations.
- Pre-push formatting, cpplint, and spelling checks passed for all changed files.
- Documentation order and Doxygen line-break checks passed.
- The full library test suite and documentation build were not run.

AI disclosure: OpenAI Codex authored the implementation, documentation, tests, commit message, and this pull request description. The commit identifies Codex as author and includes the repository-required AI co-author trailer.
