### PR TITLE
bipart: add checked in-place multiplication

### DIFF
--- a/include/libsemigroups/bipart.hpp
+++ b/include/libsemigroups/bipart.hpp
@@ -1335,8 +1335,8 @@ namespace libsemigroups {
     //! \brief Modify the current bipartition in-place to contain the product of
     //! two bipartitions.
     //!
-    //! The parameter \p thread_id can be used some temporary storage is
-    //! required to find the product of \p x and \p y.
+    //! The parameter \p thread_id selects the temporary storage used to find
+    //! the product of \p x and \p y.
     //!
     //! \param x the first bipartition to multiply.
     //! \param y the second bipartition to multiply.
@@ -1352,11 +1352,45 @@ namespace libsemigroups {
     //! If different threads call this function concurrently with the same
     //! parameter \p thread_id, then bad things will happen.
     //!
-    //! \warning This function expects its arguments to have equal degree, but
-    //! this is not checked.
+    //! \warning This function expects \p x, \p y, and `*this` to be valid
+    //! bipartitions of equal degree, with `this` distinct from `&x` and `&y`.
+    //! The value of \p thread_id must be at most
+    //! `std::thread::hardware_concurrency()`. These conditions are not checked.
+    //!
+    //! \sa product_inplace.
     void product_inplace_no_checks(Bipartition const& x,
                                    Bipartition const& y,
                                    size_t             thread_id = 0);
+
+    //! \brief Multiply two bipartitions and store the product in `*this`.
+    //!
+    //! Replaces the contents of `*this` by the product of \p x and \p y.
+    //! All three bipartitions must have equal degree, and the destination must
+    //! be distinct from both operands. The operands may be the same object.
+    //!
+    //! The parameter \p thread_id selects the temporary storage used to find
+    //! the product of \p x and \p y.
+    //!
+    //! \param x the first bipartition to multiply.
+    //! \param y the second bipartition to multiply.
+    //! \param thread_id the index of the calling thread (defaults to \c 0).
+    //!
+    //! \throws LibsemigroupsException if:
+    //! * \p x, \p y, and `*this` do not all have equal degree;
+    //! * `this` is equal to `&x` or `&y`;
+    //! * \p thread_id exceeds `std::thread::hardware_concurrency()`; or
+    //! * \p x, \p y, or `*this` is invalid.
+    //! \strong_guarantee
+    //!
+    //! \complexity
+    //! Quadratic in `x.degree()`.
+    //!
+    //! \warning Concurrent calls must use distinct values of \p thread_id.
+    //!
+    //! \sa product_inplace_no_checks, bipartition::throw_if_invalid.
+    void product_inplace(Bipartition const& x,
+                         Bipartition const& y,
+                         size_t             thread_id = 0);
 
     //! \brief Return the number of transverse blocks.
     //!
@@ -1698,14 +1732,17 @@ namespace libsemigroups {
   //! \returns
   //! A value of type \c Bipartition
   //!
-  //! \exceptions
-  //! \no_libsemigroups_except
+  //! \throws LibsemigroupsException if \p x and \p y have different degrees
+  //! or either operand is invalid.
   //!
   //! \complexity
   //! Quadratic in `x.degree()`.
   //!
-  //! \warning This function expects its arguments to have equal degree, but
-  //! this is not checked.
+  //! \warning This function uses the same temporary storage as
+  //! Bipartition::product_inplace with `thread_id = 0`. Concurrent calls must
+  //! not use this storage.
+  //!
+  //! \sa Bipartition::product_inplace.
   [[nodiscard]] Bipartition operator*(Bipartition const& x,
                                       Bipartition const& y);
 

--- a/src/bipart.cpp
+++ b/src/bipart.cpp
@@ -25,7 +25,7 @@
 #include <limits>    // for numeric_limits
 #include <numeric>   // for iota
 #include <random>    // for discrete_distribution
-#include <thread>    // for get_id
+#include <thread>    // for hardware_concurrency
 #include <utility>   // for move
 
 #include "libsemigroups/constants.hpp"  // for UNDEFINED, operator==, operator!=
@@ -68,9 +68,13 @@ namespace libsemigroups {
       return bell[1];
     }
 
+    size_t thread_storage_size() {
+      static size_t const size = std::thread::hardware_concurrency() + 1;
+      return size;
+    }
+
     std::vector<uint32_t>& thread_lookup(size_t thread_id) {
-      static std::vector<std::vector<uint32_t>> lookups(
-          std::thread::hardware_concurrency() + 1);
+      static std::vector<std::vector<uint32_t>> lookups(thread_storage_size());
       LIBSEMIGROUPS_ASSERT(thread_id < lookups.size());
       return lookups[thread_id];
     }
@@ -494,7 +498,7 @@ namespace libsemigroups {
   // TODO(2) Should be defined for all of the new element types
   Bipartition operator*(Bipartition const& x, Bipartition const& y) {
     Bipartition xy(x.degree());
-    xy.product_inplace_no_checks(x, y);
+    xy.product_inplace(x, y);
     return xy;
   }
 
@@ -569,6 +573,43 @@ namespace libsemigroups {
     return Bipartition(std::move(vector));
   }
 
+  void Bipartition::product_inplace(Bipartition const& x,
+                                    Bipartition const& y,
+                                    size_t             thread_id) {
+    if (x.degree() != y.degree()) {
+      LIBSEMIGROUPS_EXCEPTION(
+          "the 1st and 2nd arguments (bipartitions) must have the same degree, "
+          "found degrees {} and {}",
+          x.degree(),
+          y.degree());
+    }
+    if (degree() != x.degree()) {
+      LIBSEMIGROUPS_EXCEPTION(
+          "the 1st argument (bipartition) must have degree {} "
+          "(the degree of \"*this\"), found {}",
+          degree(),
+          x.degree());
+    }
+    if (this == &x) {
+      LIBSEMIGROUPS_EXCEPTION("the 1st argument (bipartition) cannot be the "
+                              "same object as \"*this\"");
+    } else if (this == &y) {
+      LIBSEMIGROUPS_EXCEPTION("the 2nd argument (bipartition) cannot be the "
+                              "same object as \"*this\"");
+    }
+    if (thread_id >= thread_storage_size()) {
+      LIBSEMIGROUPS_EXCEPTION(
+          "the 3rd argument (thread index) is out of range, "
+          "expected a value in [0, {}), but found {}",
+          thread_storage_size(),
+          thread_id);
+    }
+    bipartition::throw_if_invalid(x);
+    bipartition::throw_if_invalid(y);
+    bipartition::throw_if_invalid(*this);
+    product_inplace_no_checks(x, y, thread_id);
+  }
+
   // multiply x and y into this
   void Bipartition::product_inplace_no_checks(Bipartition const& x,
                                               Bipartition const& y,
@@ -588,8 +629,7 @@ namespace libsemigroups {
     uint32_t const nrx(xx.number_of_blocks());
     uint32_t const nry(yy.number_of_blocks());
 
-    static std::vector<std::vector<uint32_t>> fuses(
-        std::thread::hardware_concurrency() + 1);
+    static std::vector<std::vector<uint32_t>> fuses(thread_storage_size());
     LIBSEMIGROUPS_ASSERT(thread_id < fuses.size());
     std::vector<uint32_t>& fuse = fuses[thread_id];
     std::vector<uint32_t>& lookup(thread_lookup(thread_id));
@@ -629,6 +669,10 @@ namespace libsemigroups {
       }
       _vector[i] = lookup[j];
     }
+    _nr_blocks      = UNDEFINED;
+    _nr_left_blocks = UNDEFINED;
+    _rank           = UNDEFINED;
+    _trans_blocks_lookup.clear();
   }
 
   uint32_t Bipartition::number_of_blocks() const {

--- a/tests/test-bipart.cpp
+++ b/tests/test-bipart.cpp
@@ -19,7 +19,10 @@
 #include <cstddef>           // for size_t
 #include <cstdint>           // for uint32_t, int32_t
 #include <initializer_list>  // for initializer_list
+#include <iterator>          // for distance
+#include <limits>            // for numeric_limits
 #include <string>            // for allocator, basic_string
+#include <thread>            // for hardware_concurrency
 #include <unordered_set>     // for unordered_set
 #include <utility>           // for move
 #include <vector>            // for operator==
@@ -722,6 +725,171 @@ namespace libsemigroups {
                           "uniform_random chi-squared test x2",
                           "[fail][bipart]") {
     test_uniform_bipartition(5, 115'975, 117'097.3, 10);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Bipartition",
+                          "024",
+                          "checked products",
+                          "[quick][bipart]") {
+    auto const  x = make<Bipartition>({0, 0, 0, 1});
+    auto const  y = make<Bipartition>({0, 1, 0, 0});
+    Bipartition z(2);
+    z.product_inplace(x, y);
+    REQUIRE(z == make<Bipartition>({0, 0, 0, 0}));
+    REQUIRE(x * y == z);
+
+    z.product_inplace(y, x, std::thread::hardware_concurrency());
+    REQUIRE(z == make<Bipartition>({0, 1, 0, 2}));
+    REQUIRE(y * x == z);
+
+    auto const id = Bipartition::one(2);
+    z.product_inplace(x, id);
+    REQUIRE(z == x);
+    z.product_inplace(id, x);
+    REQUIRE(z == x);
+
+    auto const swap = make<Bipartition>({0, 1, 1, 0});
+    z.product_inplace(swap, swap);
+    REQUIRE(z == id);
+    REQUIRE(swap * swap == id);
+
+    Bipartition const empty;
+    Bipartition       result;
+    result.product_inplace(empty, empty);
+    REQUIRE(result == empty);
+    REQUIRE(result.degree() == 0);
+    REQUIRE(result.number_of_blocks() == 0);
+    REQUIRE(result.rank() == 0);
+    REQUIRE(empty * empty == empty);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Bipartition",
+                          "025",
+                          "checked products require equal degrees",
+                          "[quick][bipart]") {
+    // The example from Semigroups issue #1183 and libsemigroups issue #989.
+    auto const x = make<Bipartition>(
+        {{1, -1, -2}, {2, 5}, {3, 4, -3}, {-4, -5}, {6, -6}});
+    auto const y
+        = make<Bipartition>({{1, -4}, {2}, {3, -1}, {4}, {5, -3}, {-2}, {-5}});
+    auto       z      = Bipartition::one(6);
+    auto const before = z;
+    REQUIRE_EXCEPTION_MSG(
+        z.product_inplace(x, y),
+        "the 1st and 2nd arguments (bipartitions) must have the same degree, "
+        "found degrees 6 and 5");
+    REQUIRE(z == before);
+    REQUIRE_THROWS_AS(x * y, LibsemigroupsException);
+    REQUIRE_THROWS_AS(y * x, LibsemigroupsException);
+
+    auto       smaller        = Bipartition::one(5);
+    auto const smaller_before = smaller;
+    REQUIRE_EXCEPTION_MSG(
+        smaller.product_inplace(y, x),
+        "the 1st and 2nd arguments (bipartitions) must have the same degree, "
+        "found degrees 5 and 6");
+    REQUIRE(smaller == smaller_before);
+
+    for (size_t degree : {0, 4, 6}) {
+      auto       destination = Bipartition::one(degree);
+      auto const original    = destination;
+      REQUIRE_EXCEPTION_MSG(
+          destination.product_inplace(y, y),
+          fmt::format("the 1st argument (bipartition) must have degree {} "
+                      "(the degree of \"*this\"), found 5",
+                      degree));
+      REQUIRE(destination == original);
+    }
+
+    Bipartition const empty;
+    REQUIRE_THROWS_AS(empty * x, LibsemigroupsException);
+    REQUIRE_THROWS_AS(x * empty, LibsemigroupsException);
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Bipartition",
+                          "026",
+                          "checked products reject invalid arguments",
+                          "[quick][bipart]") {
+    auto const id = Bipartition::one(2);
+    auto       z  = id;
+    z.set_number_of_blocks(2);
+    REQUIRE(z.rank() == 2);
+    auto const before = z;
+
+    REQUIRE_EXCEPTION_MSG(z.product_inplace(z, id),
+                          "the 1st argument (bipartition) cannot be the same "
+                          "object as \"*this\"");
+    REQUIRE_EXCEPTION_MSG(z.product_inplace(id, z),
+                          "the 2nd argument (bipartition) cannot be the same "
+                          "object as \"*this\"");
+    REQUIRE_EXCEPTION_MSG(z.product_inplace(z, z),
+                          "the 1st argument (bipartition) cannot be the same "
+                          "object as \"*this\"");
+    size_t const thread_count = std::thread::hardware_concurrency() + 1;
+    REQUIRE_EXCEPTION_MSG(
+        z.product_inplace(id, id, thread_count),
+        fmt::format("the 3rd argument (thread index) is out of range, "
+                    "expected a value in [0, {}), but found {}",
+                    thread_count,
+                    thread_count));
+    REQUIRE_EXCEPTION_MSG(
+        z.product_inplace(id, id, std::numeric_limits<size_t>::max()),
+        fmt::format("the 3rd argument (thread index) is out of range, "
+                    "expected a value in [0, {}), but found {}",
+                    thread_count,
+                    std::numeric_limits<size_t>::max()));
+
+    // Unchecked constructors can produce invalid labels or an odd length.
+    for (auto const& invalid : {Bipartition({1, 0, 0, 0}),
+                                Bipartition({0, 2, 0, 0}),
+                                Bipartition({0, 1, 0, 1, 0})}) {
+      REQUIRE_THROWS_AS(z.product_inplace(invalid, id), LibsemigroupsException);
+      REQUIRE_THROWS_AS(z.product_inplace(id, invalid), LibsemigroupsException);
+      REQUIRE_THROWS_AS(invalid * id, LibsemigroupsException);
+      REQUIRE_THROWS_AS(id * invalid, LibsemigroupsException);
+      auto destination = invalid;
+      REQUIRE_THROWS_AS(destination.product_inplace(id, id),
+                        LibsemigroupsException);
+      REQUIRE(destination == invalid);
+    }
+    REQUIRE(z == before);
+    REQUIRE(z.number_of_blocks() == 2);
+    REQUIRE(z.number_of_left_blocks() == 2);
+    REQUIRE(z.number_of_right_blocks() == 2);
+    REQUIRE(z.rank() == 2);
+    REQUIRE(std::vector<bool>(z.cbegin_lookup(), z.cend_lookup())
+            == std::vector<bool>({true, true}));
+  }
+
+  LIBSEMIGROUPS_TEST_CASE("Bipartition",
+                          "027",
+                          "products invalidate cached block information",
+                          "[quick][bipart]") {
+    for (bool checked : {false, true}) {
+      auto z = Bipartition::one(2);
+      for (auto const& x : {make<Bipartition>({0, 0, 0, 0}),
+                            make<Bipartition>({0, 1, 2, 3}),
+                            Bipartition::one(2)}) {
+        z.set_number_of_blocks(z.number_of_blocks());
+        z.set_number_of_left_blocks(z.number_of_left_blocks());
+        z.set_rank(z.rank());
+        REQUIRE(std::distance(z.cbegin_lookup(), z.cend_lookup())
+                == z.number_of_left_blocks());
+        if (checked) {
+          z.product_inplace(x, x);
+        } else {
+          z.product_inplace_no_checks(x, x);
+        }
+        // Each operand here is idempotent, with different block information.
+        REQUIRE(z == x);
+        REQUIRE(z.number_of_blocks() == x.number_of_blocks());
+        REQUIRE(z.number_of_left_blocks() == x.number_of_left_blocks());
+        REQUIRE(z.number_of_right_blocks() == x.number_of_right_blocks());
+        REQUIRE(z.rank() == x.rank());
+        REQUIRE(std::vector<bool>(z.cbegin_lookup(), z.cend_lookup())
+                == std::vector<bool>(x.cbegin_lookup(), x.cend_lookup()));
+      }
+    }
   }
 
 }  // namespace libsemigroups


### PR DESCRIPTION
Multiplying bipartitions of different degrees could reach unchecked indexing and produce an incorrect result. Add `Bipartition::product_inplace` to reject incompatible degrees, invalid operands or destinations, destination aliasing, and out-of-range thread indices before modifying the destination. Route `operator*` through the checked API, while retaining the unchecked internal `Product<Bipartition>` adapter.

Invalidate cached rank and block information when storing a product. Update the API documentation and add regression coverage for the reported degree-6/degree-5 example, valid products, squaring, degree zero, validation errors and their messages, destination preservation, and reuse of destinations with populated caches.

Fixes #989. The Semigroups package can adopt this API once its minimum libsemigroups version includes it; its existing degree guard remains a separate downstream change.

Validation:
- Built `test_bipart` and `test_froidure_pin_bipart` with `make -j6`.
- `./test_bipart "[quick]"`: 26 cases passed, including the final exception-message changes.
- `./test_froidure_pin_bipart "[quick]"`: 4 cases passed.
- Pre-push clang-format, cpplint, and codespell hooks passed for all changed files.
- Documentation order and line-break checks passed; direct Doxygen generation and documentation fixups completed, with warnings outside the changed header.
- `make doc` stopped when Inkscape crashed regenerating the unrelated to-table diagram; Doxygen was then run directly.

AI disclosure: OpenAI Codex assisted with the investigation, implementation, documentation, regression tests, validation, commit message, and this PR description. The commit author is Codex OpenAI and the committer is James Mitchell.