### PR TITLE
docs: correct gilman_graph normal form description

### DIFF
--- a/include/libsemigroups/detail/knuth-bendix-impl.hpp
+++ b/include/libsemigroups/detail/knuth-bendix-impl.hpp
@@ -741,7 +741,8 @@ namespace libsemigroups {
       //!
       //! The Gilman WordGraph is a digraph where the labels of the paths from
       //! the initial node (corresponding to the empty word) correspond to the
-      //! lenlex normal forms of the semigroup elements.
+      //! normal forms of the semigroup elements with respect to the reduction
+      //! ordering of the \ref_knuth_bendix instance.
       //!
       //! The semigroup is finite if the graph is acyclic, and infinite
       //! otherwise.


### PR DESCRIPTION
The `gilman_graph` documentation described the accepted words as lenlex normal forms, which only holds for the corresponding reduction ordering. Describe them as normal forms with respect to the configured reduction ordering, using the existing KnuthBendix documentation alias.

Fixes #1028.

Validation: documentation section-order and line-break checks, `git diff --check`, and the pre-push formatting, cpplint, and codespell hooks passed. `make doc` passed with optional table regeneration skipped after Inkscape crashed; the generated paragraph and KnuthBendix link were checked. The documentation fixup script reported a navigation-tree warning. No C++ tests were run for this prose-only change.

AI disclosure: OpenAI Codex assisted with the documentation correction, validation, commit message, and PR description.