### PR TITLE
Propagate Sims worker exceptions to the calling thread

### DIFF
--- a/src/sims.cpp
+++ b/src/sims.cpp
@@ -28,8 +28,9 @@
 
 #include "libsemigroups/sims.hpp"
 
-#include <algorithm>   // for fill, reverse
-#include <functional>  // for function, ref
+#include <algorithm>  // for fill, reverse
+#include <exception>  // for exception_ptr, current_exception, rethrow_exception
+#include <functional>  // for function
 #include <memory>      // for unique_ptr, make_unique, swap
 #include <string>      // for basic_string, string, operator+
 #include <thread>      // for thread, yield
@@ -951,10 +952,10 @@ namespace libsemigroups {
         std::function<bool(word_graph_type const&)> hook) {
       PendingDef pd;
       auto const restarts = _sims1or2->idle_thread_restarts();
-      for (size_t i = 0; i < restarts; ++i) {
-        while ((pop_from_local_queue(pd, my_index)
-                || pop_from_other_thread_queue(pd, my_index))
-               && !_done) {
+      for (size_t i = 0; i < restarts && !_done; ++i) {
+        while (!_done
+               && (pop_from_local_queue(pd, my_index)
+                   || pop_from_other_thread_queue(pd, my_index))) {
           if (_theives[my_index]->try_define(pd)
               && _theives[my_index]->install_descendents(pd)) {
             if (hook(**_theives[my_index])) {
@@ -1020,15 +1021,37 @@ namespace libsemigroups {
     template <typename Sims1or2>
     void SimsBase<Sims1or2>::thread_runner::run(
         std::function<bool(word_graph_type const&)> hook) {
-      try {
+      std::exception_ptr exception;
+      // Avoid allocating storage after starting a thread that must be joined.
+      _threads.reserve(_num_threads);
+      {
         detail::JoinThreads joiner(_threads);
-        for (size_t i = 0; i < _num_threads; ++i) {
-          _threads.push_back(std::thread(
-              &thread_runner::worker_thread, this, i, std::ref(hook)));
+        try {
+          for (size_t i = 0; i < _num_threads; ++i) {
+            _threads.emplace_back([this, i, &hook, &exception]() {
+              try {
+                // Copying hook into worker_thread can also throw, so do it
+                // inside the handler on the worker thread.
+                worker_thread(i, hook);
+              } catch (...) {
+                std::lock_guard<std::mutex> lock(_mtx);
+                if (!exception) {
+                  exception = std::current_exception();
+                }
+                _done = true;
+              }
+            });
+          }
+        } catch (...) {
+          // Cancel existing workers before the joiner waits for them when
+          // starting a later thread fails.
+          _done = true;
+          throw;
         }
-      } catch (...) {
-        _done = true;
-        throw;
+      }
+      // All workers have been joined, so no thread can still write exception.
+      if (exception) {
+        std::rethrow_exception(exception);
       }
     }
 

--- a/tests/test-sims.cpp
+++ b/tests/test-sims.cpp
@@ -29,6 +29,7 @@
 #include <cstdint>      // for uint64_t, uint32_t, uint8_t
 #include <iostream>     // for cout
 #include <iterator>     // for distance
+#include <stdexcept>    // for runtime_error
 #include <string>       // for basic_string, operator==, string
 #include <thread>       // for thread
 #include <tuple>        // for tuple, operator==
@@ -5256,5 +5257,141 @@ namespace libsemigroups {
                       })
                 .number_of_active_nodes()
             > 128);
+  }
+
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Sims",
+                                   "138",
+                                   "propagate callback exceptions",
+                                   "[quick][low-index]",
+                                   Sims1,
+                                   Sims2) {
+    auto const              threads = GENERATE(1, 2);
+    Presentation<word_type> p;
+    p.alphabet(1).contains_empty_word(true);
+    presentation::add_rule(p, 0000_w, ""_w);
+    TestType s(p);
+    s.number_of_threads(threads);
+    if (threads == 2 && s.number_of_threads() < 2) {
+      SKIP("requires at least two worker threads");
+    }
+
+    auto const       caller = std::this_thread::get_id();
+    std::atomic_bool called_on_worker(false);
+    auto             fail = [&](auto const&) -> bool {
+      called_on_worker = std::this_thread::get_id() != caller;
+      throw std::runtime_error("Sims callback failed");
+    };
+
+    SECTION("find_if predicate") {
+      REQUIRE_THROWS_MATCHES(s.find_if(4, fail),
+                             std::runtime_error,
+                             Catch::Matchers::Message("Sims callback failed"));
+    }
+    SECTION("for_each action") {
+      REQUIRE_THROWS_MATCHES(s.for_each(4, fail),
+                             std::runtime_error,
+                             Catch::Matchers::Message("Sims callback failed"));
+    }
+    SECTION("find_if pruner") {
+      s.add_pruner(fail);
+      REQUIRE_THROWS_MATCHES(s.find_if(4, [](auto const&) { return false; }),
+                             std::runtime_error,
+                             Catch::Matchers::Message("Sims callback failed"));
+    }
+    SECTION("for_each pruner") {
+      s.add_pruner(fail);
+      REQUIRE_THROWS_MATCHES(s.for_each(4, [](auto const&) {}),
+                             std::runtime_error,
+                             Catch::Matchers::Message("Sims callback failed"));
+    }
+    SECTION("number_of_congruences pruner") {
+      s.add_pruner(fail);
+      REQUIRE_THROWS_MATCHES(s.number_of_congruences(4),
+                             std::runtime_error,
+                             Catch::Matchers::Message("Sims callback failed"));
+    }
+
+    REQUIRE(called_on_worker == (threads == 2));
+    // The same object remains usable after the failing operation has joined
+    // its workers and propagated the exception.
+    s.clear_pruners();
+    REQUIRE(s.number_of_congruences(4) == 3);
+    REQUIRE(
+        s.find_if(
+             4, [](auto const& wg) { return wg.number_of_active_nodes() == 4; })
+            .number_of_active_nodes()
+        == 4);
+  }
+
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Sims",
+                                   "139",
+                                   "propagate worker callback copy exceptions",
+                                   "[quick][low-index]",
+                                   Sims1,
+                                   Sims2) {
+    auto                    rg = ReportGuard(false);
+    Presentation<word_type> p;
+    p.alphabet(1).contains_empty_word(true);
+    presentation::add_rule(p, 0000_w, ""_w);
+    TestType s(p);
+    s.number_of_threads(2);
+    if (s.number_of_threads() < 2) {
+      SKIP("requires at least two worker threads");
+    }
+
+    struct ThrowOnWorkerCopy {
+      std::thread::id caller = std::this_thread::get_id();
+
+      ThrowOnWorkerCopy() = default;
+      ThrowOnWorkerCopy(ThrowOnWorkerCopy const& that) : caller(that.caller) {
+        if (std::this_thread::get_id() != caller) {
+          throw std::runtime_error("Sims callback copy failed");
+        }
+      }
+
+      bool operator()(word_graph_type const&) const {
+        return false;
+      }
+    };
+
+    REQUIRE_THROWS_MATCHES(
+        s.find_if(4, ThrowOnWorkerCopy()),
+        std::runtime_error,
+        Catch::Matchers::Message("Sims callback copy failed"));
+    REQUIRE(s.number_of_congruences(4) == 3);
+  }
+
+  LIBSEMIGROUPS_TEMPLATE_TEST_CASE("Sims",
+                                   "140",
+                                   "preserve non-standard worker exceptions",
+                                   "[quick][low-index]",
+                                   Sims1,
+                                   Sims2) {
+    auto                    rg = ReportGuard(false);
+    Presentation<word_type> p;
+    p.alphabet(1).contains_empty_word(true);
+    presentation::add_rule(p, 0000_w, ""_w);
+    TestType s(p);
+    s.number_of_threads(2);
+    if (s.number_of_threads() < 2) {
+      SKIP("requires at least two worker threads");
+    }
+
+    struct Error {
+      std::thread::id thread;
+      int             value;
+    };
+    auto const caller = std::this_thread::get_id();
+    try {
+      s.find_if(4, [](auto const&) -> bool {
+        throw Error{std::this_thread::get_id(), 42};
+      });
+      FAIL("expected the worker exception on the calling thread");
+    } catch (Error const& error) {
+      REQUIRE(error.thread != caller);
+      REQUIRE(std::this_thread::get_id() == caller);
+      REQUIRE(error.value == 42);
+    }
+    REQUIRE(s.number_of_congruences(4) == 3);
   }
 }  // namespace libsemigroups


### PR DESCRIPTION
Exceptions thrown by Sims worker callbacks currently escape the thread entry point and terminate the process. For Python callers, even a `try/except` around `find_if` cannot recover from a callback raising `ValueError`.

Catch exceptions inside each worker, preserve the first captured exception with `std::exception_ptr`, and signal cancellation. Join all workers before rethrowing on the calling thread. The handler also covers copying the callback into the worker function. If starting another thread fails, signal cancellation before joining existing workers.

This covers `Sims1` and `Sims2` predicates and pruners without changing the public API or adding Python dependencies. The existing Python bindings can then propagate the original Python exception and traceback.

Add regression tests for predicates, `for_each` callbacks, pruners, throwing callback copies, non-standard exception payloads, and reuse of Sims objects after failure.

Validation:

- Confirmed all three new regression groups abort the unpatched executable.
- Rebuilt `test_sims` and ran `./test_sims '[quick]'`: 76 test cases passed.
- Tested the existing Python bindings against the locally built library: 40 exception cases passed, preserving exception identity and traceback.
- `pytest tests/test_sims.py tests/test_sims_threads.py -q`: 52 passed against the patched library.
- Formatting, cpplint, codespell, and Git whitespace checks passed.

Follow-up to libsemigroups/libsemigroups_pybind11#417 and libsemigroups/libsemigroups_pybind11#492.

AI disclosure: Codex (OpenAI) assisted with the investigation, implementation, regression tests, validation, and this PR description.
